### PR TITLE
Patch to make geonames caching longer and changeable by user

### DIFF
--- a/kerykeion/astrological_subject.py
+++ b/kerykeion/astrological_subject.py
@@ -40,6 +40,7 @@ DEFAULT_SIDEREAL_MODE: SiderealMode = "FAGAN_BRADLEY"
 DEFAULT_HOUSES_SYSTEM_IDENTIFIER: HousesSystemIdentifier = "P"
 DEFAULT_ZODIAC_TYPE: ZodiacType = "Tropic"
 DEFAULT_PERSPECTIVE_TYPE: PerspectiveType = "Apparent Geocentric"
+DEFAULT_CACHE_EXPIRE_AFTER_DAYS = 30
 GEONAMES_DEFAULT_USERNAME_WARNING = (
     "\n********\n"
     "NO GEONAMES USERNAME SET!\n"
@@ -89,6 +90,7 @@ class AstrologicalSubject:
     - perspective_type (PerspectiveType, optional): The perspective to use for the calculation of the chart.
         Defaults to "Apparent Geocentric".
         Available perspectives are visible in the PerspectiveType Literal.
+    - cache_expire_after_days (int, optional): The number of days after which the geonames cache will expire. Defaults to 30.
     - is_dst (Union[None, bool], optional): Specify if the time is in DST. Defaults to None.
         By default (None), the library will try to guess if the time is in DST or not and raise an AmbiguousTimeError
         if it can't guess. If you know the time is in DST, set this to True, if you know it's not, set it to False.
@@ -187,6 +189,7 @@ class AstrologicalSubject:
         sidereal_mode: Union[SiderealMode, None] = None,
         houses_system_identifier: HousesSystemIdentifier = DEFAULT_HOUSES_SYSTEM_IDENTIFIER,
         perspective_type: PerspectiveType = DEFAULT_PERSPECTIVE_TYPE,
+        cache_expire_after_days: int = DEFAULT_CACHE_EXPIRE_AFTER_DAYS,
         is_dst: Union[None, bool] = None,
         disable_chiron_and_lilith: bool = False
     ) -> None:
@@ -219,6 +222,7 @@ class AstrologicalSubject:
         self.sidereal_mode = sidereal_mode
         self.houses_system_identifier = houses_system_identifier
         self.perspective_type = perspective_type
+        self.cache_expire_after_days = cache_expire_after_days
         self.is_dst = is_dst
         self.disable_chiron_and_lilith = disable_chiron_and_lilith
 
@@ -381,6 +385,7 @@ class AstrologicalSubject:
             self.city,
             self.nation,
             username=self.geonames_username,
+            cache_expire_after=self.cache_expire_after_days*24*60*60  # Convert days to seconds
         )
         self.city_data: dict[str, str] = geonames.get_serialized_data()
 

--- a/kerykeion/fetch_geonames.py
+++ b/kerykeion/fetch_geonames.py
@@ -25,11 +25,12 @@ class FetchGeonames:
         city_name: str,
         country_code: str,
         username: str = "century.boy",
+        cache_expire_after=86400
     ):
         self.session = CachedSession(
             cache_name="cache/kerykeion_geonames_cache",
             backend="sqlite",
-            expire_after=86400,
+            expire_after=cache_expire_after,
         )
 
         self.username = username


### PR DESCRIPTION
It seems worthwhile to me to make the geonames cache timeout changeable by the user, and default to longer. It currently defaults to 24 hours, but given how rarely the underlying data changes, making it last for weeks or even months might be useful in many applications. It would be a backdoor way to download the data from the origin and thus avoid credit limits on the geonames API, but to do so only on-demand, and to also enable periodic checks for changes/updates in the underlying data.

This PR is one proposed way to implement it in the library directly, and to shift the default to 30 days. Feel free to tweak or make changes if this doesn't align with the paradigm you prefer; my point was to try and ease the work if this approach was good, but I don't care how it gets implemented if there's another better way.

Also of note, when I made this change locally I got 33 test failures afterwards, but for tests related to charts or test_astrological_subject. As best I can tell none of those failures relate to these changes though so I'm assuming they were failing prior to this? But may be worth a doublecheck.

For others with this issue prior to PR acceptance: In my _use_ of the library for the moment I'm implementing this myself by subclassing this way:

`from kerykeion.fetch_geonames import FetchGeonames
from requests_cache import CachedSession

class CustomFetchGeonames(FetchGeonames):
    def __init__(self, city_name: str, country_code: str, username: str = "century.boy", expire_after: int = 1814400):
        super().__init__(city_name, country_code, username)
        self.session = CachedSession(
            cache_name="cache/kerykeion_geonames_extended_cache",
            backend="sqlite",
            expire_after=expire_after,
        )`

