### PR TITLE
How do you rasterise these SVG without using browser? 

### DIFF
--- a/kerykeion/charts/inline_css.py
+++ b/kerykeion/charts/inline_css.py
@@ -1,0 +1,54 @@
+import re
+from bs4 import BeautifulSoup, Tag
+import cssutils
+from typing import Dict
+
+
+def extract_css_variables(svg_content: str) -> Dict[str, str]:
+    """
+    Extracts CSS variables from the <style> tag in an SVG file.
+
+    :param svg_content: The raw SVG file content as a string.
+    :return: A dictionary mapping CSS variable names to their values.
+    """
+    soup: BeautifulSoup = BeautifulSoup(svg_content, "xml")
+    style_tag: Tag | None = soup.find("style")
+    css_variables: Dict[str, str] = {}
+
+    if style_tag:
+        css = cssutils.parseString(style_tag.text)
+        for rule in css:
+            if rule.type == rule.STYLE_RULE:
+                for property_name in rule.style:
+                    if property_name.startswith("--"):  # Only capture CSS variables
+                        css_variables[property_name] = rule.style[property_name]
+
+    return css_variables
+
+
+def replace_css_variables_with_inline_styles(svg_content: str) -> str:
+    """
+    Converts CSS variables to inline styles in an SVG file.
+
+    :param svg_content: The raw SVG file content as a string.
+    :return: The updated SVG content with inline styles.
+    """
+    soup: BeautifulSoup = BeautifulSoup(svg_content, "xml")
+    css_variables: Dict[str, str] = extract_css_variables(svg_content)
+
+    if not css_variables:
+        return str(soup)  # No variables to replace, return as-is
+
+    for element in soup.find_all(True):  # Iterate over all SVG elements
+        if isinstance(element, Tag) and element.has_attr("style"):
+            new_style: str = element["style"]
+            for var, value in css_variables.items():
+                var_pattern: str = f"var\\({re.escape(var)}\\)"
+                new_style = re.sub(var_pattern, value, new_style)  # Replace CSS variable
+            element["style"] = new_style  # Apply updated styles
+
+    # Remove the <style> tag since it's no longer needed
+    for style_tag in soup.find_all("style"):
+        style_tag.decompose()
+
+    return str(soup)

--- a/kerykeion/charts/kerykeion_chart_svg.py
+++ b/kerykeion/charts/kerykeion_chart_svg.py
@@ -45,7 +45,7 @@ from scour.scour import scourString
 from string import Template
 from typing import Union, List, Literal
 from datetime import datetime
-from .inline_css import replace_css_variables_with_inline_styles
+from .inline_css import replace_css_variables
 
 class KerykeionChartSVG:
     """
@@ -660,7 +660,7 @@ class KerykeionChartSVG:
 
         if inline_css:
             # Use serializing styles inline for embedding in PDF
-            template = replace_css_variables_with_inline_styles(template)
+            template = replace_css_variables(template)
 
         return template
 

--- a/kerykeion/charts/kerykeion_chart_svg.py
+++ b/kerykeion/charts/kerykeion_chart_svg.py
@@ -45,6 +45,7 @@ from scour.scour import scourString
 from string import Template
 from typing import Union, List, Literal
 from datetime import datetime
+from .inline_css import replace_css_variables_with_inline_styles
 
 class KerykeionChartSVG:
     """
@@ -634,7 +635,7 @@ class KerykeionChartSVG:
 
         return template_dict
 
-    def makeTemplate(self, minify: bool = False) -> str:
+    def makeTemplate(self, minify: bool = False, inline_css: bool = False) -> str:
         """Creates the template for the SVG file"""
         td = self._create_template_dictionary()
 
@@ -657,13 +658,17 @@ class KerykeionChartSVG:
         else:
             template = template.replace('"', "'")
 
+        if inline_css:
+            # Use serializing styles inline for embedding in PDF
+            template = replace_css_variables_with_inline_styles(template)
+
         return template
 
-    def makeSVG(self, minify: bool = False):
+    def makeSVG(self, minify: bool = False, inline_css: bool = False):
         """Prints out the SVG file in the specified folder"""
 
         if not hasattr(self, "template"):
-            self.template = self.makeTemplate(minify)
+            self.template = self.makeTemplate(minify, inline_css)
 
         chartname = self.output_directory / f"{self.user.name} - {self.chart_type} Chart.svg"
 
@@ -671,6 +676,16 @@ class KerykeionChartSVG:
             output_file.write(self.template)
 
         print(f"SVG Generated Correctly in: {chartname}")
+
+
+    def makeSvgString(self, minify: bool = False, inline_css: bool = False):
+        """Prints out the SVG file in the specified folder"""
+
+        if not hasattr(self, "template"):
+            self.template = self.makeTemplate(minify, inline_css)
+            return self.template
+
+
     def makeWheelOnlyTemplate(self, minify: bool = False):
         """Creates the template for the SVG file with only the wheel"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ requests = "^2.32.3"
 simple-ascii-tables = "^1.0.0"
 pytz = "^2024.2"
 typing-extensions = "^4.12.2"
+beautifulsoup4 = "^4.13.3"
+cssutils = "^2.11.1"
+lxml = "^5.3.1"
 
 [tool.poetry.scripts]
 create-docs = "scripts.docs:main"


### PR DESCRIPTION
rsvg, CairoSVG and Inkscape produce black canvas with the produced visualisation. Admittedly, it works well on the browser and browser based SVG visualisation tools. I have a use case where I was embedding the output in PDF and I did not want to fire Selenium or web browser. Thus, I have modified the code to remove CSS vars thus producing viable output with CairoSVG. 

Excellent Library. 