### PR TITLE
Add encoding utf8

### DIFF
--- a/kerykeion/settings/kerykeion_settings.py
+++ b/kerykeion/settings/kerykeion_settings.py
@@ -215,7 +215,7 @@ def get_settings_dict(new_settings_file: Union[Path, None] = None) -> Dict:
         settings_file = Path(__file__).parent / "kr.config.json"
 
     logger.debug(f"Kerykeion config file path: {settings_file}")
-    with open(settings_file, "r") as f:
+    with open(settings_file, "r", encoding="utf8") as f:
         settings_dict = load(f)
 
     return settings_dict


### PR DESCRIPTION
Hello!
I encountered an error when generating svg on the windows operating system.

Error was:
```
  ...
  File "C:\Users\parac\venvs\horoscopes\lib\site-packages\kerykeion\settings\kerykeion_settings.py", line 219, in get_settings_dict
    settings_dict = load(f)
  File "C:\Program Files\Python310\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "C:\Program Files\Python310\lib\encodings\cp1251.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 4727: character maps to <undefined>
```

This problem was solved by specifying the encoding when opening the file:
```
with open(settings_file, "r", encoding="utf8") as f:
    settings_dict = load(f)
```