### PR TITLE
perf: remove import-time get_leb_reader() call

### DIFF
--- a/kerykeion/ephemeris_backend.py
+++ b/kerykeion/ephemeris_backend.py
@@ -181,16 +181,6 @@ if BACKEND_NAME == "libephemeris":
     _mode = _backend_module.get_calc_mode()
     _tier = _backend_module.get_precision_tier()
     _parts = [f"mode={_mode}", f"tier={_tier}"]
-    if _mode in ("leb", "auto"):
-        _reader = _backend_module.state.get_leb_reader()
-        if _reader is not None:
-            _cls = type(_reader).__name__
-            if "Composite" in _cls:
-                _inner = type(_reader._readers[0]).__name__ if _reader._readers else "?"
-            else:
-                _inner = _cls
-            _fmt = "LEB2" if "LEB2" in _inner else "LEB1"
-            _parts.append(f"format={_fmt}")
     logger.info(
         "kerykeion ephemeris: libephemeris %s (%s)",
         _backend_module.__version__,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "libephemeris==1.2.0",
+    "libephemeris==1.3.0",
     "pydantic>=2.5",
     "svg-polish>=1.0.0",
     "requests-cache>=1.2.1",
@@ -57,7 +57,7 @@ dependencies = [
 
 [project.optional-dependencies]
 swiss = ["pyswisseph>=2.10.3.1"]
-all = ["pyswisseph>=2.10.3.1", "libephemeris>=1.2.0"]
+all = ["pyswisseph>=2.10.3.1", "libephemeris>=1.3.0"]
 
 [tool.uv.sources]
 libephemeris = { path = "../libephemeris", editable = true }


### PR DESCRIPTION
## Summary

- Remove `get_leb_reader()` call from `ephemeris_backend.py` startup logging — it opened all four companion LEB2 mmap files at import time just to log the format string
- Update libephemeris dependency to 1.3.0

**Context:** Part of the astrologer-api memory optimization effort. The import-time reader opening triggered mmap allocation before any calculation was needed.

## Test plan

- [ ] Verify kerykeion import succeeds without errors
- [ ] Verify ephemeris backend detection still logs mode and tier
- [ ] Run kerykeion test suite


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated libephemeris dependency to version 1.3.0 for enhanced ephemeris calculation support.
  * Streamlined startup logging output during ephemeris initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->