### PR TITLE
fix: use precise orb comparison when filtering aspects

### DIFF
--- a/kerykeion/aspects/aspects_utils.py
+++ b/kerykeion/aspects/aspects_utils.py
@@ -36,7 +36,7 @@ def get_aspect_from_two_points(
         aspect_degree = aspect["degree"]  # type: ignore
         aspect_orb = aspect["orb"]  # type: ignore
 
-        if (aspect_degree - aspect_orb) <= int(distance) <= (aspect_degree + aspect_orb):
+        if (aspect_degree - aspect_orb) <= distance <= (aspect_degree + aspect_orb):
             name = aspect["name"]  # type: ignore
             aspect_degrees = aspect_degree
             verdict = True


### PR DESCRIPTION
# What changed

  - Fix orb filtering: stop using int(distance) (which rounded down and could include aspects slightly outside the
    orb). Now compares using the float distance for accurate orb filtering.

## How to test

python -m pytest tests/aspects/ -v

## Notes

This fixes cases where aspects near the orb boundary were incorrectly included due to integer rounding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore to exclude local development artifacts, including virtual environment directories and environment configuration files.

* **Bug Fixes**
  * Improved accuracy of aspect calculations by comparing floating-point distances directly against aspect windows, eliminating precision loss from previous rounding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->