### PR TITLE
json_dump method: Minor tweaks re file output and location

### DIFF
--- a/kerykeion/main.py
+++ b/kerykeion/main.py
@@ -504,7 +504,7 @@ class KrInstance():
 
     # Utility Functions:
 
-    def json_dump(self, dump=True):
+    def json_dump(self, dump=True, new_output_directory=None):
         import jsonpickle
 
         """
@@ -517,10 +517,15 @@ class KrInstance():
         except:
             self.get_all()
 
-        self.json_path = os.path.join(
-            self.json_dir, f"{self.name}_kerykeion.json")
-        json_string = jsonpickle.encode(self)
+        if new_output_directory:
+            self.json_path = os.path.join(
+                new_output_directory, f"{self.name}_kerykeion.json")
+        else:
+            self.json_path = os.path.join(
+                self.json_dir, f"{self.name}_kerykeion.json")
 
+        json_string = jsonpickle.encode(self)
+        
         hiden_values = [f' "json_dir": "{self.json_dir}",', f', "json_path": "{self.json_path}"'
                         ]
 

--- a/kerykeion/main.py
+++ b/kerykeion/main.py
@@ -505,7 +505,7 @@ class KrInstance():
     # Utility Functions:
 
     def json_dump(self, dump=True, new_output_directory=None):
-        import jsonpickle
+        import jsonpickle, json
 
         """
         Dumps the Kerykeion object to a json file located in the home folder.
@@ -533,8 +533,9 @@ class KrInstance():
             json_string = json_string.replace(string, "")
 
         if dump:
+            json_string = json.loads(json_string.replace("'",'"'))
             with open(self.json_path, "w") as file:
-                file.write(json_string)
+                json.dump(json_string, file,  indent=4,sort_keys=True)
                 print(f"JSON file dumped in {self.json_path}.")
         else:
             pass


### PR DESCRIPTION
Changed the json_dump method so that the JSON output is in readable and parseable format, and added an ability to choose which directory to output the JSON file to

<img width="445" alt="Screen Shot 2021-11-25 at 10 43 58 PM" src="https://user-images.githubusercontent.com/54873722/143523651-035db928-b19f-43c9-b059-ba030839d255.png">

<img width="535" alt="Screen Shot 2021-11-25 at 10 44 17 PM" src="https://user-images.githubusercontent.com/54873722/143523625-21df7c7d-dc4a-439a-a023-9318db156b5d.png">
