### PR TITLE
Created a very simple proxy for the Geonames API

### DIFF
--- a/kerykeion/geoname.py
+++ b/kerykeion/geoname.py
@@ -25,22 +25,124 @@ preset vars:
     maxRows=1
 """
 
-
-
-
 from urllib.request import urlopen
 from urllib.parse import urlencode
 from xml.dom.minidom import parseString
 from socket import timeout
 from urllib.error import HTTPError, URLError
+from os import mkdir, path, getcwd, remove
+import json
+import logging
+
+
+logging.basicConfig(
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
+
+
 def _getText(nodelist):
-    """Internal function to return text from nodes
+    """"
+    Internal function to return text from nodes
     """
     rc = ""
     for node in nodelist:
         if node.nodeType == node.TEXT_NODE:
             rc = rc + node.data
     return rc
+
+
+def geonames_proxy(operation: str, params: str):
+    # directory to store cache files in
+    cache_directory = '.kerykeion'
+
+    # supported API calls and their corresponding file cache names
+    cache_file_name = {
+        'search': 'geonames_search_cache.json',
+        'timezone': 'geonames_timezone_cache.json'
+    }
+    # supported API calls and their corresponding API endpoints
+    api_endpoints = {
+        'search': "http://api.geonames.org/search?%s",
+        'timezone': "http://api.geonames.org/timezone?%s"
+    }
+    cache_file_name = cache_file_name[operation]
+    cache_file_path = path.join(cache_directory, cache_file_name)
+    api_endpoint = api_endpoints[operation]
+
+    try:
+        # try to create a directory to store the cache in
+        # might fail under wrong permission settings
+        if not path.exists(cache_directory):
+            # mkdir if it doesn't already exist
+            mkdir(cache_directory)
+    except:
+        logging.error(f'Failed to create directory: {cache_directory}')
+        logging.error(f'Maybe check permissions in: "{getcwd()}"?')
+        raise Exception(f'Error: failed to create {cache_directory} directory.')
+
+    # dict to store the cache data in the program
+    cache_dict = dict()
+    try:
+        # check if file exists
+        if path.exists(cache_file_path) and path.getsize(cache_file_path) > 0:
+            # then open it for reading with ability to write
+            # an empty file is definitely not useful to json.load() so we'll just skip that and create a new one
+            cache_file = open(cache_file_path, 'r+', encoding='utf-8')
+            # then load data from it
+            try:
+                # this can fail if json file is corrupted
+                cache_dict = json.load(cache_file)
+                logging.info(f'Loaded proxy cache file: "{cache_file_path}" and parsed as JSON.')
+
+            except:
+                logging.error(f'Failed to parse JSON file: "{cache_file_path}"!')
+                cache_file.seek(0)
+                logging.error(f'Contents: {cache_file.read()}')
+                logging.error(f'Try removing: {path.join(getcwd(),cache_directory)}')
+                raise Exception('Error: Failed to parse JSON file!')
+        else:
+            # if file doesn't exist or is empty create it for writing with ability to read
+            cache_file = open(cache_file_path, 'w+', encoding='utf-8')
+
+    except:
+        logging.error(f'Failed to access: {cache_file_path}')
+        raise Exception('Error: failed to access Geonames cache file.')
+
+    if params not in cache_dict or cache_dict[params] == "":
+        # if the file does not contain the key with the parameters proceed into the branch
+        # if the file does contain the key with the param but it's empty then we'll replace it
+        # if the file does already contain the API response then this branch is skipped and data from the file is
+        # returned instead
+        if params in cache_dict and cache_dict[params] == "":
+            logging.warning(f'Proxy cache file has an empty value for key:"{params}".')
+        elif params not in cache_dict:
+            logging.info(f'Params: "{params}" not found in proxy cache file.')
+        try:
+            # try to query geonames
+            logging.info(f'Calling Geonames API endpoint: "{api_endpoint}" with params: "{params}".')
+            http_response = urlopen(api_endpoint % params, timeout=20)
+
+        except (HTTPError, URLError) as error:
+            logging.error(f'Not retrieved because {error}\nURL: {cache_dict[params]}')
+            raise Exception('Error: failed to access Geonames service.')
+
+        except timeout:
+            logging.error('Timeout on search in Geonames API!')
+            raise Exception('Error: Timeout on connection with Geonames.')
+
+        # store the response in the dict
+        data = http_response.read()
+        cache_dict[params] = data.decode('UTF-8')
+
+        # empty the file. Without this json.dump() will append to the existing data
+        cache_file.close()
+        cache_file = open(cache_file_path, 'w', encoding='utf-8')
+
+        # dump the dict in JSON format into the file
+        json.dump(cache_dict, cache_file)
+        cache_file.close()
+        logging.info('Saved new proxy cache file.')
+
+    return cache_dict[params], cache_file_path
 
 
 def search(name='', country=''):
@@ -50,29 +152,30 @@ def search(name='', country=''):
     """
     # check name
     if name == '':
-        print('No name specified!')
+        logging.error('No name specified for Geonames search!')
         return None
 
     # open connection and read xml
     params = urlencode({'q': name, 'country': country, 'maxRows': 1,
-                       'featureClass': 'P', 'username': 'century.boy'})
+                        'featureClass': 'P', 'username': 'century.boy'})
 
     try:
-        f = urlopen("http://api.geonames.org/search?%s" % params, timeout=20)
-
-    except (HTTPError, URLError) as error:
-        print('Errir: not retrieved because %s\nURL: %s', error, f)
-
-    except timeout:
-        print('Timeout on search!')
+        data, cache_file_path = geonames_proxy('search', params)
+        dom = parseString(data)
+    except Exception:
         return None
 
-    data = f.read()
-    dom = parseString(data)
-
     # totalResultsCount
-    totalResultsCount = _getText(
-        dom.getElementsByTagName("totalResultsCount")[0].childNodes)
+    try:
+        totalResultsCount = _getText(
+            dom.getElementsByTagName("totalResultsCount")[0].childNodes)
+    except:
+        logging.error("Geonames API response could not be parsed! Maybe you exceeded API hourly limit?")
+        logging.error(f"String that failed to parse: {data}")
+        # remove the cache_file since it now contains the hourly limit error message
+        remove(cache_file_path)
+        return None
+
 
     # geoname
     geoname = []
@@ -98,18 +201,21 @@ def search(name='', country=''):
         tparams = urlencode(
             {'lat': geoname[-1]['lat'], 'lng': geoname[-1]['lng'], 'username': 'century.boy'})
         try:
-            f = urlopen("http://api.geonames.org/timezone?%s" %
-                        tparams, timeout=20)
-        except (HTTPError, URLError) as error:
-            print('Errir: not retrieved because %s\nURL: %s', error, f)
-        except timeout:
-            print('Timeout on search!')
+            data, cache_file_path = geonames_proxy('timezone', tparams)
+        except Exception:
             return None
 
-        data = f.read()
         tdom = parseString(data)
-        geoname[-1]['timezonestr'] = _getText(
-            tdom.getElementsByTagName("timezoneId")[0].childNodes)
+
+        try:
+            geoname[-1]['timezonestr'] = _getText(tdom.getElementsByTagName("timezoneId")[0].childNodes)
+        except:
+            logging.error("Geonames API response could not be parsed! Maybe you exceeded API hourly limit?")
+            logging.error(f"String that failed to parse: {data}")
+            # remove the cache_file since it now contains the hourly limit error message
+            remove(cache_file_path)
+            return None
+
         tdom.unlink()
         break
     # close dom
@@ -117,7 +223,7 @@ def search(name='', country=''):
 
     # return results
     if totalResultsCount == "0":
-        print("No results!")
+        logging.error("No results found using Geonames API!")
         return None
     else:
         return geoname

--- a/kerykeion/geoname.py
+++ b/kerykeion/geoname.py
@@ -13,16 +13,16 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenAstro.org.  If not, see <http://www.gnu.org/licenses/>.
+    along with OpenAstro.org.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 """
 docs at:
-	http://www.geonames.org/export/geonames-search.html
+    https://www.geonames.org/export/geonames-search.html
 
 preset vars:
-	featureClass=P (populated place)
-	maxRows=1
+    featureClass=P (populated place)
+    maxRows=1
 """
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r", encoding="utf8") as fh:
 
 setuptools.setup(
     name="kerykeion",
-    version="2.1.11",
+    version="2.1.12",
     author="Giacomo Battaglia",
     author_email="battaglia.giacomo@yahoo.it",
     description="An astrology library.",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
I created a simple proxy for the Geonames API as I have previously suggested in this issue: https://github.com/g-battaglia/kerykeion/issues/15

This change is backwards and forwards compatible.

The proxy works as follows:

- Previously urlopen() was called, now geonames_proxy() is called instead.
- This new function accepts two arguments: the operation (ie. search of place or timezone check) and the parameters to call the Geonames API with.
- geonames_proxy creates a directory (by default that's ```.kerykeion```) if it does not already exist. 
- It checks if there's a cache file available already
  - if yes then it will check if there's cached results of querying these parameters against the Geonames API
    - if there is then it just returns the past response for those same parameters
    - if there isn't then it queries the Geonames API, saves the response into the cache file, then returns it
- geonames_proxy will store JSON files containing parameters as keys and responses as values.

Features
- the ```.kerykeion``` directory can always be safely removed, as can any files within. This will simply prompt geonames_proxy to create it again and fill it with results
- all errors, information and warnings that I could foresee are logged using the ```logging``` module.
- this change allows for KrInstance objects to be initialized in a loop and at most 2 API calls will be made to Geonames per location (one for search and another for timezone)


Additional changes I've made:

- changed license url to use https
- changed some inconsistent indentation
- fixed an encoding issue which was making it impossible to pip install the module on Windows (that's a change in setup.py)
- wrapped the parsing of API response handling in a try-except to inform the user of a potential hourly rate limit hit against the Geonames API
- bumped the version number