### PR TITLE
return the SVG for rendering

### DIFF
--- a/kerykeion/charts/kerykeion_chart_svg.py
+++ b/kerykeion/charts/kerykeion_chart_svg.py
@@ -870,7 +870,9 @@ class KerykeionChartSVG:
             output_file.write(self.template)
 
         print(f"SVG Generated Correctly in: {chartname}")
-
+        
+        return self.template # it will return the SVG element which easy to render
+    
     def makeWheelOnlyTemplate(self, minify: bool = False, remove_css_variables = False):
         """
         Render the wheel-only chart SVG as a string.


### PR DESCRIPTION
When I was trying to retrieve the SVG, I wasn't able to do so. Then I realized that we need to return the SVG from the `makeSVG` function, which solved the problem quickly.