### PR TITLE
fix error and add french language

### DIFF
--- a/kerykeion/charts/charts_svg.py
+++ b/kerykeion/charts/charts_svg.py
@@ -1236,7 +1236,7 @@ class MakeSvgInstance:
                     # planet text
                     out += f'<text text-anchor="end" style="fill:{self.colors_settings["paper_0"]}; font-size: 10px;">{self.language_settings["planets"][self.planets_settings[i]["label"]]}</text>'
                     # planet symbol
-                    out += f'<g transform="translate(5,-8)"><use transform="scale(0.4)" xlink:href="# {self.planets_settings[i]["name"]}" /></g>'
+                    out += f'<g transform="translate(5,-8)"><use transform="scale(0.4)" xlink:href="#{self.planets_settings[i]["name"]}" /></g>'
                     # planet degree
                     out += '<text text-anchor="start" x="19" style="fill:%s; font-size: 10px;">%s</text>' % (
                         self.colors_settings['paper_0'], self.__dec2deg(self.t_planets_degree[i]))

--- a/kerykeion/kr.config.json
+++ b/kerykeion/kr.config.json
@@ -42,6 +42,48 @@
       }
     },
 
+    "FR": {
+      "info": "Informations",
+      "cusp": "Maison",
+      "longitude": "Longitude",
+      "latitude": "Latitude",
+      "north": "Nord",
+      "east": "Est",
+      "south": "Sud",
+      "west": "Ouest",
+      "fire": "Feu",
+      "earth": "Terre",
+      "air": "Air",
+      "water": "Eau",
+      "&": "et",
+      "transits": "Transites pour",
+      "type": "Type",
+      "aspects": "Les aspects",
+      "planets_and_house": "Planetes et Maisons pour",
+      "transit_name": "Au moment de la transition",
+      "lunar_phase": "Phase Lunaire",
+      "day": "Jour",
+
+      "planets": {
+        "Sun": "Soleil",
+        "Moon": "Lune",
+        "Mercury": "Mercure",
+        "Venus": "Vénus",
+        "Mars": "Mars",
+        "Jupiter": "Jupiter",
+        "Saturn": "Saturne",
+        "Uranus": "Uranus",
+        "Neptune": "Neptune",
+        "Pluto": "Pluton",
+        "Asc": "Asc",
+        "Mc": "Mc",
+        "Dsc": "Dsc",
+        "Ic": "Ic",
+        "North_Node": "Noeud Nord",
+        "Mean_Node": "Noeud Moyen"
+      }
+    },
+
     "PT": {
       "info": "Informações",
       "cusp": "Casa",


### PR DESCRIPTION
- fixed an error on planet icons in the transits column : `xlink:href="# {self.planets_settings[i]["name"]}"` to `xlink:href="#{self.planets_settings[i]["name"]}"`
- add the translate for french (FR)