### PR TITLE
Release v6.0.0a30: backward planetary-return search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## 6.0.0a30
+
+_2026-04-21_
+
+**Backward planetary-return search — `next_return_from_iso_formatted_time` / `next_return_from_date` / `next_lunar_node_crossing*` now accept `backwards=True`, matching the existing heliocentric API.**
+
+### New Features
+
+- **`backwards: bool = False` on all planetary-return entry points.** When
+  `True`, the factory calls into libephemeris' new backward-capable crossing
+  primitives and returns the most recent *past* return (or node crossing)
+  instead of the next upcoming one. Added to:
+  - `PlanetaryReturnFactory.next_return_from_iso_formatted_time(iso, return_type, backwards=False)`
+  - `PlanetaryReturnFactory.next_return_from_date(year, month, day, return_type, backwards=False)`
+  - `PlanetaryReturnFactory.next_lunar_node_crossing(julian_day, backwards=False)`
+  - `PlanetaryReturnFactory.next_lunar_node_crossing_from_iso_formatted_time(iso, backwards=False)`
+  - `PlanetaryReturnFactory.next_lunar_node_crossing_from_date(year, month, day, backwards=False)`
+  - `PlanetaryReturnFactory.next_heliocentric_return_from_date(planet, year, month, day, backwards=False)`
+
+### Backend Requirements
+
+Backward search relies on libephemeris `>= 1.1.0`, which added the `backwards`
+flag to `swe_solcross_ut`, `swe_mooncross_ut`, and `swe_mooncross_node_ut`.
+When kerykeion is running on **pyswisseph** (fallback backend), attempting
+backward search raises `KerykeionException` with a clear message directing
+the caller to install libephemeris.
+
+### Why
+
+Consumers of return charts (API servers, SDKs, UIs) always want symmetric
+navigation — "previous solar return" is as common as "next". Without a native
+backward flag, callers had to fake it by seeding the search one mean cycle
+before the target date, which fails near cycle boundaries (lunar node mean
+motion varies ±1 day per half-cycle; lunar mean motion ±0.1 d). This is the
+library-level counterpart to libephemeris 1.1.0's backward crossing support.
+
+### Tests
+
+- 12 new tests in `tests/core/test_planetary_return_backwards.py`:
+  - `TestSolarBackwards` — single-step backward, one-cycle boundary invariant,
+    date-wrapper round-trip.
+  - `TestLunarBackwards` — single-step backward, sidereal-month boundary.
+  - `TestLunarNodeCrossingBackwards` — single-step, half-nodal-month boundary,
+    date-wrapper round-trip.
+  - `TestHeliocentricBackwards` — Jupiter one-cycle (4200–4500 day) boundary.
+  - `TestSwissephFallback` — simulates pyswisseph backend via `unittest.mock`,
+    asserts `KerykeionException` with `libephemeris` in the message for each
+    of the three backward-capable entry points.
+
+### Dependencies
+
+- Bumped primary pin: `libephemeris == 1.1.0` (was `== 1.0.0a15`).
+- Bumped `all` extra: `libephemeris >= 1.1.0` (was `>= 1.0.0a13`).
+
+### Compatibility
+
+Fully backward-compatible. `backwards=False` is the default everywhere;
+existing code paths are unchanged.
+
 ## 6.0.0a29
 
 _2026-04-21_

--- a/kerykeion/planetary_return_factory.py
+++ b/kerykeion/planetary_return_factory.py
@@ -404,7 +404,7 @@ class PlanetaryReturnFactory:
             self.tz_str = self.city_data["timezonestr"]
 
     def next_return_from_iso_formatted_time(
-        self, iso_formatted_time: str, return_type: ReturnType
+        self, iso_formatted_time: str, return_type: ReturnType, backwards: bool = False
     ) -> PlanetReturnModel:
         """
         Calculate the next planetary return occurring after a specified ISO-formatted datetime.
@@ -507,19 +507,43 @@ class PlanetaryReturnFactory:
                 raise KerykeionException(
                     "Sun position is required for Solar return but is not available in the subject."
                 )
-            return_julian_date = swe.solcross_ut(
-                self.subject.sun.abs_pos,
-                julian_day,
-            )
+            if backwards:
+                try:
+                    return_julian_date = swe.solcross_ut(
+                        self.subject.sun.abs_pos,
+                        julian_day,
+                        backwards=True,
+                    )
+                except TypeError:
+                    raise KerykeionException(
+                        "Backward Solar return search requires the libephemeris backend."
+                    )
+            else:
+                return_julian_date = swe.solcross_ut(
+                    self.subject.sun.abs_pos,
+                    julian_day,
+                )
         elif return_type == "Lunar":
             if self.subject.moon is None:
                 raise KerykeionException(
                     "Moon position is required for Lunar return but is not available in the subject."
                 )
-            return_julian_date = swe.mooncross_ut(
-                self.subject.moon.abs_pos,
-                julian_day,
-            )
+            if backwards:
+                try:
+                    return_julian_date = swe.mooncross_ut(
+                        self.subject.moon.abs_pos,
+                        julian_day,
+                        backwards=True,
+                    )
+                except TypeError:
+                    raise KerykeionException(
+                        "Backward Lunar return search requires the libephemeris backend."
+                    )
+            else:
+                return_julian_date = swe.mooncross_ut(
+                    self.subject.moon.abs_pos,
+                    julian_day,
+                )
         else:
             raise KerykeionException(f"Invalid return type {return_type}. Use 'Solar' or 'Lunar'.")
 
@@ -651,7 +675,7 @@ class PlanetaryReturnFactory:
         return self.next_return_from_date(year, 1, 1, return_type=return_type)
 
     def next_return_from_date(
-        self, year: int, month: int, day: int = 1, *, return_type: ReturnType
+        self, year: int, month: int, day: int = 1, *, return_type: ReturnType, backwards: bool = False
     ) -> PlanetReturnModel:
         """
         Calculate the first planetary return occurring on or after a specified date.
@@ -713,7 +737,7 @@ class PlanetaryReturnFactory:
         start_date = datetime(year, month, day, 0, 0, tzinfo=timezone.utc)
 
         # Get the return using the existing method
-        return self.next_return_from_iso_formatted_time(start_date.isoformat(), return_type)
+        return self.next_return_from_iso_formatted_time(start_date.isoformat(), return_type, backwards=backwards)
 
     def next_return_from_month_and_year(self, year: int, month: int, return_type: ReturnType) -> PlanetReturnModel:
         """
@@ -791,6 +815,7 @@ class PlanetaryReturnFactory:
     def next_lunar_node_crossing(
         self,
         start_jd: float,
+        backwards: bool = False,
     ) -> PlanetReturnModel:
         """Find the next moment when the Moon crosses its own node.
 
@@ -799,12 +824,23 @@ class PlanetaryReturnFactory:
 
         Args:
             start_jd: Julian Day to start searching from.
+            backwards: If True, search backward in time. Requires the
+                libephemeris backend; pyswisseph does not support this.
 
         Returns:
             PlanetReturnModel for the node crossing chart.
         """
         swe.set_ephe_path(EPHE_DATA_PATH)
-        result = swe.mooncross_node_ut(start_jd, swe.FLG_SWIEPH)
+        if backwards:
+            try:
+                result = swe.mooncross_node_ut(start_jd, swe.FLG_SWIEPH, backwards=True)
+            except TypeError:
+                swe.close()
+                raise KerykeionException(
+                    "Backward lunar node crossing search requires the libephemeris backend."
+                )
+        else:
+            result = swe.mooncross_node_ut(start_jd, swe.FLG_SWIEPH)
         crossing_jd = result[0]
         swe.close()
 
@@ -868,6 +904,7 @@ class PlanetaryReturnFactory:
         year: int,
         month: int,
         day: int = 1,
+        backwards: bool = False,
     ) -> PlanetReturnModel:
         """First heliocentric return on or after a specific date (UTC).
 
@@ -878,6 +915,7 @@ class PlanetaryReturnFactory:
             year: Calendar year.
             month: Month (1-12).
             day: Day of month (default 1).
+            backwards: Search backward instead of forward.
 
         Returns:
             PlanetReturnModel for the heliocentric return chart.
@@ -891,18 +929,21 @@ class PlanetaryReturnFactory:
         return self.next_heliocentric_return(
             planet_name=planet_name,
             start_jd=datetime_to_julian(start),
+            backwards=backwards,
         )
 
     def next_lunar_node_crossing_from_iso_formatted_time(
         self,
         iso_formatted_time: str,
+        backwards: bool = False,
     ) -> PlanetReturnModel:
-        """Lunar node crossing searching forward from an ISO datetime.
+        """Lunar node crossing searching forward (or backward) from an ISO datetime.
 
         Mirrors :meth:`next_return_from_iso_formatted_time` (Solar/Lunar).
 
         Args:
             iso_formatted_time: ISO 8601 datetime string to start from.
+            backwards: Search backward instead of forward.
 
         Returns:
             PlanetReturnModel for the node crossing chart.
@@ -910,7 +951,10 @@ class PlanetaryReturnFactory:
         dt = datetime.fromisoformat(iso_formatted_time)
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
-        return self.next_lunar_node_crossing(start_jd=datetime_to_julian(dt))
+        return self.next_lunar_node_crossing(
+            start_jd=datetime_to_julian(dt),
+            backwards=backwards,
+        )
 
     def next_lunar_node_crossing_from_year(
         self,
@@ -934,6 +978,7 @@ class PlanetaryReturnFactory:
         year: int,
         month: int,
         day: int = 1,
+        backwards: bool = False,
     ) -> PlanetReturnModel:
         """First lunar node crossing on or after a specific date (UTC).
 
@@ -943,6 +988,7 @@ class PlanetaryReturnFactory:
             year: Calendar year.
             month: Month (1-12).
             day: Day of month (default 1).
+            backwards: Search backward instead of forward.
 
         Returns:
             PlanetReturnModel for the node crossing chart.
@@ -953,7 +999,10 @@ class PlanetaryReturnFactory:
         if day < 1 or day > max_day:
             raise KerykeionException(f"Invalid day {day} for {year}-{month:02d}. Day must be between 1 and {max_day}.")
         start = datetime(year, month, day, 0, 0, tzinfo=timezone.utc)
-        return self.next_lunar_node_crossing(start_jd=datetime_to_julian(start))
+        return self.next_lunar_node_crossing(
+            start_jd=datetime_to_julian(start),
+            backwards=backwards,
+        )
 
     # ── Internal helpers ─────────────────────────────────────────────────────
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kerykeion"
-version = "6.0.0a29"
+version = "6.0.0a30"
 authors = [
     { name = "Giacomo Battaglia", email = "kerykeion.astrology@gmail.com" }
 ]
@@ -45,7 +45,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "libephemeris==1.0.0a15",
+    "libephemeris==1.1.0",
     "pydantic>=2.5",
     "svg-polish>=1.0.0",
     "requests-cache>=1.2.1",
@@ -57,7 +57,10 @@ dependencies = [
 
 [project.optional-dependencies]
 swiss = ["pyswisseph>=2.10.3.1"]
-all = ["pyswisseph>=2.10.3.1", "libephemeris>=1.0.0a13"]
+all = ["pyswisseph>=2.10.3.1", "libephemeris>=1.1.0"]
+
+[tool.uv.sources]
+libephemeris = { path = "../libephemeris", editable = true }
 
 [project.urls]
 Homepage = "https://www.kerykeion.net/"

--- a/release_notes/v6.0.0a30.md
+++ b/release_notes/v6.0.0a30.md
@@ -1,0 +1,64 @@
+# v6.0.0a30
+
+## Backward planetary-return search
+
+This alpha exposes a `backwards: bool = False` parameter across all planetary-return entry points on `PlanetaryReturnFactory`. When `True`, the factory calls into libephemeris 1.1.0's new backward-capable crossing primitives and returns the most recent *past* return (or node crossing) instead of the next upcoming one. It is the library-level counterpart to libephemeris 1.1.0's native backward crossing support.
+
+### Why
+
+Consumers of return charts — API servers, SDKs, UI navigators — always want symmetric navigation. "Previous solar return" is as common a user action as "next". Before this release, callers had to fake backward search by seeding a forward search one mean cycle before the target date. That approach:
+
+- Fails near cycle boundaries (forward search can snap to the same event instead of the previous one).
+- Is unreliable for the lunar node, whose successive-crossing interval varies by about a day across the 18.6-year regression cycle.
+- Cannot express "previous return before this exact timestamp" without extra offsetting logic.
+
+The new flag resolves all three problems natively.
+
+### New Features
+
+All six entry points on `PlanetaryReturnFactory` now accept `backwards`:
+
+```python
+factory.next_return_from_iso_formatted_time(iso, return_type, backwards=True)
+factory.next_return_from_date(year, month, day, return_type, backwards=True)
+factory.next_lunar_node_crossing(julian_day, backwards=True)
+factory.next_lunar_node_crossing_from_iso_formatted_time(iso, backwards=True)
+factory.next_lunar_node_crossing_from_date(year, month, day, backwards=True)
+factory.next_heliocentric_return_from_date(planet, year, month, day, backwards=True)
+```
+
+Default value is `False` everywhere, so existing code continues to work unchanged.
+
+### Backend Requirements
+
+Backward search relies on libephemeris `>= 1.1.0`, which introduced the `backwards` flag on `swe_solcross_ut`, `swe_mooncross_ut`, and `swe_mooncross_node_ut`. When kerykeion is running on the **pyswisseph** fallback backend, calling any of the above entry points with `backwards=True` raises `KerykeionException` with a clear message pointing the caller to the libephemeris backend. This behavior is exercised by dedicated tests in `TestSwissephFallback` (see below).
+
+### Dependencies
+
+- Primary pin bumped: `libephemeris == 1.1.0` (was `== 1.0.0a15`).
+- `all` extra bumped: `libephemeris >= 1.1.0` (was `>= 1.0.0a13`).
+- `[tool.uv.sources]` block added for local editable-install ergonomics during parallel development on libephemeris. This block is ignored by pip and by uv when the package is installed as a dependency, so it is invisible to downstream consumers.
+
+### Known limitation (inherited)
+
+`backwards=True` on heliocentric returns inherits a sub-second edge case from libephemeris 1.1.0's unchanged `swe_helio_cross_ut` (threshold `1e-5°` — wide enough to swallow legitimately-nearby crossings for slow-moving outer planets). The in-app navigator consumer is unaffected because it serializes timestamps at millisecond precision, which falls deep inside the dead-zone and produces the intended full-cycle backward step. See libephemeris 1.1.0 release notes for full details. A proper fix (per-planet threshold calibration, direction guard, Brent-fallback interaction) is deferred to a future libephemeris release.
+
+### Tests
+
+12 new tests in `tests/core/test_planetary_return_backwards.py`:
+
+- `TestSolarBackwards` — single-step backward, one-cycle boundary invariant, date-wrapper round-trip.
+- `TestLunarBackwards` — single-step backward, sidereal-month boundary.
+- `TestLunarNodeCrossingBackwards` — single-step, half-nodal-month boundary, date-wrapper round-trip.
+- `TestHeliocentricBackwards` — Jupiter one-cycle (4200–4500 day) boundary.
+- `TestSwissephFallback` — mocks the backend to `pyswisseph` via `unittest.mock` and asserts `KerykeionException` with `libephemeris` in the message for each of the three backward-capable entry points.
+
+All 12 pass on libephemeris 1.1.0. Full kerykeion test suite: 8953 / 8953 passed (+ 123 online-only skipped).
+
+### Compatibility
+
+Fully backward-compatible. `backwards=False` is the default on every affected entry point; callers who do not pass the argument see identical behavior to 6.0.0a29.
+
+### Breaking Changes
+
+None.

--- a/tests/core/test_planetary_return_backwards.py
+++ b/tests/core/test_planetary_return_backwards.py
@@ -1,0 +1,247 @@
+"""
+Backward planetary return tests for PlanetaryReturnFactory.
+
+Covers ``backwards=True`` on:
+  - ``next_return_from_iso_formatted_time`` (Solar / Lunar)
+  - ``next_return_from_date`` (Solar / Lunar)
+  - ``next_heliocentric_return*`` (already partial — round-trip added)
+  - ``next_lunar_node_crossing*``
+
+The libephemeris backend is required for backward search. When pyswisseph
+is active, the factory must raise ``KerykeionException`` with a clear
+message pointing at the backend limitation.
+"""
+
+from __future__ import annotations
+
+import os
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from kerykeion import AstrologicalSubjectFactory
+from kerykeion.planetary_return_factory import PlanetaryReturnFactory
+from kerykeion.schemas import KerykeionException
+from kerykeion.utilities import datetime_to_julian, julian_to_datetime
+
+
+TROPICAL_YEAR = 365.2422
+SIDEREAL_MONTH = 27.3217
+NODAL_HALF_MONTH = 13.61
+
+
+@pytest.fixture(scope="module")
+def subject():
+    return AstrologicalSubjectFactory.from_birth_data(
+        "Test",
+        1990,
+        6,
+        15,
+        12,
+        0,
+        lat=40.7128,
+        lng=-74.006,
+        tz_str="America/New_York",
+        online=False,
+        suppress_geonames_warning=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def factory(subject):
+    return PlanetaryReturnFactory(
+        subject,
+        city="New York",
+        nation="US",
+        lat=40.7128,
+        lng=-74.006,
+        tz_str="America/New_York",
+        online=False,
+    )
+
+
+def _iso_to_jd(iso: str) -> float:
+    dt = datetime.fromisoformat(iso)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return datetime_to_julian(dt)
+
+
+def _jd_to_iso(jd: float) -> str:
+    """Round-trip safely: precise JD → ISO string with microseconds."""
+    dt = julian_to_datetime(jd).replace(tzinfo=timezone.utc)
+    return dt.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Solar backward
+# ---------------------------------------------------------------------------
+
+
+class TestSolarBackwards:
+    def test_backwards_returns_past(self, factory):
+        past = factory.next_return_from_iso_formatted_time(
+            "2025-12-31T00:00:00+00:00", "Solar", backwards=True
+        )
+        ret_jd = _iso_to_jd(past.iso_formatted_utc_datetime)
+        start_jd = _iso_to_jd("2025-12-31T00:00:00+00:00")
+        assert ret_jd < start_jd
+        assert start_jd - ret_jd < TROPICAL_YEAR + 5
+
+    def test_back_is_one_cycle_earlier(self, factory):
+        """back(fwd) must be exactly one tropical year before fwd."""
+        fwd = factory.next_return_from_iso_formatted_time(
+            "2024-01-01T00:00:00+00:00", "Solar"
+        )
+        back = factory.next_return_from_iso_formatted_time(
+            _jd_to_iso(fwd.julian_day), "Solar", backwards=True
+        )
+        delta_days = fwd.julian_day - back.julian_day
+        assert abs(delta_days - TROPICAL_YEAR) < 2.0, (
+            f"Delta {delta_days} days ≠ ~1 tropical year"
+        )
+
+    def test_date_wrapper_backwards(self, factory):
+        back = factory.next_return_from_date(2025, 12, 31, return_type="Solar", backwards=True)
+        assert "2025" in back.iso_formatted_utc_datetime or "2024" in back.iso_formatted_utc_datetime
+
+
+# ---------------------------------------------------------------------------
+# Lunar backward
+# ---------------------------------------------------------------------------
+
+
+class TestLunarBackwards:
+    def test_backwards_returns_past(self, factory):
+        past = factory.next_return_from_iso_formatted_time(
+            "2024-06-01T00:00:00+00:00", "Lunar", backwards=True
+        )
+        ret_jd = _iso_to_jd(past.iso_formatted_utc_datetime)
+        start_jd = _iso_to_jd("2024-06-01T00:00:00+00:00")
+        assert ret_jd < start_jd
+        assert start_jd - ret_jd < 30  # within a sidereal month
+
+    def test_back_is_one_cycle_earlier(self, factory):
+        """back(fwd) must be exactly one sidereal month before fwd."""
+        fwd = factory.next_return_from_iso_formatted_time(
+            "2024-01-01T00:00:00+00:00", "Lunar"
+        )
+        back = factory.next_return_from_iso_formatted_time(
+            _jd_to_iso(fwd.julian_day), "Lunar", backwards=True
+        )
+        delta_days = fwd.julian_day - back.julian_day
+        assert abs(delta_days - SIDEREAL_MONTH) < 0.5, (
+            f"Delta {delta_days} days ≠ ~1 sidereal month"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Lunar node crossing backward
+# ---------------------------------------------------------------------------
+
+
+class TestLunarNodeCrossingBackwards:
+    def test_backwards_returns_past(self, factory):
+        past = factory.next_lunar_node_crossing_from_iso_formatted_time(
+            "2024-06-15T00:00:00+00:00", backwards=True
+        )
+        ret_jd = _iso_to_jd(past.iso_formatted_utc_datetime)
+        start_jd = _iso_to_jd("2024-06-15T00:00:00+00:00")
+        assert ret_jd < start_jd
+        assert start_jd - ret_jd < NODAL_HALF_MONTH + 3
+
+    def test_date_wrapper_backwards(self, factory):
+        back = factory.next_lunar_node_crossing_from_date(2024, 6, 15, backwards=True)
+        assert back.iso_formatted_utc_datetime  # sanity — produced a chart
+
+    def test_back_is_one_cycle_earlier(self, factory):
+        """back(fwd) must be ~half a nodal month earlier."""
+        fwd = factory.next_lunar_node_crossing_from_iso_formatted_time(
+            "2024-01-01T00:00:00+00:00"
+        )
+        back = factory.next_lunar_node_crossing_from_iso_formatted_time(
+            _jd_to_iso(fwd.julian_day), backwards=True
+        )
+        delta_days = fwd.julian_day - back.julian_day
+        assert abs(delta_days - NODAL_HALF_MONTH) < 1.5, (
+            f"Delta {delta_days} days ≠ ~13.61 (half nodal month)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Heliocentric backward (already exists — add round-trip)
+# ---------------------------------------------------------------------------
+
+
+class TestHeliocentricBackwards:
+    def test_back_is_earlier(self, factory):
+        """Heliocentric Jupiter back step must land earlier than fwd."""
+        jd = datetime_to_julian(datetime(2024, 1, 1, tzinfo=timezone.utc))
+        fwd = factory.next_heliocentric_return("Jupiter", jd)
+        back = factory.next_heliocentric_return("Jupiter", fwd.julian_day, backwards=True)
+        assert back.julian_day < fwd.julian_day
+        # Jupiter heliocentric period ~11.86 years ~= 4333 days
+        delta_days = fwd.julian_day - back.julian_day
+        assert 4200 < delta_days < 4500, f"Jupiter cycle delta {delta_days} out of bounds"
+
+
+# ---------------------------------------------------------------------------
+# Swisseph fallback — raise KerykeionException with clear message
+# ---------------------------------------------------------------------------
+
+
+class TestSwissephFallback:
+    """When pyswisseph is the backend, backward methods must raise cleanly.
+
+    We simulate the fallback by patching ``swe.solcross_ut`` /
+    ``swe.mooncross_ut`` / ``swe.mooncross_node_ut`` so calling them with
+    ``backwards=True`` raises ``TypeError`` (what pyswisseph does).
+    """
+
+    def test_solar_backwards_raises_on_swisseph(self, factory):
+        import kerykeion.planetary_return_factory as prf
+
+        original = prf.swe.solcross_ut
+
+        def fake_solcross(*args, **kwargs):
+            if "backwards" in kwargs:
+                raise TypeError("pyswisseph solcross_ut() got an unexpected keyword argument 'backwards'")
+            return original(*args, **kwargs)
+
+        with patch.object(prf.swe, "solcross_ut", side_effect=fake_solcross):
+            with pytest.raises(KerykeionException, match="libephemeris"):
+                factory.next_return_from_iso_formatted_time(
+                    "2025-12-31T00:00:00+00:00", "Solar", backwards=True
+                )
+
+    def test_lunar_backwards_raises_on_swisseph(self, factory):
+        import kerykeion.planetary_return_factory as prf
+
+        original = prf.swe.mooncross_ut
+
+        def fake_mooncross(*args, **kwargs):
+            if "backwards" in kwargs:
+                raise TypeError("pyswisseph mooncross_ut() got an unexpected keyword argument 'backwards'")
+            return original(*args, **kwargs)
+
+        with patch.object(prf.swe, "mooncross_ut", side_effect=fake_mooncross):
+            with pytest.raises(KerykeionException, match="libephemeris"):
+                factory.next_return_from_iso_formatted_time(
+                    "2024-06-01T00:00:00+00:00", "Lunar", backwards=True
+                )
+
+    def test_node_crossing_backwards_raises_on_swisseph(self, factory):
+        import kerykeion.planetary_return_factory as prf
+
+        original = prf.swe.mooncross_node_ut
+
+        def fake_node(*args, **kwargs):
+            if "backwards" in kwargs:
+                raise TypeError("pyswisseph mooncross_node_ut() got an unexpected keyword argument 'backwards'")
+            return original(*args, **kwargs)
+
+        with patch.object(prf.swe, "mooncross_node_ut", side_effect=fake_node):
+            with pytest.raises(KerykeionException, match="libephemeris"):
+                factory.next_lunar_node_crossing_from_iso_formatted_time(
+                    "2024-06-15T00:00:00+00:00", backwards=True
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "kerykeion"
-version = "6.0.0a29"
+version = "6.0.0a30"
 source = { editable = "." }
 dependencies = [
     { name = "libephemeris" },
@@ -496,8 +496,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "libephemeris", specifier = "==1.0.0a15" },
-    { name = "libephemeris", marker = "extra == 'all'", specifier = ">=1.0.0a13" },
+    { name = "libephemeris", editable = "../libephemeris" },
+    { name = "libephemeris", marker = "extra == 'all'", editable = "../libephemeris" },
     { name = "pydantic", specifier = ">=2.5" },
     { name = "pyswisseph", marker = "extra == 'all'", specifier = ">=2.10.3.1" },
     { name = "pyswisseph", marker = "extra == 'swiss'", specifier = ">=2.10.3.1" },
@@ -546,8 +546,8 @@ wheels = [
 
 [[package]]
 name = "libephemeris"
-version = "1.0.0a15"
-source = { registry = "https://pypi.org/simple" }
+version = "1.1.0"
+source = { editable = "../libephemeris" }
 dependencies = [
     { name = "astroquery" },
     { name = "certifi" },
@@ -557,10 +557,44 @@ dependencies = [
     { name = "skyfield-data" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/4d/98cdcd2547844dde56d58093332fc58d721ea74258a92e02c1b0578fd67e/libephemeris-1.0.0a15.tar.gz", hash = "sha256:acb307e2c701f9db09c9343fd76edc03eafa0c7a5ea72247ff0e94c6149afd07", size = 12397822, upload-time = "2026-04-02T21:30:53.133Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/76/082105903fedd9c1a46cfe3d07ff13ad19d330c047578a08e02f3fe72de4/libephemeris-1.0.0a15-py3-none-any.whl", hash = "sha256:9a522a9a8d0e54afd88692918b5ad5b8f6307b64613750607aceda3190b2f8d7", size = 12442799, upload-time = "2026-04-02T21:30:49.437Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "assist", marker = "extra == 'all'", specifier = ">=1.1.0" },
+    { name = "assist", marker = "extra == 'nbody'", specifier = ">=1.1.0" },
+    { name = "astropy", marker = "extra == 'all'", specifier = ">=5.0.0" },
+    { name = "astropy", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "astropy", marker = "extra == 'stars'", specifier = ">=5.0.0" },
+    { name = "astroquery", specifier = ">=0.4.7" },
+    { name = "black", marker = "extra == 'dev'", specifier = ">=25.1.0" },
+    { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "certifi" },
+    { name = "click", specifier = ">=8.0" },
+    { name = "ebooklib", marker = "extra == 'dev'", specifier = ">=0.20" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "markdown", marker = "extra == 'dev'", specifier = ">=3.7" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0.0" },
+    { name = "poethepoet", marker = "extra == 'dev'", specifier = ">=0.37.0,<0.38.0" },
+    { name = "pyerfa", specifier = ">=2.0.0" },
+    { name = "pyswisseph", marker = "extra == 'dev'", specifier = ">=2.10.3.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<9.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "pytest-sugar", marker = "extra == 'dev'", specifier = ">=1.1.1" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "rebound", marker = "extra == 'all'", specifier = ">=4.0.0" },
+    { name = "rebound", marker = "extra == 'nbody'", specifier = ">=4.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.6" },
+    { name = "skyfield", specifier = ">=1.54" },
+    { name = "skyfield-data", specifier = ">=7.0.0" },
+    { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0.0" },
+    { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=2.0.0" },
+    { name = "spiceypy", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "zstandard", specifier = ">=0.22.0" },
 ]
+provides-extras = ["stars", "nbody", "all", "dev", "docs"]
 
 [[package]]
 name = "librt"


### PR DESCRIPTION
## Summary

Release PR for **kerykeion v6.0.0a30**. Exposes a `backwards: bool = False` parameter across all six planetary-return entry points on `PlanetaryReturnFactory`. When `True`, the factory delegates to libephemeris 1.1.0's backward-capable crossing primitives and returns the most recent past return (or node crossing) instead of the next upcoming one.

This is the library-level counterpart to libephemeris 1.1.0 ([PR #2](https://github.com/g-battaglia/libephemeris/pull/2), merged).

## Public API

```python
factory.next_return_from_iso_formatted_time(iso, return_type, backwards=True)
factory.next_return_from_date(year, month, day, return_type, backwards=True)
factory.next_lunar_node_crossing(julian_day, backwards=True)
factory.next_lunar_node_crossing_from_iso_formatted_time(iso, backwards=True)
factory.next_lunar_node_crossing_from_date(year, month, day, backwards=True)
factory.next_heliocentric_return_from_date(planet, year, month, day, backwards=True)
```

Default `False` everywhere → existing call sites unchanged.

## Backend Requirements

Backward search requires libephemeris `>= 1.1.0`. On the **pyswisseph** fallback backend the factory catches `TypeError` from `swe.solcross_ut(..., backwards=True)` and raises `KerykeionException` with a clear message directing the caller to install libephemeris. Covered by `TestSwissephFallback`.

## Verification

| Suite | Result |
|-------|--------|
| `tests/core/test_planetary_return_backwards.py` | 12/12 passing |
| Full kerykeion test suite | 8953/8953 passing |

## Files

- `kerykeion/planetary_return_factory.py` — `backwards` flag on all 6 entry points + swisseph-fallback error handling
- `pyproject.toml` — version bump to `6.0.0a30`, `libephemeris` pin to `==1.1.0`, `all` extra to `>=1.1.0`, added `[tool.uv.sources]` for local editable-install ergonomics
- `uv.lock` — regenerated for dependency change
- `CHANGELOG.md` — new `6.0.0a30` entry
- `release_notes/v6.0.0a30.md` — full release notes
- `tests/core/test_planetary_return_backwards.py` — new file (12 tests)

## Known limitation (inherited from libephemeris 1.1.0)

`backwards=True` on heliocentric returns inherits a sub-second edge case from libephemeris' unchanged `swe_helio_cross_ut` (threshold `1e-5°`, which converts to ~10 s Jupiter, ~25 s Saturn, up to ~3.6 min Pluto). The in-app navigator consumer is unaffected because it serializes timestamps at millisecond precision, which falls deep inside the dead-zone and produces the intended full-cycle backward step.

Documented in:
- Release notes `release_notes/v6.0.0a30.md` → "Known limitation (inherited)"
- Downstream: `v6.astrologer-api/KNOWN_ISSUES.md`
- Upstream libephemeris `CHANGELOG.md` + `release-notes/v1.1.0.md` → "Known limitations"

## Tag

`v6.0.0a30` was tagged on commit `e647ae77` and pushed to origin.

## Test plan

- [x] `uv run pytest tests/core/test_planetary_return_backwards.py -v` — 12 passed
- [x] `uv run pytest tests/` — 8953 passed, 123 skipped (online-only)
- [x] Downstream: v6.astrologer-api return-navigation tests pass against this build
- [ ] CodeRabbit review
- [ ] Manual review of release notes phrasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `backwards` parameter to planetary return methods, enabling retrieval of past occurrences instead of upcoming ones
  * Requires libephemeris >= 1.1.0; raises error on pyswisseph fallback

* **Tests**
  * Comprehensive coverage for backward solar and lunar returns, node crossings, and heliocentric returns
  * Fallback error behavior validation

* **Chores**
  * Updated libephemeris dependency to 1.1.0
  * Version bumped to 6.0.0a30

<!-- end of auto-generated comment: release notes by coderabbit.ai -->