### PR TITLE
Revamp logging

### DIFF
--- a/exemples/eg_create_chart.py
+++ b/exemples/eg_create_chart.py
@@ -19,4 +19,7 @@ def main():
 
 
 if __name__ == "__main__":
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
+    
     main()

--- a/kerykeion/aspects/natal_aspects.py
+++ b/kerykeion/aspects/natal_aspects.py
@@ -5,14 +5,12 @@
 
 from pathlib import Path
 from kerykeion import AstrologicalSubject
-from logging import getLogger, basicConfig
+import logging
 from typing import Union
 from kerykeion.settings.kerykeion_settings import get_settings
 from dataclasses import dataclass
 from kerykeion.aspects.aspects_utils import planet_id_decoder, get_aspect_from_two_points, get_active_points_list
 
-logger = getLogger(__name__)
-basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level="INFO")
 
 AXES_LIST = [
     "First_House",
@@ -97,10 +95,10 @@ class NatalAspects:
         """
 
         if self._relevant_aspects is not None:
-            logger.debug("Relevant aspects already calculated, returning cached value")
+            logging.debug("Relevant aspects already calculated, returning cached value")
             return self._relevant_aspects
 
-        logger.debug("Relevant aspects not already calculated, calculating now...")
+        logging.debug("Relevant aspects not already calculated, calculating now...")
         self.all_aspects
 
         aspects_filtered = []
@@ -131,7 +129,9 @@ class NatalAspects:
 
 
 if __name__ == "__main__":
-    basicConfig(level="DEBUG", force=True)
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
+
     johnny = AstrologicalSubject("Johnny Depp", 1963, 6, 9, 0, 0, "Owensboro", "US")
 
     # All aspects

--- a/kerykeion/aspects/synastry_aspects.py
+++ b/kerykeion/aspects/synastry_aspects.py
@@ -94,6 +94,9 @@ class SynastryAspects(NatalAspects):
 
 
 if __name__ == "__main__":
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
+
     john = AstrologicalSubject("John", 1940, 10, 9, 10, 30, "Liverpool")
     yoko = AstrologicalSubject("Yoko", 1933, 2, 18, 10, 30, "Tokyo")
 

--- a/kerykeion/astrological_subject.py
+++ b/kerykeion/astrological_subject.py
@@ -6,9 +6,9 @@
 import math
 import pytz
 import swisseph as swe
+import logging
 
 from datetime import datetime
-from logging import getLogger, basicConfig
 from kerykeion.fetch_geonames import FetchGeonames
 from kerykeion.kr_types import (
     KerykeionException,
@@ -22,12 +22,6 @@ from pathlib import Path
 from typing import Union, Literal
 
 DEFAULT_GEONAMES_USERNAME = "century.boy"
-
-logger = getLogger(__name__)
-basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    level="INFO"
-)
 
 
 class AstrologicalSubject:
@@ -51,7 +45,6 @@ class AstrologicalSubject:
     - lng (Union[int, float], optional): _ Defaults to False.
     - lat (Union[int, float], optional): _ Defaults to False.
     - tz_str (Union[str, bool], optional): _ Defaults to False.
-    - logger (Union[Logger, None], optional): _ Defaults to None.
     - geonames_username (str, optional): _ Defaults to 'century.boy'.
     - online (bool, optional): Sets if you want to use the online mode (using
         geonames) or not. Defaults to True.
@@ -136,7 +129,7 @@ class AstrologicalSubject:
         zodiac_type: ZodiacType = "Tropic",
         online: bool = True,
     ) -> None:
-        logger.debug("Starting Kerykeion")
+        logging.debug("Starting Kerykeion")
 
         # We set the swisseph path to the current directory
         swe.set_ephe_path(
@@ -163,7 +156,7 @@ class AstrologicalSubject:
 
         # This message is set to encourage the user to set a custom geonames username
         if geonames_username is None and online:
-            logger.info(
+            logging.info(
                 "\n"
                 "********" + \
                 "\n" + \
@@ -184,11 +177,11 @@ class AstrologicalSubject:
 
         if not self.city:
             self.city = "London"
-            logger.warning("No city specified, using London as default")
+            logging.warning("No city specified, using London as default")
 
         if not self.nation:
             self.nation = "GB"
-            logger.warning("No nation specified, using GB as default")
+            logging.warning("No nation specified, using GB as default")
 
         if (not self.online) and (not lng or not lat or not tz_str):
             raise KerykeionException(
@@ -219,7 +212,7 @@ class AstrologicalSubject:
 
     def _fetch_tz_from_geonames(self) -> None:
         """Gets the nearest time zone for the calculation"""
-        logger.debug("Conneting to Geonames...")
+        logging.debug("Conneting to Geonames...")
 
         geonames = FetchGeonames(
             self.city,
@@ -243,11 +236,11 @@ class AstrologicalSubject:
 
         if self.lat > 66.0:
             self.lat = 66.0
-            logger.info("Polar circle override for houses, using 66 degrees")
+            logging.info("Polar circle override for houses, using 66 degrees")
 
         elif self.lat < -66.0:
             self.lat = -66.0
-            logger.info("Polar circle override for houses, using -66 degrees")
+            logging.info("Polar circle override for houses, using -66 degrees")
 
     def _get_utc(self) -> None:
         """Converts local time to utc time."""
@@ -608,7 +601,7 @@ class AstrologicalSubject:
 
             with open(json_path, "w", encoding="utf-8") as file:
                 file.write(json_string)
-                logger.info(f"JSON file dumped in {json_path}.")
+                logging.info(f"JSON file dumped in {json_path}.")
 
         return json_string
 
@@ -622,7 +615,8 @@ class AstrologicalSubject:
 
 if __name__ == "__main__":
     import json
-    basicConfig(level="DEBUG", force=True)
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
 
     johnny = AstrologicalSubject("Johnny Depp", 1963, 6, 9, 0, 0, "Owensboro", "US")
     print(json.loads(johnny.json(dump=True)))

--- a/kerykeion/charts/kerykeion_chart_svg.py
+++ b/kerykeion/charts/kerykeion_chart_svg.py
@@ -5,6 +5,7 @@
 
 
 import pytz
+import logging
 
 from datetime import datetime
 from kerykeion.settings.kerykeion_settings import get_settings
@@ -14,17 +15,9 @@ from kerykeion.astrological_subject import AstrologicalSubject
 from kerykeion.kr_types import KerykeionException, ChartType
 from kerykeion.kr_types import ChartTemplateModel
 from kerykeion.charts.charts_utils import decHourJoin, degreeDiff, offsetToTz, sliceToX, sliceToY
-from logging import getLogger, basicConfig
 from pathlib import Path
 from string import Template
 from typing import Union
-
-
-logger = getLogger(__name__)
-basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    level="INFO"
-)
 
 
 class KerykeionChartSVG:
@@ -166,7 +159,7 @@ class KerykeionChartSVG:
         self.home_countrycode = self.user.nation
         self.home_timezonestr = self.user.tz_str
 
-        logger.info(f"{self.user.name} birth location: {self.home_location}, {self.home_geolat}, {self.home_geolon}")
+        logging.info(f"{self.user.name} birth location: {self.home_location}, {self.home_geolat}, {self.home_geolon}")
 
         # default location
         self.location = self.home_location
@@ -238,7 +231,7 @@ class KerykeionChartSVG:
         Sets the output direcotry and returns it's path.
         """
         self.output_directory = dir_path
-        logger.info(f"Output direcotry set to: {self.output_directory}")
+        logging.info(f"Output direcotry set to: {self.output_directory}")
 
     def parse_json_settings(self, settings_file):
         """
@@ -534,7 +527,7 @@ class KerykeionChartSVG:
         for i in range(len(self.available_planets_setting)):
             if self.available_planets_setting[i]["is_active"] == 1:
                 # list of planets sorted by degree
-                logger.debug(f"planet: {i}, degree: {self.points_deg_ut[i]}")
+                logging.debug(f"planet: {i}, degree: {self.points_deg_ut[i]}")
                 planets_degut[self.points_deg_ut[i]] = i
 
             self._value_element_from_planet(i)
@@ -566,7 +559,7 @@ class KerykeionChartSVG:
             diffb = degreeDiff(next, self.points_deg_ut[i])
             planets_by_pos[e] = [i, diffa, diffb]
 
-            logger.debug(f'{self.available_planets_setting[i]["label"]}, {diffa}, {diffb}')
+            logging.debug(f'{self.available_planets_setting[i]["label"]}, {diffa}, {diffb}')
 
             if diffb < planet_drange:
                 if group_open:
@@ -931,7 +924,7 @@ class KerykeionChartSVG:
                 for l, w in opp[k].items():
                     for a, b in sq.items():
                         if k in sq[a] and l in sq[a]:
-                            logger.debug(f"Got tsquare {a} {k} {l}")
+                            logging.debug(f"Got tsquare {a} {k} {l}")
                             if k > l:
                                 tsquare[f"{a},{l},{k}"] = f"{self.available_planets_setting[a]['label']} => {self.available_planets_setting[l]['label']}, {self.available_planets_setting[k]['label']}"
 
@@ -1474,7 +1467,7 @@ class KerykeionChartSVG:
 
         # return filename
 
-        logger.debug(f"Template dictionary keys: {td.keys()}")
+        logging.debug(f"Template dictionary keys: {td.keys()}")
 
         self._createTemplateDictionary()
         return template.replace('"', "'")
@@ -1490,11 +1483,12 @@ class KerykeionChartSVG:
         with open(self.chartname, "w", encoding="utf-8", errors="ignore") as output_file:
             output_file.write(self.template)
 
-        logger.info(f"SVG Generated Correctly in: {self.chartname}")
+        logging.info(f"SVG Generated Correctly in: {self.chartname}")
 
 
 if __name__ == "__main__":
-    basicConfig(level="DEBUG", force=True)
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
 
     first = AstrologicalSubject("John Lennon", 1940, 10, 9, 10, 30, "Liverpool", "GB")
     second = AstrologicalSubject("Paul McCartney", 1942, 6, 18, 15, 30, "Liverpool", "GB")

--- a/kerykeion/fetch_geonames.py
+++ b/kerykeion/fetch_geonames.py
@@ -4,17 +4,10 @@
 """
 
 
-from logging import getLogger, basicConfig
+import logging
 from requests import Request
 from requests_cache import CachedSession
 from typing import Union
-
-
-logger = getLogger(__name__)
-basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    level="INFO"
-)
 
 
 class FetchGeonames:
@@ -25,8 +18,6 @@ class FetchGeonames:
     city_name (str): Name of the city
     country_code (str): Two letters country code
     username (str, optional): GeoNames username, defaults to "century.boy".
-    logger (Union[logging.Logger, None], optional):
-        Optional logger, defaults to None. If none provided creates one.
     """
 
     def __init__(
@@ -57,21 +48,21 @@ class FetchGeonames:
         params = {"lat": lat, "lng": lon, "username": self.username}
 
         prepared_request = Request("GET", self.timezone_url, params=params).prepare()
-        logger.debug(f"Requesting data from GeoName timezones: {prepared_request.url}")
+        logging.debug(f"Requesting data from GeoName timezones: {prepared_request.url}")
 
         try:
             response = self.session.send(prepared_request)
             response_json = response.json()
 
         except Exception as e:
-            logger.error(f"Error fetching {self.timezone_url}: {e}")
+            logging.error(f"Error fetching {self.timezone_url}: {e}")
             return {}
 
         try:
             timezone_data["timezonestr"] = response_json["timezoneId"]
 
         except Exception as e:
-            logger.error(f"Error serializing data maybe wrong username? Details: {e}")
+            logging.error(f"Error serializing data maybe wrong username? Details: {e}")
             return {}
 
         if hasattr(response, "from_cache"):
@@ -95,14 +86,14 @@ class FetchGeonames:
         }
 
         prepared_request = Request("GET", self.base_url, params=params).prepare()
-        logger.debug(f"Requesting data from geonames basic: {prepared_request.url}")
+        logging.debug(f"Requesting data from geonames basic: {prepared_request.url}")
 
         try:
             response = self.session.send(prepared_request)
             response_json = response.json()
 
         except Exception as e:
-            logger.error(f"Error in fetching {self.base_url}: {e}")
+            logging.error(f"Error in fetching {self.base_url}: {e}")
             return {}
 
         try:
@@ -112,7 +103,7 @@ class FetchGeonames:
             city_data_whitout_tz["countryCode"] = response_json["geonames"][0]["countryCode"]
 
         except Exception as e:
-            logger.error(f"Error serializing data maybe wrong username? Details: {e}")
+            logging.error(f"Error serializing data maybe wrong username? Details: {e}")
             return {}
 
         if hasattr(response, "from_cache"):
@@ -132,18 +123,15 @@ class FetchGeonames:
             timezone_response = self.__get_timezone(city_data_response["lat"], city_data_response["lng"])
 
         except Exception as e:
-            logger.error(f"Error in fetching timezone: {e}")
+            logging.error(f"Error in fetching timezone: {e}")
             return {}
 
         return {**timezone_response, **city_data_response}
 
 
 if __name__ == "__main__":
-    basicConfig(
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        level="DEBUG",
-        force=True,
-    )
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
 
     geonames = FetchGeonames("Roma", "IT")
     print(geonames.get_serialized_data())

--- a/kerykeion/kr_types/kr_models.py
+++ b/kerykeion/kr_types/kr_models.py
@@ -160,6 +160,9 @@ class AstrologicalSubjectModel(BaseModel):
 
 
 if __name__ == "__main__":
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
+
     sun = KerykeionPointModel(
         name="Sun",
         element="Air",

--- a/kerykeion/kr_types/settings_models.py
+++ b/kerykeion/kr_types/settings_models.py
@@ -5,14 +5,9 @@
 
 
 from json import load
-from logging import getLogger, basicConfig
 from pydantic import BaseModel, Field
 from pathlib import Path
 from typing import Dict, List, Union
-
-
-logger = getLogger(__name__)
-basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level="INFO")
 
 
 class CustomBaseModel(BaseModel):

--- a/kerykeion/relationship_score.py
+++ b/kerykeion/relationship_score.py
@@ -5,16 +5,9 @@
 
 from kerykeion import AstrologicalSubject
 from kerykeion.aspects.synastry_aspects import SynastryAspects
-from logging import basicConfig, getLogger
+import logging
 from pathlib import Path
 from typing import Union
-
-
-logger = getLogger(__name__)
-basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    level="INFO"
-)
 
 
 class RelationshipScore:
@@ -78,7 +71,7 @@ class RelationshipScore:
         }
 
     def _log_aspect(self, aspect: dict, points: int) -> None:
-        logger.debug(
+        logging.debug(
             f"{points} Points: {aspect['p1_name']} {aspect['aspect']} {aspect['p2_name']}, rounded orbit: {int(aspect['orbit'])}"
         )
 
@@ -87,7 +80,7 @@ class RelationshipScore:
         5 points if is a destiny sign:
         """
         if self.first_subject.sun["quality"] == self.second_subject.sun["quality"]:
-            logger.debug(
+            logging.debug(
                 f'5 points: Destiny sign, {self.first_subject.sun["sign"]} and {self.second_subject.sun["sign"]}'
             )
             self.is_destiny_sign = True
@@ -200,7 +193,8 @@ class RelationshipScore:
 
 
 if __name__ == "__main__":
-    basicConfig(level="DEBUG", force=True)
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
 
     lui = AstrologicalSubject("John", 1975, 10, 10, 21, 15, "Roma", "IT")
     lei = AstrologicalSubject("Sarah", 1978, 2, 9, 15, 50, "Roma", "IT")

--- a/kerykeion/report.py
+++ b/kerykeion/report.py
@@ -83,6 +83,9 @@ class Report:
 
 
 if __name__ == "__main__":
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
+
     john = AstrologicalSubject("John", 1975, 10, 10, 21, 15, "Roma", "IT")
     report = Report(john)
     report.print_report()

--- a/kerykeion/settings/kerykeion_settings.py
+++ b/kerykeion/settings/kerykeion_settings.py
@@ -5,16 +5,10 @@
 
 
 from json import load
-from logging import getLogger, basicConfig
+import logging
 from pathlib import Path
 from typing import Dict, Union
 from kerykeion.kr_types import KerykeionSettingsModel
-
-
-logger = getLogger(__name__)
-basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level="INFO")
-
-
 
 
 def get_settings(new_settings_file: Union[Path, None] = None) -> KerykeionSettingsModel:
@@ -47,7 +41,7 @@ def get_settings(new_settings_file: Union[Path, None] = None) -> KerykeionSettin
     if not settings_file.exists():
         settings_file = Path(__file__).parent / "kr.config.json"
 
-    logger.debug(f"Kerykeion config file path: {settings_file}")
+    logging.debug(f"Kerykeion config file path: {settings_file}")
     with open(settings_file, "r", encoding="utf8") as f:
         settings_dict = load(f)
 
@@ -71,4 +65,7 @@ def merge_settings(settings: KerykeionSettingsModel, new_settings: Dict) -> Kery
 
 
 if __name__ == "__main__":
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
+
     print(get_settings())

--- a/kerykeion/utilities.py
+++ b/kerykeion/utilities.py
@@ -1,8 +1,6 @@
 from kerykeion.kr_types import KerykeionPointModel, KerykeionException, KerykeionSettingsModel, AstrologicalSubjectModel
 from typing import Union, Literal
-from logging import getLogger
-
-logger = getLogger(__name__)
+import logging
 
 
 def get_number_from_name(name: str) -> int:
@@ -204,3 +202,16 @@ def calculate_position(
         raise KerykeionException(f"Error in calculating positions! Degrees: {degree}")
 
     return KerykeionPointModel(**dictionary)
+
+def setup_logging(level: str) -> None:
+    """Setup logging for testing.
+    
+    Args:
+        level: Log level as a string, options: debug, info, warning, error"""
+    logopt: dict[str, int]  = {"debug": logging.DEBUG, 
+                               "info": logging.INFO, 
+                               "warning": logging.WARNING , 
+                               "error": logging.ERROR}
+    format: str             = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    loglevel: int           = logopt.get(level, logging.INFO)
+    logging.basicConfig(format=format, level=loglevel)

--- a/tests/test_json_dump.py
+++ b/tests/test_json_dump.py
@@ -105,6 +105,9 @@ class TestJsonDump:
 
 
 if __name__ == "__main__":
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
+
     test = TestJsonDump()
     test.setup_class()
     test.test_json_dump_data()

--- a/tests/test_kr_instance.py
+++ b/tests/test_kr_instance.py
@@ -1,7 +1,4 @@
 from kerykeion import AstrologicalSubject
-from logging import getLogger
-
-logger = getLogger(__name__)
 
 
 class TestAstrologicalSubject:

--- a/tests/test_relationship_score.py
+++ b/tests/test_relationship_score.py
@@ -17,4 +17,7 @@ def test_relationship_score():
 
 
 if __name__ == "__main__":
+    from kerykeion.utilities import setup_logging
+    setup_logging(level="debug")
+
     test_relationship_score()


### PR DESCRIPTION
Solves #85

Allows downstream projects using the ```logging``` library to maintain their own logging formatting. Centralizes logging formatting in this project.

- Created ```setup_logging()``` in kerykeion/utilities.py. This is where the format is set. Takes argument for log level.
- Removed logging setup throughout project.
- Changed relevant imports simply to  ```import logging```.
- Changed instances of ```logger``` to ```logging```.
- Added a call to import and run ```setup_logging()``` anywhere where a file was setup to be run directly, i.e. the file contained ```if __name__ == "__main__":```. This has an effect even in files where it's not used as some of those files call others that do.
- Removed stray, unused instances and imports for ```logging```.