### PR TITLE
Update aspects.py

### DIFF
--- a/kerykeion/aspects.py
+++ b/kerykeion/aspects.py
@@ -38,7 +38,7 @@ class NatalAspects():
         else:
             settings_file = Path(self.new_settings_file)
 
-        with open(settings_file, 'r') as f:
+        with open(settings_file, 'r',encoding="cp866") as f:
             settings = json.load(f)
 
         self.colors_settings = settings['colors']


### PR DESCRIPTION
This fixes the `UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 1341: character maps to <undefined>` error for me. Although I only tested it for "Natal".