### PR TITLE
perf: refactor hot paths per REFACTORY.md (TIER 0-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,5 @@ test-refactoring-proposal.md
 sync-docs.sh
 *.bsp
 .env
-.opencode/plans
+.opencode/
 /task/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 6.0.0a25
+
+_2026-04-17_
+
+**Performance refactor of hot paths (TIER 0-2), plus targeted bug fixes from Codex and CodeRabbit review.**
+
+### Performance
+
+- Refactor hot paths per `REFACTORY.md` TIER 0-2 — zero breaking changes, 260 SHA-256 signatures byte-identical across all chart types, house systems, sidereal modes, perspectives, returns, transits, eclipses, occultations, ACG, primary directions, fixed stars, dignities.
+- Central constants unification (`STANDARD_PLANETS`, `POINT_NUMBER_MAP`, `AXIAL_POINTS` frozenset) in `kerykeion.settings.config_constants`.
+- Aspect loop optimization, SVG `list+join` rendering, pre-indexed aspect grid (`O(n²·k)` → `O(n² + k)`), cached `get_args()`, `O(n+m)` orb merge, matching-setting lookup in transit range.
+- Measured speedups (min-of-N, best-of-2): `svg_natal` -39.3% (1.65x), `house_comparison` -23.4% (1.30x), `custom_aspects_squares` -20.5% (1.26x), `composite_midpoint` -19.4% (1.24x), `svg_synastry` -17.7% (1.21x), `transits_time_range` -15.4% (1.18x), 15/15 benchmarks faster, 0 regressions.
+
+### Bug Fixes
+
+- Fix `_update_aspect_settings` regression in `AspectsFactory`: when `active_aspects` contains duplicate names, the first occurrence's orb now wins (the prior dict-comprehension refactor had silently introduced last-wins semantics). Uses `dict.setdefault` instead.
+- Restore runtime availability of `AstrologicalSubjectModel`, `PlanetReturnModel`, `HouseComparisonModel`, `ChartDataModel`, `AspectModel`, `CompositeSubjectModel`, `KerykeionPointModel`, `ChartType`, `KerykeionException`, `AstrologicalPoint` in modules that expose them as public annotations. The perf refactor had moved them under `if TYPE_CHECKING:`, which would break `typing.get_type_hints()` introspection for downstream consumers that rely on runtime type resolution (e.g. FastAPI).
+- `_setup_gauquelin_sectors` now clears `template_dict["makeHouseSectors"]` when Gauquelin mode is active — the 12-wedge invisible hit-area overlay was inconsistent with the 36-sector visible ring and would mislead any frontend using it for click/hover targeting.
+
+### Public API hygiene (CodeRabbit review)
+
+- `kerykeion.astrological_subject_factory.STANDARD_PLANETS` is now re-exported as a shallow copy of the canonical dict in `config_constants`, so downstream mutation of the public symbol no longer leaks into the shared constant.
+- `ReportGenerator._celestial_points_report` now preserves duplicate point entries when ordering the report (previously collapsed by `{p.name: p}` dict comprehension).
+- `POINT_NUMBER_MAP` docstring rewritten to accurately describe it as the Swiss Ephemeris–compatible subset and enumerate which point classes are outside its scope.
+
+### Chores
+
+- `.opencode/` fully gitignored (replaces the narrower `.opencode/plans` rule).
+
+### Breaking Changes
+
+None — all changes preserve public API, model schemas, and SVG output structure. 260 byte-identical SVG signatures across the test matrix verify output stability.
+
 ## 6.0.0a24
 
 _2026-04-16_

--- a/REFACTORY.md
+++ b/REFACTORY.md
@@ -249,6 +249,11 @@ def get_planet_house(planet_degree, houses_degree_ut_list):
 
 ### 1.2 — Eliminare chiamata EQUATORIAL `calc_ut` duplicata per ogni pianeta
 
+> **RICLASSIFICAZIONE POST-REVIEW:** Questo punto e' numerato 1.2 per continuita' storica, ma
+> la sua classificazione effettiva e' **TIER 3 (rischio alto)**. Non va implementato insieme
+> ai cleanup sicuri del TIER 1. Vedere la sezione "Strategia di esecuzione" per il posizionamento
+> corretto nel piano.
+
 **File:** `kerykeion/astrological_subject_factory.py`, linea 1684-1691
 
 **Problema:** Per ogni pianeta vengono fatte **2 chiamate** a `swe.calc_ut()`:
@@ -267,20 +272,74 @@ Dove:
 - `lambda` = longitudine eclittica (gia' calcolata)
 - `beta` = latitudine eclittica (gia' calcolata)
 
-**Riclassificazione:** questa ottimizzazione **non va trattata come safe by default**.
-E' promettente, ma deve essere eseguita con validazione numerica estesa e quindi va pianificata come
-**Fase 3 / TIER 2**, non insieme ai cleanup sicuri.
+**Riclassificazione:** questa ottimizzazione **non va trattata come safe**.
+La formula trigonometrica sferica assume che le coordinate eclittiche ricevute siano le stesse
+coordinate su cui Swiss Ephemeris basa la sua conversione interna ECLIPTIC→EQUATORIAL. In realta'
+SE applica internamente una **matrice di rotazione completa** (precession + nutation frame) che
+gestisce in modo integrato:
+- aberrazione della luce (annual + planetary)
+- ritardo luce (light-time iteration)
+- nutazione (true obliquity vs mean obliquity, a seconda dei flag)
+- termini relativistici per corpi vicini (Sole, Luna)
+
+La formula analitica `asin(...)` usa l'obliquita' **istantanea** letta da `ECL_NUT`, ma non replica
+i termini di aberrazione e light-time che SE applica *prima* della rotazione di coordinate.
+Su corpi con latitudine eclittica significativa (Luna ~5°, Pluto ~17°) e su prospettive non standard
+(Topocentric con parallasse locale, Heliocentric senza aberrazione), la differenza puo' raggiungere
+ordini di **decimi di arcosecondo** — sufficienti a rompere i golden file.
+
+**Inventario completo dei call site `FLG_EQUATORIAL`:**
+
+Prima di implementare questa ottimizzazione, bisogna avere chiaro che `FLG_EQUATORIAL` non viene
+usato solo in `_calculate_single_planet()`. I call site sono **7**, distribuiti su **4 file**:
+
+| # | File | Linea | Contesto | Note |
+|---|---|---|---|---|
+| 1 | `astrological_subject_factory.py` | 1684 | `calc_pctr` planetocentrico | iflag specifico del centro |
+| 2 | `astrological_subject_factory.py` | 1688 | `calc_ut` fallback geocentrico | dentro try/except |
+| 3 | `astrological_subject_factory.py` | 1691 | `calc_ut` standard planets | il caso principale |
+| 4 | `astrological_subject_factory.py` | 1834 | `_ensure_point_calculated` | prerequisiti Arabic Parts |
+| 5 | `astrological_subject_factory.py` | 2110 | nodi lunari (post-calc override) | sovrascrive declinazione |
+| 6 | `astrological_subject_factory.py` | 2274 | White_Moon fallback (Mean Lilith) | declinazione negata |
+| 7 | `astrological_subject_factory.py` | 2150 | `fixstar_ut` stelle fisse | **non eliminabile** con formula planetaria |
+
+**Attenzione:** il call site #7 (`fixstar_ut` con `FLG_EQUATORIAL`) usa un'API diversa da `calc_ut`.
+Le stelle fisse non hanno latitudine eclittica nel senso standard, quindi la formula analitica
+non si applica direttamente. Questo call site **deve restare invariato**.
+
+In aggiunta, `FLG_EQUATORIAL` e' usato anche **fuori** dal subject factory:
+
+| # | File | Linea | Contesto |
+|---|---|---|---|
+| 8 | `primary_directions/directions_factory.py` | 226 | speculum: RA e Dec per direzioni primarie |
+| 9 | `moon_phase_details/utils.py` | 535 | posizione equatoriale del Sole |
+| 10 | `fixed_stars/discovery_factory.py` | 146 | declinazione stelle fisse |
+
+Questi call site **non sono eliminabili** dall'ottimizzazione 1.2 perche' operano in contesti
+diversi (direzioni primarie necessitano di RA, non solo Dec; moon_phase usa coordinate orizzontali).
+Quindi il risparmio reale e' limitato ai call site #1-#6, e solo dove la validazione numerica
+lo conferma.
+
+**Impatto reale corretto:** Sui 18 active points default, i call site #1-#3 producono ~18 chiamate
+EQUATORIAL (una per pianeta). I call site #4-#6 aggiungono ~3-5 chiamate condizionali (nodi,
+White_Moon, Arabic Parts prerequisites). Stelle fisse (#7) aggiungono ~23 chiamate `fixstar_ut`
+con EQUATORIAL che **non sono eliminabili**. Il risparmio massimo e' quindi ~21-23 chiamate
+`calc_ut`, non il 45% inizialmente stimato sull'intera catena.
 
 **Verifica richiesta:** non basta un confronto su chart tropicali standard. La parita' numerica va dimostrata
 almeno su:
 - Tropical / Apparent Geocentric
 - True Geocentric
-- Topocentric
-- Heliocentric
-- almeno un Sidereal mode
+- Topocentric (parallasse locale altera le coordinate eclittiche apparenti)
+- Heliocentric (nessuna aberrazione annua: la formula diverge di piu')
+- almeno un Sidereal mode (ayanamsa shift applicato prima o dopo?)
 - almeno un codepath planetocentric (`calc_pctr`)
+- almeno un corpo con latitudine eclittica significativa (Luna, Pluto)
+- almeno una data storica pre-1900 e una data futura post-2100
 
-**Impatto:** Da 29 a ~16 chiamate `calc_ut` per subject (~45% in meno).
+La soglia di accettazione dev'essere **< 0.01 arcsec** per ogni corpo su ogni configurazione.
+Se anche un singolo caso supera questa soglia, l'ottimizzazione va scartata o limitata ai soli
+codepath dove la parita' e' dimostrata.
 
 **Codice attuale (linee 1689-1694):**
 ```python
@@ -289,7 +348,7 @@ planet_eq = swe.calc_ut(julian_day, planet_id, iflag | swe.FLG_EQUATORIAL)[0]
 declination = planet_eq[1]
 ```
 
-**Codice target:**
+**Codice target (se validato):**
 ```python
 planet_calc = swe.calc_ut(julian_day, planet_id, iflag)[0]
 # Declination from ecliptic coords + obliquity (no extra calc_ut needed)
@@ -300,11 +359,14 @@ declination = math.degrees(math.asin(
 ```
 
 L'obliquita' (`obliquity`) non va solo letta in `_calculate_single_planet()`: per avere comportamento coerente,
-la stessa logica va applicata anche ai codepath secondari che oggi ricalcolano la declinazione in modo separato
-(prerequisiti delle Arabic Parts, nodi, fallback correlati). Una patch parziale introdurrebbe comportamento misto.
+la stessa logica va applicata anche ai call site #4 (`_ensure_point_calculated`), #5 (nodi lunari)
+e #6 (White_Moon fallback). Una patch parziale introdurrebbe **comportamento misto** dove alcuni
+punti hanno la declinazione da SE e altri dalla formula analitica — questo renderebbe impossibile
+diagnosticare regressioni.
 
 **Attenzione per `calc_pctr`:** Lo stesso pattern si applica ai calcoli planetocentrici
-(linee 1683-1684). La formula analitica resta identica, va solo usata l'obliquita' corretta.
+(call site #1, linea 1683-1684). La formula analitica resta identica, ma va usata l'obliquita'
+corretta per il frame planetocentrico, che potrebbe differire da quella geocentrica.
 
 ### 1.3 — Pre-build lookup dict per aspect settings
 
@@ -455,6 +517,14 @@ in coordinate siderali, non tropicali.
 **Azione sicura:** Solo se il chart e' **Tropical + Apparent Geocentric**, riusare il valore gia' calcolato.
 In tutti gli altri casi, mantenere la chiamata separata. Aggiungere un parametro opzionale
 `sun_tropical_lon: Optional[float] = None` al metodo.
+
+**Nota aggiuntiva (post-review):** Lo stesso pattern esiste in `_ensure_point_calculated()` (linea 1832-1834)
+che fa una coppia `calc_ut` ECLIPTIC + EQUATORIAL per i prerequisiti delle Arabic Parts.
+Se la longitudine del Sole e' gia' stata calcolata da `_calculate_single_planet()`, il ricalcolo
+in `_ensure_point_calculated` e' ridondante **solo** quando il Sole e' gia' in `data`.
+Il codice attuale gia' controlla `if point_key in data: return` (linea 1810-1811), quindi
+il ricalcolo avviene solo per Arabic Parts con prerequisiti non ancora calcolati. Il costo
+e' quindi trascurabile nella maggioranza dei casi.
 
 ### 1.7 — Unificare `_POINT_NUMBER_MAP` e `STANDARD_PLANETS` in `config_constants.py`
 
@@ -695,13 +765,48 @@ Queste modifiche hanno impatto significativo ma richiedono analisi e test approf
 - Date storiche (pre-1970) potrebbero comportarsi diversamente
 - La libreria di astrologia calcola spesso date storiche molto antiche
 
-**Prerequisiti:**
+**Differenza semantica critica — `is_dst` vs `fold`:**
+
+`pytz` gestisce le ambiguita' DST con il parametro `is_dst` in `localize()`:
+```python
+local_timezone.localize(naive_datetime, is_dst=data.get("is_dst"))
+```
+Questo parametro (linea 1398 del factory) viene passato dall'utente per risolvere le ambiguita'.
+
+`zoneinfo` usa invece il parametro `fold` (PEP 495) sul datetime stesso:
+```python
+datetime(..., tzinfo=ZoneInfo(tz_str), fold=1)  # fold=1 = seconda occorrenza
+```
+
+La semantica e' **invertita**: `is_dst=True` corrisponde a `fold=0` (prima occorrenza, DST attiva),
+`is_dst=False` a `fold=1` (seconda occorrenza, standard time). Inoltre `pytz` lancia
+`AmbiguousTimeError` quando `is_dst=None`, mentre `zoneinfo` sceglie silenziosamente `fold=0`.
+Questo significa che la migrazione non e' un semplice search/replace: la logica di gestione
+dell'ambiguita' in `_calculate_time_conversions()` va riscritta, e il contratto dell'API
+pubblica (`is_dst` come parametro utente di `from_birth_data`) va mantenuto compatibile.
+
+**Call site completi di `pytz`:**
+
+| # | File | Linea | Uso |
+|---|---|---|---|
+| 1 | `astrological_subject_factory.py` | 1190 | `pytz.timezone()` in `_resolve_timezone` |
+| 2 | `astrological_subject_factory.py` | 1392 | `pytz.timezone()` + `localize()` in `_calculate_time_conversions` |
+| 3 | `astrological_subject_factory.py` | 1399 | `pytz.exceptions.AmbiguousTimeError` catch |
+| 4 | `astrological_subject_factory.py` | 1404 | `pytz.exceptions.NonExistentTimeError` catch |
+| 5 | `astrological_subject_factory.py` | 1411 | `pytz.utc` per conversione UTC |
+| 6 | `moon_phase_details/factory.py` | 232-234 | `pytz.timezone()` per sunrise/sunset DST |
+
+**Prerequisiti aggiornati (post-review):**
 1. Test con date storiche (e.g. 1800, 1900, 1950) in varie timezone
 2. Confronto preciso dei risultati Julian Day con pytz vs zoneinfo
-3. Verifica che `pytz` non sia usato anche da dipendenze (requests-cache lo usa?)
-
-**Correzione del piano:** includere anche i codepath `moon_phase_details/*`, non solo
-`astrological_subject_factory.py`, perche' anche li' la semantica `pytz.localize()` e' usata in modo esplicito.
+3. ~~Verifica che `pytz` non sia usato anche da dipendenze (requests-cache lo usa?)~~
+   **Risolto:** `requests-cache>=1.2.1` **non** dipende da `pytz` — usa `datetime` stdlib.
+   La rimozione di `pytz` da `pyproject.toml` non rompe dipendenze transitive.
+4. **Nuovo:** Verifica che la logica `is_dst`→`fold` mapping sia corretta per tutte le timezone
+   IANA usate nei test (soprattutto timezone con regole DST storiche cambiate, e.g. `Europe/Moscow`
+   che ha cambiato regime DST nel 2014)
+5. **Nuovo:** Includere il codepath `moon_phase_details/factory.py` (linea 232-234) che usa
+   `pytz.timezone()` in modo esplicito per calcoli sunrise/sunset con DST
 
 **Se implementato:** Rimuovere `pytz` e `types-pytz` da `pyproject.toml`.
 
@@ -723,7 +828,27 @@ piu' lento dell'accesso diretto `.field`.
 - Bisognerebbe fare un audit **completo** di ogni call site per determinare se l'oggetto e'
   un Pydantic model o un plain dict prima di cambiare la sintassi.
 
+**Dettaglio dei tipi misti (post-review):**
+
+Il problema strutturale e' che il codebase passa dati eterogenei attraverso le stesse interfacce:
+
+| Call site | Oggetto | Tipo reale | `["key"]` safe | `.key` safe |
+|---|---|---|---|---|
+| `charts_utils.py` `draw_aspect_grid` | `planet_a`, `planet_b` | `dict` (da `planets_settings`) | si' | **NO** |
+| `charts_utils.py` `draw_aspect_grid` | `aspect` | `dict` (da `aspects`) | si' | **NO** |
+| `charts_utils.py` `draw_aspect_line` | `aspect` | `AspectModel` o `dict` | si' | solo se `AspectModel` |
+| `aspects_utils.py:222` | `subject` | `AstrologicalSubjectModel` | si' | si' |
+| `aspects_utils.py:222` | `planet` | `dict` (da `celestial_points_settings`) | si' | **NO** |
+| `chart_drawer.py` init | `celestial_points_settings` | `list[dict]` | si' | **NO** |
+| `report.py:155,163` | `aspect` | Pydantic model | si' | si' |
+
+Senza un refactoring strutturale che separi chiaramente i dict dalle istanze Pydantic
+(e.g. creando modelli tipizzati per `planets_settings` e `aspects_settings`), qualsiasi
+sostituzione `["key"]`→`.key` rischia di rompere a runtime in modo silenzioso.
+
 **Se implementato:** Solo su oggetti **certamente** Pydantic (non dict), e solo nei path caldi.
+Una strada piu' sicura sarebbe introdurre `TypedDict` per le configurazioni, ma questo e'
+un refactoring architetturale che va oltre lo scope di questo piano.
 
 ### 3.3 — `__slots__` su dataclass interne
 
@@ -793,6 +918,14 @@ In sintesi, i win a maggiore confidenza sono:
 
 Il win potenzialmente piu' grande sul core numerico resta `1.2`, ma **solo dopo** validazione estesa.
 
+**Nota post-review sul conteggio `FLG_EQUATORIAL`:** L'inventario completo (sezione 1.2) mostra
+10 call site distribuiti su 4 file. Di questi, solo i 6 in `astrological_subject_factory.py`
+sono candidati all'ottimizzazione (e solo 5 dopo aver escluso `fixstar_ut`). I restanti 4
+(in `primary_directions`, `moon_phase_details`, `fixed_stars`) non sono eliminabili perche'
+necessitano di Right Ascension, non solo Declination. Il risparmio reale per subject e' quindi
+piu' basso di quanto inizialmente stimato (~21 chiamate risparmiabili su ~34 totali), e il
+rischio di divergenza numerica resta concreto.
+
 ## Matrice di validazione
 
 Per garantire piena retrocompatibilita', la validazione va espansa per area. Il principio operativo e':
@@ -822,11 +955,13 @@ Eseguire:
 - `pytest tests/core/test_oob_and_declination_aspects.py -q`
 - `pytest tests/core/test_transits.py -q`
 - `pytest tests/core/test_subject_factory_parametrized.py -q`
+- `pytest tests/core/test_primary_directions.py -q` *(usa `FLG_EQUATORIAL` indipendentemente dal factory)*
 
 Quando il refactor tocca coordinate, prospettive o backend:
 - `pytest tests/core/test_planetocentric.py -q`
 - `pytest tests/core/test_houses_positions.py -q`
 - `pytest tests/core/test_planetary_positions.py -q`
+- `pytest tests/core/test_barycentric.py -q`
 - `poe test:compare` **se** entrambi i backend sono disponibili
 
 **Scopo:** non limitarsi ai casi canonici di `test:core`, ma coprire anche house systems, sidereal modes,
@@ -936,12 +1071,8 @@ Applicare una modifica alla volta, con commit separati e `poe test:core` dopo ci
 - Gate 0 sempre
 - Gate 2 per ogni modifica che tocca rendering, template o SVG utility
 
-### Fase 3: TIER 2 (moderate)
+### Fase 3: TIER 2 (moderate, escluso 1.2)
 Ogni modifica richiede test mirato:
-- `1.2` (declinazione analitica):
-  - Gate 0
-  - Gate 1 completo
-  - Gate RC prima del merge
 - `2.1` (fork compatibile di `scour`):
   - Gate 0
   - Gate 2 completo
@@ -950,13 +1081,19 @@ Ogni modifica richiede test mirato:
   - Gate 0
   - eventuale Gate 1 / Gate 2 / Gate 3 a seconda del modulo toccato
 
-### Fase 4: TIER 3 (avanzate)
+### Fase 4: TIER 3 (avanzate, incluso 1.2)
 Solo dopo aver completato e validato TIER 0-2:
-- 3.1 (pytz): Richiede test matrix con date storiche
-- 3.2 (dict vs dot access): Richiede audit completo dei tipi
+- 1.2 (declinazione analitica — riclassificato da TIER 1):
+  - Gate 0
+  - Gate 1 completo (incluso `test_primary_directions.py` e `test_barycentric.py`)
+  - Script di validazione numerica dedicato (N >= 1000 date, tutti i perspective_type)
+  - Soglia: < 0.01 arcsec di scostamento per ogni corpo/configurazione
+  - Gate RC prima del merge
+- 3.1 (pytz): Richiede test matrix con date storiche e verifica mapping `is_dst`→`fold`
+- 3.2 (dict vs dot access): Richiede audit completo dei tipi (vedere tabella in sezione 3.2)
 - 3.3 (slots): Verifica assenza di `__dict__` access
 
-**Gate richiesto:** sempre Gate RC; per `3.1` anche Gate 4 completo.
+**Gate richiesto:** sempre Gate RC; per `1.2` e `3.1` anche Gate 4 completo.
 
 ### Regola finale di accettazione
 

--- a/REFACTORY.md
+++ b/REFACTORY.md
@@ -1,0 +1,967 @@
+# Kerykeion v6 — Piano di Refactoring e Ottimizzazione
+
+> **Versione:** 6.0.0a24 | **Branch:** `alpha/v6` | **Data analisi:** 2026-04-16
+>
+> **Principio guida:** Nessun breaking change, nessuna regressione su edge case.
+> Ogni modifica deve produrre output identico al precedente.
+> `poe test:core` e' il **gate minimo**, non il gate sufficiente per chiudere un refactor.
+
+## Vincoli non negoziabili
+
+- **Retrocompatibilita' totale**: nessuna modifica a API pubbliche, nomi esportati, shape dei modelli,
+  semantics dei flag, ordine dei risultati o comportamento documentato.
+- **Output stabile**: dove esistono fixture/golden file, l'output deve restare identico. Le baseline non
+  vanno rigenerate per "far passare" un refactor; prima si spiega il delta, poi eventualmente si decide.
+- **Nessuna rimozione di dipendenze o path pubblici** senza una necessita' esplicita. In particolare,
+  `scour` **non va rimosso**: il piano assume continuita' tramite fork compatibile.
+- **Le ottimizzazioni numeriche non sono "safe" solo perche' matematicamente plausibili**: devono essere
+  validate anche su codepath sidereal, topocentric, heliocentric, planetocentric e date storiche.
+- **Le ottimizzazioni di performance non devono peggiorare la leggibilita' strutturale**: si preferiscono
+  refactor piccoli e locali nei path caldi, non sweep repo-wide a basso ROI.
+
+---
+
+## Sommario
+
+- [Contesto e architettura](#contesto-e-architettura)
+- [Benchmark di riferimento](#benchmark-di-riferimento)
+- [TIER 0 — Cleanup puro](#tier-0--cleanup-puro-zero-rischio)
+- [TIER 1 — Ottimizzazioni sicure](#tier-1--ottimizzazioni-sicure-logica-identica)
+- [TIER 2 — Ottimizzazioni moderate](#tier-2--ottimizzazioni-moderate-test-mirati-necessari)
+- [TIER 3 — Ottimizzazioni avanzate](#tier-3--ottimizzazioni-avanzate-rischio-più-alto)
+- [TIER 4 — Architetturali (fuori scope)](#tier-4--architetturali-fuori-scope-per-ora)
+- [Impatto stimato](#impatto-stimato)
+- [Strategia di esecuzione](#strategia-di-esecuzione)
+
+---
+
+## Contesto e architettura
+
+### Backend ephemeris (libephemeris con LEB)
+
+Tutte le chiamate standard `swe.calc_ut()` utilizzano il backend **LEB** (file `.leb` precomputati
+con polinomi di Chebyshev). **Skyfield non viene mai usato per i calcoli standard** — si attiva
+come fallback esclusivamente per `swe.gauquelin_sector()`.
+
+La catena di chiamata per un singolo subject (18 active points di default):
+
+```
+from_birth_data()  ~1.57ms totali
+  ├── _calculate_time_conversions()     pytz.timezone() + UTC conversion
+  ├── _calculate_houses()               1x swe.houses_ex2()  ~0.17ms
+  ├── _calculate_single_planet() x13    13x swe.calc_ut(ECLIPTIC) + 13x swe.calc_ut(EQUATORIAL)
+  ├── _compute_is_diurnal()             1x swe.calc_ut(Sun) + 1x swe.azalt()  ← Sun già calcolato
+  ├── _calculate_derived_points()       Puro calcolo aritmetico (opposite +180°)
+  └── model_copy(update=...)            Pydantic model update per optional calculations
+```
+
+**Totale chiamate `calc_ut` per subject: 29** (13 ECLIPTIC + 13 EQUATORIAL + 1 ECL_NUT + 1 Sun diurnal + 1 extra True_Node EQUATORIAL).
+
+### Pydantic v2 e `SubscriptableBaseModel`
+
+Tutti i modelli dati ereditano da `SubscriptableBaseModel(BaseModel)` che aggiunge:
+
+```python
+def __getitem__(self, key): return getattr(self, key)
+```
+
+Questo permette accesso dict-style `model["field"]` su modelli Pydantic, ma è **~1.5x più lento**
+dell'accesso diretto `model.field`. Viene usato intensivamente nei path caldi
+(`aspects_utils.py`, `charts_utils.py`).
+
+**ATTENZIONE:** In alcuni codepath (specialmente `charts_utils.py`), vengono passati **plain `dict`**
+e non modelli Pydantic. Cambiare `obj["key"]` in `obj.key` senza un audit completo di ogni call site
+causerebbe `AttributeError` sui dict. Questa modifica è classificata come **TIER 3 (alto rischio)**.
+
+### Generazione SVG
+
+Il rendering SVG usa template-based string substitution:
+
+1. Template SVG caricato da file (con `@lru_cache(maxsize=8)`)
+2. Dati calcolati e inseriti via `string.Template.substitute()`
+3. Post-processing opzionale: `scour` (78ms) o regex-only (3ms)
+
+Il bottleneck principale SVG e' `draw_aspect_grid()` in `charts_utils.py:1063` con complessita' **O(n^3)**:
+per ogni cella nella griglia triangolare, fa uno scan lineare di TUTTI gli aspetti.
+
+---
+
+## Benchmark di riferimento
+
+Valori misurati con `scripts/benchmark.py` su macchina di sviluppo:
+
+| Operazione | Tempo |
+|---|---|
+| Subject creation (`from_birth_data`) | ~1.57ms |
+| Aspect calculation (18 points, 6 aspects) | ~0.45ms |
+| SVG Natal (con minify scour) | ~85ms |
+| SVG Natal (senza minify) | ~7ms |
+| `swe.houses_ex2()` singola | ~0.17ms |
+| `swe.calc_ut()` singola (LEB) | ~0.04ms |
+| `scourString()` su SVG reale | ~78ms |
+| Regex minification su SVG reale | ~3ms |
+| Import iniziale kerykeion (cold) | ~2s (1.3s numpy/skyfield) |
+| Gauquelin sector (fallback Skyfield) | ~26.5ms |
+
+**Nota importante:** questi numeri non sono tutti coperti automaticamente da `scripts/benchmark.py`.
+Lo script corrente misura subject creation, aspects e SVG standard, ma **non** copre direttamente:
+- cold import iniziale;
+- costo isolato di `scour`;
+- byte-size/minify stability;
+- confronto byte-identico degli SVG minificati.
+
+Per modifiche che toccano minify, SVG golden o path di import servono quindi benchmark e confronti mirati,
+non solo il benchmark standard.
+
+---
+
+## TIER 0 — Cleanup puro (zero rischio)
+
+Modifiche che non cambiano nessun comportamento: rimozione di codice morto, import inutilizzati,
+e micro-correzioni stilistiche.
+
+### 0.1 — Rimuovere 14 import `Path` inutilizzati
+
+Dopo un refactoring, `pathlib.Path` e' rimasto importato ma non usato in molti factory module.
+
+**File coinvolti:**
+
+| File | Linea |
+|---|---|
+| `kerykeion/astro_cartography/acg_factory.py` | 21 |
+| `kerykeion/eclipses/eclipse_factory.py` | 17 |
+| `kerykeion/heliacal/heliacal_factory.py` | 21 |
+| `kerykeion/moon_phase_details/utils.py` | 27 |
+| `kerykeion/occultations/occultation_factory.py` | 35 |
+| `kerykeion/planetary_nodes/nodes_factory.py` | 17 |
+| `kerykeion/planetary_phenomena/phenomena_factory.py` | 18 |
+| `kerykeion/planetary_return_factory.py` | 73 |
+| `kerykeion/primary_directions/directions_factory.py` | 22 |
+| `kerykeion/relocated_chart_factory.py` | 15 |
+
+**Azione:** Rimuovere le righe `from pathlib import Path` in ognuno di questi file.
+
+### 0.2 — Rimuovere import inutilizzati in chart_drawer.py
+
+| Import | Linea | Motivo |
+|---|---|---|
+| `datetime.datetime` | 10 | Non usato nel file |
+| `kerykeion.schemas.kr_models.ChartDataModel` | 50 | Importato ma mai referenziato |
+
+### 0.3 — Rimuovere import inutilizzato in charts_utils.py
+
+| Import | Linea | Motivo |
+|---|---|---|
+| `kerykeion.schemas.kr_models.HouseComparisonModel` | 24 | Non usato nel file |
+
+### 0.4 — Rimuovere import inutilizzati in house_comparison_factory.py
+
+| Import | Linea | Motivo |
+|---|---|---|
+| `kerykeion.schemas.AstrologicalSubjectModel` | 19 | Non usato |
+| `kerykeion.schemas.PlanetReturnModel` | 19 | Non usato |
+
+### 0.5 — Rimuovere import inutilizzato in moon_phase_details/factory.py
+
+| Import | Linea | Motivo |
+|---|---|---|
+| `datetime.timedelta` | 31 | Non usato nel file |
+
+### 0.6 — Compilare regex a livello modulo in utilities.py
+
+**File:** `kerykeion/utilities.py`, linea 800
+
+**Problema attuale:** `re.compile()` viene chiamato dentro un `for style_block in style_blocks` loop
+nella funzione `inline_css_variables_in_svg()`. Il pattern e' invariante e dovrebbe essere
+compilato una sola volta a livello modulo.
+
+**Codice attuale (linea 800):**
+```python
+for style_block in style_blocks:
+    css_variable_pattern = re.compile(r"--([a-zA-Z0-9_-]+)\s*:\s*([^;]+);")
+    for match in css_variable_pattern.finditer(style_block):
+        ...
+```
+
+**Codice target:**
+```python
+# A livello modulo, fuori dalla funzione:
+_CSS_VARIABLE_PATTERN = re.compile(r"--([a-zA-Z0-9_-]+)\s*:\s*([^;]+);")
+
+# Dentro la funzione:
+for style_block in style_blocks:
+    for match in _CSS_VARIABLE_PATTERN.finditer(style_block):
+        ...
+```
+
+### 0.7 — Eliminare 3 lambda `should_calculate` duplicate
+
+**File:** `kerykeion/astrological_subject_factory.py`, linee 1540, 1750, 2061
+
+**Problema:** Tre metodi diversi definiscono la stessa identica lambda wrapper:
+```python
+should_calculate = lambda point: AstrologicalSubjectFactory._should_calculate(point, active_points)
+```
+
+La lambda non fa altro che delegare al metodo statico `_should_calculate(point, active_points)` (linea 1481).
+
+**Azione:** Sostituire ogni occorrenza di `should_calculate(point)` con la chiamata diretta
+`AstrologicalSubjectFactory._should_calculate(point, active_points)`, oppure — piu' leggibile —
+rinominare il metodo statico e usarlo direttamente. Eliminare le 3 definizioni di lambda.
+
+---
+
+## TIER 1 — Ottimizzazioni sicure (logica identica)
+
+Queste modifiche producono risultati **matematicamente identici** ma con codice piu' efficiente.
+
+### 1.1 — Cache `get_args(Houses)` a livello modulo
+
+**File:** `kerykeion/utilities.py`, linea 328
+
+**Problema:** `get_planet_house()` viene chiamato ~29 volte per subject. Ogni chiamata esegue
+`get_args(Houses)` che internamente fa introspezione sul tipo `Literal` — costa ~0.25us per call
+vs ~0.08us se cachato.
+
+**Codice attuale:**
+```python
+def get_planet_house(planet_degree, houses_degree_ut_list):
+    house_names = get_args(Houses)  # <-- chiamato ogni volta
+    for i in range(len(house_names)):
+        ...
+```
+
+**Codice target:**
+```python
+# A livello modulo:
+_HOUSE_NAMES: tuple[str, ...] = get_args(Houses)
+
+def get_planet_house(planet_degree, houses_degree_ut_list):
+    for i in range(len(_HOUSE_NAMES)):
+        start_degree = houses_degree_ut_list[i]
+        end_degree = houses_degree_ut_list[(i + 1) % len(houses_degree_ut_list)]
+        if is_point_between(start_degree, end_degree, planet_degree):
+            return _HOUSE_NAMES[i]
+    ...
+```
+
+**Stessa cosa per** `get_args(LunarPhaseEmoji)` e `get_args(LunarPhaseName)` alle linee 481 e 499.
+
+### 1.2 — Eliminare chiamata EQUATORIAL `calc_ut` duplicata per ogni pianeta
+
+**File:** `kerykeion/astrological_subject_factory.py`, linea 1684-1691
+
+**Problema:** Per ogni pianeta vengono fatte **2 chiamate** a `swe.calc_ut()`:
+1. ECLIPTIC (per longitudine, latitudine, velocita')
+2. EQUATORIAL (solo per estrarre la declinazione)
+
+La declinazione si puo' calcolare analiticamente dalle coordinate eclittiche + obliquita' dell'eclittica:
+
+```
+sin(delta) = sin(epsilon) * sin(lambda) * cos(beta) + cos(epsilon) * sin(beta)
+```
+
+Dove:
+- `delta` = declinazione
+- `epsilon` = obliquita' eclittica (ottenibile da `swe.calc_ut(jd, SE_ECL_NUT, 0)` gia' chiamato 1 volta)
+- `lambda` = longitudine eclittica (gia' calcolata)
+- `beta` = latitudine eclittica (gia' calcolata)
+
+**Riclassificazione:** questa ottimizzazione **non va trattata come safe by default**.
+E' promettente, ma deve essere eseguita con validazione numerica estesa e quindi va pianificata come
+**Fase 3 / TIER 2**, non insieme ai cleanup sicuri.
+
+**Verifica richiesta:** non basta un confronto su chart tropicali standard. La parita' numerica va dimostrata
+almeno su:
+- Tropical / Apparent Geocentric
+- True Geocentric
+- Topocentric
+- Heliocentric
+- almeno un Sidereal mode
+- almeno un codepath planetocentric (`calc_pctr`)
+
+**Impatto:** Da 29 a ~16 chiamate `calc_ut` per subject (~45% in meno).
+
+**Codice attuale (linee 1689-1694):**
+```python
+planet_calc = swe.calc_ut(julian_day, planet_id, iflag)[0]
+planet_eq = swe.calc_ut(julian_day, planet_id, iflag | swe.FLG_EQUATORIAL)[0]
+declination = planet_eq[1]
+```
+
+**Codice target:**
+```python
+planet_calc = swe.calc_ut(julian_day, planet_id, iflag)[0]
+# Declination from ecliptic coords + obliquity (no extra calc_ut needed)
+declination = math.degrees(math.asin(
+    math.sin(math.radians(obliquity)) * math.sin(math.radians(planet_calc[0])) * math.cos(math.radians(planet_calc[1]))
+    + math.cos(math.radians(obliquity)) * math.sin(math.radians(planet_calc[1]))
+))
+```
+
+L'obliquita' (`obliquity`) non va solo letta in `_calculate_single_planet()`: per avere comportamento coerente,
+la stessa logica va applicata anche ai codepath secondari che oggi ricalcolano la declinazione in modo separato
+(prerequisiti delle Arabic Parts, nodi, fallback correlati). Una patch parziale introdurrebbe comportamento misto.
+
+**Attenzione per `calc_pctr`:** Lo stesso pattern si applica ai calcoli planetocentrici
+(linee 1683-1684). La formula analitica resta identica, va solo usata l'obliquita' corretta.
+
+### 1.3 — Pre-build lookup dict per aspect settings
+
+**File:** `kerykeion/aspects/aspects_utils.py`, linee 35-43
+
+**Problema:** `get_aspect_from_two_points()` per ogni coppia di pianeti fa un **scan lineare**
+di `aspects_settings` per trovare l'aspetto corrispondente. Con 6 aspetti default e ~153 coppie
+(18 punti), sono ~918 confronti.
+
+**Codice attuale:**
+```python
+for aspect in aspects_settings:
+    aspect_degree = aspect["degree"]
+    aspect_orb = aspect["orb"]
+    if (aspect_degree - aspect_orb) <= distance <= (aspect_degree + aspect_orb):
+        ...
+```
+
+**Approccio:** Non si puo' usare un dict diretto perche' il matching e' per range (degree +/- orb).
+Pero' si puo' pre-ordinare per degree e usare binary search (`bisect`), oppure — visto che sono solo
+6-11 aspetti — lasciar stare e concentrarsi sui bottleneck piu' grandi (1.2, 1.4).
+
+**Alternativa pragmatica:** Pre-estrarre `degree` e `orb` come tuple per evitare il dict lookup
+ripetuto dentro il loop.
+
+**Priorita':** bassa. Questo punto non va anteposto ai bottleneck confermati (`1.4`, string building mirato,
+validazione del refactor declinazione).
+
+```python
+# Pre-process una sola volta:
+_settings_tuples = [(a["degree"], a["orb"], a["name"]) for a in aspects_settings]
+
+# Nel loop hot:
+for degree, orb, name in _settings_tuples:
+    if (degree - orb) <= distance <= (degree + orb):
+        ...
+```
+
+### 1.4 — `draw_aspect_grid` da O(n^3) a O(n^2 + k) con pre-index
+
+**File:** `kerykeion/charts/charts_utils.py`, linee 1098-1123
+
+**Problema:** Questo e' il **bottleneck #1 del rendering SVG** (58% del tempo).
+Per ogni cella nella griglia triangolare degli aspetti, fa uno scan lineare di TUTTI gli aspetti
+per cercare se esiste un aspetto tra `planet_a` e `planet_b`.
+
+Con 18 pianeti attivi: 153 celle * ~50 aspetti = ~7650 confronti, piu' 866K chiamate a `__getitem__`.
+
+**Codice attuale (linee 1118-1122):**
+```python
+for aspect in aspects:
+    if (aspect["p1"] == planet_a["id"] and aspect["p2"] == planet_b["id"]) or (
+        aspect["p1"] == planet_b["id"] and aspect["p2"] == planet_a["id"]
+    ):
+        svg_output += f'<use x="..." xlink:href="#orb{aspect["aspect_degrees"]}" />'
+```
+
+**Codice target:** Costruire un dizionario di lookup **prima** del loop:
+
+```python
+# Pre-build: O(k) dove k = numero aspetti
+aspect_lookup: dict[tuple[int, int], dict] = {}
+for aspect in aspects:
+    key = (min(aspect["p1"], aspect["p2"]), max(aspect["p1"], aspect["p2"]))
+    aspect_lookup[key] = aspect
+
+# Nel loop: O(1) per cella
+for planet_b in reversed_planets[index + 1:]:
+    svg_output += f'<rect .../>'
+    key = (min(planet_a["id"], planet_b["id"]), max(planet_a["id"], planet_b["id"]))
+    if key in aspect_lookup:
+        aspect = aspect_lookup[key]
+        svg_output += f'<use x="..." xlink:href="#orb{aspect["aspect_degrees"]}" />'
+```
+
+**Impatto:** Da O(n^2 * k) a O(n^2 + k). Con valori reali: da ~7650 confronti a ~153 lookup O(1).
+
+### 1.5 — `+=` string concatenation nei loop SVG con `list.append()` + `"".join()`
+
+**File principali:**
+- `kerykeion/charts/charts_utils.py` — **218 operazioni `+=`**, 0 `"".join()`
+- `kerykeion/charts/draw_modern.py` — **83 operazioni `+=`**
+- `kerykeion/charts/chart_drawer.py` — 36 operazioni `+=`
+- `kerykeion/charts/draw_planets.py` — 9 operazioni `+=`
+
+**Problema:** Ogni `svg_output += f'<...'` dentro un loop crea un **nuovo oggetto stringa** copiando
+tutto il contenuto precedente. In Python le stringhe sono immutabili, quindi la complessita' di
+n concatenazioni e' O(n^2) nel caso peggiore.
+
+**I casi piu' critici:**
+
+1. **`draw_aspect_grid()` — triple nested loop** (linee 1098-1123): Ogni iterazione del loop
+   piu' interno aggiunge una riga SVG. Con la griglia triangolare, sono centinaia di allocazioni.
+
+2. **`draw_houses_cusps_and_text_number()` — 11 `+=` per iterazione** (linee 1220-1252):
+   Per ogni casa (12 iterazioni), 11 concatenazioni = 132 riallocazioni di stringa.
+
+3. **`draw_transit_ring_degree_steps()` / `draw_degree_ring()`** (linee 888-936):
+   72 iterazioni con 1 `+=` ciascuna.
+
+4. **`draw_modern.py` — `_draw_cusp_ring()`** (linee 410-493):
+   ~15 `+=` per iterazione * 12 case = ~180 riallocazioni.
+
+**Pattern target:**
+```python
+# PRIMA (O(n^2)):
+svg_output = ""
+for item in items:
+    svg_output += f'<rect x="{item.x}" .../>'
+
+# DOPO (O(n)):
+parts: list[str] = []
+for item in items:
+    parts.append(f'<rect x="{item.x}" .../>')
+svg_output = "".join(parts)
+```
+
+**Nota:** `draw_planets.py` linea 781 usa GIA' il pattern corretto (`parts` list + `"".join()`).
+
+**Correzione del piano:** non fare una sweep indiscriminata su tutti i `+=` del package. Limitarsi ai
+codepath davvero caldi e facili da verificare:
+1. `draw_aspect_grid()`
+2. `draw_houses_cusps_and_text_number()`
+3. `_draw_cusp_ring()` in `draw_modern.py`
+
+Gli altri casi vanno toccati solo se mostrano guadagni misurabili o se migliorano chiaramente la leggibilita'.
+
+### 1.6 — Evitare ri-calcolo Sun in `_compute_is_diurnal()`
+
+**File:** `kerykeion/astrological_subject_factory.py`, linee 1873-1876
+
+**Problema:** `_compute_is_diurnal()` chiama `swe.calc_ut(julian_day, 0, sun_tropical_flags)` per
+ottenere la longitudine del Sole. Ma il Sole e' gia' stato calcolato in `_calculate_single_planet()`
+poco prima.
+
+**Codice attuale (linea 1875):**
+```python
+sun_tropical_flags = swe.FLG_SWIEPH | swe.FLG_SPEED
+sun_calc = swe.calc_ut(julian_day, 0, sun_tropical_flags)[0]
+sun_lon = sun_calc[0]
+```
+
+**Soluzione:** Passare la longitudine del Sole gia' calcolata come parametro. Attenzione pero':
+il commento nel codice spiega che si usa intenzionalmente un calcolo **tropicale geocentrico**
+indipendente dal `zodiac_type` del chart. Se il chart e' siderale, `data["sun"].abs_pos` sarebbe
+in coordinate siderali, non tropicali.
+
+**Azione sicura:** Solo se il chart e' **Tropical + Apparent Geocentric**, riusare il valore gia' calcolato.
+In tutti gli altri casi, mantenere la chiamata separata. Aggiungere un parametro opzionale
+`sun_tropical_lon: Optional[float] = None` al metodo.
+
+### 1.7 — Unificare `_POINT_NUMBER_MAP` e `STANDARD_PLANETS` in `config_constants.py`
+
+**File coinvolti:**
+- `kerykeion/utilities.py`, linee 56-97: `_POINT_NUMBER_MAP`
+- `kerykeion/astrological_subject_factory.py`, linee 88-122: `STANDARD_PLANETS`
+
+**Problema:** Due dizionari quasi identici che mappano nomi di pianeti a ID Swiss Ephemeris.
+Il commento in `utilities.py:52-55` spiega che la duplicazione e' intenzionale per evitare
+circular import con `astrological_subject_factory.py`.
+
+**Differenza chiave:** `_POINT_NUMBER_MAP` include entry extra non presenti in `STANDARD_PLANETS`:
+- `Mean_South_Lunar_Node: 1000`
+- `True_South_Lunar_Node: 1100`
+- `White_Moon: 56`
+- `Ascendant: 9900`, `Descendant: 9901`, `Medium_Coeli: 9902`, `Imum_Coeli: 9903`
+
+**Soluzione:** Spostare entrambi i mapping in `kerykeion/settings/config_constants.py` (che non
+importa da nessuno dei due moduli, quindi niente circular import). Poi importare da li'.
+
+**Vincolo di retrocompatibilita':** se `STANDARD_PLANETS` continua a essere importato dall'esterno,
+il nome deve restare disponibile in `astrological_subject_factory.py` come alias/import re-export.
+Stesso principio per `_POINT_NUMBER_MAP` se si decide di centralizzarlo mantenendo il simbolo storico.
+
+`config_constants.py` gia' contiene le costanti condivise della libreria — e' il posto naturale.
+
+### 1.8 — Unificare costanti angoli in config_constants.py
+
+**Duplicazione attuale:**
+
+| Costante | File | Linea |
+|---|---|---|
+| `_ANGLES = ["Ascendant", "Medium_Coeli", "Descendant", "Imum_Coeli"]` | `report.py` | 47 |
+| `axial_points = {"Ascendant", "Medium_Coeli", "Descendant", "Imum_Coeli"}` | `relocated_chart_factory.py` | 130 |
+| `_MAIN_PLANETS = ["Sun", "Moon", ...]` | `report.py` | 45 |
+| `_NODES = ["Mean_North_Lunar_Node", "True_North_Lunar_Node"]` | `report.py` | 46 |
+
+**Azione:** Definire `AXIAL_POINTS`, `MAIN_PLANETS`, `LUNAR_NODES` in `config_constants.py`
+(dove gia' esistono `DEFAULT_ACTIVE_POINTS`, `ALL_ACTIVE_POINTS` ecc.) e importarli dove servono.
+
+---
+
+## TIER 2 — Ottimizzazioni moderate (test mirati necessari)
+
+Queste modifiche sono logicamente corrette ma toccano aree con piu' surface area di test.
+
+### 2.1 — Ottimizzare `scour` tramite fork compatibile, mantenendo output stabile
+
+**File:** `kerykeion/charts/chart_drawer.py`, linee 3912-3927
+
+**Problema:** `scourString()` impiega **~78ms** per SVG — il 92% del tempo di rendering.
+Il costo e' reale, ma il piano **non** puo' rimuovere `scour` o cambiare il path di minify di default,
+perche' il vincolo e' mantenere output e retrocompatibilita'.
+
+**Codice attuale:**
+```python
+if minify:
+    try:
+        template = scourString(template)     # ~78ms!
+    except Exception as exc:
+        logging.warning(...)
+    template = template.replace('"', "'")    # ~1ms
+    template = re.sub(r"\s+", " ", template) # ~1ms
+    template = re.sub(r">\s+<", "><", template)
+    template = template.strip()
+```
+
+**Direzione corretta:**
+
+**A) Fork trasparente e byte-stable (target principale):**
+- mantenere la stessa API (`scourString`);
+- sostituire l'implementazione solo se il fork produce output identico sulle fixture rilevanti;
+- non cambiare firma pubblica, flag esistenti o ordine delle trasformazioni.
+
+**B) Fast path sperimentale solo opt-in (facoltativo):**
+- ammesso solo dietro nuovo flag interno/non pubblico oppure tooling di benchmark;
+- mai come default finche' non e' dimostrata equivalenza piena.
+
+**Rischio:** il minify attuale e' coperto da golden SVG minificati. Anche differenze puramente
+strutturali o di ordinamento attributi sono regressioni finche' il principio guida resta
+"output identico".
+
+**Nota:** nessuna rimozione di `scour` da `pyproject.toml` in questo piano.
+
+### 2.2 — `report.py` sorting O(n*m) con dict lookup
+
+**File:** `kerykeion/report.py`, linee 521-524
+
+**Problema:** Per ogni nome nella lista di ordinamento, scansiona l'intera lista di punti:
+```python
+for name in _ANGLES + _MAIN_PLANETS + _NODES:
+    sorted_points.extend([p for p in points if p.name == name])
+```
+
+Con 18 punti * 18 nomi = 324 confronti. Non e' un bottleneck critico, ma e' un pattern
+migliorabile.
+
+**Codice target:**
+```python
+points_by_name = {p.name: p for p in points}
+for name in _ANGLES + _MAIN_PLANETS + _NODES:
+    if name in points_by_name:
+        sorted_points.append(points_by_name.pop(name))
+sorted_points.extend(points_by_name.values())  # remaining points
+```
+
+### 2.3 — `dict(aspect)` da Pydantic v1 pattern in report.py
+
+**File:** `kerykeion/report.py`, linee 155, 163
+
+**Problema:** Usa `dict(aspect)` (pattern Pydantic v1/v2 compat) su modelli Pydantic v2.
+Non e' un problema di correttezza oggi, ma `.model_dump()` e' il pattern esplicito e leggibile.
+
+**Priorita':** cleanup, non performance-critical.
+
+**Codice attuale:**
+```python
+self._active_aspects = [dict(aspect) for aspect in self.model.active_aspects]
+```
+
+**Codice target:**
+```python
+self._active_aspects = [aspect.model_dump() for aspect in self.model.active_aspects]
+```
+
+### 2.4 — Aspect factory: `range(len())` e cache accessi dict nel loop
+
+**File:** `kerykeion/aspects/aspects_factory.py`, linee 327-348
+
+**Problema:** Il loop usa `range(len())` con accesso per indice ripetuto. Migliora soprattutto la leggibilita'.
+
+**Nota:** evitare di sostituire tutto con slicing (`active_points_list[first_idx + 1:]`) se l'obiettivo e'
+la micro-performance, perche' lo slicing crea una lista temporanea.
+
+**Codice attuale:**
+```python
+for first in range(len(active_points_list)):
+    for second in range(first + 1, len(active_points_list)):
+        first_name = active_points_list[first]["name"]
+        second_name = active_points_list[second]["name"]
+        ...
+        first_speed = active_points_list[first].get("speed") or 0.0
+```
+
+**Codice target:**
+```python
+for first_idx, first_point in enumerate(active_points_list):
+    for second_point in active_points_list[first_idx + 1:]:
+        first_name = first_point["name"]
+        second_name = second_point["name"]
+        ...
+        first_speed = first_point.get("speed") or 0.0
+```
+
+### 2.5 — `_merge_active_aspects_with_settings` O(n^2) con dict join
+
+**File:** `kerykeion/aspects/aspects_factory.py`, linee 509-516
+
+**Problema:** Nested loop con `dict()` copy ad ogni match:
+```python
+for aspect_setting in aspects_settings:
+    for active_aspect in active_aspects:
+        if aspect_setting["name"] == active_aspect["name"]:
+            aspect_setting_copy = dict(aspect_setting)
+            aspect_setting_copy["orb"] = active_aspect["orb"]
+            filtered_settings.append(aspect_setting_copy)
+            break
+```
+
+Con 11 settings * 6 active = 66 confronti + 6 `dict()` copies.
+
+**Codice target:**
+```python
+active_orbs = {a["name"]: a["orb"] for a in active_aspects}
+filtered_settings = []
+for setting in aspects_settings:
+    if setting["name"] in active_orbs:
+        merged = dict(setting)
+        merged["orb"] = active_orbs[setting["name"]]
+        filtered_settings.append(merged)
+```
+
+Da O(n*m) a O(n+m).
+
+### 2.6 — Rimuovere `list()` e `.copy()` non necessari
+
+| File | Linea | Pattern | Azione |
+|---|---|---|---|
+| `aspects_factory.py` | 545 | `return list(all_aspects)` dove `all_aspects` e' gia' una lista | `return all_aspects` |
+| `utilities.py` | 577 | `return degrees.copy()` per lista con <=1 elemento | `return degrees` (o `return list(degrees)` se serve copia) |
+| `astrological_subject_factory.py` | 2310 | `.copy()` prima di `.extend()` su lista temporanea | Usare direttamente `calculated_planets + calculated_axial_cusps` |
+
+**Correzione del piano:** ogni rimozione di copy/list va fatta solo dove il non-aliasing non e' parte
+implicita del comportamento. Il ROI e' basso; non vale introdurre side effect sottili per guadagni minimi.
+
+### 2.7 — Chart drawer: evitare dict copy inutile all'init
+
+**File:** `kerykeion/charts/chart_drawer.py`, linee 1996-1997
+
+```python
+self.planets_settings = [dict(body) for body in celestial_points_settings]
+self.aspects_settings = [dict(aspect) for aspect in aspects_settings]
+```
+
+**Verifica necessaria:** i due casi vanno separati.
+
+- `self.planets_settings`: **la copia oggi serve**, perche' il codice marca i body attivi mutando
+  `body["is_active"] = True`. Assegnare direttamente la lista originale introdurrebbe leakage sul config condiviso.
+- `self.aspects_settings`: puo' essere candidata a rimozione della copia **solo se** si conferma che non viene mai mutata.
+
+### 2.8 — Transit time range: list filtering con dict lookup
+
+**File:** `kerykeion/transits_time_range_factory.py`, linea 423
+
+```python
+aspect_settings = [s for s in DEFAULT_CHART_ASPECTS_SETTINGS if s["name"] == aspect_name]
+```
+
+Questo e' dentro un loop di ricerca. Costruire un dict `{name: settings}` una sola volta
+prima del loop.
+
+---
+
+## TIER 3 — Ottimizzazioni avanzate (rischio piu' alto)
+
+Queste modifiche hanno impatto significativo ma richiedono analisi e test approfonditi.
+
+### 3.1 — `pytz` -> `zoneinfo` (stdlib Python 3.9+)
+
+**File:** `kerykeion/astrological_subject_factory.py` e moduli che usano `pytz`
+
+**Problema:** `pytz.timezone()` ha overhead di lazy initialization ed e' ~3x piu' lento di
+`zoneinfo.ZoneInfo()` (stdlib dal Python 3.9, kerykeion richiede >=3.12).
+
+**Rischio ALTO:**
+- `pytz` ha semantica diversa da `zoneinfo` per le transizioni DST storiche
+- `pytz` richiede `.localize()` per "attaccare" la timezone, `zoneinfo` usa `datetime.replace(tzinfo=...)`
+- Date storiche (pre-1970) potrebbero comportarsi diversamente
+- La libreria di astrologia calcola spesso date storiche molto antiche
+
+**Prerequisiti:**
+1. Test con date storiche (e.g. 1800, 1900, 1950) in varie timezone
+2. Confronto preciso dei risultati Julian Day con pytz vs zoneinfo
+3. Verifica che `pytz` non sia usato anche da dipendenze (requests-cache lo usa?)
+
+**Correzione del piano:** includere anche i codepath `moon_phase_details/*`, non solo
+`astrological_subject_factory.py`, perche' anche li' la semantica `pytz.localize()` e' usata in modo esplicito.
+
+**Se implementato:** Rimuovere `pytz` e `types-pytz` da `pyproject.toml`.
+
+### 3.2 — `model["field"]` da `model.field` nei path caldi
+
+**File principali:**
+- `kerykeion/aspects/aspects_utils.py:222` — `subject[planet["name"].lower()]`
+- `kerykeion/charts/charts_utils.py` — `planet_a["name"]`, `aspect["p1"]` ecc.
+
+**Problema:** `model["field"]` su Pydantic model passa per `__getitem__` -> `getattr()`, ~1.5x
+piu' lento dell'accesso diretto `.field`.
+
+**Rischio ALTO:**
+- In `charts_utils.py`, le funzioni ricevono parametri tipizzati come `list[dict]` — sono
+  effettivamente dict, non Pydantic models. Cambiare `dict["key"]` in `dict.key` causerebbe
+  `AttributeError`.
+- In `aspects_utils.py:222`, `subject` e' tipizzato come `AstrologicalSubjectModel` (Pydantic)
+  ma `planet` e' un dict da `celestial_points_settings`.
+- Bisognerebbe fare un audit **completo** di ogni call site per determinare se l'oggetto e'
+  un Pydantic model o un plain dict prima di cambiare la sintassi.
+
+**Se implementato:** Solo su oggetti **certamente** Pydantic (non dict), e solo nei path caldi.
+
+### 3.3 — `__slots__` su dataclass interne
+
+**File:** `kerykeion/astrological_subject_factory.py`
+- `ChartConfiguration` dataclass (linea 326)
+- `LocationData` dataclass (linea 442)
+
+**Problema:** Senza `__slots__`, ogni istanza dataclass ha un `__dict__` che occupa ~200 bytes extra.
+Con `__slots__`, l'accesso agli attributi e' anche leggermente piu' veloce.
+
+**Rischio:** Se qualche codice accede a `instance.__dict__` o usa `setattr()` dinamico,
+l'aggiunta di `__slots__` lo romperebbe.
+
+**Azione:** Aggiungere `@dataclass(slots=True)` (Python 3.10+, kerykeion richiede >=3.12).
+
+**Priorita':** molto bassa. Il beneficio assoluto e' piccolo rispetto ai bottleneck confermati della libreria,
+quindi non va anticipato rispetto ai refactor con ROI chiaro.
+
+---
+
+## TIER 4 — Architetturali (fuori scope per ora)
+
+Menzione per completezza, da considerare in future versioni major.
+
+### 4.1 — Lazy import numpy/skyfield
+
+L'import iniziale di kerykeion impiega ~2s, di cui ~1.3s per la catena numpy -> skyfield.
+Questa catena viene caricata da `libephemeris` anche se Skyfield viene usato solo come fallback
+per `gauquelin_sector`.
+
+**Possibile azione:** Lazy import in `libephemeris` stesso (upstream).
+
+### 4.2 — Batch `calc_ut` per piu' pianeti
+
+Attualmente si chiama `swe.calc_ut()` una volta per pianeta. Una API batch che calcoli
+tutti i pianeti in una sola chiamata C eliminerebbe l'overhead Python per-call.
+
+**Richiede:** Modifica a `libephemeris` (upstream).
+
+### 4.3 — Caching `ephemeris_context()` tra subject multipli
+
+`ephemeris_context()` fa setup/teardown del backend SwissEph per ogni subject. Se si calcolano
+molti subject con la stessa configurazione (stesso `zodiac_type`, `perspective_type`, ecc.),
+il context potrebbe essere condiviso.
+
+**Richiede:** Rethink del lifecycle del backend.
+
+---
+
+## Impatto stimato
+
+Le stime precedenti erano troppo ottimistiche per un piano a **retrocompatibilita' totale**.
+La lettura corretta dei guadagni e' questa:
+
+- **Cleanup puro (TIER 0):** impatto trascurabile sulle prestazioni, utile per ridurre rumore e maintenance cost.
+- **SVG non minificato:** il guadagno piu' affidabile viene da `draw_aspect_grid` (`1.4`) e dalla conversione
+  mirata dei loop string-building (`1.5`). Qui il miglioramento e' reale e difendibile.
+- **Subject creation:** i guadagni restano modesti finche' `1.2` non passa una validazione completa.
+  Prima di allora, aspettarsi miglioramenti incrementali, non un salto del 30%.
+- **SVG minificato:** il tempo resta dominato da `scour`. Il vero guadagno dipende dal fork compatibile,
+  non dalla sostituzione con regex-only, che e' fuori piano.
+
+In sintesi, i win a maggiore confidenza sono:
+1. `1.4` pre-index di `draw_aspect_grid`
+2. `1.5` applicato solo ai loop SVG piu' caldi
+3. `1.1` cache di introspezione `get_args()`
+
+Il win potenzialmente piu' grande sul core numerico resta `1.2`, ma **solo dopo** validazione estesa.
+
+## Matrice di validazione
+
+Per garantire piena retrocompatibilita', la validazione va espansa per area. Il principio operativo e':
+**piu' il refactor tocca numerica, rendering o compatibilita' cross-backend, piu' il gate deve salire**.
+
+### Gate 0 — Obbligatorio per qualsiasi modifica
+
+- `poe lint`
+- `poe analyze`
+- `poe typecheck`
+- `poe test:core`
+
+**Scopo:** bloccare regressioni immediate di sintassi, typing e comportamento core offline.
+
+### Gate 1 — Refactor del core numerico (subject, aspetti, houses, declinazioni, transits)
+
+Obbligatorio per modifiche in:
+- `astrological_subject_factory.py`
+- `utilities.py` se tocca logica houses/angles/time
+- `aspects/*`
+- `transits_time_range_factory.py`
+- moduli che leggono o producono `declination`, `julian_day`, `houses`, `active_points`
+
+Eseguire:
+- `poe test:core`
+- `poe test:base`
+- `pytest tests/core/test_oob_and_declination_aspects.py -q`
+- `pytest tests/core/test_transits.py -q`
+- `pytest tests/core/test_subject_factory_parametrized.py -q`
+
+Quando il refactor tocca coordinate, prospettive o backend:
+- `pytest tests/core/test_planetocentric.py -q`
+- `pytest tests/core/test_houses_positions.py -q`
+- `pytest tests/core/test_planetary_positions.py -q`
+- `poe test:compare` **se** entrambi i backend sono disponibili
+
+**Scopo:** non limitarsi ai casi canonici di `test:core`, ma coprire anche house systems, sidereal modes,
+perspectives, range temporali e differenze tra libephemeris e swisseph.
+
+### Gate 2 — Rendering SVG / Chart layout / minify
+
+Obbligatorio per modifiche in:
+- `charts/charts_utils.py`
+- `charts/chart_drawer.py`
+- `charts/draw_modern.py`
+- `charts/draw_planets.py`
+- `utilities.py` se tocca SVG processing o CSS inlining
+
+Eseguire:
+- `poe test:core`
+- `pytest tests/core/test_chart_drawer.py -q`
+- `pytest tests/core/test_chart_parametrized.py -q`
+- `pytest tests/core/test_utilities.py -q`
+- `poe benchmark`
+
+Se la modifica tocca minify, `scour`, template SVG o post-processing:
+- confrontare anche gli SVG minificati golden gia' esistenti;
+- usare gli script `regenerate:*` **solo per ispezione del delta**, non come criterio automatico di accettazione;
+- verificare sia il path classic sia il path modern.
+
+**Scopo:** prevenire regressioni strutturali, differenze di layout, drift nei chart parametrizzati e
+peggioramenti prestazionali nei path caldi del rendering.
+
+### Gate 3 — Report, snapshot testuali e documentazione eseguibile
+
+Obbligatorio per modifiche in:
+- `report.py`
+- serializer/context/report snapshot
+- formattazione testuale di date, coordinate, aspetti, case, output fixture
+
+Eseguire:
+- `poe test:core`
+- `pytest tests/core/test_report.py -q`
+- `poe docs:snippets`
+- `poe docs:check`
+
+Se necessario per audit del delta:
+- `poe regenerate:reports`
+
+**Scopo:** proteggere output user-facing non SVG, snapshot ASCII e snippet documentati.
+
+### Gate 4 — Compatibilita' timezone / date storiche / BCE
+
+Obbligatorio per modifiche in:
+- conversioni orarie
+- timezone handling
+- DST ambiguity
+- BCE / Julian Day conversion
+- `pytz` / `zoneinfo`
+
+Eseguire:
+- `poe test:core`
+- `pytest tests/core/test_astrological_subject.py -q`
+- `pytest tests/core/test_bce_dates.py -q`
+- `pytest tests/core/test_moon_phase_historical_verification.py -q`
+- `poe test:medium`
+
+**Scopo:** intercettare regressioni che spesso non emergono nei chart moderni standard ma rompono date
+storiche, DST edge cases o calcoli astronomici di base.
+
+### Gate RC — Release candidate per refactor ad alto impatto
+
+Obbligatorio prima del merge dei refactor che toccano piu' moduli core oppure cambiano un hot path globale.
+
+Eseguire:
+- `poe quality`
+- `poe test:medium`
+- `pytest tests/core/test_chart_drawer.py -q`
+- `pytest tests/core/test_chart_parametrized.py -q`
+- `pytest tests/core/test_subject_factory_parametrized.py -q`
+- `pytest tests/core/test_report.py -q`
+- `poe benchmark`
+- `poe test:compare` se l'ambiente ha entrambi i backend installati
+
+Per cambi SVG/minify/report:
+- confronto manuale dei delta generati da `regenerate:svg`, `regenerate:reports`, `regenerate:configurations`
+- nessuna accettazione automatica di baseline nuove senza spiegazione del perche' il delta sia compatibile
+
+**Scopo:** trattare il refactor come un piccolo release train, non come un semplice cleanup locale.
+
+---
+
+## Strategia di esecuzione
+
+### Fase 1: TIER 0 (cleanup)
+Applicare tutte le modifiche TIER 0 in un singolo commit.
+
+**Gate richiesto:** Gate 0.
+
+Nessun rischio atteso: solo rimozione di codice morto e micro-cleanup locali.
+
+### Fase 2: TIER 1 (ottimizzazioni sicure)
+Applicare una modifica alla volta, con commit separati e `poe test:core` dopo ciascuna:
+1. Cache `get_args()` (1.1)
+2. Pre-index `draw_aspect_grid` (1.4) — il piu' impattante per SVG
+3. String concatenation -> list+join (1.5) — **solo nei loop caldi confermati**
+4. Riuso Sun in `_compute_is_diurnal` (1.6) — solo nel caso Tropical + Apparent Geocentric
+5. Unificare costanti (1.7, 1.8) — piu' refactoring che performance, con alias compatibili
+
+**Gate consigliato per ogni step SVG/chart:**
+- Gate 0 sempre
+- Gate 2 per ogni modifica che tocca rendering, template o SVG utility
+
+### Fase 3: TIER 2 (moderate)
+Ogni modifica richiede test mirato:
+- `1.2` (declinazione analitica):
+  - Gate 0
+  - Gate 1 completo
+  - Gate RC prima del merge
+- `2.1` (fork compatibile di `scour`):
+  - Gate 0
+  - Gate 2 completo
+  - Gate RC se cambia il default path del minify
+- `2.2-2.8`:
+  - Gate 0
+  - eventuale Gate 1 / Gate 2 / Gate 3 a seconda del modulo toccato
+
+### Fase 4: TIER 3 (avanzate)
+Solo dopo aver completato e validato TIER 0-2:
+- 3.1 (pytz): Richiede test matrix con date storiche
+- 3.2 (dict vs dot access): Richiede audit completo dei tipi
+- 3.3 (slots): Verifica assenza di `__dict__` access
+
+**Gate richiesto:** sempre Gate RC; per `3.1` anche Gate 4 completo.
+
+### Regola finale di accettazione
+
+Una modifica entra solo se soddisfa **tutti** i criteri seguenti:
+- nessun breaking change osservabile;
+- nessun delta inatteso nei golden file rilevanti;
+- benchmark non peggiori sul path toccato;
+- codice finale piu' semplice o almeno non piu' fragile di prima.

--- a/kerykeion/aspects/aspects_factory.py
+++ b/kerykeion/aspects/aspects_factory.py
@@ -323,42 +323,44 @@ class AspectsFactory:
         }
 
         all_aspects_list = []
+        n_points = len(active_points_list)
 
-        for first in range(len(active_points_list)):
+        for first_idx, first_point in enumerate(active_points_list):
+            first_name = first_point["name"]
+            first_abs_pos = first_point["abs_pos"]
+            first_speed = first_point.get("speed") or 0.0
+            first_in_axes = first_name in AXES_LIST
             # Generate aspects list without repetitions (single chart - same chart)
-            for second in range(first + 1, len(active_points_list)):
-                # Skip predefined opposite pairs (AC/DC, MC/IC, North/South nodes)
-                first_name = active_points_list[first]["name"]
-                second_name = active_points_list[second]["name"]
+            for second_idx in range(first_idx + 1, n_points):
+                second_point = active_points_list[second_idx]
+                second_name = second_point["name"]
 
+                # Skip predefined opposite pairs (AC/DC, MC/IC, North/South nodes)
                 if (first_name, second_name) in opposite_pairs:
                     continue
 
-                aspect = get_aspect_from_two_points(
-                    filtered_settings, active_points_list[first]["abs_pos"], active_points_list[second]["abs_pos"]
-                )
+                second_abs_pos = second_point["abs_pos"]
+                aspect = get_aspect_from_two_points(filtered_settings, first_abs_pos, second_abs_pos)
 
                 if aspect["verdict"]:
                     # Get planet IDs using lookup dictionary for better performance
                     first_planet_id = planet_id_lookup.get(first_name, 0)
                     second_planet_id = planet_id_lookup.get(second_name, 0)
 
-                    # Get speeds first, fall back to 0.0 only if missing/None
-                    first_speed = active_points_list[first].get("speed") or 0.0
-                    second_speed = active_points_list[second].get("speed") or 0.0
+                    second_speed = second_point.get("speed") or 0.0
 
                     # Determine aspect movement.
                     # If both points are chart axes, there is no meaningful
                     # dynamic movement between them, so we mark the aspect as
                     # "Static" regardless of any synthetic speeds.
                     aspect_movement: AspectMovementType
-                    if first_name in AXES_LIST and second_name in AXES_LIST:
+                    if first_in_axes and second_name in AXES_LIST:
                         aspect_movement = "Static"
                     else:
                         # Calculate aspect movement (applying/separating/fixed)
                         aspect_movement = calculate_aspect_movement(
-                            active_points_list[first]["abs_pos"],
-                            active_points_list[second]["abs_pos"],
+                            first_abs_pos,
+                            second_abs_pos,
                             aspect["aspect_degrees"],
                             first_speed,
                             second_speed,
@@ -367,10 +369,10 @@ class AspectsFactory:
                     aspect_model = AspectModel(
                         p1_name=first_name,
                         p1_owner=subject.name,
-                        p1_abs_pos=active_points_list[first]["abs_pos"],
+                        p1_abs_pos=first_abs_pos,
                         p2_name=second_name,
                         p2_owner=subject.name,
-                        p2_abs_pos=active_points_list[second]["abs_pos"],
+                        p2_abs_pos=second_abs_pos,
                         aspect=aspect["name"],
                         orbit=aspect["orbit"],
                         aspect_degrees=aspect["aspect_degrees"],
@@ -506,14 +508,14 @@ class AspectsFactory:
         Returns:
             List of filtered and updated aspect settings
         """
+        active_orbs = {a["name"]: a["orb"] for a in active_aspects}
         filtered_settings = []
         for aspect_setting in aspects_settings:
-            for active_aspect in active_aspects:
-                if aspect_setting["name"] == active_aspect["name"]:
-                    aspect_setting_copy = dict(aspect_setting)  # Don't modify original
-                    aspect_setting_copy["orb"] = active_aspect["orb"]
-                    filtered_settings.append(aspect_setting_copy)
-                    break
+            orb = active_orbs.get(aspect_setting["name"])
+            if orb is not None:
+                aspect_setting_copy = dict(aspect_setting)  # Don't modify original
+                aspect_setting_copy["orb"] = orb
+                filtered_settings.append(aspect_setting_copy)
         return filtered_settings
 
     @staticmethod

--- a/kerykeion/aspects/aspects_factory.py
+++ b/kerykeion/aspects/aspects_factory.py
@@ -508,7 +508,9 @@ class AspectsFactory:
         Returns:
             List of filtered and updated aspect settings
         """
-        active_orbs = {a["name"]: a["orb"] for a in active_aspects}
+        active_orbs: dict[str, float] = {}
+        for a in active_aspects:
+            active_orbs.setdefault(a["name"], a["orb"])
         filtered_settings = []
         for aspect_setting in aspects_settings:
             orb = active_orbs.get(aspect_setting["name"])

--- a/kerykeion/astro_cartography/acg_factory.py
+++ b/kerykeion/astro_cartography/acg_factory.py
@@ -18,7 +18,6 @@ This is part of Kerykeion (C) 2025 Giacomo Battaglia
 
 import math
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
-from pathlib import Path
 from typing import List, Optional, Dict, Literal
 from pydantic import BaseModel, Field
 

--- a/kerykeion/astrological_subject_factory.py
+++ b/kerykeion/astrological_subject_factory.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from typing import Optional, List, Dict, Any, get_args
 from dataclasses import dataclass, field
 from contextlib import contextmanager
+from functools import partial
 
 
 from kerykeion.fetch_geonames import FetchGeonames
@@ -64,7 +65,10 @@ from kerykeion.utilities import (
     format_ancient_iso,
     normalize_zodiac_type,
 )
-from kerykeion.settings.config_constants import DEFAULT_ACTIVE_POINTS
+from kerykeion.settings.config_constants import (
+    DEFAULT_ACTIVE_POINTS,
+    STANDARD_PLANETS as _STANDARD_PLANETS_CANONICAL,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -84,42 +88,12 @@ DEFAULT_GEONAMES_CACHE_EXPIRE_AFTER_DAYS = 30
 # Using a centralized configuration eliminates repetitive code and makes
 # it easier to add new celestial bodies in the future.
 
-# Standard planets with direct Swiss Ephemeris IDs (0-20+)
-STANDARD_PLANETS: Dict[AstrologicalPoint, int] = {
-    "Sun": 0,
-    "Moon": 1,
-    "Mercury": 2,
-    "Venus": 3,
-    "Mars": 4,
-    "Jupiter": 5,
-    "Saturn": 6,
-    "Uranus": 7,
-    "Neptune": 8,
-    "Pluto": 9,
-    "Mean_North_Lunar_Node": 10,
-    "True_North_Lunar_Node": 11,
-    "Mean_Lilith": 12,
-    "True_Lilith": 13,
-    "Earth": 14,
-    "Chiron": 15,
-    "Pholus": 16,
-    "Ceres": 17,
-    "Pallas": 18,
-    "Juno": 19,
-    "Vesta": 20,
-    # Interpolated lunar apse points (SwissEph IDs 21-22)
-    "Interpolated_Lilith": 21,  # SE_INTP_APOG — proper interpolated apogee
-    "Interpolated_Perigee": 22,  # SE_INTP_PERG — proper interpolated perigee
-    # Uranian / Hamburg School hypothetical planets (SwissEph IDs 40-47)
-    "Cupido": 40,
-    "Hades": 41,
-    "Zeus": 42,
-    "Kronos": 43,
-    "Apollon": 44,
-    "Admetos": 45,
-    "Vulkanus": 46,
-    "Poseidon": 47,
-}
+# Standard planets with direct Swiss Ephemeris IDs (0-22, 40-47).
+# Canonical definition lives in `kerykeion.settings.config_constants.STANDARD_PLANETS`.
+# Re-exported here as the historical public symbol for backward compatibility
+# (imported by transits_time_range_factory, planetary_return_factory,
+# primary_directions/directions_factory, etc.).
+STANDARD_PLANETS: Dict[AstrologicalPoint, int] = _STANDARD_PLANETS_CANONICAL
 
 # Trans-Neptunian Objects requiring AST_OFFSET
 # These use Swiss Ephemeris asteroid offset + minor planet number
@@ -1537,7 +1511,7 @@ class AstrologicalSubjectFactory:
             for angles).
         """
 
-        should_calculate = lambda point: AstrologicalSubjectFactory._should_calculate(point, active_points)
+        should_calculate = partial(AstrologicalSubjectFactory._should_calculate, active_points=active_points)
 
         # Track which axial cusps are actually calculated
         calculated_axial_cusps: List[AstrologicalPoint] = []
@@ -1747,7 +1721,7 @@ class AstrologicalSubjectFactory:
             names to calculated_planets.
         """
 
-        should_calculate = lambda point: AstrologicalSubjectFactory._should_calculate(point, active_points)
+        should_calculate = partial(AstrologicalSubjectFactory._should_calculate, active_points=active_points)
 
         for derived_name, config in OPPOSITE_PAIRS.items():
             if not should_calculate(derived_name):
@@ -2058,7 +2032,7 @@ class AstrologicalSubjectFactory:
             This ensures that dependent calculations and aspects only use valid data.
         """
 
-        should_calculate = lambda point: AstrologicalSubjectFactory._should_calculate(point, active_points)
+        should_calculate = partial(AstrologicalSubjectFactory._should_calculate, active_points=active_points)
 
         point_type: PointType = "AstrologicalPoint"
         julian_day = data["julian_day"]

--- a/kerykeion/astrological_subject_factory.py
+++ b/kerykeion/astrological_subject_factory.py
@@ -93,7 +93,7 @@ DEFAULT_GEONAMES_CACHE_EXPIRE_AFTER_DAYS = 30
 # Re-exported here as the historical public symbol for backward compatibility
 # (imported by transits_time_range_factory, planetary_return_factory,
 # primary_directions/directions_factory, etc.).
-STANDARD_PLANETS: Dict[AstrologicalPoint, int] = _STANDARD_PLANETS_CANONICAL
+STANDARD_PLANETS: Dict[AstrologicalPoint, int] = dict(_STANDARD_PLANETS_CANONICAL)
 
 # Trans-Neptunian Objects requiring AST_OFFSET
 # These use Swiss Ephemeris asteroid offset + minor planet number

--- a/kerykeion/charts/chart_drawer.py
+++ b/kerykeion/charts/chart_drawer.py
@@ -3542,6 +3542,10 @@ class ChartDrawer:  # type: ignore[no-redef]
                 seventh_house_degree_ut=self.first_obj.seventh_house.abs_pos,
                 color=self.chart_colors_settings["houses_radix_line"],
             )
+            # Clear the 12-house invisible hit-area wedges: in Gauquelin mode the
+            # visible ring is 36 sectors, so the 12-wedge geometry would mislead
+            # any frontend using makeHouseSectors for click/hover targeting.
+            template_dict["makeHouseSectors"] = ""
             template_dict["makeGauquelinSectors"] = ""
         else:
             template_dict["makeGauquelinSectors"] = ""

--- a/kerykeion/charts/chart_drawer.py
+++ b/kerykeion/charts/chart_drawer.py
@@ -7,7 +7,6 @@ import logging
 import re
 from functools import lru_cache
 from math import ceil
-from datetime import datetime
 from pathlib import Path
 from string import Template
 from typing import Any, Mapping, Optional, Sequence, Union, get_args
@@ -47,7 +46,6 @@ from kerykeion.schemas.kr_literals import (
     KerykeionChartLanguage,
     AstrologicalPoint,
 )
-from kerykeion.schemas.kr_models import ChartDataModel
 from kerykeion.settings.config_constants import DEFAULT_ACTIVE_POINTS
 from kerykeion.settings.translations import get_translations, load_language_settings
 from kerykeion.charts.charts_utils import (
@@ -344,6 +342,7 @@ from typing import Protocol, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from kerykeion.charts.chart_drawer import ChartDrawer  # type: ignore[attr-defined]  # noqa: F811
+    from kerykeion.schemas.kr_models import ChartDataModel  # noqa: F401
 
 
 class ChartRendererProtocol(Protocol):

--- a/kerykeion/charts/chart_drawer.py
+++ b/kerykeion/charts/chart_drawer.py
@@ -340,9 +340,10 @@ DEFAULT_GRID_POSITIONS = GridPositionsConfig()
 
 from typing import Protocol, TYPE_CHECKING
 
+from kerykeion.schemas.kr_models import ChartDataModel
+
 if TYPE_CHECKING:
     from kerykeion.charts.chart_drawer import ChartDrawer  # type: ignore[attr-defined]  # noqa: F811
-    from kerykeion.schemas.kr_models import ChartDataModel  # noqa: F401
 
 
 class ChartRendererProtocol(Protocol):

--- a/kerykeion/charts/charts_utils.py
+++ b/kerykeion/charts/charts_utils.py
@@ -17,7 +17,7 @@ The module is organized in the following sections:
 
 import datetime
 import math
-from typing import Literal, Mapping, Optional, Sequence, TYPE_CHECKING, Union
+from typing import Literal, Mapping, Optional, Sequence, Union
 
 from kerykeion.schemas import ChartType, KerykeionException
 from kerykeion.schemas.kr_literals import AstrologicalPoint
@@ -25,12 +25,10 @@ from kerykeion.schemas.kr_models import (
     AspectModel,
     AstrologicalSubjectModel,
     CompositeSubjectModel,
+    HouseComparisonModel,
     KerykeionPointModel,
     PlanetReturnModel,
 )
-
-if TYPE_CHECKING:
-    from kerykeion.schemas.kr_models import HouseComparisonModel  # noqa: F401
 from kerykeion.schemas.settings_models import (
     KerykeionLanguageCelestialPointModel,
     KerykeionSettingsCelestialPointModel,

--- a/kerykeion/charts/charts_utils.py
+++ b/kerykeion/charts/charts_utils.py
@@ -17,7 +17,7 @@ The module is organized in the following sections:
 
 import datetime
 import math
-from typing import Literal, Mapping, Optional, Sequence, Union
+from typing import Literal, Mapping, Optional, Sequence, TYPE_CHECKING, Union
 
 from kerykeion.schemas import ChartType, KerykeionException
 from kerykeion.schemas.kr_literals import AstrologicalPoint
@@ -25,10 +25,12 @@ from kerykeion.schemas.kr_models import (
     AspectModel,
     AstrologicalSubjectModel,
     CompositeSubjectModel,
-    HouseComparisonModel,
     KerykeionPointModel,
     PlanetReturnModel,
 )
+
+if TYPE_CHECKING:
+    from kerykeion.schemas.kr_models import HouseComparisonModel  # noqa: F401
 from kerykeion.schemas.settings_models import (
     KerykeionLanguageCelestialPointModel,
     KerykeionSettingsCelestialPointModel,
@@ -1085,7 +1087,6 @@ def draw_aspect_grid(
     Returns:
         SVG string containing the aspect grid rectangles and symbols.
     """
-    svg_output = ""
     style = f"stroke:{stroke_color}; stroke-width: 0.5px; fill:none"
     box_size = 14
 
@@ -1095,10 +1096,25 @@ def draw_aspect_grid(
     # Reverse the list of active planets for the first iteration
     reversed_planets = active_planets[::-1]
 
+    # Pre-index aspects by unordered pair (O(k)) so the grid loop can look up aspects
+    # in O(1) instead of scanning the full aspects list for every cell (was O(n^2 * k)).
+    # Preserve original order when multiple aspects exist for the same pair (synastry).
+    aspect_lookup: dict[tuple[int, int], list] = {}
+    for aspect in aspects:
+        p1 = aspect["p1"]
+        p2 = aspect["p2"]
+        key = (p1, p2) if p1 <= p2 else (p2, p1)
+        aspect_lookup.setdefault(key, []).append(aspect)
+
+    parts: list[str] = []
     for index, planet_a in enumerate(reversed_planets):
         # Draw the grid box for the planet
-        svg_output += f'<rect kr:node="AspectsGridRect" x="{x_start}" y="{y_start}" width="{box_size}" height="{box_size}" style="{style}"/>'
-        svg_output += f'<use transform="scale(0.4)" x="{(x_start + 2) * 2.5}" y="{(y_start + 1) * 2.5}" xlink:href="#{planet_a["name"]}" />'
+        parts.append(
+            f'<rect kr:node="AspectsGridRect" x="{x_start}" y="{y_start}" width="{box_size}" height="{box_size}" style="{style}"/>'
+        )
+        parts.append(
+            f'<use transform="scale(0.4)" x="{(x_start + 2) * 2.5}" y="{(y_start + 1) * 2.5}" xlink:href="#{planet_a["name"]}" />'
+        )
 
         # Update the starting coordinates for the next box
         x_start += box_size
@@ -1108,20 +1124,26 @@ def draw_aspect_grid(
         x_aspect = x_start
         y_aspect = y_start + box_size
 
+        planet_a_id = planet_a["id"]
         # Iterate over the remaining planets
         for planet_b in reversed_planets[index + 1 :]:
             # Draw the grid box for the aspect
-            svg_output += f'<rect kr:node="AspectsGridRect" x="{x_aspect}" y="{y_aspect}" width="{box_size}" height="{box_size}" style="{style}"/>'
+            parts.append(
+                f'<rect kr:node="AspectsGridRect" x="{x_aspect}" y="{y_aspect}" width="{box_size}" height="{box_size}" style="{style}"/>'
+            )
             x_aspect += box_size
 
-            # Check for aspects between the planets
-            for aspect in aspects:
-                if (aspect["p1"] == planet_a["id"] and aspect["p2"] == planet_b["id"]) or (
-                    aspect["p1"] == planet_b["id"] and aspect["p2"] == planet_a["id"]
-                ):
-                    svg_output += f'<use  x="{x_aspect - box_size + 1}" y="{y_aspect + 1}" xlink:href="#orb{aspect["aspect_degrees"]}" />'
+            # Check for aspects between the planets via pre-built index
+            planet_b_id = planet_b["id"]
+            key = (planet_a_id, planet_b_id) if planet_a_id <= planet_b_id else (planet_b_id, planet_a_id)
+            matches = aspect_lookup.get(key)
+            if matches:
+                for aspect in matches:
+                    parts.append(
+                        f'<use  x="{x_aspect - box_size + 1}" y="{y_aspect + 1}" xlink:href="#orb{aspect["aspect_degrees"]}" />'
+                    )
 
-    return svg_output
+    return "".join(parts)
 
 
 def draw_houses_cusps_and_text_number(
@@ -1169,7 +1191,7 @@ def draw_houses_cusps_and_text_number(
             or transit_house_cusp_color but they are None.
     """
 
-    path = ""
+    parts: list[str] = []
     xr = 12
 
     for i in range(xr):
@@ -1222,15 +1244,21 @@ def draw_houses_cusps_and_text_number(
 
             # Add the house number text for the second subject
             fill_opacity = "0" if chart_type == "Transit" else ".4"
-            path += f'<g kr:node="HouseNumber" kr:house="{i + 1}" kr:horoscope="1">'
-            path += f'<text style="fill: var(--kerykeion-chart-color-house-number); fill-opacity: {fill_opacity}; font-size: 14px"><tspan x="{xtext - 3}" y="{ytext + 3}">{i + 1}</tspan></text>'
-            path += "</g>"
+            parts.append(f'<g kr:node="HouseNumber" kr:house="{i + 1}" kr:horoscope="1">')
+            parts.append(
+                f'<text style="fill: var(--kerykeion-chart-color-house-number); fill-opacity: {fill_opacity}; font-size: 14px"><tspan x="{xtext - 3}" y="{ytext + 3}">{i + 1}</tspan></text>'
+            )
+            parts.append("</g>")
 
             # Add the house cusp line for the second subject
             stroke_opacity = "0" if chart_type == "Transit" else ".3"
-            path += f'<g kr:node="Cusp" kr:absoluteposition="{second_subject_houses_list[i].abs_pos}" kr:signposition="{second_subject_houses_list[i].position}" kr:sign="{second_subject_houses_list[i].sign}" kr:slug="{second_subject_houses_list[i].name}" kr:horoscope="1">'
-            path += f"<line x1='{t_x1}' y1='{t_y1}' x2='{t_x2}' y2='{t_y2}' style='stroke: {t_linecolor}; stroke-width: 1px; stroke-opacity:{stroke_opacity};'/>"
-            path += "</g>"
+            parts.append(
+                f'<g kr:node="Cusp" kr:absoluteposition="{second_subject_houses_list[i].abs_pos}" kr:signposition="{second_subject_houses_list[i].position}" kr:sign="{second_subject_houses_list[i].sign}" kr:slug="{second_subject_houses_list[i].name}" kr:horoscope="1">'
+            )
+            parts.append(
+                f"<line x1='{t_x1}' y1='{t_y1}' x2='{t_x2}' y2='{t_y2}' style='stroke: {t_linecolor}; stroke-width: 1px; stroke-opacity:{stroke_opacity};'/>"
+            )
+            parts.append("</g>")
 
         # Adjust dropin based on chart type and external view
         dropin_map = {"Transit": 84, "Synastry": 84, "DualReturnChart": 84}
@@ -1242,16 +1270,22 @@ def draw_houses_cusps_and_text_number(
         ytext = sliceToY(0, (r - dropin), text_offset) + dropin
 
         # Add the house cusp line for the first subject
-        path += f'<g kr:node="Cusp" kr:absoluteposition="{first_subject_houses_list[i].abs_pos}" kr:signposition="{first_subject_houses_list[i].position}" kr:sign="{first_subject_houses_list[i].sign}" kr:slug="{first_subject_houses_list[i].name}" kr:horoscope="0">'
-        path += f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" style="stroke: {linecolor}; stroke-width: 1px; stroke-dasharray:3,2; stroke-opacity:.4;"/>'
-        path += "</g>"
+        parts.append(
+            f'<g kr:node="Cusp" kr:absoluteposition="{first_subject_houses_list[i].abs_pos}" kr:signposition="{first_subject_houses_list[i].position}" kr:sign="{first_subject_houses_list[i].sign}" kr:slug="{first_subject_houses_list[i].name}" kr:horoscope="0">'
+        )
+        parts.append(
+            f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" style="stroke: {linecolor}; stroke-width: 1px; stroke-dasharray:3,2; stroke-opacity:.4;"/>'
+        )
+        parts.append("</g>")
 
         # Add the house number text for the first subject
-        path += f'<g kr:node="HouseNumber" kr:house="{i + 1}" kr:horoscope="0">'
-        path += f'<text style="fill: var(--kerykeion-chart-color-house-number); fill-opacity: .6; font-size: 14px"><tspan x="{xtext - 3}" y="{ytext + 3}">{i + 1}</tspan></text>'
-        path += "</g>"
+        parts.append(f'<g kr:node="HouseNumber" kr:house="{i + 1}" kr:horoscope="0">')
+        parts.append(
+            f'<text style="fill: var(--kerykeion-chart-color-house-number); fill-opacity: .6; font-size: 14px"><tspan x="{xtext - 3}" y="{ytext + 3}">{i + 1}</tspan></text>'
+        )
+        parts.append("</g>")
 
-    return path
+    return "".join(parts)
 
 
 def draw_transit_aspect_list(

--- a/kerykeion/charts/draw_modern.py
+++ b/kerykeion/charts/draw_modern.py
@@ -403,9 +403,11 @@ def _draw_cusp_ring(
     Returns:
         SVG group string for the cusp ring.
     """
-    out = '<g kr:node="CuspRing">\n'
+    parts: list[str] = ['<g kr:node="CuspRing">\n']
 
-    out += f'<path d="{_annulus_path(R_CUSP_OUTER, R_CUSP_INNER)}" fill="{COLOR_BACKGROUND}" fill-rule="evenodd"/>\n'
+    parts.append(
+        f'<path d="{_annulus_path(R_CUSP_OUTER, R_CUSP_INNER)}" fill="{COLOR_BACKGROUND}" fill-rule="evenodd"/>\n'
+    )
 
     for house in houses:
         cusp_angle = _zodiac_to_wheel_angle(house.abs_pos, seventh_house_degree_ut)
@@ -425,7 +427,7 @@ def _draw_cusp_ring(
         # Upright angle counteracts global (-90) and group (-cusp_angle)
         angle_upright = 90 + cusp_angle
 
-        out += (
+        parts.append(
             f'  <g kr:node="Cusp" kr:absoluteposition="{house.abs_pos}" '
             f'kr:signposition="{house.position}" kr:sign="{sign_abbrev}" '
             f'kr:slug="{house.name}" '
@@ -434,7 +436,7 @@ def _draw_cusp_ring(
 
         if is_upper_half:
             # Minutes text
-            out += (
+            parts.append(
                 f'    <text text-anchor="middle" dominant-baseline="middle" '
                 f'x="{CENTER}" y="2.75" font-size="{CUSP_FONT_SIZE}" fill="{COLOR_TEXT}" '
                 f'font-weight="500" '
@@ -445,14 +447,14 @@ def _draw_cusp_ring(
 
             # Sign glyph
             final_scale = 0.12 * ZODIAC_OUTER_SCALE_MAP.get(sign_abbrev, 1.0)
-            out += (
+            parts.append(
                 f'    <g transform="translate({CENTER} 2.75) rotate({angle_upright:.6f}) scale({final_scale}) translate(-16 -16)">\n'
                 f'      <use xlink:href="#{sign_abbrev}" fill="{COLOR_TEXT}" />\n'
                 f"    </g>\n"
             )
 
             # Degrees text
-            out += (
+            parts.append(
                 f'    <text text-anchor="middle" dominant-baseline="middle" '
                 f'x="{CENTER}" y="2.75" font-size="{CUSP_FONT_SIZE}" fill="{COLOR_TEXT}" '
                 f'font-weight="500" '
@@ -463,7 +465,7 @@ def _draw_cusp_ring(
         else:
             # Alternate layout for lower half (mirrored text order)
             # Minutes text
-            out += (
+            parts.append(
                 f'    <text text-anchor="middle" dominant-baseline="middle" '
                 f'x="{CENTER}" y="2.75" font-size="{CUSP_FONT_SIZE}" fill="{COLOR_TEXT}" '
                 f'font-weight="500" '
@@ -474,14 +476,14 @@ def _draw_cusp_ring(
 
             # Sign glyph
             final_scale = 0.12 * ZODIAC_OUTER_SCALE_MAP.get(sign_abbrev, 1.0)
-            out += (
+            parts.append(
                 f'    <g transform="translate({CENTER} 2.75) rotate({angle_upright:.6f}) scale({final_scale}) translate(-16 -16)">\n'
                 f'      <use xlink:href="#{sign_abbrev}" fill="{COLOR_TEXT}" />\n'
                 f"    </g>\n"
             )
 
             # Degrees text
-            out += (
+            parts.append(
                 f'    <text text-anchor="middle" dominant-baseline="middle" '
                 f'x="{CENTER}" y="2.75" font-size="{CUSP_FONT_SIZE}" fill="{COLOR_TEXT}" '
                 f'font-weight="500" '
@@ -490,7 +492,7 @@ def _draw_cusp_ring(
                 f"{degrees}º</text>\n"
             )
 
-        out += "  </g>\n"
+        parts.append("  </g>\n")
 
     # Only draw signs that are NOT already represented by a house cusp.
     # Skip entirely when the outer zodiac background ring is active,
@@ -508,15 +510,15 @@ def _draw_cusp_ring(
                 upright_angle = 90 + sign_angle
                 final_scale = 0.12 * ZODIAC_OUTER_SCALE_MAP.get(sign_abbrev, 1.0)
 
-                out += (
+                parts.append(
                     f'<g transform="rotate(-{sign_angle:.6f} {CENTER} {CENTER}) '
                     f'translate({CENTER} 2.75) rotate({upright_angle:.6f}) scale({final_scale}) translate(-16 -16)">\n'
                     f'  <use xlink:href="#{sign_abbrev}" fill="{COLOR_TEXT}"/>\n'
                     f"</g>\n"
                 )
 
-    out += "</g>\n"
-    return out
+    parts.append("</g>\n")
+    return "".join(parts)
 
 
 # =============================================================================

--- a/kerykeion/eclipses/eclipse_factory.py
+++ b/kerykeion/eclipses/eclipse_factory.py
@@ -14,7 +14,6 @@ Eclipse type bit flags (pyswisseph uses both SE_ prefix and non-prefix):
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import List, Optional
 
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH

--- a/kerykeion/heliacal/heliacal_factory.py
+++ b/kerykeion/heliacal/heliacal_factory.py
@@ -18,7 +18,6 @@ This is part of Kerykeion (C) 2025 Giacomo Battaglia
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
 
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH

--- a/kerykeion/house_comparison/house_comparison_factory.py
+++ b/kerykeion/house_comparison/house_comparison_factory.py
@@ -13,16 +13,14 @@ from kerykeion.house_comparison.house_comparison_utils import (
     calculate_points_in_reciprocal_houses,
     calculate_cusps_in_reciprocal_houses,
 )
-from typing import TYPE_CHECKING, Union
+from typing import Union
 from kerykeion.settings.config_constants import DEFAULT_ACTIVE_POINTS
-from kerykeion.schemas.kr_models import HouseComparisonModel
+from kerykeion.schemas.kr_models import (
+    AstrologicalSubjectModel,
+    HouseComparisonModel,
+    PlanetReturnModel,
+)
 from kerykeion.schemas.kr_literals import AstrologicalPoint
-
-if TYPE_CHECKING:
-    from kerykeion.schemas.kr_models import (  # noqa: F401
-        AstrologicalSubjectModel,
-        PlanetReturnModel,
-    )
 
 
 class HouseComparisonFactory:

--- a/kerykeion/house_comparison/house_comparison_factory.py
+++ b/kerykeion/house_comparison/house_comparison_factory.py
@@ -13,11 +13,16 @@ from kerykeion.house_comparison.house_comparison_utils import (
     calculate_points_in_reciprocal_houses,
     calculate_cusps_in_reciprocal_houses,
 )
-from typing import Union
+from typing import TYPE_CHECKING, Union
 from kerykeion.settings.config_constants import DEFAULT_ACTIVE_POINTS
 from kerykeion.schemas.kr_models import HouseComparisonModel
-from kerykeion.schemas import AstrologicalSubjectModel, PlanetReturnModel
 from kerykeion.schemas.kr_literals import AstrologicalPoint
+
+if TYPE_CHECKING:
+    from kerykeion.schemas.kr_models import (  # noqa: F401
+        AstrologicalSubjectModel,
+        PlanetReturnModel,
+    )
 
 
 class HouseComparisonFactory:

--- a/kerykeion/moon_phase_details/factory.py
+++ b/kerykeion/moon_phase_details/factory.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import logging
 import math
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from typing import Optional
 
 from kerykeion.schemas.kr_models import (

--- a/kerykeion/moon_phase_details/utils.py
+++ b/kerykeion/moon_phase_details/utils.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import logging
 import math
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Optional
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
 

--- a/kerykeion/occultations/occultation_factory.py
+++ b/kerykeion/occultations/occultation_factory.py
@@ -32,7 +32,6 @@ License: AGPL-3.0
 import logging
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
 
-from pathlib import Path
 from pydantic import Field
 from typing import List
 

--- a/kerykeion/planetary_nodes/nodes_factory.py
+++ b/kerykeion/planetary_nodes/nodes_factory.py
@@ -14,7 +14,6 @@ Methods: NODBIT_MEAN (mean elements), NODBIT_OSCU (osculating/instantaneous)
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Dict, List, Optional
 
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH

--- a/kerykeion/planetary_phenomena/phenomena_factory.py
+++ b/kerykeion/planetary_phenomena/phenomena_factory.py
@@ -15,7 +15,6 @@ determine morning/evening star status.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import List, Optional
 
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH

--- a/kerykeion/planetary_return_factory.py
+++ b/kerykeion/planetary_return_factory.py
@@ -70,7 +70,6 @@ License: AGPL-3.0
 
 import calendar
 import logging
-from pathlib import Path
 
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
 

--- a/kerykeion/primary_directions/directions_factory.py
+++ b/kerykeion/primary_directions/directions_factory.py
@@ -19,7 +19,6 @@ This is part of Kerykeion (C) 2025 Giacomo Battaglia
 
 import math
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
-from pathlib import Path
 from typing import List, Optional, Literal
 from pydantic import BaseModel, Field
 

--- a/kerykeion/relocated_chart_factory.py
+++ b/kerykeion/relocated_chart_factory.py
@@ -12,13 +12,15 @@ Swiss Ephemeris function: ``swe.houses_armc(armc, lat, eps, hsys)``
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Optional
 
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
 
 from kerykeion.schemas.kr_models import AstrologicalSubjectModel
+from kerykeion.settings.config_constants import AXIAL_POINTS
 from kerykeion.utilities import get_kerykeion_point_from_degree, get_planet_house
+
+_AXIAL_POINTS_SET: frozenset[str] = frozenset(AXIAL_POINTS)
 
 _EPHE_PATH = EPHE_DATA_PATH
 
@@ -127,9 +129,8 @@ class RelocatedChartFactory:
         relocated_data["houses_names_list"] = houses_list
 
         # Reassign planets to new houses
-        axial_points = {"Ascendant", "Medium_Coeli", "Descendant", "Imum_Coeli"}
         for point_name in subject.active_points:
-            if point_name in axial_points:
+            if point_name in _AXIAL_POINTS_SET:
                 continue
             field_name = point_name.lower()
             point = relocated_data.get(field_name)

--- a/kerykeion/report.py
+++ b/kerykeion/report.py
@@ -17,6 +17,7 @@ from kerykeion.schemas.kr_models import (
     SingleChartDataModel,
     KerykeionPointModel,
 )
+from kerykeion.settings.config_constants import AXIAL_POINTS, LUNAR_NODES, MAIN_PLANETS
 
 
 ASPECT_SYMBOLS = {
@@ -41,10 +42,12 @@ MOVEMENT_SYMBOLS = {
 SubjectLike = Union[AstrologicalSubjectModel, CompositeSubjectModel, PlanetReturnModel]
 LiteralReportKind = Literal["subject", "single_chart", "dual_chart", "moon_phase_overview"]
 
-# Ordering constants for celestial point reports
-_MAIN_PLANETS = ["Sun", "Moon", "Mercury", "Venus", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune", "Pluto"]
-_NODES = ["Mean_North_Lunar_Node", "True_North_Lunar_Node"]
-_ANGLES = ["Ascendant", "Medium_Coeli", "Descendant", "Imum_Coeli"]
+# Ordering constants for celestial point reports.
+# Canonical definitions live in `kerykeion.settings.config_constants`; the module-private
+# aliases below are kept so downstream code referring to them keeps working unchanged.
+_MAIN_PLANETS = list(MAIN_PLANETS)
+_NODES = list(LUNAR_NODES)
+_ANGLES = list(AXIAL_POINTS)
 
 
 def _humanize(name: str) -> str:
@@ -516,12 +519,13 @@ class ReportGenerator:
         if not points:
             return "No celestial points data available."
 
+        points_by_name = {p.name: p for p in points}
         sorted_points = []
         for name in _ANGLES + _MAIN_PLANETS + _NODES:
-            sorted_points.extend([p for p in points if p.name == name])
-
-        used_names = set(_ANGLES + _MAIN_PLANETS + _NODES)
-        sorted_points.extend([p for p in points if p.name not in used_names])
+            point = points_by_name.pop(name, None)
+            if point is not None:
+                sorted_points.append(point)
+        sorted_points.extend(points_by_name.values())
 
         celestial_data: list[list[str]] = [["Point", "Sign", "Position", "Speed", "Decl.", "Ret.", "House"]]
         for point in sorted_points:

--- a/kerykeion/report.py
+++ b/kerykeion/report.py
@@ -519,13 +519,19 @@ class ReportGenerator:
         if not points:
             return "No celestial points data available."
 
-        points_by_name = {p.name: p for p in points}
-        sorted_points = []
+        ordered_names = set(_ANGLES + _MAIN_PLANETS + _NODES)
+        grouped_points: dict[str, list] = {}
+        remaining_points: list = []
+        for point in points:
+            if point.name in ordered_names:
+                grouped_points.setdefault(point.name, []).append(point)
+            else:
+                remaining_points.append(point)
+
+        sorted_points: list = []
         for name in _ANGLES + _MAIN_PLANETS + _NODES:
-            point = points_by_name.pop(name, None)
-            if point is not None:
-                sorted_points.append(point)
-        sorted_points.extend(points_by_name.values())
+            sorted_points.extend(grouped_points.get(name, []))
+        sorted_points.extend(remaining_points)
 
         celestial_data: list[list[str]] = [["Point", "Sign", "Position", "Speed", "Decl.", "Ret.", "House"]]
         for point in sorted_points:

--- a/kerykeion/settings/config_constants.py
+++ b/kerykeion/settings/config_constants.py
@@ -559,9 +559,14 @@ POINT_NUMBER_MAP: dict[str, int] = {
     "Imum_Coeli": 9903,
 }
 """
-Full mapping of astrological point names to Swiss Ephemeris IDs, including
-synthetic IDs (>=1000) for points that don't have a native SE identifier
-(South Nodes, axial cusps, White Moon).
+Swiss Ephemeris–compatible subset of astrological points: bodies with native SE
+IDs plus synthetic IDs (>=1000) for points that can still be looked up by this
+map (South Nodes, axial cusps, White Moon).
+
+This is NOT a full mapping of all `AstrologicalPoint` values. Many active points
+(Vertex, Arabic parts / Lots, fixed stars, TNOs, etc.) are intentionally absent
+because they are not used by the call sites that consume this constant. Callers
+that can receive arbitrary `AstrologicalPoint` names must handle `KeyError`.
 """
 
 MAIN_PLANETS: list[AstrologicalPoint] = [

--- a/kerykeion/settings/config_constants.py
+++ b/kerykeion/settings/config_constants.py
@@ -496,3 +496,98 @@ DISCEPOLO_SCORE_ACTIVE_ASPECTS: list[ActiveAspect] = [
 """
 List of active aspects with their orbs according to Ciro Discepolo's affinity scoring methodology.
 """
+
+
+# =============================================================================
+# POINT ID MAPPINGS (Swiss Ephemeris)
+# =============================================================================
+# Centralized celestial point name -> Swiss Ephemeris ID mappings.
+# Previously duplicated in `utilities.py` (_POINT_NUMBER_MAP) and
+# `astrological_subject_factory.py` (STANDARD_PLANETS); unified here to
+# eliminate drift between the two. Historic symbols remain re-exported in
+# those modules for backward compatibility.
+
+STANDARD_PLANETS: dict[AstrologicalPoint, int] = {
+    "Sun": 0,
+    "Moon": 1,
+    "Mercury": 2,
+    "Venus": 3,
+    "Mars": 4,
+    "Jupiter": 5,
+    "Saturn": 6,
+    "Uranus": 7,
+    "Neptune": 8,
+    "Pluto": 9,
+    "Mean_North_Lunar_Node": 10,
+    "True_North_Lunar_Node": 11,
+    "Mean_Lilith": 12,
+    "True_Lilith": 13,
+    "Earth": 14,
+    "Chiron": 15,
+    "Pholus": 16,
+    "Ceres": 17,
+    "Pallas": 18,
+    "Juno": 19,
+    "Vesta": 20,
+    # Interpolated lunar apse points (SwissEph IDs 21-22)
+    "Interpolated_Lilith": 21,  # SE_INTP_APOG -- proper interpolated apogee
+    "Interpolated_Perigee": 22,  # SE_INTP_PERG -- proper interpolated perigee
+    # Uranian / Hamburg School hypothetical planets (SwissEph IDs 40-47)
+    "Cupido": 40,
+    "Hades": 41,
+    "Zeus": 42,
+    "Kronos": 43,
+    "Apollon": 44,
+    "Admetos": 45,
+    "Vulkanus": 46,
+    "Poseidon": 47,
+}
+"""
+Standard planets with direct Swiss Ephemeris IDs (0-22, 40-47).
+Used for `swe.calc_ut()` calls where the planet identifier is a native SE code.
+"""
+
+POINT_NUMBER_MAP: dict[str, int] = {
+    **STANDARD_PLANETS,
+    # Extra points without Swiss Ephemeris IDs
+    "Mean_South_Lunar_Node": 1000,
+    "True_South_Lunar_Node": 1100,
+    "White_Moon": 56,  # SE_WHITE_MOON / Selena
+    "Ascendant": 9900,
+    "Descendant": 9901,
+    "Medium_Coeli": 9902,
+    "Imum_Coeli": 9903,
+}
+"""
+Full mapping of astrological point names to Swiss Ephemeris IDs, including
+synthetic IDs (>=1000) for points that don't have a native SE identifier
+(South Nodes, axial cusps, White Moon).
+"""
+
+MAIN_PLANETS: list[AstrologicalPoint] = [
+    "Sun",
+    "Moon",
+    "Mercury",
+    "Venus",
+    "Mars",
+    "Jupiter",
+    "Saturn",
+    "Uranus",
+    "Neptune",
+    "Pluto",
+]
+"""The ten main planets (Sun, Moon, Mercury..Pluto) in canonical report order."""
+
+LUNAR_NODES: list[AstrologicalPoint] = [
+    "Mean_North_Lunar_Node",
+    "True_North_Lunar_Node",
+]
+"""North lunar nodes (mean and true). South nodes are derived via OPPOSITE_PAIRS."""
+
+AXIAL_POINTS: list[AstrologicalPoint] = [
+    "Ascendant",
+    "Medium_Coeli",
+    "Descendant",
+    "Imum_Coeli",
+]
+"""The four axial cusps (angles) of the horoscope."""

--- a/kerykeion/transits_time_range_factory.py
+++ b/kerykeion/transits_time_range_factory.py
@@ -420,14 +420,18 @@ class TransitsTimeRangeFactory:
                 return None
 
             # Build the aspect settings filter for the target aspect
-            aspect_settings = [s for s in DEFAULT_CHART_ASPECTS_SETTINGS if s["name"] == aspect_name]
-            if not aspect_settings:
+            matching_setting = next(
+                (s for s in DEFAULT_CHART_ASPECTS_SETTINGS if s["name"] == aspect_name),
+                None,
+            )
+            if matching_setting is None:
                 return None
+            aspect_settings = [matching_setting]
 
             # Resolve matching active_aspect orb
             for aa in self.active_aspects:
                 if aa["name"] == aspect_name:
-                    aspect_settings = [dict(aspect_settings[0])]
+                    aspect_settings = [dict(matching_setting)]
                     aspect_settings[0]["orb"] = aa["orb"]
                     break
 

--- a/kerykeion/utilities.py
+++ b/kerykeion/utilities.py
@@ -31,6 +31,7 @@ from kerykeion.schemas.kr_literals import (
     AstrologicalPoint,
     Houses,
 )
+from kerykeion.settings.config_constants import POINT_NUMBER_MAP as _POINT_NUMBER_MAP_IMPORT
 from typing import Union, Optional, get_args, cast
 from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL, basicConfig, getLogger
 import math
@@ -41,6 +42,15 @@ from datetime import datetime
 logger = getLogger(__name__)
 
 
+# Pre-compiled regex patterns (invariant, compiled once at module load)
+_CSS_VARIABLE_PATTERN = re.compile(r"--([a-zA-Z0-9_-]+)\s*:\s*([^;]+);")
+
+# Cached get_args() tuples (type introspection is expensive, values are invariant)
+_HOUSE_NAMES_TUPLE: tuple[Houses, ...] = get_args(Houses)
+_LUNAR_PHASE_EMOJIS: tuple[LunarPhaseEmoji, ...] = get_args(LunarPhaseEmoji)
+_LUNAR_PHASE_NAMES: tuple[LunarPhaseName, ...] = get_args(LunarPhaseName)
+
+
 # =============================================================================
 # CONSTANTS AND MAPPINGS
 # =============================================================================
@@ -48,53 +58,11 @@ logger = getLogger(__name__)
 # Maximum latitude for reliable house calculations
 _POLAR_LATITUDE_LIMIT = 66.0
 
-# Mapping of astrological point names to Swiss Ephemeris IDs
-# NOTE: The main planets (Sun through Poseidon) are defined in STANDARD_PLANETS
-# in astrological_subject_factory.py. The entries below include those plus
-# extra points (South Nodes, White Moon, Axial Cusps) that don't have SE IDs.
-# Kept explicit here to avoid circular imports with astrological_subject_factory.
-_POINT_NUMBER_MAP: dict[str, int] = {
-    # Main planets (must match STANDARD_PLANETS in astrological_subject_factory.py)
-    "Sun": 0,
-    "Moon": 1,
-    "Mercury": 2,
-    "Venus": 3,
-    "Mars": 4,
-    "Jupiter": 5,
-    "Saturn": 6,
-    "Uranus": 7,
-    "Neptune": 8,
-    "Pluto": 9,
-    "Mean_North_Lunar_Node": 10,
-    "True_North_Lunar_Node": 11,
-    "Mean_Lilith": 12,
-    "True_Lilith": 13,
-    "Earth": 14,
-    "Chiron": 15,
-    "Pholus": 16,
-    "Ceres": 17,
-    "Pallas": 18,
-    "Juno": 19,
-    "Vesta": 20,
-    "Interpolated_Lilith": 21,  # SE_INTP_APOG
-    "Interpolated_Perigee": 22,  # SE_INTP_PERG
-    "Cupido": 40,
-    "Hades": 41,
-    "Zeus": 42,
-    "Kronos": 43,
-    "Apollon": 44,
-    "Admetos": 45,
-    "Vulkanus": 46,
-    "Poseidon": 47,
-    # Extra points without Swiss Ephemeris IDs
-    "Mean_South_Lunar_Node": 1000,
-    "True_South_Lunar_Node": 1100,
-    "White_Moon": 56,  # SE_WHITE_MOON / Selena
-    "Ascendant": 9900,
-    "Descendant": 9901,
-    "Medium_Coeli": 9902,
-    "Imum_Coeli": 9903,
-}
+# Mapping of astrological point names to Swiss Ephemeris IDs.
+# Canonical definition lives in `kerykeion.settings.config_constants.POINT_NUMBER_MAP`
+# (shared with STANDARD_PLANETS in astrological_subject_factory). The historical
+# module-private alias is preserved here for backward compatibility.
+_POINT_NUMBER_MAP: dict[str, int] = _POINT_NUMBER_MAP_IMPORT
 
 # Zodiac sign properties lookup table
 _ZODIAC_SIGNS: dict[int, ZodiacSignModel] = {
@@ -325,14 +293,12 @@ def get_planet_house(planet_degree: Union[int, float], houses_degree_ut_list: li
     Raises:
         ValueError: If the planet's position doesn't fall within any house range
     """
-    house_names = get_args(Houses)
-
-    for i in range(len(house_names)):
+    for i in range(len(_HOUSE_NAMES_TUPLE)):
         start_degree = houses_degree_ut_list[i]
         end_degree = houses_degree_ut_list[(i + 1) % len(houses_degree_ut_list)]
 
         if is_point_between(start_degree, end_degree, planet_degree):
-            return house_names[i]
+            return _HOUSE_NAMES_TUPLE[i]
 
     raise ValueError(f"Error in house calculation, planet: {planet_degree}, houses: {houses_degree_ut_list}")
 
@@ -478,9 +444,8 @@ def get_moon_emoji_from_phase_int(phase: int) -> LunarPhaseEmoji:
     Raises:
         KerykeionException: If phase is outside valid range
     """
-    lunar_phase_emojis = get_args(LunarPhaseEmoji)
     index = _get_lunar_phase_index(phase)
-    return lunar_phase_emojis[index]
+    return _LUNAR_PHASE_EMOJIS[index]
 
 
 def get_moon_phase_name_from_phase_int(phase: int) -> LunarPhaseName:
@@ -496,9 +461,8 @@ def get_moon_phase_name_from_phase_int(phase: int) -> LunarPhaseName:
     Raises:
         KerykeionException: If phase is outside valid range
     """
-    lunar_phase_names = get_args(LunarPhaseName)
     index = _get_lunar_phase_index(phase)
-    return lunar_phase_names[index]
+    return _LUNAR_PHASE_NAMES[index]
 
 
 def check_and_adjust_polar_latitude(latitude: float) -> float:
@@ -797,8 +761,7 @@ def inline_css_variables_in_svg(svg_content: str) -> str:
     style_blocks = style_tag_pattern.findall(svg_content)
 
     for style_block in style_blocks:
-        css_variable_pattern = re.compile(r"--([a-zA-Z0-9_-]+)\s*:\s*([^;]+);")
-        for match in css_variable_pattern.finditer(style_block):
+        for match in _CSS_VARIABLE_PATTERN.finditer(style_block):
             variable_name = match.group(1)
             variable_value = match.group(2).strip()
             css_variable_map[f"--{variable_name}"] = variable_value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kerykeion"
-version = "6.0.0a24"
+version = "6.0.0a25"
 authors = [
     { name = "Giacomo Battaglia", email = "kerykeion.astrology@gmail.com" }
 ]

--- a/release_notes/v6.0.0a25.md
+++ b/release_notes/v6.0.0a25.md
@@ -1,0 +1,55 @@
+# v6.0.0a25
+
+## Hot-path performance refactor + targeted bug fixes
+
+This alpha bundles the `REFACTORY.md` TIER 0-2 performance work with three bug fixes surfaced by Codex and CodeRabbit review. All changes preserve public API, model schemas, and SVG output — 260 SHA-256 signatures across the chart matrix are byte-identical.
+
+### Performance
+
+Hot paths profiled in v6.0.0a24 have been optimized with local, low-risk rewrites. The measured speedups are (min-of-N, best-of-2):
+
+| Benchmark | Before | After | Δ | Factor |
+| --- | --- | --- | --- | --- |
+| `svg_natal` | 2.52 ms | 1.53 ms | −39.3% | 1.65x |
+| `house_comparison` | 336 µs | 258 µs | −23.4% | 1.30x |
+| `custom_aspects_squares` | 159 µs | 127 µs | −20.5% | 1.26x |
+| `composite_midpoint` | 175 µs | 141 µs | −19.4% | 1.24x |
+| `svg_synastry` | 3.26 ms | 2.68 ms | −17.7% | 1.21x |
+| `transits_time_range` | 7.43 ms | 6.28 ms | −15.4% | 1.18x |
+| `chart_data_natal` | 373 µs | 322 µs | −13.7% | 1.16x |
+| `natal_aspects` | 303 µs | 265 µs | −12.6% | 1.14x |
+| `relocated_chart` | 1.34 ms | 1.21 ms | −9.9% | 1.11x |
+
+6 further benchmarks improved 1–5%. 15/15 faster, 0 regressions.
+
+Key changes:
+
+- Centralize `STANDARD_PLANETS`, `POINT_NUMBER_MAP`, `AXIAL_POINTS` in `kerykeion.settings.config_constants` (no more per-module duplicates).
+- Pre-index the aspect grid lookup: `O(n² · k)` → `O(n² + k)` in `draw_aspect_grid`.
+- Cache `typing.get_args()` results on literals accessed in hot paths.
+- `O(n + m)` merge of orb overrides for active aspects (was quadratic).
+- List + `"".join(...)` instead of repeated string concatenation in SVG construction.
+
+### Bug fixes
+
+- **Aspects**: `AspectsFactory._update_aspect_settings` preserves first-wins semantics when `active_aspects` contains duplicate names. The previous dict-comprehension refactor had silently introduced last-wins behavior.
+- **Public-API type introspection**: restore runtime availability of model types (`AstrologicalSubjectModel`, `PlanetReturnModel`, `HouseComparisonModel`, `ChartDataModel`, `AspectModel`, `CompositeSubjectModel`, `KerykeionPointModel`, `ChartType`, `KerykeionException`, `AstrologicalPoint`) in modules that expose them as public annotations. The perf refactor had moved these imports under `if TYPE_CHECKING:`, which would break `typing.get_type_hints()` for frameworks that rely on runtime type resolution (FastAPI, Pydantic-backed APIs, etc.).
+- **Gauquelin charts**: `_setup_gauquelin_sectors` now clears `template_dict["makeHouseSectors"]` when Gauquelin mode is active. The 12-wedge hit-area overlay was inconsistent with the 36-sector visible ring and would mislead any frontend using it for click/hover targeting.
+
+### Public API hygiene
+
+Three small clarifications from CodeRabbit review:
+
+- `kerykeion.astrological_subject_factory.STANDARD_PLANETS` is re-exported as `dict(_STANDARD_PLANETS_CANONICAL)` — a shallow copy — so downstream mutation of the public symbol no longer contaminates the canonical constant in `config_constants`.
+- `ReportGenerator._celestial_points_report` preserves duplicate `active_points` entries when ordering the report (previously collapsed by a dict keyed on `point.name`).
+- `POINT_NUMBER_MAP` docstring rewritten: it is a Swiss Ephemeris–compatible subset, not a full `AstrologicalPoint` map. Callers that can receive arbitrary point names must handle `KeyError`.
+
+### Migration
+
+None. No breaking changes.
+
+### Validation
+
+- `poe test:core`: 2564 / 2564 passed.
+- `poe test:extended`: 8922 / 8922 passed, 123 skipped (online).
+- 260 SHA-256 SVG signatures byte-identical across the full chart matrix (natal, synastry, transit, composite, dual-return, ACG, Gauquelin, sidereal modes, topocentric / heliocentric / barycentric, themes, languages, toggles).

--- a/uv.lock
+++ b/uv.lock
@@ -446,7 +446,7 @@ wheels = [
 
 [[package]]
 name = "kerykeion"
-version = "6.0.0a24"
+version = "6.0.0a25"
 source = { editable = "." }
 dependencies = [
     { name = "libephemeris" },


### PR DESCRIPTION
## Summary
- Implementation of REFACTORY.md plan (TIER 0, 1.1/1.4/1.5/1.7/1.8, 2.2/2.4/2.5/2.8)
- Zero breaking changes: 260 SHA-256 signatures byte-identical across all chart types, house systems, sidereal modes, perspectives, geographic/temporal extremes
- Central constants unification, aspect loop optimization, SVG list+join, pre-indexed aspect grid, cached `get_args()`, O(n+m) orb merge, `AXIAL_POINTS` frozenset, matching-setting lookup

## Validation
- `poe test:extended`: **8922 passed, 0 failed**, 123 skipped (online), 210s
- `poe test:core`: **2564 passed, 0 failed**
- **260 SHA-256 firme byte-identiche** tra pre- e post-refactor (stash diff)
  - 47 baseline (subject, aspects, svg, report, composite, relocated, etc.)
  - 15 extended (Arabic parts, sidereal modes, house comparison, …)
  - 105 deep (all 23 house systems, geographic/temporal edges, themes, languages, styles, returns, transits, eclipses, occultations, ACG, primary directions, fixed stars, nodes, dignities, JSON round-trip)
  - 93 megadeep (asteroids, TNOs, Uranian, Arabic parts full set, SVG toggles, zodiac×perspective matrix, synastry inversion, polar chart, altitude variations, …)

## Performance (min-of-N, best-of-2 runs, 40-500 iter/bench)

| Benchmark | Before | After | Δ% | Speedup |
|---|---|---|---|---|
| `svg_natal` | 2.52 ms | 1.53 ms | −39.3% | 1.65x |
| `house_comparison` | 336 µs | 258 µs | −23.4% | 1.30x |
| `custom_aspects_squares` | 159 µs | 127 µs | −20.5% | 1.26x |
| `composite_midpoint` | 175 µs | 141 µs | −19.4% | 1.24x |
| `svg_synastry` | 3.26 ms | 2.68 ms | −17.7% | 1.21x |
| `transits_time_range_10d` | 7.43 ms | 6.28 ms | −15.4% | 1.18x |
| `chart_data_natal` | 373 µs | 322 µs | −13.7% | 1.16x |
| `natal_aspects` | 303 µs | 265 µs | −12.6% | 1.14x |
| `relocated_chart` | 1.34 ms | 1.21 ms | −9.9% | 1.11x |
| `report_generator` | 822 µs | 784 µs | −4.6% | 1.05x |
| `synastry_aspects` | 508 µs | 490 µs | −3.5% | 1.04x |
| `subject_from_birth_data` | 1.58 ms | 1.53 ms | −2.8% | 1.03x |
| `chart_data_synastry` | 1.38 ms | 1.35 ms | −2.2% | 1.02x |
| `moon_phase_details` | 301.6 ms | 295.3 ms | −2.1% | 1.02x |
| `svg_natal_minified` | 79.4 ms | 78.4 ms | −1.2% | 1.01x |

**15/15 più veloci, 0 regressioni.**

## TIER implementati
- **TIER 0**: cleanup completo (import morti, regex, lambdas, backwards-compat shims)
- **TIER 1.1**: cache di `get_args()` a livello modulo → validazione subject più rapida
- **TIER 1.4**: pre-index `draw_aspect_grid` per O(1) lookup invece di `next(filter(...))`
- **TIER 1.5**: `list+join` nei loop SVG caldi (sostituisce concatenazione di stringhe)
- **TIER 1.7+1.8**: unificazione costanti in `config_constants.py` (STANDARD_PLANETS, POINT_NUMBER_MAP, MAIN_PLANETS, LUNAR_NODES, AXIAL_POINTS) con alias retrocompatibili
- **TIER 2.2**: `ReportGenerator` sorting con lookup dict invece di list scan
- **TIER 2.4**: `AspectsFactory` enumerate+cache (nomi, abs_pos, speed, axes hoisted fuori loop)
- **TIER 2.5**: merge orb settings O(n+m) invece di O(n×m)
- **TIER 2.8**: `TransitsTimeRangeFactory` matching-setting lookup

## TIER skippati con giustificazione
- **TIER 1.6**: plan premise errata (`_compute_is_diurnal` chiamato prima di `_calculate_planets`)
- **TIER 2.3**: `ActiveAspect` è `TypedDict`, non Pydantic — no `.model_dump()`
- **TIER 2.6/2.7**: ROI basso e rischio di aliasing/mutazione
- **TIER 3.3**: pyright 1.1.408 blocca `@dataclass(slots=True)` con errori a cascata; roll-back per preservare gate 0 cleanliness. Plan esplicitamente "priorità molto bassa"

## Test plan
- [x] `poe test:extended` — 8922 pass
- [x] `poe test:core` — 2564 pass
- [x] 260 SHA-256 signatures byte-identical
- [x] Ruff linter — nessun nuovo errore (4 preesistenti)
- [x] pyright — baseline invariata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a refactoring/optimization roadmap for v6.0.0a24.

* **Refactor**
  * Improved performance of aspect calculations, chart/report ordering, and SVG rendering.
  * Introduced cached lookups to speed utility functions and reduce repeated work.
  * Centralized celestial/configuration constants for consistent ordering.

* **Chores**
  * Removed multiple unused imports for cleaner code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->