### PR TITLE
change encoding to utf-8 for output file

### DIFF
--- a/kerykeion/utilities/charts/charts_svg.py
+++ b/kerykeion/utilities/charts/charts_svg.py
@@ -509,7 +509,7 @@ class MakeSvgInstance:
         self.chartname = os.path.join(
             self.output_directory, f'{self.name}{self.type}Chart.svg')
 
-        with open(self.chartname, "w") as output_file:
+        with open(self.chartname, "w", encoding='utf-8') as output_file:
             output_file.write(self.template)
 
         return print(f"SVG Generated Correctly in: {self.output_directory}")


### PR DESCRIPTION
I encountered an error - the degree symbol (°) was not displayed correctly in the svg file:
```
XML Parsing Error: not well-formed
Location: file:///KanyeNatalChart.svg
Line Number 16, Column 76:
<text x="20" y="86" style="fill: #000000; font-size: 11px">Latitude: 41￿2.143444,14.821704 C 22.143444,18.116795 22.143444,21.411884 22.143444,24.706975 z " style="fill: #6b3d00;" />
```
This happens because the encoding in the [open function](https://docs.python.org/3.10/library/functions.html#open) is platform dependent and we need to specify it
```python
  with open(self.chartname, "w", encoding='utf-8') as output_file:
      output_file.write(self.template)
```