### PR TITLE
Add backend-specific fixed star discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 6.0.0a37
+
+_2026-05-08_
+
+### New Features
+
+- **Backend-specific fixed-star discovery.** `FixedStarDiscoveryFactory` now
+  dispatches explicitly by ephemeris backend: `swisseph` scans the Swiss
+  Ephemeris `sefstars.txt` catalog, while `libephemeris` uses the native
+  `list_fixed_stars()` / `batch_fixstars_ut()` APIs and never reads Swiss
+  catalog files.
+- **Fixed-star discovery metadata.** Discovery results now carry optional
+  `near_point`, `orb`, `aspect`, `longitude`, `latitude`, and `degree` fields
+  on `KerykeionPointModel`, matching the API shape expected by UI consumers.
+
+### Performance
+
+- Swiss discovery now scans candidate positions without `FLG_SPEED` and only
+  computes speed, declination, and magnitude for stars that actually fall within
+  the requested conjunction orb.
+- The libephemeris path uses ordered batch calculation for the native catalog.
+
+### Backward compatibility
+
+Additive only. Existing fixed-star point fields remain unchanged. Catalog size
+and specific discovery results may differ by backend because each backend now
+uses its own catalog source intentionally.
+
 ## 6.0.0a36
 
 _2026-04-28_

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,19 @@
+# Release Notes
+
+## 6.0.0a37 — 2026-05-08
+
+Kerykeion 6.0.0a37 separates fixed-star discovery by ephemeris backend.
+
+Highlights:
+
+- `swisseph` continues to use the Swiss Ephemeris `sefstars.txt` catalog.
+- `libephemeris` now uses its native fixed-star catalog and batch API; it never
+  reads Swiss catalog files.
+- Discovery output includes optional `near_point`, `orb`, `aspect`, `longitude`,
+  `latitude`, and `degree` metadata for API/UI consumers.
+- Swiss discovery avoids calculating fixed-star speed during the full catalog
+  scan and only enriches matching stars.
+
+This alpha is backward-compatible for existing point fields. Backend catalogs are
+intentionally independent, so exact discovery result sets can differ between
+`swisseph` and `libephemeris`.

--- a/kerykeion/fixed_stars/discovery_factory.py
+++ b/kerykeion/fixed_stars/discovery_factory.py
@@ -2,30 +2,32 @@
 """
 Fixed Star Discovery Factory (v6.0)
 
-Scans the Swiss Ephemeris sefstars.txt catalog and finds fixed stars
-that are conjunct natal planets within a configurable orb.
+Finds fixed stars conjunct natal points within a configurable orb.
+
+The implementation is backend-specific by design:
+- swisseph scans the Swiss Ephemeris ``sefstars.txt`` catalog.
+- libephemeris uses its native fixed-star catalog/API and never reads
+  ``sefstars.txt``.
 
 This is part of Kerykeion (C) 2025 Giacomo Battaglia
 """
 
+from functools import lru_cache
 import logging
-from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
 from pathlib import Path
 from typing import List, Optional
 
+from kerykeion.ephemeris_backend import BACKEND_NAME, EPHE_DATA_PATH, swe
 from kerykeion.schemas.kr_models import AstrologicalSubjectModel, KerykeionPointModel
 from kerykeion.utilities import get_kerykeion_point_from_degree, get_planet_house
 
 logger = logging.getLogger(__name__)
 
 
-def _parse_star_names_from_catalog(catalog_path: str) -> List[str]:
-    """Parse star names from the sefstars.txt catalog file.
-
-    Returns a list of primary star names (the first name before any comma
-    on each non-comment, non-empty line).
-    """
-    names: List[str] = []
+@lru_cache(maxsize=8)
+def _parse_star_names_from_catalog(catalog_path: str) -> tuple[str, ...]:
+    """Parse primary star names from a Swiss Ephemeris sefstars.txt file."""
+    names: list[str] = []
     try:
         with open(catalog_path, "r", encoding="utf-8", errors="replace") as f:
             for line in f:
@@ -33,28 +35,101 @@ def _parse_star_names_from_catalog(catalog_path: str) -> List[str]:
                 if not line or line.startswith("#"):
                     continue
                 # sefstars.txt format: "name, nomenclature, equinox, RA, Dec, ..."
-                # The first field (before the first comma) is the star name
                 name = line.split(",")[0].strip()
                 if name:
                     names.append(name)
     except Exception as e:
         logger.warning(f"Could not parse star catalog: {e}")
-    return names
+    return tuple(names)
+
+
+def _collect_planet_positions(subject: AstrologicalSubjectModel) -> list[tuple[str, float]]:
+    """Collect calculated active point positions for conjunction checks."""
+    planet_positions: list[tuple[str, float]] = []
+    for point_name in subject.active_points:
+        point = subject.get(point_name.lower())
+        if point is not None and hasattr(point, "abs_pos"):
+            planet_positions.append((str(point_name), point.abs_pos))
+    return planet_positions
+
+
+def _collect_house_cusps(subject: AstrologicalSubjectModel) -> list[float]:
+    """Collect house cusp longitudes for house placement."""
+    houses_degree_ut: list[float] = []
+    house_keys = [
+        "first_house",
+        "second_house",
+        "third_house",
+        "fourth_house",
+        "fifth_house",
+        "sixth_house",
+        "seventh_house",
+        "eighth_house",
+        "ninth_house",
+        "tenth_house",
+        "eleventh_house",
+        "twelfth_house",
+    ]
+    for house_key in house_keys:
+        house = getattr(subject, house_key, None)
+        if house is not None:
+            houses_degree_ut.append(house.abs_pos)
+    return houses_degree_ut
+
+
+def _nearest_conjunction(
+    star_deg: float,
+    planet_positions: list[tuple[str, float]],
+    orb: float,
+) -> tuple[str, float] | None:
+    """Return nearest conjunct point and orb, or None when outside orb."""
+    nearest: tuple[str, float] | None = None
+    for point_name, planet_pos in planet_positions:
+        diff = abs(star_deg - planet_pos)
+        if diff > 180:
+            diff = 360 - diff
+        if diff <= orb and (nearest is None or diff < nearest[1]):
+            nearest = (point_name, diff)
+    return nearest
+
+
+def _build_discovery_point(
+    star_name: str,
+    pos_ecl: tuple,
+    pos_eq: tuple | None,
+    star_mag: float | None,
+    houses_degree_ut: list[float],
+    near_point: str,
+    discovery_orb: float,
+) -> KerykeionPointModel:
+    """Build a Kerykeion point enriched with discovery metadata."""
+    star_deg = pos_ecl[0]
+    star_lat = pos_ecl[1] if len(pos_ecl) > 1 else None
+    star_speed = pos_ecl[3] if len(pos_ecl) > 3 else 0.0
+    star_dec = pos_eq[1] if pos_eq is not None and len(pos_eq) > 1 else None
+
+    point = get_kerykeion_point_from_degree(
+        star_deg,
+        star_name,
+        point_type="AstrologicalPoint",
+        speed=star_speed,
+        declination=star_dec,
+        magnitude=star_mag,
+    )
+    if houses_degree_ut:
+        point.house = get_planet_house(star_deg, houses_degree_ut)
+    point.retrograde = False
+    point.near_point = near_point
+    point.orb = discovery_orb
+    point.aspect = "conjunction"
+    point.longitude = star_deg
+    point.latitude = star_lat
+    point.degree = point.position
+    return point
 
 
 class FixedStarDiscoveryFactory:
-    """
-    Factory for discovering prominent fixed stars in an astrological chart.
-
-    Scans the Swiss Ephemeris fixed star catalog (~1000 stars) and returns
-    those that form a conjunction with any natal planet within the specified orb.
-
-    Example:
-        >>> subject = AstrologicalSubjectFactory.from_birth_data("John", 1940, 10, 9, 18, 30, "Liverpool", "GB")
-        >>> prominent = FixedStarDiscoveryFactory.find_prominent_stars(subject, orb=1.0)
-        >>> for star in prominent:
-        ...     print(f"{star.name} at {star.abs_pos:.2f} (mag {star.magnitude})")
-    """
+    """Factory for discovering fixed-star conjunctions in a chart."""
 
     @staticmethod
     def find_prominent_stars(
@@ -63,21 +138,25 @@ class FixedStarDiscoveryFactory:
         *,
         catalog_path: Optional[str] = None,
     ) -> List[KerykeionPointModel]:
+        """Find fixed stars conjunct natal planets.
+
+        The active backend determines the catalog source. The Swiss Ephemeris
+        backend reads ``sefstars.txt``; libephemeris uses its own native catalog.
         """
-        Find fixed stars conjunct natal planets.
+        if BACKEND_NAME == "swisseph":
+            return FixedStarDiscoveryFactory._find_prominent_stars_swisseph(subject, orb=orb, catalog_path=catalog_path)
+        if BACKEND_NAME == "libephemeris":
+            return FixedStarDiscoveryFactory._find_prominent_stars_libephemeris(subject, orb=orb)
+        raise RuntimeError(f"Unsupported ephemeris backend for fixed-star discovery: {BACKEND_NAME}")
 
-        Scans the full sefstars.txt catalog and returns stars whose ecliptic
-        longitude is within *orb* degrees of any calculated planet in the subject.
-
-        Args:
-            subject: An astrological subject with calculated planet positions.
-            orb: Maximum orb in degrees for conjunction (default 1.0).
-            catalog_path: Optional path to sefstars.txt. If None, uses the
-                bundled catalog.
-
-        Returns:
-            List of KerykeionPointModel for each prominent star found.
-        """
+    @staticmethod
+    def _find_prominent_stars_swisseph(
+        subject: AstrologicalSubjectModel,
+        orb: float = 1.0,
+        *,
+        catalog_path: Optional[str] = None,
+    ) -> List[KerykeionPointModel]:
+        """Swiss Ephemeris implementation backed by sefstars.txt."""
         if catalog_path is None:
             catalog_path = str(Path(EPHE_DATA_PATH) / "sefstars.txt")
 
@@ -86,87 +165,124 @@ class FixedStarDiscoveryFactory:
             logger.warning("No star names found in catalog")
             return []
 
-        # Collect natal planet positions for conjunction check
-        planet_positions: List[float] = []
-        for point_name in subject.active_points:
-            point = subject.get(point_name.lower())
-            if point is not None and hasattr(point, "abs_pos"):
-                planet_positions.append(point.abs_pos)
-
+        planet_positions = _collect_planet_positions(subject)
         if not planet_positions:
             return []
 
-        # Get house cusps for house placement
-        houses_degree_ut: List[float] = []
-        for i in range(1, 13):
-            house_key = [
-                "first_house", "second_house", "third_house", "fourth_house",
-                "fifth_house", "sixth_house", "seventh_house", "eighth_house",
-                "ninth_house", "tenth_house", "eleventh_house", "twelfth_house",
-            ][i - 1]
-            h = getattr(subject, house_key, None)
-            if h is not None:
-                houses_degree_ut.append(h.abs_pos)
-
-        # Setup ephemeris
-        ephe_path = EPHE_DATA_PATH
-        swe.set_ephe_path(ephe_path)
-        iflag = swe.FLG_SWIEPH | swe.FLG_SPEED
+        houses_degree_ut = _collect_house_cusps(subject)
+        swe.set_ephe_path(EPHE_DATA_PATH)
+        base_iflag = swe.FLG_SWIEPH
         jd = subject.julian_day
 
         prominent: List[KerykeionPointModel] = []
-        seen_names: set = set()
+        seen_positions: set[float] = set()
+        try:
+            for star_name in star_names:
+                try:
+                    pos_scan = swe.fixstar_ut(star_name, jd, base_iflag)[0]
+                    star_deg = pos_scan[0]
 
-        for star_name in star_names:
-            try:
-                pos_ecl = swe.fixstar_ut(star_name, jd, iflag)[0]
-                star_deg = pos_ecl[0]
+                    nearest = _nearest_conjunction(star_deg, planet_positions, orb)
+                    if nearest is None:
+                        continue
 
-                # Check conjunction with any natal planet
-                is_conjunct = False
-                for planet_pos in planet_positions:
-                    diff = abs(star_deg - planet_pos)
-                    if diff > 180:
-                        diff = 360 - diff
-                    if diff <= orb:
-                        is_conjunct = True
-                        break
+                    rounded_pos = round(star_deg, 2)
+                    if rounded_pos in seen_positions:
+                        continue
+                    seen_positions.add(rounded_pos)
 
-                if not is_conjunct:
+                    pos_ecl = swe.fixstar_ut(star_name, jd, base_iflag | swe.FLG_SPEED)[0]
+                    pos_eq = swe.fixstar_ut(star_name, jd, base_iflag | swe.FLG_EQUATORIAL)[0]
+                    try:
+                        star_mag = swe.fixstar2_mag(star_name)[0]
+                    except Exception:
+                        star_mag = None
+
+                    prominent.append(
+                        _build_discovery_point(
+                            star_name,
+                            pos_ecl,
+                            pos_eq,
+                            star_mag,
+                            houses_degree_ut,
+                            near_point=nearest[0],
+                            discovery_orb=nearest[1],
+                        )
+                    )
+                except Exception:
+                    continue
+        finally:
+            swe.close()
+
+        prominent.sort(key=lambda p: p.magnitude if p.magnitude is not None else 99)
+        return prominent
+
+    @staticmethod
+    def _find_prominent_stars_libephemeris(
+        subject: AstrologicalSubjectModel,
+        orb: float = 1.0,
+    ) -> List[KerykeionPointModel]:
+        """libephemeris implementation backed by its native catalog/API."""
+        planet_positions = _collect_planet_positions(subject)
+        if not planet_positions:
+            return []
+
+        list_fixed_stars = getattr(swe, "list_fixed_stars", None)
+        batch_fixstars_ut = getattr(swe, "batch_fixstars_ut", None)
+        if list_fixed_stars is None or batch_fixstars_ut is None:
+            raise RuntimeError("libephemeris fixed-star discovery requires libephemeris >= 1.2.0")
+
+        catalog = tuple(list_fixed_stars())
+        if not catalog:
+            return []
+
+        houses_degree_ut = _collect_house_cusps(subject)
+        swe.set_ephe_path(EPHE_DATA_PATH)
+        base_iflag = swe.FLG_SWIEPH
+        jd = subject.julian_day
+        star_names = tuple(star.name for star in catalog)
+
+        prominent: List[KerykeionPointModel] = []
+        seen_positions: set[float] = set()
+        try:
+            scanned_positions = batch_fixstars_ut(star_names, jd, base_iflag, skip_errors=True)
+
+            for catalog_entry, scan_result in zip(catalog, scanned_positions):
+                if scan_result is None:
+                    continue
+                star_name = scan_result[1] or catalog_entry.name
+                pos_scan = scan_result[0]
+                star_deg = pos_scan[0]
+
+                nearest = _nearest_conjunction(star_deg, planet_positions, orb)
+                if nearest is None:
                     continue
 
-                # Avoid duplicates (catalog may have alternate names)
                 rounded_pos = round(star_deg, 2)
-                if rounded_pos in seen_names:
+                if rounded_pos in seen_positions:
                     continue
-                seen_names.add(rounded_pos)
-
-                # Full calculation
-                star_speed = pos_ecl[3] if len(pos_ecl) > 3 else 0.0
-                pos_eq = swe.fixstar_ut(star_name, jd, iflag | swe.FLG_EQUATORIAL)[0]
-                star_dec = pos_eq[1] if len(pos_eq) > 1 else None
+                seen_positions.add(rounded_pos)
 
                 try:
-                    star_mag = swe.fixstar2_mag(star_name)[0]
+                    pos_ecl = swe.fixstar_ut(star_name, jd, base_iflag | swe.FLG_SPEED)[0]
+                    pos_eq = swe.fixstar_ut(star_name, jd, base_iflag | swe.FLG_EQUATORIAL)[0]
                 except Exception:
-                    star_mag = None
+                    continue
 
-                point = get_kerykeion_point_from_degree(
-                    star_deg, star_name, point_type="AstrologicalPoint",
-                    speed=star_speed, declination=star_dec, magnitude=star_mag,
+                prominent.append(
+                    _build_discovery_point(
+                        star_name,
+                        pos_ecl,
+                        pos_eq,
+                        catalog_entry.magnitude,
+                        houses_degree_ut,
+                        near_point=nearest[0],
+                        discovery_orb=nearest[1],
+                    )
                 )
-                if houses_degree_ut:
-                    point.house = get_planet_house(star_deg, houses_degree_ut)
-                point.retrograde = False
+        finally:
+            reset = getattr(swe, "reset_session", None) or swe.close
+            reset()
 
-                prominent.append(point)
-
-            except Exception:
-                # Star not found or calculation error — skip silently
-                continue
-
-        swe.close()
-
-        # Sort by magnitude (brightest first), None magnitudes last
         prominent.sort(key=lambda p: p.magnitude if p.magnitude is not None else 99)
         return prominent

--- a/kerykeion/fixed_stars/discovery_factory.py
+++ b/kerykeion/fixed_stars/discovery_factory.py
@@ -39,7 +39,7 @@ def _parse_star_names_from_catalog(catalog_path: str) -> tuple[str, ...]:
                 if name:
                     names.append(name)
     except Exception as e:
-        logger.warning(f"Could not parse star catalog: {e}")
+        logger.warning(f"Could not parse star catalog {catalog_path}: {e}")
     return tuple(names)
 
 
@@ -143,6 +143,9 @@ class FixedStarDiscoveryFactory:
         The active backend determines the catalog source. The Swiss Ephemeris
         backend reads ``sefstars.txt``; libephemeris uses its own native catalog.
         """
+        if orb < 0:
+            raise ValueError(f"orb must be >= 0, got {orb}")
+
         if BACKEND_NAME == "swisseph":
             return FixedStarDiscoveryFactory._find_prominent_stars_swisseph(subject, orb=orb, catalog_path=catalog_path)
         if BACKEND_NAME == "libephemeris":
@@ -196,7 +199,8 @@ class FixedStarDiscoveryFactory:
                     pos_eq = swe.fixstar_ut(star_name, jd, scan_iflag | swe.FLG_EQUATORIAL)[0]
                     try:
                         star_mag = swe.fixstar2_mag(star_name)[0]
-                    except Exception:
+                    except Exception as e:
+                        logger.debug(f"No magnitude for {star_name}: {e}")
                         star_mag = None
 
                     prominent.append(
@@ -210,7 +214,8 @@ class FixedStarDiscoveryFactory:
                             discovery_orb=nearest[1],
                         )
                     )
-                except Exception:
+                except Exception as e:
+                    logger.debug(f"Skipping star {star_name}: {e}")
                     continue
         finally:
             swe.close()
@@ -267,7 +272,8 @@ class FixedStarDiscoveryFactory:
                 try:
                     pos_ecl = swe.fixstar_ut(star_name, jd, base_iflag | swe.FLG_SPEED)[0]
                     pos_eq = swe.fixstar_ut(star_name, jd, base_iflag | swe.FLG_EQUATORIAL)[0]
-                except Exception:
+                except Exception as e:
+                    logger.debug(f"Skipping star {star_name}: {e}")
                     continue
 
                 prominent.append(

--- a/kerykeion/fixed_stars/discovery_factory.py
+++ b/kerykeion/fixed_stars/discovery_factory.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 @lru_cache(maxsize=8)
 def _parse_star_names_from_catalog(catalog_path: str) -> tuple[str, ...]:
-    """Parse primary star names from a Swiss Ephemeris sefstars.txt file."""
+    """Parse primary star names from a sefstars.txt file (swisseph backend only)."""
     names: list[str] = []
     try:
         with open(catalog_path, "r", encoding="utf-8", errors="replace") as f:

--- a/kerykeion/fixed_stars/discovery_factory.py
+++ b/kerykeion/fixed_stars/discovery_factory.py
@@ -15,7 +15,7 @@ This is part of Kerykeion (C) 2025 Giacomo Battaglia
 from functools import lru_cache
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from kerykeion.ephemeris_backend import BACKEND_NAME, EPHE_DATA_PATH, swe
 from kerykeion.schemas.kr_models import AstrologicalSubjectModel, KerykeionPointModel
@@ -137,7 +137,7 @@ class FixedStarDiscoveryFactory:
         orb: float = 1.0,
         *,
         catalog_path: Optional[str] = None,
-    ) -> List[KerykeionPointModel]:
+    ) -> list[KerykeionPointModel]:
         """Find fixed stars conjunct natal planets.
 
         The active backend determines the catalog source. The Swiss Ephemeris
@@ -146,6 +146,8 @@ class FixedStarDiscoveryFactory:
         if BACKEND_NAME == "swisseph":
             return FixedStarDiscoveryFactory._find_prominent_stars_swisseph(subject, orb=orb, catalog_path=catalog_path)
         if BACKEND_NAME == "libephemeris":
+            if catalog_path is not None:
+                logger.warning("catalog_path is ignored with the libephemeris backend (uses its own native catalog)")
             return FixedStarDiscoveryFactory._find_prominent_stars_libephemeris(subject, orb=orb)
         raise RuntimeError(f"Unsupported ephemeris backend for fixed-star discovery: {BACKEND_NAME}")
 
@@ -155,7 +157,7 @@ class FixedStarDiscoveryFactory:
         orb: float = 1.0,
         *,
         catalog_path: Optional[str] = None,
-    ) -> List[KerykeionPointModel]:
+    ) -> list[KerykeionPointModel]:
         """Swiss Ephemeris implementation backed by sefstars.txt."""
         if catalog_path is None:
             catalog_path = str(Path(EPHE_DATA_PATH) / "sefstars.txt")
@@ -171,16 +173,16 @@ class FixedStarDiscoveryFactory:
 
         houses_degree_ut = _collect_house_cusps(subject)
         swe.set_ephe_path(EPHE_DATA_PATH)
-        base_iflag = swe.FLG_SWIEPH
+        scan_iflag = swe.FLG_SWIEPH | swe.FLG_SPEED
         jd = subject.julian_day
 
-        prominent: List[KerykeionPointModel] = []
+        prominent: list[KerykeionPointModel] = []
         seen_positions: set[float] = set()
         try:
             for star_name in star_names:
                 try:
-                    pos_scan = swe.fixstar_ut(star_name, jd, base_iflag)[0]
-                    star_deg = pos_scan[0]
+                    pos_ecl = swe.fixstar_ut(star_name, jd, scan_iflag)[0]
+                    star_deg = pos_ecl[0]
 
                     nearest = _nearest_conjunction(star_deg, planet_positions, orb)
                     if nearest is None:
@@ -191,8 +193,7 @@ class FixedStarDiscoveryFactory:
                         continue
                     seen_positions.add(rounded_pos)
 
-                    pos_ecl = swe.fixstar_ut(star_name, jd, base_iflag | swe.FLG_SPEED)[0]
-                    pos_eq = swe.fixstar_ut(star_name, jd, base_iflag | swe.FLG_EQUATORIAL)[0]
+                    pos_eq = swe.fixstar_ut(star_name, jd, scan_iflag | swe.FLG_EQUATORIAL)[0]
                     try:
                         star_mag = swe.fixstar2_mag(star_name)[0]
                     except Exception:
@@ -221,7 +222,7 @@ class FixedStarDiscoveryFactory:
     def _find_prominent_stars_libephemeris(
         subject: AstrologicalSubjectModel,
         orb: float = 1.0,
-    ) -> List[KerykeionPointModel]:
+    ) -> list[KerykeionPointModel]:
         """libephemeris implementation backed by its native catalog/API."""
         planet_positions = _collect_planet_positions(subject)
         if not planet_positions:
@@ -242,7 +243,7 @@ class FixedStarDiscoveryFactory:
         jd = subject.julian_day
         star_names = tuple(star.name for star in catalog)
 
-        prominent: List[KerykeionPointModel] = []
+        prominent: list[KerykeionPointModel] = []
         seen_positions: set[float] = set()
         try:
             scanned_positions = batch_fixstars_ut(star_names, jd, base_iflag, skip_errors=True)

--- a/kerykeion/schemas/kr_models.py
+++ b/kerykeion/schemas/kr_models.py
@@ -401,6 +401,18 @@ class KerykeionPointModel(SubscriptableBaseModel):
     magnitude: Optional[float] = Field(
         default=None, description="Apparent visual magnitude (fixed stars only). Lower = brighter."
     )
+    near_point: Optional[str] = Field(default=None, description="Nearest chart point for fixed-star discovery results.")
+    orb: Optional[float] = Field(
+        default=None, description="Orb from the nearest chart point in fixed-star discovery results."
+    )
+    aspect: Optional[str] = Field(default=None, description="Aspect name for discovery results, usually 'conjunction'.")
+    longitude: Optional[float] = Field(
+        default=None, description="Ecliptic longitude for discovery consumers. Mirrors abs_pos."
+    )
+    latitude: Optional[float] = Field(default=None, description="Ecliptic latitude for fixed-star discovery results.")
+    degree: Optional[float] = Field(
+        default=None, description="Degree within sign for discovery consumers. Mirrors position."
+    )
     # Essential Dignities (v6.0)
     decan_number: Optional[int] = Field(
         default=None, description="Decan number (1-3) within the sign, each spanning 10 degrees."
@@ -543,15 +555,12 @@ class AstrologicalBaseModel(SubscriptableBaseModel):
         if self.sidereal_mode == "USER":
             if self.custom_ayanamsa_t0 is None or self.custom_ayanamsa_ayan_t0 is None:
                 raise ValueError(
-                    "custom_ayanamsa_t0 and custom_ayanamsa_ayan_t0 are both required "
-                    "when sidereal_mode is 'USER'."
+                    "custom_ayanamsa_t0 and custom_ayanamsa_ayan_t0 are both required when sidereal_mode is 'USER'."
                 )
         has_t0 = self.custom_ayanamsa_t0 is not None
         has_ayan = self.custom_ayanamsa_ayan_t0 is not None
         if has_t0 != has_ayan:
-            raise ValueError(
-                "custom_ayanamsa_t0 and custom_ayanamsa_ayan_t0 must be both set or both None."
-            )
+            raise ValueError("custom_ayanamsa_t0 and custom_ayanamsa_ayan_t0 must be both set or both None.")
         return self
 
     # Common celestial points

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kerykeion"
-version = "6.0.0a36"
+version = "6.0.0a37"
 authors = [
     { name = "Giacomo Battaglia", email = "kerykeion.astrology@gmail.com" }
 ]
@@ -45,7 +45,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "libephemeris==1.1.0",
+    "libephemeris==1.2.0",
     "pydantic>=2.5",
     "svg-polish>=1.0.0",
     "requests-cache>=1.2.1",
@@ -57,7 +57,7 @@ dependencies = [
 
 [project.optional-dependencies]
 swiss = ["pyswisseph>=2.10.3.1"]
-all = ["pyswisseph>=2.10.3.1", "libephemeris>=1.1.0"]
+all = ["pyswisseph>=2.10.3.1", "libephemeris>=1.2.0"]
 
 [tool.uv.sources]
 libephemeris = { path = "../libephemeris", editable = true }

--- a/tests/core/test_dynamic_fixed_stars.py
+++ b/tests/core/test_dynamic_fixed_stars.py
@@ -3,15 +3,25 @@
 
 import pytest
 from kerykeion import AstrologicalSubjectFactory, FixedStarDiscoveryFactory
+from kerykeion.ephemeris_backend import BACKEND_NAME
 
 
 @pytest.fixture(scope="module")
 def subject_default_stars():
     """Subject with default active_points including some fixed stars."""
     return AstrologicalSubjectFactory.from_birth_data(
-        "Stars Default", 1990, 6, 15, 14, 30,
-        lng=12.4964, lat=41.9028, tz_str="Europe/Rome",
-        city="Rome", nation="IT", online=False,
+        "Stars Default",
+        1990,
+        6,
+        15,
+        14,
+        30,
+        lng=12.4964,
+        lat=41.9028,
+        tz_str="Europe/Rome",
+        city="Rome",
+        nation="IT",
+        online=False,
     )
 
 
@@ -19,9 +29,18 @@ def subject_default_stars():
 def subject_extra_stars():
     """Subject with extra dynamic fixed stars beyond the default 23."""
     return AstrologicalSubjectFactory.from_birth_data(
-        "Stars Extra", 1990, 6, 15, 14, 30,
-        lng=12.4964, lat=41.9028, tz_str="Europe/Rome",
-        city="Rome", nation="IT", online=False,
+        "Stars Extra",
+        1990,
+        6,
+        15,
+        14,
+        30,
+        lng=12.4964,
+        lat=41.9028,
+        tz_str="Europe/Rome",
+        city="Rome",
+        nation="IT",
+        online=False,
         active_fixed_stars=["Galactic Center", "Polaris", "Castor"],
     )
 
@@ -30,10 +49,20 @@ def subject_extra_stars():
 def subject_all_stars():
     """Subject with all default active_points (includes 23 hardcoded stars)."""
     from kerykeion.settings.config_constants import ALL_ACTIVE_POINTS
+
     return AstrologicalSubjectFactory.from_birth_data(
-        "Stars All", 1990, 6, 15, 14, 30,
-        lng=12.4964, lat=41.9028, tz_str="Europe/Rome",
-        city="Rome", nation="IT", online=False,
+        "Stars All",
+        1990,
+        6,
+        15,
+        14,
+        30,
+        lng=12.4964,
+        lat=41.9028,
+        tz_str="Europe/Rome",
+        city="Rome",
+        nation="IT",
+        online=False,
         active_points=ALL_ACTIVE_POINTS,
     )
 
@@ -66,10 +95,9 @@ class TestDynamicFixedStars:
     def test_extra_stars_in_list(self, subject_extra_stars):
         """Extra dynamic stars should appear in the fixed_stars list."""
         star_names = [s.name for s in subject_extra_stars.fixed_stars]
-        # At least one of the requested extras should be found
-        # (Galactic Center is guaranteed to be in sefstars.txt)
-        assert any("Galactic" in name or "Polaris" in name or "Castor" in name
-                    for name in star_names), (
+        # At least one of the requested extras should be found. swisseph can use
+        # Galactic Center from sefstars.txt; libephemeris uses its native catalog.
+        assert any("Galactic" in name or "Polaris" in name or "Castor" in name for name in star_names), (
             f"None of the extra stars found. Got: {star_names}"
         )
 
@@ -85,13 +113,21 @@ class TestDynamicFixedStars:
         assert subject_all_stars.spica is not None
         assert 0 <= subject_all_stars.regulus.abs_pos < 360
 
-
     def test_nonexistent_star_silently_skipped(self):
         """Non-existent star names should not crash, just be silently skipped."""
         subject = AstrologicalSubjectFactory.from_birth_data(
-            "Nonexistent Star", 1990, 6, 15, 14, 30,
-            lng=12.4964, lat=41.9028, tz_str="Europe/Rome",
-            city="Rome", nation="IT", online=False,
+            "Nonexistent Star",
+            1990,
+            6,
+            15,
+            14,
+            30,
+            lng=12.4964,
+            lat=41.9028,
+            tz_str="Europe/Rome",
+            city="Rome",
+            nation="IT",
+            online=False,
             active_fixed_stars=["NonExistentStarXYZ123", "AnotherFakeStar"],
         )
         # Should not crash; fake stars are simply not in the list
@@ -101,25 +137,81 @@ class TestDynamicFixedStars:
 class TestFixedStarEdgeCases:
     """Test edge-case branches in FixedStarDiscoveryFactory and helpers."""
 
-    def test_empty_catalog_returns_empty(self, subject_all_stars):
-        """If no star names parsed from catalog, should return []."""
+    def test_dispatches_to_swisseph_backend(self, subject_all_stars):
+        """swisseph backend must use the Swiss-specific discovery path."""
         from unittest.mock import patch
+
+        with (
+            patch("kerykeion.fixed_stars.discovery_factory.BACKEND_NAME", "swisseph"),
+            patch.object(
+                FixedStarDiscoveryFactory,
+                "_find_prominent_stars_swisseph",
+                return_value=["swiss"],
+            ) as swiss_path,
+            patch.object(FixedStarDiscoveryFactory, "_find_prominent_stars_libephemeris") as lib_path,
+        ):
+            result = FixedStarDiscoveryFactory.find_prominent_stars(subject_all_stars, orb=2.0)
+
+        assert result == ["swiss"]
+        swiss_path.assert_called_once()
+        lib_path.assert_not_called()
+
+    def test_dispatches_to_libephemeris_backend(self, subject_all_stars):
+        """libephemeris backend must use the libephemeris-specific discovery path."""
+        from unittest.mock import patch
+
+        with (
+            patch("kerykeion.fixed_stars.discovery_factory.BACKEND_NAME", "libephemeris"),
+            patch.object(FixedStarDiscoveryFactory, "_find_prominent_stars_swisseph") as swiss_path,
+            patch.object(
+                FixedStarDiscoveryFactory,
+                "_find_prominent_stars_libephemeris",
+                return_value=["lib"],
+            ) as lib_path,
+        ):
+            result = FixedStarDiscoveryFactory.find_prominent_stars(subject_all_stars, orb=2.0)
+
+        assert result == ["lib"]
+        lib_path.assert_called_once()
+        swiss_path.assert_not_called()
+
+    def test_libephemeris_backend_does_not_parse_swiss_catalog(self, subject_all_stars):
+        """libephemeris fixed-star discovery must not read sefstars.txt."""
+        if BACKEND_NAME != "libephemeris":
+            pytest.skip("libephemeris-specific behavior")
+
+        from unittest.mock import patch
+
         with patch(
             "kerykeion.fixed_stars.discovery_factory._parse_star_names_from_catalog",
-            return_value=[],
+            side_effect=AssertionError("sefstars.txt must not be used by libephemeris"),
         ):
+            result = FixedStarDiscoveryFactory.find_prominent_stars(subject_all_stars, orb=2.0)
+        assert isinstance(result, list)
+
+    def test_empty_catalog_returns_empty(self, subject_all_stars):
+        """If the backend catalog is empty, discovery should return []."""
+        from unittest.mock import patch
+
+        if BACKEND_NAME == "swisseph":
+            target = "kerykeion.fixed_stars.discovery_factory._parse_star_names_from_catalog"
+        else:
+            target = "kerykeion.fixed_stars.discovery_factory.swe.list_fixed_stars"
+        with patch(target, return_value=[]):
             result = FixedStarDiscoveryFactory.find_prominent_stars(subject_all_stars, orb=2.0)
             assert result == []
 
     def test_parse_catalog_exception_returns_empty(self):
-        """_parse_star_names_from_catalog should return [] on file read error."""
+        """_parse_star_names_from_catalog should return empty tuple on file read error."""
         from kerykeion.fixed_stars.discovery_factory import _parse_star_names_from_catalog
+
         result = _parse_star_names_from_catalog("/nonexistent/path/sefstars.txt")
-        assert result == []
+        assert result == ()
 
     def test_empty_planet_positions_returns_empty(self):
         """If subject has no active points with abs_pos, should return []."""
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock
+
         mock_subject = MagicMock()
         mock_subject.active_points = []
         mock_subject.julian_day = 2451545.0
@@ -128,9 +220,10 @@ class TestFixedStarEdgeCases:
 
     def test_fixstar2_mag_exception_gives_none(self, subject_all_stars):
         """If swe.fixstar2_mag raises, magnitude should be None for that star."""
+        if BACKEND_NAME != "swisseph":
+            pytest.skip("fixstar2_mag enrichment is Swiss-specific in discovery")
+
         from unittest.mock import patch
-        from kerykeion.ephemeris_backend import swe
-        original = swe.fixstar2_mag
 
         def fail_mag(name):
             raise RuntimeError("No magnitude data")
@@ -165,23 +258,24 @@ class TestFixedStarEdgeCases:
 class TestFixedStarDiscovery:
     def test_find_prominent_stars(self, subject_all_stars):
         """Auto-discovery should find stars conjunct natal planets."""
-        prominent = FixedStarDiscoveryFactory.find_prominent_stars(
-            subject_all_stars, orb=2.0
-        )
+        prominent = FixedStarDiscoveryFactory.find_prominent_stars(subject_all_stars, orb=2.0)
         assert isinstance(prominent, list)
-        # With a 2-degree orb and 10+ planets, we should find at least a few stars
-        # (there are ~1000 stars spread across 360 degrees)
+        # With a 2-degree orb and 10+ points, each backend catalog should find
+        # at least one conjunction.
         assert len(prominent) >= 1, "A 2-degree orb with 10+ natal points should discover at least one star"
 
     def test_prominent_stars_have_positions(self, subject_all_stars):
         """Prominent stars should have full position data."""
-        prominent = FixedStarDiscoveryFactory.find_prominent_stars(
-            subject_all_stars, orb=2.0
-        )
+        prominent = FixedStarDiscoveryFactory.find_prominent_stars(subject_all_stars, orb=2.0)
         for star in prominent:
             assert 0 <= star.abs_pos < 360
             assert star.sign is not None
             assert star.retrograde is False
+            assert star.near_point is not None
+            assert star.orb is not None
+            assert star.aspect == "conjunction"
+            assert star.longitude == star.abs_pos
+            assert star.degree == star.position
 
     def test_tight_orb_fewer_stars(self, subject_all_stars):
         """Tighter orb should find fewer or equal stars."""
@@ -191,9 +285,7 @@ class TestFixedStarDiscovery:
 
     def test_sorted_by_magnitude(self, subject_all_stars):
         """Results should be sorted by magnitude (brightest first)."""
-        prominent = FixedStarDiscoveryFactory.find_prominent_stars(
-            subject_all_stars, orb=3.0
-        )
+        prominent = FixedStarDiscoveryFactory.find_prominent_stars(subject_all_stars, orb=3.0)
         mags = [s.magnitude for s in prominent if s.magnitude is not None]
         assert len(mags) >= 2, "A 3-degree orb should discover at least 2 stars with magnitude data"
         assert mags == sorted(mags), "Stars should be sorted by magnitude (brightest first)"

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "kerykeion"
-version = "6.0.0a36"
+version = "6.0.0a37"
 source = { editable = "." }
 dependencies = [
     { name = "libephemeris" },
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "libephemeris"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "../libephemeris" }
 dependencies = [
     { name = "astroquery" },


### PR DESCRIPTION
@coderabbitai review

## Summary
- Split fixed-star discovery by backend: `swisseph` uses `sefstars.txt`, while `libephemeris` uses its native `list_fixed_stars()` / `batch_fixstars_ut()` APIs.
- Add optional discovery metadata fields (`near_point`, `orb`, `aspect`, `longitude`, `latitude`, `degree`) to fixed-star point models.
- Bump Kerykeion to 6.0.0a37 and require libephemeris 1.2.0, with changelog and release notes.

## Tests
- `uv run ruff check kerykeion/fixed_stars/discovery_factory.py kerykeion/schemas/kr_models.py tests/core/test_dynamic_fixed_stars.py`
- `uv run pytest tests/core/test_dynamic_fixed_stars.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fixed-star discovery now returns richer metadata: nearest point, orb, aspect, longitude, latitude, and degree.

* **Performance**
  * Scanning optimized to defer costly calculations until candidates fall within the configured orb; bulk backend path uses ordered batch processing.

* **Compatibility**
  * Backend-specific discovery behavior may yield different result sets across ephemeris backends but remains additive/backward-compatible.

* **Tests**
  * Expanded tests and edge-case coverage for fixed-star discovery and backend dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->