### PR TITLE
feat: dominants calculator with pluggable schools (modern, almuten figuris, elemental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 6.0.0a49
+
+_2026-05-28_
+
+New **dominants calculator** — the dominant planet, sign, element, modality and
+house of a chart — offering several interchangeable calculation "schools" behind
+a Strategy pattern, plus a first-class custom-strategy extension point.
+
+### Added
+
+- **`DominantsFactory`** (`kerykeion/dominants/`). Computes a chart's dominants
+  via `DominantsFactory.from_subject(subject, strategy=...)` (or the
+  `from_birth_data` convenience), returning the new fixed-shape `DominantsModel`.
+- Three built-in schools, selectable by name (the new `DominantMethod` literal):
+  - **`"modern"`** — modern weighted method (Astrotheme-style): planetary
+    strength from angularity, aspect activity, a mild essential-dignity
+    bonus/penalty and rulership bonuses, from which the dominant signs, houses,
+    elements, modes, polarity, hemispheres and quadrants are derived.
+    Speed and retrogradation are excluded by design.
+  - **`"almuten_figuris"`** — the traditional Lord of the Geniture: essential
+    dignities tallied for every classical planet over the five hylegiacal places
+    (Sun, Moon, Ascendant, Part of Fortune and the prenatal Syzygy), with an
+    optional accidental-dignity layer (house placement, weekday ruler).
+  - **`"elemental"`** — simple elemental/modal balance, reusing the library's
+    `calculate_element_points` / `calculate_quality_points` helpers.
+- **Custom schools via the Strategy pattern.** `DominantStrategy` (a
+  `runtime_checkable` Protocol) plus the optional `BaseDominantStrategy` base
+  (shared ranking / percentage / winner machinery) let callers plug in their own
+  school with no registration step.
+- New `DominantMethod` literal and the `DominantsModel`, `DominantScoreModel` and
+  `DominantBreakdownItemModel` models, all re-exported from the package root and
+  verified `get_type_hints`-resolvable for runtime (FastAPI) introspection.
+
+### Notes
+
+- The dominants engine reuses existing building blocks rather than duplicating
+  them: the Ptolemaic dignity tables (`kerykeion.dignities`), the element/quality
+  distribution helpers, the aspect engine, and the rulership data. The prenatal
+  Syzygy is found with a self-contained, bracketed bisection over the Sun–Moon
+  elongation and accesses the ephemeris under `EPHEMERIS_LOCK`.
+
+---
+
 ## 6.0.0a48
 
 _2026-05-28_

--- a/kerykeion/__init__.py
+++ b/kerykeion/__init__.py
@@ -124,6 +124,7 @@ from .schemas.kr_models import (
     DominantScoreModel,
     DominantBreakdownItemModel,
 )
+from .schemas.kr_literals import DominantMethod
 
 # =============================================================================
 # SETTINGS AND UTILITIES
@@ -198,6 +199,7 @@ __all__ = [
     "DominantsModel",
     "DominantScoreModel",
     "DominantBreakdownItemModel",
+    "DominantMethod",
     # Settings and Utilities
     "KerykeionSettingsModel",
     "to_context",

--- a/kerykeion/__init__.py
+++ b/kerykeion/__init__.py
@@ -94,6 +94,7 @@ from .secondary_progressions import (
 from .aspects import AspectsFactory
 from .relationship_score_factory import RelationshipScoreFactory
 from .house_comparison.house_comparison_factory import HouseComparisonFactory
+from .dominants import DominantsFactory, DominantStrategy, BaseDominantStrategy
 
 # =============================================================================
 # VISUALIZATION
@@ -119,6 +120,9 @@ from .schemas.kr_models import (
     PlanetaryHoursModel,
     VoidOfCourseAspectModel,
     VoidOfCourseMoonModel,
+    DominantsModel,
+    DominantScoreModel,
+    DominantBreakdownItemModel,
 )
 
 # =============================================================================
@@ -170,6 +174,9 @@ __all__ = [
     "AspectsFactory",
     "RelationshipScoreFactory",
     "HouseComparisonFactory",
+    "DominantsFactory",
+    "DominantStrategy",
+    "BaseDominantStrategy",
     # Visualization
     "ChartDrawer",
     "ReportGenerator",
@@ -188,6 +195,9 @@ __all__ = [
     "PlanetaryHoursModel",
     "VoidOfCourseAspectModel",
     "VoidOfCourseMoonModel",
+    "DominantsModel",
+    "DominantScoreModel",
+    "DominantBreakdownItemModel",
     # Settings and Utilities
     "KerykeionSettingsModel",
     "to_context",

--- a/kerykeion/dominants/__init__.py
+++ b/kerykeion/dominants/__init__.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+Dominants calculator
+====================
+
+Compute the *dominants* of a natal chart — the dominant planet, sign, element,
+modality, house (and, for the modern method, polarity, hemispheres and
+quadrants) — under one of several interchangeable astrological "schools", or a
+user-defined custom strategy.
+
+Built-in schools (see :data:`~kerykeion.schemas.kr_literals.DominantMethod`):
+    - ``"modern"``: modern weighted method (Astrotheme-style).
+    - ``"almuten_figuris"``: traditional Almuten Figuris / Lord of the Geniture.
+    - ``"elemental"``: simple elemental & modal balance.
+
+Quick start:
+    >>> from kerykeion import AstrologicalSubjectFactory, DominantsFactory
+    >>> subject = AstrologicalSubjectFactory.from_birth_data(
+    ...     "John Lennon", 1940, 10, 9, 18, 30,
+    ...     lat=53.4084, lng=-2.9916, tz_str="Europe/London", online=False)
+    >>> dominants = DominantsFactory.from_subject(subject, strategy="modern")
+    >>> dominants.dominant_planet  # doctest: +SKIP
+    'Pluto'
+
+Extensibility — plug in a custom school via the Strategy pattern:
+    >>> from kerykeion import BaseDominantStrategy, DominantsFactory
+    >>> class MySchool(BaseDominantStrategy):
+    ...     name = "my_school"
+    ...     def compute(self, subject, config):
+    ...         ...  # build and return a DominantsModel (helpers in the base class)
+    >>> DominantsFactory.from_subject(subject, strategy=MySchool())  # doctest: +SKIP
+
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+from kerykeion.dominants.base import (
+    BaseDominantStrategy,
+    BreakdownItem,
+    Category,
+    DominantsConfig,
+    DominantStrategy,
+)
+from kerykeion.dominants.factory import DominantsFactory
+from kerykeion.dominants.strategies import (
+    AlmutenFigurisStrategy,
+    ElementalBalanceStrategy,
+    ModernDominantStrategy,
+)
+
+__all__ = [
+    # Public entry point
+    "DominantsFactory",
+    # Strategy contract + optional base (custom-school extension point)
+    "DominantStrategy",
+    "BaseDominantStrategy",
+    "DominantsConfig",
+    # Built-in schools
+    "ModernDominantStrategy",
+    "AlmutenFigurisStrategy",
+    "ElementalBalanceStrategy",
+    # Internal value objects (useful when writing a custom strategy)
+    "Category",
+    "BreakdownItem",
+]

--- a/kerykeion/dominants/base.py
+++ b/kerykeion/dominants/base.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+"""
+Strategy contract and shared machinery for the dominants calculator.
+====================================================================
+
+This module defines the seam that makes the calculator extensible:
+
+- :class:`DominantStrategy` — a structural ``typing.Protocol``. Anything with a
+  ``name`` and a ``compute(subject, config)`` method that returns a
+  :class:`DominantsModel` is a valid strategy, so users can plug in their own
+  school without subclassing anything (mirrors the project's existing
+  ``ChartRendererProtocol`` idiom).
+- :class:`BaseDominantStrategy` — an optional convenience base implementing the
+  *Template Method* pattern: it owns the boring, shared work (ranking a category,
+  normalizing percentages, choosing winners, assembling the public model) so a
+  concrete school only has to produce raw per-category scores.
+- :class:`DominantsConfig` — the single, growable bag of options the factory
+  injects into a strategy, keeping ``compute``'s signature stable over time.
+
+The intermediate value objects (:class:`Category`, :class:`BreakdownItem`) are
+plain dataclasses so strategies never touch Pydantic directly; the base class is
+the one place that builds the public :class:`DominantsModel`.
+
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Literal, Optional, Protocol, runtime_checkable
+
+from kerykeion.dominants.data import DOMINANT_PLANET_COUNT
+from kerykeion.schemas.kr_literals import DominantMethod
+from kerykeion.schemas.kr_models import (
+    AstrologicalSubjectModel,
+    DominantBreakdownItemModel,
+    DominantScoreModel,
+    DominantsModel,
+)
+from kerykeion.utilities import distribute_percentages_to_100
+
+#: Allowed distribution methods for the element/quality tally (mirrors
+#: ``charts_utils.ElementQualityDistributionMethod`` without importing the
+#: rendering package).
+DistributionMethod = Literal["pure_count", "weighted"]
+
+#: The fixed set of categories every result exposes, in display order. The base
+#: class always emits all of them so the public model shape is stable.
+CATEGORY_NAMES: tuple[str, ...] = (
+    "planets",
+    "signs",
+    "elements",
+    "qualities",
+    "houses",
+    "polarities",
+    "hemispheres",
+    "quadrants",
+)
+
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+
+@dataclass
+class DominantsConfig:
+    """Tunable options passed by the factory into a strategy's ``compute``.
+
+    Bundling the knobs in one object keeps the strategy contract stable as
+    options are added (open/closed principle): new fields here never change the
+    ``compute`` signature.
+
+    Attributes:
+        active_points: Optional explicit subset of point names to consider. When
+            ``None``, each school uses its natural default set.
+        distribution_method: ``"weighted"`` (default) or ``"pure_count"`` for the
+            element/modality tally.
+        custom_weights: Optional per-point weight overrides for the element/
+            modality tally (case-insensitive point names).
+        include_accidental_dignities: When ``True``, the Almuten Figuris adds its
+            optional accidental-dignity layer (house placement, day ruler).
+        include_score_breakdown: When ``True``, strategies populate the model's
+            ``score_breakdown`` with a per-rule audit trail.
+        dominant_planet_count: How many top planets are flagged as dominant.
+    """
+
+    active_points: Optional[List[str]] = None
+    distribution_method: DistributionMethod = "weighted"
+    custom_weights: Optional[Dict[str, float]] = None
+    include_accidental_dignities: bool = False
+    include_score_breakdown: bool = False
+    dominant_planet_count: int = DOMINANT_PLANET_COUNT
+
+
+# =============================================================================
+# INTERNAL VALUE OBJECTS (no Pydantic — strategies stay model-agnostic)
+# =============================================================================
+
+
+@dataclass
+class Category:
+    """Raw scores for one dominant category, before ranking.
+
+    Attributes:
+        scores: Mapping of item name to raw score (e.g. ``{"Sun": 12.4}``).
+        dominant: The subset of names a school flags as dominant for this
+            category (e.g. the top-N planets, or elements above a threshold).
+    """
+
+    scores: Dict[str, float] = field(default_factory=dict)
+    dominant: set[str] = field(default_factory=set)
+
+
+@dataclass
+class BreakdownItem:
+    """A single audit line for ``score_breakdown`` (see the public model)."""
+
+    category: str
+    target: str
+    rule: str
+    points: float
+    detail: Optional[str] = None
+
+
+# =============================================================================
+# STRATEGY PROTOCOL
+# =============================================================================
+
+
+@runtime_checkable
+class DominantStrategy(Protocol):
+    """Structural contract for a dominant-calculation school.
+
+    Any object exposing a ``name`` attribute and a ``compute`` method with the
+    signature below satisfies the protocol — no inheritance required. This is
+    the extension point for user-defined schools.
+
+    Attributes:
+        name: Human-readable identifier of the school, copied into
+            :attr:`DominantsModel.strategy_name`.
+    """
+
+    name: str
+
+    def compute(self, subject: AstrologicalSubjectModel, config: DominantsConfig) -> DominantsModel:
+        """Compute the dominants of ``subject`` under ``config``.
+
+        Args:
+            subject: The (already calculated) natal/event chart.
+            config: Options bundle (see :class:`DominantsConfig`).
+
+        Returns:
+            A fully populated :class:`DominantsModel`.
+        """
+        ...
+
+
+# =============================================================================
+# OPTIONAL BASE CLASS (Template Method)
+# =============================================================================
+
+
+class BaseDominantStrategy:
+    """Convenience base that centralizes ranking, normalization and assembly.
+
+    A concrete school subclasses this, sets :attr:`name` (and optionally
+    :attr:`method`), and produces raw :class:`Category` scores; the inherited
+    :meth:`build_model` turns those into the ranked, percentage-normalized public
+    model. Subclassing is optional — see :class:`DominantStrategy`.
+
+    Attributes:
+        name: Identifier of the school (overridden by subclasses).
+        method: The built-in :data:`DominantMethod` this school implements, or
+            ``None`` for a custom strategy.
+    """
+
+    name: str = "base"
+    method: Optional[DominantMethod] = None
+
+    def compute(self, subject: AstrologicalSubjectModel, config: DominantsConfig) -> DominantsModel:
+        """Compute the dominants. Must be overridden by concrete schools."""
+        raise NotImplementedError(f"{type(self).__name__} must implement compute(subject, config).")
+
+    # -- shared helpers -----------------------------------------------------
+
+    @staticmethod
+    def _rank_category(category: Category) -> List[DominantScoreModel]:
+        """Rank one category's raw scores into ordered :class:`DominantScoreModel`.
+
+        Entries are sorted by descending score with a deterministic name-based
+        tie-break. Percentages are computed over the non-negative part of the
+        scores (negative scores, e.g. dignity penalties, would otherwise distort
+        a share-of-total) and reuse the library's largest-remainder rounding.
+
+        Args:
+            category: The raw scores and dominant flags for the category.
+
+        Returns:
+            Ranked score models (rank 1 = strongest); empty if no scores.
+        """
+        scores = category.scores
+        if not scores:
+            return []
+
+        ordered = sorted(scores.items(), key=lambda kv: (-kv[1], kv[0]))
+        percentages = distribute_percentages_to_100({name: max(0.0, value) for name, value in scores.items()})
+
+        return [
+            DominantScoreModel(
+                name=name,
+                score=round(value, 4),
+                percentage=float(percentages.get(name, 0)),
+                rank=rank,
+                is_dominant=name in category.dominant,
+            )
+            for rank, (name, value) in enumerate(ordered, start=1)
+        ]
+
+    @staticmethod
+    def _winner(items: List[DominantScoreModel]) -> Optional[str]:
+        """Return the name of the category winner.
+
+        The winner is the highest-ranked entry flagged dominant; if a school
+        flags none, the top-ranked entry is used. ``None`` for an empty category.
+        """
+        for item in items:
+            if item.is_dominant:
+                return item.name
+        return items[0].name if items else None
+
+    def build_model(
+        self,
+        *,
+        categories: Dict[str, Category],
+        breakdown: Optional[List[BreakdownItem]] = None,
+    ) -> DominantsModel:
+        """Assemble the public :class:`DominantsModel` from raw categories.
+
+        Args:
+            categories: Raw scores keyed by category name (see
+                :data:`CATEGORY_NAMES`). Missing categories become empty lists.
+            breakdown: Optional audit trail; included verbatim in the model.
+
+        Returns:
+            The ranked, percentage-normalized, winner-annotated model.
+        """
+        ranked: Dict[str, List[DominantScoreModel]] = {
+            name: self._rank_category(categories.get(name, Category())) for name in CATEGORY_NAMES
+        }
+
+        breakdown_models = [
+            DominantBreakdownItemModel(
+                category=item.category,
+                target=item.target,
+                rule=item.rule,
+                points=round(item.points, 4),
+                detail=item.detail,
+            )
+            for item in (breakdown or [])
+        ]
+
+        return DominantsModel(
+            strategy_name=self.name,
+            method=self.method,
+            planets=ranked["planets"],
+            signs=ranked["signs"],
+            elements=ranked["elements"],
+            qualities=ranked["qualities"],
+            houses=ranked["houses"],
+            polarities=ranked["polarities"],
+            hemispheres=ranked["hemispheres"],
+            quadrants=ranked["quadrants"],
+            dominant_planet=self._winner(ranked["planets"]),
+            dominant_sign=self._winner(ranked["signs"]),
+            dominant_element=self._winner(ranked["elements"]),
+            dominant_quality=self._winner(ranked["qualities"]),
+            dominant_house=self._winner(ranked["houses"]),
+            score_breakdown=breakdown_models,
+        )

--- a/kerykeion/dominants/data.py
+++ b/kerykeion/dominants/data.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from typing import Dict, List, Tuple
 
 from kerykeion.schemas.kr_literals import Element, Quality, Sign
+from kerykeion.schemas.kr_models import ActiveAspect
 
 # =============================================================================
 # ZODIAC: SIGN INDEX -> ELEMENT / QUALITY (Title-case)
@@ -199,7 +200,7 @@ ASPECT_STRENGTH: Dict[int, float] = {
 #: for the modern method. Orbs are deliberately generous because we are
 #: measuring overall *activity*, not drawing a chart. Each orb is also the
 #: denominator of the orb-exactitude term (tighter aspect ⇒ larger weight).
-DOMINANT_ASPECTS: List[Dict[str, object]] = [
+DOMINANT_ASPECTS: List[ActiveAspect] = [
     {"name": "conjunction", "orb": 10.0},
     {"name": "opposition", "orb": 10.0},
     {"name": "trine", "orb": 8.0},

--- a/kerykeion/dominants/data.py
+++ b/kerykeion/dominants/data.py
@@ -1,0 +1,334 @@
+# -*- coding: utf-8 -*-
+"""
+Reference tables and tunable constants for the dominants calculator.
+====================================================================
+
+This module is the single place where every weight, threshold and lookup table
+used by the dominant-calculation schools lives. Keeping the numbers separate
+from the algorithms makes each school auditable at a glance and lets advanced
+users fork a strategy with different calibration without touching logic.
+
+Sources / lineage:
+    - Modern weighted method: the criteria publicly described by Astrotheme
+      (angularity, aspect activity, dignity, rulership). The exact point values
+      Astrotheme uses are proprietary, so the constants below are a transparent,
+      well-documented approximation — tune them freely.
+    - Almuten Figuris: Ptolemaic essential dignities (domicile 5, exaltation 4,
+      triplicity 3, term 2, face 1) tallied over the five hylegiacal places, as
+      documented on kerykeion.net. Accidental-dignity values follow common
+      traditional schemes and are an *optional* layer.
+
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from kerykeion.schemas.kr_literals import Element, Quality, Sign
+
+# =============================================================================
+# ZODIAC: SIGN INDEX -> ELEMENT / QUALITY (Title-case)
+# =============================================================================
+# Indexed by ``sign_num`` (0 = Aries … 11 = Pisces). Title-case so the values
+# match the ``Element`` / ``Quality`` literals AND the keys of the dignity
+# tables (e.g. ``TRIPLICITY_RULERS["Fire"]``). A separate lowercase mapping
+# already exists under ``charts/`` for the chart drawer; we keep a Title-case
+# copy here to stay decoupled from the rendering package.
+
+#: Element of each zodiac sign, indexed by ``sign_num`` (0-11).
+SIGN_NUM_TO_ELEMENT: Tuple[Element, ...] = (
+    "Fire",  # Aries
+    "Earth",  # Taurus
+    "Air",  # Gemini
+    "Water",  # Cancer
+    "Fire",  # Leo
+    "Earth",  # Virgo
+    "Air",  # Libra
+    "Water",  # Scorpio
+    "Fire",  # Sagittarius
+    "Earth",  # Capricorn
+    "Air",  # Aquarius
+    "Water",  # Pisces
+)
+
+#: Quality (modality) of each zodiac sign, indexed by ``sign_num`` (0-11).
+SIGN_NUM_TO_QUALITY: Tuple[Quality, ...] = (
+    "Cardinal",  # Aries
+    "Fixed",  # Taurus
+    "Mutable",  # Gemini
+    "Cardinal",  # Cancer
+    "Fixed",  # Leo
+    "Mutable",  # Virgo
+    "Cardinal",  # Libra
+    "Fixed",  # Scorpio
+    "Mutable",  # Sagittarius
+    "Cardinal",  # Capricorn
+    "Fixed",  # Aquarius
+    "Mutable",  # Pisces
+)
+
+#: Polarity (Yang/Yin) of each element. Fire & Air are Yang (active,
+#: extrovert); Earth & Water are Yin (receptive, introvert).
+POLARITY_BY_ELEMENT: Dict[Element, str] = {
+    "Fire": "Yang",
+    "Air": "Yang",
+    "Earth": "Yin",
+    "Water": "Yin",
+}
+
+#: Map the lowercase element keys returned by ``calculate_element_points`` to
+#: the Title-case ``Element`` literal used by the public models.
+ELEMENT_LOWER_TO_TITLE: Dict[str, Element] = {
+    "fire": "Fire",
+    "earth": "Earth",
+    "air": "Air",
+    "water": "Water",
+}
+
+#: Map the lowercase modality keys returned by ``calculate_quality_points`` to
+#: the Title-case ``Quality`` literal used by the public models.
+QUALITY_LOWER_TO_TITLE: Dict[str, Quality] = {
+    "cardinal": "Cardinal",
+    "fixed": "Fixed",
+    "mutable": "Mutable",
+}
+
+
+# =============================================================================
+# RULERSHIP — MODERN (used by the modern weighted method)
+# =============================================================================
+# The traditional rulerships live in ``kerykeion.dignities.dignity_data`` and
+# are consumed verbatim by the dignity engine and the Almuten Figuris. The
+# modern weighted method instead assigns the outer planets as rulers of the
+# three signs they are commonly given in modern practice, so we keep a separate
+# MODERN map here (and never pollute the traditional one).
+
+#: Sign -> modern ruling planet(s). Differs from the traditional table only for
+#: Scorpio (Pluto), Aquarius (Uranus) and Pisces (Neptune).
+MODERN_RULERS: Dict[Sign, List[str]] = {
+    "Ari": ["Mars"],
+    "Tau": ["Venus"],
+    "Gem": ["Mercury"],
+    "Can": ["Moon"],
+    "Leo": ["Sun"],
+    "Vir": ["Mercury"],
+    "Lib": ["Venus"],
+    "Sco": ["Pluto"],
+    "Sag": ["Jupiter"],
+    "Cap": ["Saturn"],
+    "Aqu": ["Uranus"],
+    "Pis": ["Neptune"],
+}
+
+
+# =============================================================================
+# CLASSICAL PLANETS & PLANETARY DAY RULERS
+# =============================================================================
+
+#: The seven classical planets, in traditional (Chaldean, slowest-first) weight
+#: order. Used as the candidate set for the Almuten Figuris and as the final,
+#: deterministic tie-break order (earlier = wins a tie).
+ALMUTEN_TIEBREAK_ORDER: Tuple[str, ...] = ("Saturn", "Jupiter", "Mars", "Sun", "Venus", "Mercury", "Moon")
+
+#: The seven classical planets in luminary-first order (the candidate set used
+#: when tallying dignities). Membership matches ``dignity_data.DIGNITY_PLANETS``.
+CLASSICAL_PLANETS: Tuple[str, ...] = ("Sun", "Moon", "Mercury", "Venus", "Mars", "Jupiter", "Saturn")
+
+#: Planetary ruler of each weekday, numbered 0 = Sunday … 6 = Saturday to match
+#: the ``(int(jd + 0.5) + 1) % 7`` convention. Used for the optional Almuten
+#: day-ruler accidental bonus.
+WEEKDAY_RULERS: Tuple[str, ...] = ("Sun", "Moon", "Mars", "Mercury", "Jupiter", "Venus", "Saturn")
+
+
+# =============================================================================
+# MODERN WEIGHTED METHOD — ANGULARITY
+# =============================================================================
+
+#: Maximum orb (degrees) within which a planet is considered "angular". Beyond
+#: this distance from an angle the angularity contribution is zero. Astrotheme
+#: documents 15° as the distance at which the influence starts to manifest.
+ANGULARITY_ORB: float = 15.0
+
+#: Points awarded to a planet exactly conjunct the *Ascendant* (the strongest
+#: angle). Other angles scale this down via ``ANGLE_WEIGHTS`` and the orb falls
+#: off linearly to zero at ``ANGULARITY_ORB``.
+ANGULARITY_MAX_POINTS: float = 4.0
+
+#: Relative strength of each of the four angles, in decreasing order
+#: Asc > MC > Desc > IC (per Astrotheme's documented hierarchy).
+ANGLE_WEIGHTS: Dict[str, float] = {
+    "Ascendant": 1.00,
+    "Medium_Coeli": 0.80,
+    "Descendant": 0.60,
+    "Imum_Coeli": 0.50,
+}
+
+
+# =============================================================================
+# MODERN WEIGHTED METHOD — ASPECT ACTIVITY
+# =============================================================================
+
+#: Base scale applied to every aspect contribution before the type/orb/pair
+#: multipliers. Larger values make the chart's aspect network weigh more in the
+#: planetary totals relative to angularity and rulership.
+ASPECT_BASE_POINTS: float = 3.0
+
+#: Extra multiplier when one of the two bodies of an aspect is a chart angle
+#: (Asc/MC/Desc/IC). Aspects to the angles are emphasised, as in Astrotheme.
+ASPECT_TO_ANGLE_MULTIPLIER: float = 1.5
+
+#: Strength of each aspect *type*, keyed by its exact degree (matches
+#: ``AspectModel.aspect_degrees``). Conjunction is strongest, then the soft/hard
+#: majors, then the minors. Tune to taste.
+ASPECT_STRENGTH: Dict[int, float] = {
+    0: 1.00,  # conjunction
+    180: 0.85,  # opposition
+    120: 0.85,  # trine
+    90: 0.60,  # square
+    60: 0.50,  # sextile
+    150: 0.30,  # quincunx (inconjunct)
+    45: 0.20,  # semi-square
+    135: 0.20,  # sesquiquadrate
+    30: 0.15,  # semi-sextile
+    72: 0.15,  # quintile
+    144: 0.15,  # biquintile
+}
+
+#: Active aspects (name + orb) fed to ``AspectsFactory.single_chart_aspects``
+#: for the modern method. Orbs are deliberately generous because we are
+#: measuring overall *activity*, not drawing a chart. Each orb is also the
+#: denominator of the orb-exactitude term (tighter aspect ⇒ larger weight).
+DOMINANT_ASPECTS: List[Dict[str, object]] = [
+    {"name": "conjunction", "orb": 10.0},
+    {"name": "opposition", "orb": 10.0},
+    {"name": "trine", "orb": 8.0},
+    {"name": "square", "orb": 8.0},
+    {"name": "sextile", "orb": 6.0},
+    {"name": "quincunx", "orb": 3.0},
+    {"name": "semi-sextile", "orb": 2.0},
+    {"name": "semi-square", "orb": 2.0},
+    {"name": "sesquiquadrate", "orb": 2.0},
+    {"name": "quintile", "orb": 2.0},
+    {"name": "biquintile", "orb": 2.0},
+]
+
+#: Per-aspect orb lookup derived from ``DOMINANT_ASPECTS`` (name -> orb), used as
+#: the orb-exactitude denominator.
+ASPECT_ORB_BY_NAME: Dict[str, float] = {str(a["name"]): float(a["orb"]) for a in DOMINANT_ASPECTS}
+
+#: Static "speed tier" of each body: fast bodies (Moon, inner planets) carry more
+#: weight than slow ones, so a generational Neptune-Pluto aspect counts far less
+#: than a personal Moon-Mars aspect. This is a *doctrinal* weight on the body's
+#: nature, NOT the chart's instantaneous speed (speed/retrogradation are
+#: deliberately excluded from the modern scoring).
+PLANET_SPEED_TIER: Dict[str, float] = {
+    "Moon": 1.00,
+    "Mercury": 0.90,
+    "Venus": 0.90,
+    "Sun": 0.90,
+    "Mars": 0.80,
+    "Jupiter": 0.60,
+    "Saturn": 0.55,
+    "Uranus": 0.35,
+    "Neptune": 0.30,
+    "Pluto": 0.30,
+    "Ascendant": 0.90,
+    "Medium_Coeli": 0.90,
+    "Descendant": 0.90,
+    "Imum_Coeli": 0.90,
+    "Mean_North_Lunar_Node": 0.40,
+    "True_North_Lunar_Node": 0.40,
+    "Chiron": 0.40,
+}
+
+#: Fallback speed tier for any body not listed above (asteroids, TNOs, etc.).
+PLANET_SPEED_TIER_DEFAULT: float = 0.30
+
+
+# =============================================================================
+# MODERN WEIGHTED METHOD — ESSENTIAL DIGNITY (deliberately MILD)
+# =============================================================================
+# Astrotheme applies only a small bonus/penalty for dignity so it never
+# distorts the result. We therefore map the dignity *label* to a small value
+# instead of using the raw Ptolemaic score (which ranges -5..+5).
+
+#: Mild bonus/penalty by essential-dignity label.
+DIGNITY_BONUS: Dict[str, float] = {
+    "Domicile": 1.00,
+    "Exaltation": 0.75,
+    "Triplicity": 0.40,
+    "Term": 0.25,
+    "Face": 0.15,
+    "Peregrine": 0.00,
+    "Detriment": -1.00,
+    "Fall": -0.75,
+}
+
+
+# =============================================================================
+# MODERN WEIGHTED METHOD — RULERSHIP BONUS
+# =============================================================================
+# The ruler of the Ascendant is the single most important planet of a chart;
+# the rulers of the MC, the Sun sign and the Moon sign follow in decreasing
+# importance.
+
+RULER_BONUS_ASC: float = 3.0
+RULER_BONUS_MC: float = 2.0
+RULER_BONUS_SUN_SIGN: float = 1.5
+RULER_BONUS_MOON_SIGN: float = 1.0
+
+
+# =============================================================================
+# MODERN WEIGHTED METHOD — DERIVATION THRESHOLDS
+# =============================================================================
+
+#: How many top-scoring planets are flagged as "dominant".
+DOMINANT_PLANET_COUNT: int = 3
+
+#: How many top entries are flagged dominant in the sign and house categories.
+DOMINANT_SIGN_COUNT: int = 3
+DOMINANT_HOUSE_COUNT: int = 3
+
+#: Flat weight added to the Ascendant's own sign when deriving dominant signs,
+#: so the rising sign is always prominent.
+ASC_SIGN_BONUS: float = 3.0
+
+
+# =============================================================================
+# ALMUTEN FIGURIS — ESSENTIAL & ACCIDENTAL DIGNITIES
+# =============================================================================
+
+#: Points for each essential dignity, summed across the five hylegiacal places.
+ESSENTIAL_DIGNITY_POINTS: Dict[str, int] = {
+    "Domicile": 5,
+    "Exaltation": 4,
+    "Triplicity": 3,
+    "Term": 2,
+    "Face": 1,
+}
+
+#: The five hylegiacal places evaluated, in canonical order. ``Pars_Fortunae``
+#: and ``Syzygy`` may be unavailable (unknown birth time, ephemeris gap) and are
+#: then skipped — the tally simply runs over the remaining places.
+ALMUTEN_PLACES: Tuple[str, ...] = ("Sun", "Moon", "Ascendant", "Pars_Fortunae", "Syzygy")
+
+#: OPTIONAL accidental-dignity points by house of residence (a common
+#: traditional scheme). Only applied when ``include_accidental_dignities=True``.
+ALMUTEN_HOUSE_PLACEMENT_POINTS: Dict[int, int] = {
+    1: 12,
+    10: 11,
+    7: 10,
+    4: 9,
+    11: 8,
+    5: 7,
+    2: 6,
+    9: 5,
+    8: 4,
+    3: 3,
+    12: 2,
+    6: 1,
+}
+
+#: OPTIONAL bonus for the planet ruling the weekday of birth.
+ALMUTEN_DAY_RULER_BONUS: float = 7.0

--- a/kerykeion/dominants/factory.py
+++ b/kerykeion/dominants/factory.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+"""
+Public entry point for the dominants calculator.
+=================================================
+
+:class:`DominantsFactory` is the one class users touch. It resolves which
+calculation *school* to run — either a built-in method selected by name
+(``"modern"``, ``"almuten_figuris"``, ``"elemental"``) or a user-supplied custom
+strategy object — and returns a :class:`DominantsModel`.
+
+Built-in schools are stateless and shared via a small registry; a custom school
+is any object satisfying the :class:`~kerykeion.dominants.base.DominantStrategy`
+protocol (a ``name`` attribute and a ``compute(subject, config)`` method), so no
+registration step is required:
+
+    >>> class MySchool(BaseDominantStrategy):
+    ...     name = "my_school"
+    ...     def compute(self, subject, config):
+    ...         ...  # build and return a DominantsModel
+    >>> DominantsFactory.from_subject(subject, strategy=MySchool())
+
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Union
+
+from kerykeion.dominants.base import DistributionMethod, DominantsConfig, DominantStrategy
+from kerykeion.dominants.strategies import (
+    AlmutenFigurisStrategy,
+    ElementalBalanceStrategy,
+    ModernDominantStrategy,
+)
+from kerykeion.schemas.kerykeion_exception import KerykeionException
+from kerykeion.schemas.kr_literals import DominantMethod
+from kerykeion.schemas.kr_models import AstrologicalSubjectModel, DominantsModel
+
+#: Registry of built-in schools. Instances are stateless and safe to share.
+_BUILTIN_STRATEGIES: Dict[str, DominantStrategy] = {
+    "modern": ModernDominantStrategy(),
+    "almuten_figuris": AlmutenFigurisStrategy(),
+    "elemental": ElementalBalanceStrategy(),
+}
+
+
+class DominantsFactory:
+    """Compute the dominants of a chart with a built-in or custom school.
+
+    Example:
+        >>> from kerykeion import AstrologicalSubjectFactory, DominantsFactory
+        >>> subject = AstrologicalSubjectFactory.from_birth_data(
+        ...     "John Lennon", 1940, 10, 9, 18, 30,
+        ...     lat=53.4084, lng=-2.9916, tz_str="Europe/London", online=False)
+        >>> dominants = DominantsFactory.from_subject(subject, strategy="modern")
+        >>> dominants.dominant_planet, dominants.dominant_element  # doctest: +SKIP
+        ('Mars', 'Earth')
+    """
+
+    @classmethod
+    def from_subject(
+        cls,
+        subject: AstrologicalSubjectModel,
+        *,
+        strategy: Union[DominantMethod, DominantStrategy] = "modern",
+        active_points: Optional[list[str]] = None,
+        distribution_method: DistributionMethod = "weighted",
+        custom_weights: Optional[Dict[str, float]] = None,
+        include_accidental_dignities: bool = False,
+        include_score_breakdown: bool = False,
+    ) -> DominantsModel:
+        """Compute the dominants of an already-calculated subject.
+
+        Args:
+            subject: The natal/event chart to analyse.
+            strategy: Either a built-in method name (``"modern"``,
+                ``"almuten_figuris"`` or ``"elemental"``) or a custom object
+                implementing the :class:`DominantStrategy` protocol.
+            active_points: Optional explicit subset of point names to consider
+                (used by the ``elemental`` school). When ``None``, the subject's
+                own active points are used.
+            distribution_method: ``"weighted"`` (default) or ``"pure_count"`` for
+                the element/modality tally.
+            custom_weights: Optional per-point weight overrides for the
+                element/modality tally (case-insensitive point names).
+            include_accidental_dignities: When ``True``, the Almuten Figuris adds
+                its optional accidental-dignity layer.
+            include_score_breakdown: When ``True``, the result's
+                ``score_breakdown`` is populated with a per-rule audit trail.
+
+        Returns:
+            A :class:`DominantsModel` for the chosen school.
+
+        Raises:
+            KerykeionException: If ``strategy`` is neither a known built-in name
+                nor a valid :class:`DominantStrategy` instance.
+        """
+        config = DominantsConfig(
+            active_points=active_points,
+            distribution_method=distribution_method,
+            custom_weights=custom_weights,
+            include_accidental_dignities=include_accidental_dignities,
+            include_score_breakdown=include_score_breakdown,
+        )
+        resolved = cls._resolve_strategy(strategy)
+        return resolved.compute(subject, config)
+
+    @classmethod
+    def from_birth_data(
+        cls,
+        name: str,
+        year: int,
+        month: int,
+        day: int,
+        hour: int = 12,
+        minute: int = 0,
+        *,
+        strategy: Union[DominantMethod, DominantStrategy] = "modern",
+        active_points: Optional[list[str]] = None,
+        distribution_method: DistributionMethod = "weighted",
+        custom_weights: Optional[Dict[str, float]] = None,
+        include_accidental_dignities: bool = False,
+        include_score_breakdown: bool = False,
+        **subject_kwargs: object,
+    ) -> DominantsModel:
+        """Build a subject from birth data, then compute its dominants.
+
+        A thin convenience over :meth:`from_subject`. The positional birth
+        arguments and any extra keyword arguments (``lat``, ``lng``, ``tz_str``,
+        ``online``, …) are forwarded verbatim to
+        :meth:`AstrologicalSubjectFactory.from_birth_data`.
+
+        Args:
+            name: Subject name.
+            year, month, day, hour, minute: Birth date and time.
+            strategy: See :meth:`from_subject`.
+            active_points, distribution_method, custom_weights,
+                include_accidental_dignities, include_score_breakdown:
+                See :meth:`from_subject`.
+            **subject_kwargs: Forwarded to ``AstrologicalSubjectFactory``
+                (e.g. ``lat``, ``lng``, ``tz_str``, ``city``, ``nation``,
+                ``online``, ``zodiac_type``).
+
+        Returns:
+            A :class:`DominantsModel` for the chosen school.
+        """
+        # Local import avoids an import-time dependency on the subject factory.
+        from kerykeion.astrological_subject_factory import AstrologicalSubjectFactory
+
+        subject = AstrologicalSubjectFactory.from_birth_data(name, year, month, day, hour, minute, **subject_kwargs)
+        return cls.from_subject(
+            subject,
+            strategy=strategy,
+            active_points=active_points,
+            distribution_method=distribution_method,
+            custom_weights=custom_weights,
+            include_accidental_dignities=include_accidental_dignities,
+            include_score_breakdown=include_score_breakdown,
+        )
+
+    @staticmethod
+    def available_methods() -> list[str]:
+        """Return the names of the built-in dominant-calculation methods."""
+        return sorted(_BUILTIN_STRATEGIES)
+
+    @staticmethod
+    def _resolve_strategy(strategy: Union[DominantMethod, DominantStrategy]) -> DominantStrategy:
+        """Resolve a method name or custom strategy to a concrete strategy.
+
+        Args:
+            strategy: A built-in method name or a :class:`DominantStrategy`.
+
+        Returns:
+            The strategy instance to run.
+
+        Raises:
+            KerykeionException: For an unknown name or an invalid object.
+        """
+        if isinstance(strategy, str):
+            try:
+                return _BUILTIN_STRATEGIES[strategy]
+            except KeyError:
+                valid = ", ".join(sorted(_BUILTIN_STRATEGIES))
+                raise KerykeionException(
+                    f"Unknown dominant method {strategy!r}. Valid built-in methods: {valid}. "
+                    f"Alternatively pass a custom DominantStrategy instance."
+                ) from None
+
+        if isinstance(strategy, DominantStrategy):
+            return strategy
+
+        raise KerykeionException(
+            "strategy must be a built-in method name (str) or a DominantStrategy instance "
+            "(an object with a 'name' attribute and a 'compute(subject, config)' method)."
+        )

--- a/kerykeion/dominants/strategies/__init__.py
+++ b/kerykeion/dominants/strategies/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+Built-in dominant-calculation strategies (the "schools").
+
+Each module here implements one citable school behind the shared
+:class:`~kerykeion.dominants.base.DominantStrategy` contract:
+
+- :class:`~kerykeion.dominants.strategies.elemental.ElementalBalanceStrategy`
+- :class:`~kerykeion.dominants.strategies.almuten_figuris.AlmutenFigurisStrategy`
+- :class:`~kerykeion.dominants.strategies.modern.ModernDominantStrategy`
+
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+from kerykeion.dominants.strategies.almuten_figuris import AlmutenFigurisStrategy
+from kerykeion.dominants.strategies.elemental import ElementalBalanceStrategy
+from kerykeion.dominants.strategies.modern import ModernDominantStrategy
+
+__all__ = [
+    "ElementalBalanceStrategy",
+    "AlmutenFigurisStrategy",
+    "ModernDominantStrategy",
+]

--- a/kerykeion/dominants/strategies/almuten_figuris.py
+++ b/kerykeion/dominants/strategies/almuten_figuris.py
@@ -53,6 +53,13 @@ class AlmutenFigurisStrategy(BaseDominantStrategy):
     and the polarity/hemisphere/quadrant categories are not part of this
     technique and stay empty.
 
+    Note:
+        The technique is traditionally **tropical**. For a sidereal subject the
+        dignities are tallied on the sidereal signs the points fall in: this is
+        internally consistent and deterministic, but departs from classical
+        (tropical) practice, so a sidereal Almuten should be read with that in
+        mind.
+
     Example:
         >>> from kerykeion import AstrologicalSubjectFactory, DominantsFactory
         >>> subject = AstrologicalSubjectFactory.from_birth_data(

--- a/kerykeion/dominants/strategies/almuten_figuris.py
+++ b/kerykeion/dominants/strategies/almuten_figuris.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+"""
+Almuten Figuris — the traditional "Lord of the Geniture".
+=========================================================
+
+A medieval/Renaissance technique for the single planet that most rules a chart.
+For each of the five *hylegiacal places* — the degrees of the Sun, the Moon, the
+Ascendant, the Part of Fortune and the prenatal Syzygy — every classical planet
+earns points for the essential dignities it holds over that degree:
+
+    Domicile 5 · Exaltation 4 · Triplicity 3 (by sect) · Term 2 · Face 1
+
+The planet with the highest total across all places is the Almuten Figuris. An
+optional accidental-dignity layer (house placement, weekday ruler) can be added
+on request; the essential tally is the firm core and the default.
+
+Reference: kerykeion.net "The Almuten Figuris". The dignity tables themselves are
+reused verbatim from :mod:`kerykeion.dignities.dignity_data`, so this school is
+consistent with the rest of the library's traditional astrology.
+
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+from kerykeion.dignities.dignity_data import DOMICILE_RULERS, EXALTATION_TABLE, TRIPLICITY_RULERS
+
+# The term/face lookups are non-trivial (Egyptian bounds, Chaldean decans); we
+# reuse the dignity engine's helpers rather than duplicate those tables.
+from kerykeion.dignities.dignity_factory import _get_decan, _get_decan_ruler, _get_term_ruler
+from kerykeion.dominants.base import BaseDominantStrategy, BreakdownItem, Category, DominantsConfig
+from kerykeion.dominants.data import (
+    ALMUTEN_DAY_RULER_BONUS,
+    ALMUTEN_HOUSE_PLACEMENT_POINTS,
+    ALMUTEN_TIEBREAK_ORDER,
+    CLASSICAL_PLANETS,
+    ESSENTIAL_DIGNITY_POINTS,
+    WEEKDAY_RULERS,
+)
+from kerykeion.dominants.utils import ZodiacPosition, part_of_fortune_degree, prenatal_syzygy, zodiac_breakdown
+from kerykeion.schemas.kr_models import AstrologicalSubjectModel, DominantsModel
+from kerykeion.utilities import get_house_number
+
+
+class AlmutenFigurisStrategy(BaseDominantStrategy):
+    """Compute the Almuten Figuris (traditional Lord of the Geniture).
+
+    Populates the ``planets`` category (all seven classical planets, ranked by
+    dignity total) and, for convenience, fills the winner's sign / element /
+    modality / house into the matching single-entry categories. Modern points
+    and the polarity/hemisphere/quadrant categories are not part of this
+    technique and stay empty.
+
+    Example:
+        >>> from kerykeion import AstrologicalSubjectFactory, DominantsFactory
+        >>> subject = AstrologicalSubjectFactory.from_birth_data(
+        ...     "John Lennon", 1940, 10, 9, 18, 30,
+        ...     lat=53.4084, lng=-2.9916, tz_str="Europe/London", online=False)
+        >>> result = DominantsFactory.from_subject(subject, strategy="almuten_figuris")
+        >>> result.dominant_planet  # the Almuten Figuris  # doctest: +SKIP
+        'Saturn'
+    """
+
+    name = "almuten_figuris"
+    method = "almuten_figuris"
+
+    def compute(self, subject: AstrologicalSubjectModel, config: DominantsConfig) -> DominantsModel:
+        """Tally essential (and optionally accidental) dignities and rank planets.
+
+        Args:
+            subject: The chart to analyse.
+            config: Options; honours ``include_accidental_dignities`` and
+                ``include_score_breakdown``.
+
+        Returns:
+            A :class:`DominantsModel` whose ``dominant_planet`` is the Almuten.
+        """
+        sect = "day" if bool(getattr(subject, "is_diurnal", True)) else "night"
+        places = self._collect_places(subject)
+
+        essential: Dict[str, float] = {planet: 0.0 for planet in CLASSICAL_PLANETS}
+        major_count: Dict[str, int] = {planet: 0 for planet in CLASSICAL_PLANETS}
+        accidental: Dict[str, float] = {planet: 0.0 for planet in CLASSICAL_PLANETS}
+        breakdown: List[BreakdownItem] = []
+
+        # --- essential dignities over each hylegiacal place ------------------
+        for place_name, position in places:
+            holders = self._dignity_holders(position, sect)
+            for dignity, planets in holders.items():
+                points = ESSENTIAL_DIGNITY_POINTS[dignity]
+                for planet in planets:
+                    if planet is None:
+                        continue
+                    essential[planet] += points
+                    if dignity in ("Domicile", "Exaltation"):
+                        major_count[planet] += 1
+                    if config.include_score_breakdown:
+                        breakdown.append(
+                            BreakdownItem(
+                                category="place",
+                                target=planet,
+                                rule=dignity,
+                                points=float(points),
+                                detail=f"{place_name} @ {position.sign} {position.position:.1f}°",
+                            )
+                        )
+
+        # --- optional accidental dignities -----------------------------------
+        if config.include_accidental_dignities:
+            self._add_accidental_dignities(subject, accidental, breakdown)
+
+        totals: Dict[str, float] = {planet: essential[planet] + accidental[planet] for planet in CLASSICAL_PLANETS}
+        winner = self._resolve_winner(totals, essential, major_count)
+
+        categories = {"planets": Category(scores=totals, dominant={winner})}
+        self._fill_winner_placement(subject, winner, totals[winner], categories)
+
+        return self.build_model(categories=categories, breakdown=breakdown)
+
+    # -- helpers ------------------------------------------------------------
+
+    @staticmethod
+    def _collect_places(subject: AstrologicalSubjectModel) -> List[Tuple[str, ZodiacPosition]]:
+        """Return the available hylegiacal places as (name, zodiac position).
+
+        Places whose point is absent (e.g. no Ascendant for an unknown birth
+        time, or no resolvable prenatal syzygy) are simply omitted, so the tally
+        runs over whatever is available.
+        """
+        places: List[Tuple[str, ZodiacPosition]] = []
+
+        def add(name: str, degree: Optional[float]) -> None:
+            if degree is not None:
+                places.append((name, zodiac_breakdown(degree)))
+
+        add("Sun", subject.sun.abs_pos if subject.sun else None)
+        add("Moon", subject.moon.abs_pos if subject.moon else None)
+        add("Ascendant", subject.ascendant.abs_pos if subject.ascendant else None)
+        add("Pars_Fortunae", part_of_fortune_degree(subject))
+
+        syzygy = prenatal_syzygy(subject)
+        add("Syzygy", syzygy.degree if syzygy else None)
+
+        return places
+
+    @staticmethod
+    def _dignity_holders(position: ZodiacPosition, sect: str) -> Dict[str, List[Optional[str]]]:
+        """Return, for one degree, which planet holds each essential dignity.
+
+        Args:
+            position: The zodiacal breakdown of the place's degree.
+            sect: ``"day"`` or ``"night"`` (selects the triplicity ruler).
+
+        Returns:
+            Mapping of dignity name to the planet(s) that hold it at this degree.
+        """
+        triplicity = TRIPLICITY_RULERS.get(position.element, {}).get(sect)
+        exaltation = EXALTATION_TABLE.get(position.sign, (None, None))[0]
+        return {
+            "Domicile": list(DOMICILE_RULERS.get(position.sign, [])),
+            "Exaltation": [exaltation],
+            "Triplicity": [triplicity],
+            "Term": [_get_term_ruler(position.sign, position.position)],
+            "Face": [_get_decan_ruler(position.sign, _get_decan(position.position))],
+        }
+
+    @staticmethod
+    def _add_accidental_dignities(
+        subject: AstrologicalSubjectModel,
+        accidental: Dict[str, float],
+        breakdown: List[BreakdownItem],
+    ) -> None:
+        """Add the optional accidental-dignity layer in place.
+
+        Two contributions are applied: points for the house each classical planet
+        occupies, and a bonus for the planet ruling the weekday of birth. (The
+        planetary-hour ruler is intentionally not included; it would require the
+        full sunrise-based planetary-hours computation.)
+        """
+        # House placement.
+        for planet in CLASSICAL_PLANETS:
+            point = getattr(subject, planet.lower(), None)
+            if point is None or point.house is None:
+                continue
+            house_points = ALMUTEN_HOUSE_PLACEMENT_POINTS.get(get_house_number(point.house))
+            if house_points:
+                accidental[planet] += house_points
+                breakdown.append(
+                    BreakdownItem("accidental", planet, "house placement", float(house_points), point.house)
+                )
+
+        # Weekday (day) ruler. Weekday index: 0 = Sunday … 6 = Saturday.
+        julian_day = getattr(subject, "julian_day", None)
+        if julian_day is not None:
+            weekday_index = (int(julian_day + 0.5) + 1) % 7
+            day_ruler = WEEKDAY_RULERS[weekday_index]
+            accidental[day_ruler] += ALMUTEN_DAY_RULER_BONUS
+            breakdown.append(BreakdownItem("accidental", day_ruler, "day ruler", ALMUTEN_DAY_RULER_BONUS))
+
+    @staticmethod
+    def _resolve_winner(
+        totals: Dict[str, float],
+        essential: Dict[str, float],
+        major_count: Dict[str, int],
+    ) -> str:
+        """Pick the Almuten, breaking ties deterministically.
+
+        Tie-break order: higher total, then higher essential-only subtotal, then
+        more rulership-grade dignities (domicile/exaltation), then the
+        traditional planetary order (Saturn → Moon) via
+        :data:`ALMUTEN_TIEBREAK_ORDER`.
+        """
+        return min(
+            CLASSICAL_PLANETS,
+            key=lambda planet: (
+                -totals[planet],
+                -essential[planet],
+                -major_count[planet],
+                ALMUTEN_TIEBREAK_ORDER.index(planet),
+            ),
+        )
+
+    @staticmethod
+    def _fill_winner_placement(
+        subject: AstrologicalSubjectModel,
+        winner: str,
+        winner_score: float,
+        categories: Dict[str, Category],
+    ) -> None:
+        """Populate sign/element/quality/house categories from the winner's point.
+
+        This lets the convenience ``dominant_sign`` / ``dominant_element`` /
+        ``dominant_quality`` / ``dominant_house`` fields reflect where the Almuten
+        sits, without claiming a full sign/house ranking the technique does not
+        produce.
+        """
+        point = getattr(subject, winner.lower(), None)
+        if point is None:
+            return
+        categories["signs"] = Category(scores={point.sign: winner_score}, dominant={point.sign})
+        categories["elements"] = Category(scores={point.element: winner_score}, dominant={point.element})
+        categories["qualities"] = Category(scores={point.quality: winner_score}, dominant={point.quality})
+        if point.house is not None:
+            categories["houses"] = Category(scores={point.house: winner_score}, dominant={point.house})

--- a/kerykeion/dominants/strategies/elemental.py
+++ b/kerykeion/dominants/strategies/elemental.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""
+Elemental & modal balance — the simplest dominant school.
+=========================================================
+
+This school answers the everyday question "is this an Air chart? a Fixed
+chart?" by tallying the chart's points per element (Fire/Earth/Air/Water) and
+per modality (Cardinal/Fixed/Mutable), then taking the heaviest of each. It is
+intentionally thin: it delegates the actual counting to the library's existing
+``calculate_element_points`` / ``calculate_quality_points`` so the numbers match
+the element/quality distributions shown elsewhere (charts, reports), including
+the ``"weighted"`` vs ``"pure_count"`` methods and per-point weight overrides.
+
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from kerykeion.dominants.base import BaseDominantStrategy, BreakdownItem, Category, DominantsConfig
+from kerykeion.dominants.data import (
+    ELEMENT_LOWER_TO_TITLE,
+    POLARITY_BY_ELEMENT,
+    QUALITY_LOWER_TO_TITLE,
+)
+from kerykeion.schemas.kr_models import AstrologicalSubjectModel, DominantsModel
+
+
+class ElementalBalanceStrategy(BaseDominantStrategy):
+    """Dominant element and modality by weighted (or pure) count.
+
+    Populates the ``elements``, ``qualities`` and ``polarities`` categories; the
+    planet/sign/house/hemisphere/quadrant categories are left empty (this school
+    does not score them). The dominant of each populated category is its single
+    heaviest entry.
+
+    Example:
+        >>> from kerykeion import AstrologicalSubjectFactory, DominantsFactory
+        >>> subject = AstrologicalSubjectFactory.from_birth_data(
+        ...     "John Lennon", 1940, 10, 9, 18, 30,
+        ...     lat=53.4084, lng=-2.9916, tz_str="Europe/London", online=False)
+        >>> result = DominantsFactory.from_subject(subject, strategy="elemental")
+        >>> result.dominant_element, result.dominant_quality  # doctest: +SKIP
+        ('Air', 'Cardinal')
+    """
+
+    name = "elemental"
+    method = "elemental"
+
+    def compute(self, subject: AstrologicalSubjectModel, config: DominantsConfig) -> DominantsModel:
+        """Tally elements and modalities and pick the heaviest of each.
+
+        Args:
+            subject: The chart to analyse.
+            config: Options; honours ``distribution_method``, ``custom_weights``
+                and ``active_points``.
+
+        Returns:
+            A :class:`DominantsModel` with the element, quality and polarity
+            categories populated.
+        """
+        # Local import: the element/quality helpers live in the (heavier) charts
+        # package; importing lazily keeps the dominants package import-light and
+        # free of any import-time coupling to the rendering code.
+        from kerykeion.charts.charts_utils import calculate_element_points, calculate_quality_points
+        from kerykeion.settings.chart_defaults import DEFAULT_CELESTIAL_POINTS_SETTINGS
+
+        point_names: List[str] = list(config.active_points) if config.active_points else list(subject.active_points)
+
+        # Raw totals come back keyed lowercase (e.g. "fire"); we relabel them to
+        # the Title-case Element/Quality literals the public model expects.
+        element_totals = calculate_element_points(
+            DEFAULT_CELESTIAL_POINTS_SETTINGS,
+            point_names,
+            subject,
+            method=config.distribution_method,
+            custom_weights=config.custom_weights,
+        )
+        quality_totals = calculate_quality_points(
+            DEFAULT_CELESTIAL_POINTS_SETTINGS,
+            point_names,
+            subject,
+            method=config.distribution_method,
+            custom_weights=config.custom_weights,
+        )
+
+        elements = {ELEMENT_LOWER_TO_TITLE[key]: value for key, value in element_totals.items()}
+        qualities = {QUALITY_LOWER_TO_TITLE[key]: value for key, value in quality_totals.items()}
+
+        # Polarity: Fire+Air = Yang, Earth+Water = Yin.
+        polarities: Dict[str, float] = {"Yang": 0.0, "Yin": 0.0}
+        for element, value in elements.items():
+            polarities[POLARITY_BY_ELEMENT[element]] += value
+
+        categories = {
+            "elements": Category(scores=elements, dominant=_top_keys(elements, 1)),
+            "qualities": Category(scores=qualities, dominant=_top_keys(qualities, 1)),
+            "polarities": Category(scores=polarities, dominant=_top_keys(polarities, 1)),
+        }
+
+        breakdown: List[BreakdownItem] = []
+        if config.include_score_breakdown:
+            for element, value in elements.items():
+                breakdown.append(BreakdownItem("element", element, config.distribution_method, value))
+            for quality, value in qualities.items():
+                breakdown.append(BreakdownItem("quality", quality, config.distribution_method, value))
+
+        return self.build_model(categories=categories, breakdown=breakdown)
+
+
+def _top_keys(scores: Dict[str, float], count: int) -> set[str]:
+    """Return the ``count`` highest-scoring keys (deterministic tie-break by name).
+
+    Args:
+        scores: Mapping of name to score.
+        count: How many top keys to return.
+
+    Returns:
+        The set of the highest-scoring keys.
+    """
+    ordered = sorted(scores.items(), key=lambda kv: (-kv[1], kv[0]))
+    return {name for name, _ in ordered[:count]}

--- a/kerykeion/dominants/strategies/modern.py
+++ b/kerykeion/dominants/strategies/modern.py
@@ -218,7 +218,7 @@ class ModernDominantStrategy(BaseDominantStrategy):
         aspects_model = AspectsFactory.single_chart_aspects(
             subject,
             active_points=planet_names + list(_ANGLE_NAMES),
-            active_aspects=DOMINANT_ASPECTS,  # type: ignore[arg-type]
+            active_aspects=DOMINANT_ASPECTS,
         )
 
         for aspect in aspects_model.aspects:

--- a/kerykeion/dominants/strategies/modern.py
+++ b/kerykeion/dominants/strategies/modern.py
@@ -1,0 +1,440 @@
+# -*- coding: utf-8 -*-
+"""
+Modern weighted dominants (Astrotheme-style).
+==============================================
+
+The popular modern method: each planet accumulates a strength score from four
+parameters, and the chart's dominant signs, houses, elements, modes, polarity,
+hemispheres and quadrants are then derived from those planetary scores.
+
+A planet's score = angularity + aspect activity + essential dignity + rulership:
+
+1. **Angularity** — proximity to the four angles (Asc > MC > Desc > IC), within a
+   15° orb, the contribution fading linearly to zero at the edge of the orb.
+2. **Aspect activity** — every aspect the planet makes, weighted by aspect type,
+   by orb exactitude (tighter = stronger), and by a static "speed tier" so a
+   slow Neptune-Pluto aspect counts far less than a fast Moon-Mars one; aspects
+   to an angle are emphasised.
+3. **Essential dignity** — a deliberately mild bonus/penalty for domicile,
+   exaltation, detriment or fall (kept small so it never distorts the result).
+4. **Rulership** — a bonus for ruling the Ascendant (largest), the MC, the Sun
+   sign and the Moon sign.
+
+Speed and retrogradation are deliberately **excluded** from the scoring, as in
+Astrotheme's documented method. The exact point values Astrotheme uses are
+proprietary; the constants in :mod:`kerykeion.dominants.data` are a transparent,
+tunable approximation of the documented behaviour.
+
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from kerykeion.dignities.dignity_factory import calculate_essential_dignity
+from kerykeion.dominants.base import BaseDominantStrategy, BreakdownItem, Category, DominantsConfig
+from kerykeion.dominants.data import (
+    ANGLE_WEIGHTS,
+    ANGULARITY_MAX_POINTS,
+    ANGULARITY_ORB,
+    ASC_SIGN_BONUS,
+    ASPECT_BASE_POINTS,
+    ASPECT_ORB_BY_NAME,
+    ASPECT_STRENGTH,
+    ASPECT_TO_ANGLE_MULTIPLIER,
+    DIGNITY_BONUS,
+    DOMINANT_HOUSE_COUNT,
+    DOMINANT_SIGN_COUNT,
+    DOMINANT_ASPECTS,
+    MODERN_RULERS,
+    PLANET_SPEED_TIER,
+    PLANET_SPEED_TIER_DEFAULT,
+    POLARITY_BY_ELEMENT,
+    RULER_BONUS_ASC,
+    RULER_BONUS_MC,
+    RULER_BONUS_MOON_SIGN,
+    RULER_BONUS_SUN_SIGN,
+)
+from kerykeion.dominants.utils import angle_degrees, rulers_inverse, scoring_planets
+from kerykeion.schemas.kr_models import AstrologicalSubjectModel, DominantsModel, KerykeionPointModel
+from kerykeion.utilities import get_house_number
+
+#: The four chart angles, in the order the engine references them.
+_ANGLE_NAMES: tuple[str, ...] = ("Ascendant", "Medium_Coeli", "Descendant", "Imum_Coeli")
+
+#: Subject attributes for the twelve house cusps, in order 1..12.
+_HOUSE_ATTRS: tuple[str, ...] = (
+    "first_house",
+    "second_house",
+    "third_house",
+    "fourth_house",
+    "fifth_house",
+    "sixth_house",
+    "seventh_house",
+    "eighth_house",
+    "ninth_house",
+    "tenth_house",
+    "eleventh_house",
+    "twelfth_house",
+)
+
+#: House numbers in the eastern half of the chart (Ascendant side).
+_EASTERN_HOUSES = frozenset({10, 11, 12, 1, 2, 3})
+
+#: Quadrant name by 1-based quadrant index.
+_QUADRANT_NAMES = ("First_Quadrant", "Second_Quadrant", "Third_Quadrant", "Fourth_Quadrant")
+
+
+def _angular_separation(a: float, b: float) -> float:
+    """Smallest separation between two ecliptic longitudes (0-180°)."""
+    diff = abs(a - b) % 360.0
+    return min(diff, 360.0 - diff)
+
+
+class ModernDominantStrategy(BaseDominantStrategy):
+    """Modern weighted dominants for every category Astrotheme reports.
+
+    Example:
+        >>> from kerykeion import AstrologicalSubjectFactory, DominantsFactory
+        >>> subject = AstrologicalSubjectFactory.from_birth_data(
+        ...     "John Lennon", 1940, 10, 9, 18, 30,
+        ...     lat=53.4084, lng=-2.9916, tz_str="Europe/London", online=False)
+        >>> result = DominantsFactory.from_subject(subject, strategy="modern")
+        >>> result.dominant_planet, result.dominant_sign  # doctest: +SKIP
+        ('Mars', 'Tau')
+    """
+
+    name = "modern"
+    method = "modern"
+
+    def compute(self, subject: AstrologicalSubjectModel, config: DominantsConfig) -> DominantsModel:
+        """Score the planets, then derive every dominant category from them.
+
+        Args:
+            subject: The chart to analyse.
+            config: Options; honours ``dominant_planet_count`` and
+                ``include_score_breakdown``.
+
+        Returns:
+            A fully populated :class:`DominantsModel`.
+        """
+        planets = scoring_planets(subject)
+        planet_names = [point.name for point in planets]
+        angles = angle_degrees(subject)
+        include_breakdown = config.include_score_breakdown
+        breakdown: List[BreakdownItem] = []
+
+        # --- planetary strength = four additive parameters ------------------
+        angularity = self._angularity_scores(planets, angles, breakdown, include_breakdown)
+        activity = self._aspect_scores(subject, planet_names, breakdown, include_breakdown)
+        dignity = self._dignity_scores(subject, planets, breakdown, include_breakdown)
+        rulership = self._rulership_scores(subject, planet_names, breakdown, include_breakdown)
+
+        totals: Dict[str, float] = {
+            name: angularity.get(name, 0.0)
+            + activity.get(name, 0.0)
+            + dignity.get(name, 0.0)
+            + rulership.get(name, 0.0)
+            for name in planet_names
+        }
+        dominant_planets = _top_keys(totals, config.dominant_planet_count)
+
+        # --- derive the remaining categories from the planetary scores ------
+        categories = {
+            "planets": Category(scores=totals, dominant=dominant_planets),
+            "signs": self._sign_category(subject, planets, totals, dominant_planets),
+            "houses": self._house_category(subject, planets, totals, dominant_planets),
+            "elements": self._element_category(planets, totals),
+            "qualities": self._quality_category(planets, totals),
+            "polarities": self._polarity_category(planets, totals),
+            "hemispheres": self._hemisphere_category(planets, totals),
+            "quadrants": self._quadrant_category(planets, totals),
+        }
+
+        return self.build_model(categories=categories, breakdown=breakdown)
+
+    # -- parameter 1: angularity -------------------------------------------
+
+    @staticmethod
+    def _angularity_scores(
+        planets: List[KerykeionPointModel],
+        angles: Dict[str, Optional[float]],
+        breakdown: List[BreakdownItem],
+        include_breakdown: bool,
+    ) -> Dict[str, float]:
+        """Score each planet by its proximity to the four angles.
+
+        The contribution from an angle is ``ANGULARITY_MAX_POINTS`` scaled by the
+        angle's weight and by a linear orb falloff (full strength at exact
+        conjunction, zero at ``ANGULARITY_ORB``). Contributions from all angles
+        are summed.
+        """
+        scores: Dict[str, float] = {}
+        for point in planets:
+            total = 0.0
+            for angle_name, angle_degree in angles.items():
+                if angle_degree is None:
+                    continue
+                separation = _angular_separation(point.abs_pos, angle_degree)
+                if separation > ANGULARITY_ORB:
+                    continue
+                falloff = (ANGULARITY_ORB - separation) / ANGULARITY_ORB
+                contribution = ANGULARITY_MAX_POINTS * ANGLE_WEIGHTS[angle_name] * falloff
+                total += contribution
+                if include_breakdown and contribution > 0:
+                    breakdown.append(
+                        BreakdownItem(
+                            "angularity", point.name, f"near {angle_name}", contribution, f"orb {separation:.1f}°"
+                        )
+                    )
+            scores[point.name] = total
+        return scores
+
+    # -- parameter 2: aspect activity --------------------------------------
+
+    @staticmethod
+    def _aspect_scores(
+        subject: AstrologicalSubjectModel,
+        planet_names: List[str],
+        breakdown: List[BreakdownItem],
+        include_breakdown: bool,
+    ) -> Dict[str, float]:
+        """Score each planet by the weighted activity of the aspects it makes.
+
+        A single pass over the chart's aspects feeds both endpoints: each scoring
+        planet gains points for every aspect it is part of, weighted by aspect
+        type, orb exactitude, the speed tiers of the two bodies, and an angle
+        bonus when the partner is one of the four angles.
+        """
+        # Local import keeps the dominants package free of an import-time
+        # dependency on the (heavier) aspects/subject machinery.
+        from kerykeion.aspects.aspects_factory import AspectsFactory
+
+        scores: Dict[str, float] = {name: 0.0 for name in planet_names}
+        planet_set = set(planet_names)
+        angle_set = set(_ANGLE_NAMES)
+
+        aspects_model = AspectsFactory.single_chart_aspects(
+            subject,
+            active_points=planet_names + list(_ANGLE_NAMES),
+            active_aspects=DOMINANT_ASPECTS,  # type: ignore[arg-type]
+        )
+
+        for aspect in aspects_model.aspects:
+            type_weight = ASPECT_STRENGTH.get(aspect.aspect_degrees, 0.0)
+            orb_limit = ASPECT_ORB_BY_NAME.get(aspect.aspect)
+            if type_weight <= 0.0 or not orb_limit:
+                continue
+            orb_weight = max(0.0, 1.0 - abs(aspect.orbit) / orb_limit)
+            if orb_weight <= 0.0:
+                continue
+
+            # Feed both endpoints: each scoring planet sees the other as partner.
+            for primary, partner in ((aspect.p1_name, aspect.p2_name), (aspect.p2_name, aspect.p1_name)):
+                if primary not in planet_set:
+                    continue
+                pair_weight = (
+                    PLANET_SPEED_TIER.get(primary, PLANET_SPEED_TIER_DEFAULT)
+                    + PLANET_SPEED_TIER.get(partner, PLANET_SPEED_TIER_DEFAULT)
+                ) / 2.0
+                angle_weight = ASPECT_TO_ANGLE_MULTIPLIER if partner in angle_set else 1.0
+                contribution = ASPECT_BASE_POINTS * type_weight * orb_weight * pair_weight * angle_weight
+                scores[primary] += contribution
+                if include_breakdown and contribution > 0:
+                    breakdown.append(
+                        BreakdownItem(
+                            "aspect",
+                            primary,
+                            f"{aspect.aspect} {partner}",
+                            contribution,
+                            f"orb {abs(aspect.orbit):.1f}°",
+                        )
+                    )
+        return scores
+
+    # -- parameter 3: essential dignity (mild) -----------------------------
+
+    @staticmethod
+    def _dignity_scores(
+        subject: AstrologicalSubjectModel,
+        planets: List[KerykeionPointModel],
+        breakdown: List[BreakdownItem],
+        include_breakdown: bool,
+    ) -> Dict[str, float]:
+        """Apply a small bonus/penalty for each planet's essential dignity."""
+        is_diurnal = bool(getattr(subject, "is_diurnal", True))
+        scores: Dict[str, float] = {}
+        for point in planets:
+            result = calculate_essential_dignity(point.name, point.sign, point.element, point.position, is_diurnal)
+            label = result.get("essential_dignity")
+            bonus = DIGNITY_BONUS.get(label, 0.0) if label else 0.0
+            scores[point.name] = bonus
+            if include_breakdown and bonus:
+                breakdown.append(BreakdownItem("dignity", point.name, str(label), bonus, point.sign))
+        return scores
+
+    # -- parameter 4: rulership --------------------------------------------
+
+    @staticmethod
+    def _rulership_scores(
+        subject: AstrologicalSubjectModel,
+        planet_names: List[str],
+        breakdown: List[BreakdownItem],
+        include_breakdown: bool,
+    ) -> Dict[str, float]:
+        """Bonus the rulers of the Ascendant, MC, Sun sign and Moon sign.
+
+        The Ascendant ruler gets the largest bonus, then the MC ruler, then the
+        rulers of the Sun and Moon signs (modern rulerships).
+        """
+        scores: Dict[str, float] = {name: 0.0 for name in planet_names}
+        planet_set = set(planet_names)
+
+        key_signs = (
+            (subject.ascendant, RULER_BONUS_ASC, "ruler of Ascendant"),
+            (subject.medium_coeli, RULER_BONUS_MC, "ruler of MC"),
+            (subject.sun, RULER_BONUS_SUN_SIGN, "ruler of Sun sign"),
+            (subject.moon, RULER_BONUS_MOON_SIGN, "ruler of Moon sign"),
+        )
+        for point, bonus, rule in key_signs:
+            if point is None:
+                continue
+            for ruler in MODERN_RULERS.get(point.sign, []):
+                if ruler in planet_set:
+                    scores[ruler] += bonus
+                    if include_breakdown:
+                        breakdown.append(BreakdownItem("rulership", ruler, rule, bonus, point.sign))
+        return scores
+
+    # -- derivations --------------------------------------------------------
+
+    @staticmethod
+    def _sign_category(
+        subject: AstrologicalSubjectModel,
+        planets: List[KerykeionPointModel],
+        totals: Dict[str, float],
+        dominant_planets: set[str],
+    ) -> Category:
+        """Derive dominant signs from occupancy, the Ascendant, and rulership.
+
+        A sign accrues weight from (a) the scores of the planets occupying it,
+        (b) a flat bonus for the rising sign, and (c) the scores of the dominant
+        planets that rule it (modern rulerships).
+        """
+        scores: Dict[str, float] = {}
+        for point in planets:
+            value = totals[point.name]
+            if value > 0:
+                scores[point.sign] = scores.get(point.sign, 0.0) + value
+
+        if subject.ascendant is not None:
+            scores[subject.ascendant.sign] = scores.get(subject.ascendant.sign, 0.0) + ASC_SIGN_BONUS
+
+        ruled_by = rulers_inverse(MODERN_RULERS)
+        for planet in dominant_planets:
+            for sign in ruled_by.get(planet, []):
+                scores[sign] = scores.get(sign, 0.0) + totals[planet]
+
+        return Category(scores=scores, dominant=_top_keys(scores, DOMINANT_SIGN_COUNT))
+
+    @staticmethod
+    def _house_category(
+        subject: AstrologicalSubjectModel,
+        planets: List[KerykeionPointModel],
+        totals: Dict[str, float],
+        dominant_planets: set[str],
+    ) -> Category:
+        """Derive dominant houses from occupancy plus dominant-ruler emphasis.
+
+        Each house accrues the scores of the planets it contains; additionally a
+        house whose cusp sign is ruled by a dominant planet gains half that
+        planet's score. Houses are skipped entirely for charts without a known
+        birth time (no house placements).
+        """
+        scores: Dict[str, float] = {}
+        for point in planets:
+            if point.house is None:
+                continue
+            scores[point.house] = scores.get(point.house, 0.0) + totals[point.name]
+
+        # Emphasise houses whose cusp is ruled by a dominant planet.
+        for attr in _HOUSE_ATTRS:
+            cusp = getattr(subject, attr, None)
+            if cusp is None:
+                continue
+            for ruler in MODERN_RULERS.get(cusp.sign, []):
+                if ruler in dominant_planets:
+                    scores[cusp.name] = scores.get(cusp.name, 0.0) + totals[ruler] * 0.5
+
+        return Category(scores=scores, dominant=_top_keys(scores, DOMINANT_HOUSE_COUNT))
+
+    @staticmethod
+    def _element_category(planets: List[KerykeionPointModel], totals: Dict[str, float]) -> Category:
+        """Score-weighted element tally (each planet's element gains its score)."""
+        scores: Dict[str, float] = {}
+        for point in planets:
+            scores[point.element] = scores.get(point.element, 0.0) + totals[point.name]
+        return Category(scores=scores, dominant=_top_keys(scores, 1))
+
+    @staticmethod
+    def _quality_category(planets: List[KerykeionPointModel], totals: Dict[str, float]) -> Category:
+        """Score-weighted modality tally (each planet's modality gains its score)."""
+        scores: Dict[str, float] = {}
+        for point in planets:
+            scores[point.quality] = scores.get(point.quality, 0.0) + totals[point.name]
+        return Category(scores=scores, dominant=_top_keys(scores, 1))
+
+    @staticmethod
+    def _polarity_category(planets: List[KerykeionPointModel], totals: Dict[str, float]) -> Category:
+        """Yang (Fire+Air) vs Yin (Earth+Water), score-weighted."""
+        scores: Dict[str, float] = {"Yang": 0.0, "Yin": 0.0}
+        for point in planets:
+            scores[POLARITY_BY_ELEMENT[point.element]] += totals[point.name]
+        return Category(scores=scores, dominant=_top_keys(scores, 1))
+
+    @staticmethod
+    def _hemisphere_category(planets: List[KerykeionPointModel], totals: Dict[str, float]) -> Category:
+        """North/South (below/above horizon) and East/West, score-weighted.
+
+        Uses each planet's house: houses 1-6 are the Northern (below-horizon)
+        hemisphere and 7-12 the Southern; houses 10-3 are the Eastern
+        (Ascendant-side) hemisphere and 4-9 the Western.
+        """
+        scores: Dict[str, float] = {"North": 0.0, "South": 0.0, "East": 0.0, "West": 0.0}
+        for point in planets:
+            if point.house is None:
+                continue
+            house_number = get_house_number(point.house)
+            value = totals[point.name]
+            scores["North" if house_number <= 6 else "South"] += value
+            scores["East" if house_number in _EASTERN_HOUSES else "West"] += value
+
+        # Flag the winner of each independent axis as dominant.
+        dominant = {
+            max(("North", "South"), key=lambda key: scores[key]),
+            max(("East", "West"), key=lambda key: scores[key]),
+        }
+        return Category(scores=scores, dominant=dominant)
+
+    @staticmethod
+    def _quadrant_category(planets: List[KerykeionPointModel], totals: Dict[str, float]) -> Category:
+        """Score-weighted distribution across the four quadrants (houses 1-3, …)."""
+        scores: Dict[str, float] = {name: 0.0 for name in _QUADRANT_NAMES}
+        for point in planets:
+            if point.house is None:
+                continue
+            quadrant_index = (get_house_number(point.house) - 1) // 3
+            scores[_QUADRANT_NAMES[quadrant_index]] += totals[point.name]
+        return Category(scores=scores, dominant=_top_keys(scores, 1))
+
+
+def _top_keys(scores: Dict[str, float], count: int) -> set[str]:
+    """Return the ``count`` highest-scoring keys (deterministic tie-break by name).
+
+    Keys with a non-positive score are never flagged dominant, so an empty or
+    all-zero category yields no dominants.
+    """
+    positive = {name: value for name, value in scores.items() if value > 0}
+    ordered = sorted(positive.items(), key=lambda kv: (-kv[1], kv[0]))
+    return {name for name, _ in ordered[:count]}

--- a/kerykeion/dominants/utils.py
+++ b/kerykeion/dominants/utils.py
@@ -1,0 +1,382 @@
+# -*- coding: utf-8 -*-
+"""
+Pure domain helpers for the dominants calculator.
+==================================================
+
+These functions are deliberately free of any Pydantic model construction and of
+any I/O beyond the (locked) ephemeris call needed for the prenatal syzygy. They
+turn a computed :class:`AstrologicalSubjectModel` into the small primitives the
+strategies need — angle degrees, house cusps, the list of scoring planets, a
+zodiacal breakdown of an arbitrary degree, rulership lookups and the prenatal
+syzygy — so each scoring school can stay focused on *weighting*, not plumbing.
+
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from kerykeion.dominants.data import (
+    MODERN_RULERS,
+    SIGN_NUM_TO_ELEMENT,
+    SIGN_NUM_TO_QUALITY,
+)
+from kerykeion.ephemeris_backend import EPHEMERIS_LOCK, swe
+from kerykeion.moon_phase_details.utils import configure_ephemeris_path
+from kerykeion.schemas.kr_literals import SIGN_CODES, Element, Quality, Sign
+from kerykeion.schemas.kr_models import AstrologicalSubjectModel, KerykeionPointModel
+
+# =============================================================================
+# SMALL VALUE OBJECTS
+# =============================================================================
+
+#: Internal attribute names of the ten traditional + modern planets on a subject,
+#: in canonical order. ``point.name`` exposes the public Title-case name.
+_PLANET_ATTRS: tuple[str, ...] = (
+    "sun",
+    "moon",
+    "mercury",
+    "venus",
+    "mars",
+    "jupiter",
+    "saturn",
+    "uranus",
+    "neptune",
+    "pluto",
+)
+
+#: The four chart angles, public name -> subject attribute.
+_ANGLE_ATTRS: Dict[str, str] = {
+    "Ascendant": "ascendant",
+    "Medium_Coeli": "medium_coeli",
+    "Descendant": "descendant",
+    "Imum_Coeli": "imum_coeli",
+}
+
+#: Subject attributes holding the twelve house cusps, in order 1..12.
+_HOUSE_ATTRS: tuple[str, ...] = (
+    "first_house",
+    "second_house",
+    "third_house",
+    "fourth_house",
+    "fifth_house",
+    "sixth_house",
+    "seventh_house",
+    "eighth_house",
+    "ninth_house",
+    "tenth_house",
+    "eleventh_house",
+    "twelfth_house",
+)
+
+
+@dataclass(frozen=True)
+class ZodiacPosition:
+    """The zodiacal breakdown of an absolute ecliptic longitude.
+
+    Attributes:
+        sign: Three-letter sign code (e.g. "Ari").
+        sign_num: Sign index 0-11 (Aries = 0).
+        position: Degree within the sign (0-30).
+        element: Title-case element of the sign.
+        quality: Title-case modality of the sign.
+    """
+
+    sign: Sign
+    sign_num: int
+    position: float
+    element: Element
+    quality: Quality
+
+
+@dataclass(frozen=True)
+class SyzygyInfo:
+    """The prenatal syzygy (the New or Full Moon immediately before birth).
+
+    Attributes:
+        degree: Absolute ecliptic longitude of the syzygy, already expressed in
+            the subject's zodiac (tropical or sidereal).
+        kind: "New" for a preceding New Moon, "Full" for a preceding Full Moon.
+        julian_day: Julian Day (UT) of the syzygy.
+    """
+
+    degree: float
+    kind: str
+    julian_day: float
+
+
+# =============================================================================
+# ZODIAC / GEOMETRY HELPERS
+# =============================================================================
+
+
+def zodiac_breakdown(degree: float) -> ZodiacPosition:
+    """Break an absolute ecliptic longitude into sign, degree, element, modality.
+
+    Args:
+        degree: Absolute longitude in degrees (any real number; normalized to
+            ``[0, 360)``).
+
+    Returns:
+        The :class:`ZodiacPosition` for the normalized degree.
+    """
+    deg = degree % 360.0
+    sign_num = int(deg // 30)
+    return ZodiacPosition(
+        sign=SIGN_CODES[sign_num],
+        sign_num=sign_num,
+        position=deg % 30.0,
+        element=SIGN_NUM_TO_ELEMENT[sign_num],
+        quality=SIGN_NUM_TO_QUALITY[sign_num],
+    )
+
+
+def angle_degrees(subject: AstrologicalSubjectModel) -> Dict[str, Optional[float]]:
+    """Return the absolute longitudes of the four chart angles.
+
+    Args:
+        subject: The chart to read.
+
+    Returns:
+        Mapping of angle name (Ascendant/Medium_Coeli/Descendant/Imum_Coeli) to
+        its ``abs_pos`` in degrees, or ``None`` when the angle is absent (e.g.
+        a chart built without a known birth time).
+    """
+    result: Dict[str, Optional[float]] = {}
+    for public_name, attr in _ANGLE_ATTRS.items():
+        point = getattr(subject, attr, None)
+        result[public_name] = point.abs_pos if point is not None else None
+    return result
+
+
+def house_cusps(subject: AstrologicalSubjectModel) -> List[float]:
+    """Return the twelve house-cusp longitudes in order 1..12.
+
+    Args:
+        subject: The chart to read.
+
+    Returns:
+        A list of twelve cusp longitudes suitable for
+        :func:`kerykeion.utilities.get_planet_house`.
+    """
+    return [getattr(subject, attr).abs_pos for attr in _HOUSE_ATTRS]
+
+
+def scoring_planets(subject: AstrologicalSubjectModel) -> List[KerykeionPointModel]:
+    """Return the ten planets present on the subject (Sun … Pluto).
+
+    Points that were not calculated for the chart (``None``) are skipped, so the
+    caller can rely on every returned point being usable.
+
+    Args:
+        subject: The chart to read.
+
+    Returns:
+        The present planetary points, in canonical Sun-to-Pluto order.
+    """
+    points: List[KerykeionPointModel] = []
+    for attr in _PLANET_ATTRS:
+        point = getattr(subject, attr, None)
+        if point is not None:
+            points.append(point)
+    return points
+
+
+def part_of_fortune_degree(subject: AstrologicalSubjectModel) -> Optional[float]:
+    """Return the Part of Fortune longitude, computing it if not pre-calculated.
+
+    Prefers the subject's own ``pars_fortunae`` when present (so the value is
+    consistent with the rest of the chart, including sidereal frames); otherwise
+    derives it from the sect-sensitive lot formula — ``Asc + Moon - Sun`` by day,
+    ``Asc + Sun - Moon`` by night — so the Almuten's fifth hylegiacal place is
+    available for any chart with a known birth time.
+
+    Args:
+        subject: The chart to read.
+
+    Returns:
+        The Part of Fortune longitude in the subject's zodiac, or ``None`` when
+        the Ascendant/Sun/Moon are unavailable (e.g. unknown birth time).
+    """
+    existing = getattr(subject, "pars_fortunae", None)
+    if existing is not None:
+        return existing.abs_pos
+
+    ascendant, sun, moon = subject.ascendant, subject.sun, subject.moon
+    if ascendant is None or sun is None or moon is None:
+        return None
+
+    if bool(getattr(subject, "is_diurnal", True)):
+        degree = ascendant.abs_pos + moon.abs_pos - sun.abs_pos
+    else:
+        degree = ascendant.abs_pos + sun.abs_pos - moon.abs_pos
+    return degree % 360.0
+
+
+# =============================================================================
+# RULERSHIP HELPERS
+# =============================================================================
+
+
+def sign_ruler(sign: Sign, rulers: Dict[Sign, List[str]] = MODERN_RULERS) -> List[str]:
+    """Return the ruling planet(s) of a sign for the given rulership table.
+
+    Args:
+        sign: Three-letter sign code.
+        rulers: Rulership table to use (defaults to the modern rulerships).
+
+    Returns:
+        The ruling planet name(s); an empty list if the sign is unknown.
+    """
+    return list(rulers.get(sign, []))
+
+
+def rulers_inverse(rulers: Dict[Sign, List[str]] = MODERN_RULERS) -> Dict[str, List[Sign]]:
+    """Invert a rulership table into planet -> signs it rules.
+
+    Args:
+        rulers: Sign -> ruler(s) table (defaults to the modern rulerships).
+
+    Returns:
+        Planet name -> list of signs that planet rules.
+    """
+    inverse: Dict[str, List[Sign]] = {}
+    for sign, planets in rulers.items():
+        for planet in planets:
+            inverse.setdefault(planet, []).append(sign)
+    return inverse
+
+
+# =============================================================================
+# ZODIAC-FRAME CONVERSION
+# =============================================================================
+
+
+def to_subject_zodiac(tropical_degree: float, subject: AstrologicalSubjectModel) -> float:
+    """Convert a raw tropical longitude into the subject's zodiac frame.
+
+    The ephemeris returns tropical longitudes; a sidereal chart measures signs
+    from a precessed origin. Subtracting the chart's ayanamsa aligns a raw
+    longitude with the sign boundaries the subject actually uses.
+
+    Args:
+        tropical_degree: A raw tropical longitude (e.g. from ``swe.calc_ut``).
+        subject: The chart whose zodiac frame to match.
+
+    Returns:
+        The longitude in the subject's zodiac, normalized to ``[0, 360)``.
+    """
+    if getattr(subject, "zodiac_type", "Tropical") == "Sidereal" and subject.ayanamsa_value:
+        return (tropical_degree - subject.ayanamsa_value) % 360.0
+    return tropical_degree % 360.0
+
+
+# =============================================================================
+# PRENATAL SYZYGY
+# =============================================================================
+# The Sun-Moon elongation is a sawtooth (it wraps every synodic month), so a
+# plain bracketless search over a wide window is unreliable. We instead (1) read
+# the elongation at birth to know which syzygy is the most recent and roughly
+# when it was, then (2) bracket a few days around that estimate — where the
+# elongation IS monotonic — and bisect. This is self-contained and robust for
+# any date the ephemeris covers.
+
+#: Mean synodic month in days (Chapront ELP 2000-82B).
+_SYNODIC_MONTH: float = 29.530588853
+
+#: Mean daily growth of the Sun-Moon elongation (~12.19°/day).
+_MEAN_DAILY_ELONGATION: float = 360.0 / _SYNODIC_MONTH
+
+
+def _wrap_180(angle: float) -> float:
+    """Wrap an angle into the signed range ``[-180, 180)``."""
+    return (angle + 180.0) % 360.0 - 180.0
+
+
+def _sun_moon_longitudes(julian_day: float) -> tuple[float, float]:
+    """Return the (Sun, Moon) tropical ecliptic longitudes at a Julian Day.
+
+    The caller must hold :data:`EPHEMERIS_LOCK`.
+    """
+    sun = float(swe.calc_ut(julian_day, swe.SUN, swe.FLG_SWIEPH)[0][0])
+    moon = float(swe.calc_ut(julian_day, swe.MOON, swe.FLG_SWIEPH)[0][0])
+    return sun, moon
+
+
+def prenatal_syzygy(subject: AstrologicalSubjectModel) -> Optional[SyzygyInfo]:
+    """Compute the prenatal syzygy — the New or Full Moon just before birth.
+
+    The most recent of the preceding New Moon and the preceding Full Moon is the
+    syzygy. We determine *which* it is directly from the elongation at birth (a
+    waxing chart — elongation below 180° — was most recently preceded by a New
+    Moon; otherwise by a Full Moon), estimate when that crossing happened, and
+    refine it by bisection over a tight, monotonic bracket.
+
+    The significant degree follows tradition: for a New Moon it is the
+    conjunction degree (the Sun's longitude, equal to the Moon's); for a Full
+    Moon it is the longitude of the luminary *above the horizon* at birth — the
+    Sun for a day chart, the Moon for a night chart. The result is expressed in
+    the subject's own zodiac so sign lookups are consistent for sidereal charts.
+
+    All ephemeris access is guarded by :data:`EPHEMERIS_LOCK`, which the backend
+    requires for its mutable global state.
+
+    Args:
+        subject: The chart to read (must carry a ``julian_day``).
+
+    Returns:
+        A :class:`SyzygyInfo`, or ``None`` when the birth Julian Day is missing
+        or the ephemeris cannot resolve the lunation.
+    """
+    birth_jd = getattr(subject, "julian_day", None)
+    if birth_jd is None:
+        return None
+
+    try:
+        with EPHEMERIS_LOCK:
+            configure_ephemeris_path()
+
+            sun_birth, moon_birth = _sun_moon_longitudes(birth_jd)
+            elongation = (moon_birth - sun_birth) % 360.0
+
+            # Waxing (elongation < 180°) ⇒ the last syzygy was a New Moon;
+            # waning ⇒ a Full Moon. This is always the more recent of the two.
+            kind = "New" if elongation < 180.0 else "Full"
+            target = 0.0 if kind == "New" else 180.0
+
+            # Estimate how far back the elongation last equalled the target, then
+            # bracket ±3 days (monotonic there) and bisect the signed offset.
+            degrees_since = (elongation - target) % 360.0
+            estimate_jd = birth_jd - degrees_since / _MEAN_DAILY_ELONGATION
+            low, high = estimate_jd - 3.0, estimate_jd + 3.0
+
+            for _ in range(60):
+                mid = (low + high) / 2.0
+                sun_mid, moon_mid = _sun_moon_longitudes(mid)
+                offset = _wrap_180((moon_mid - sun_mid) - target)
+                if offset < 0.0:
+                    low = mid  # syzygy is later than mid
+                else:
+                    high = mid  # syzygy is at or before mid
+                if high - low < 1e-7:
+                    break
+
+            syzygy_jd = (low + high) / 2.0
+            sun_lon, moon_lon = _sun_moon_longitudes(syzygy_jd)
+    except (RuntimeError, AttributeError, TypeError, IndexError):
+        # Ephemeris gap / backend hiccup: the Almuten simply drops this place.
+        return None
+
+    is_diurnal = bool(getattr(subject, "is_diurnal", True))
+    if kind == "New":
+        raw_degree = sun_lon  # Sun and Moon coincide at the conjunction.
+    else:  # Full Moon — use the luminary above the horizon at birth.
+        raw_degree = sun_lon if is_diurnal else moon_lon
+
+    return SyzygyInfo(
+        degree=to_subject_zodiac(raw_degree, subject),
+        kind=kind,
+        julian_day=syzygy_jd,
+    )

--- a/kerykeion/dominants/utils.py
+++ b/kerykeion/dominants/utils.py
@@ -15,6 +15,7 @@ This is part of Kerykeion (C) 2025 Giacomo Battaglia
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
@@ -27,6 +28,8 @@ from kerykeion.ephemeris_backend import EPHEMERIS_LOCK, swe
 from kerykeion.moon_phase_details.utils import configure_ephemeris_path
 from kerykeion.schemas.kr_literals import SIGN_CODES, Element, Quality, Sign
 from kerykeion.schemas.kr_models import AstrologicalSubjectModel, KerykeionPointModel
+
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # SMALL VALUE OBJECTS
@@ -365,8 +368,13 @@ def prenatal_syzygy(subject: AstrologicalSubjectModel) -> Optional[SyzygyInfo]:
 
             syzygy_jd = (low + high) / 2.0
             sun_lon, moon_lon = _sun_moon_longitudes(syzygy_jd)
-    except (RuntimeError, AttributeError, TypeError, IndexError):
-        # Ephemeris gap / backend hiccup: the Almuten simply drops this place.
+    except Exception as exc:
+        # Any ephemeris failure (e.g. an out-of-range date raising the backend's
+        # range error — which is NOT a RuntimeError) is non-fatal here: the
+        # prenatal syzygy is an optional hylegiacal place, so we log and let the
+        # Almuten drop it rather than propagate. Deliberately backend-agnostic
+        # (libephemeris and swisseph raise different exception types).
+        logger.debug("Prenatal syzygy skipped (ephemeris unavailable): %s", exc)
         return None
 
     is_diurnal = bool(getattr(subject, "is_diurnal", True))

--- a/kerykeion/schemas/__init__.py
+++ b/kerykeion/schemas/__init__.py
@@ -32,6 +32,7 @@ from .kr_literals import (
     CompositeChartType,
     AspectName,
     ReturnType,
+    DominantMethod,
 )
 from .kr_models import (
     SubscriptableBaseModel,
@@ -52,6 +53,9 @@ from .kr_models import (
     ActiveAspect,
     TransitMomentModel,
     TransitsTimeRangeModel,
+    DominantScoreModel,
+    DominantBreakdownItemModel,
+    DominantsModel,
 )
 from .chart_template_model import ChartTemplateModel
 from .settings_models import KerykeionSettingsModel
@@ -90,6 +94,7 @@ __all__ = [
     "CompositeChartType",
     "AspectName",
     "ReturnType",
+    "DominantMethod",
     # Main Model Classes (from kr_models)
     "SubscriptableBaseModel",
     "LunarPhaseModel",
@@ -109,4 +114,7 @@ __all__ = [
     "NutationObliquityModel",
     "TransitMomentModel",
     "TransitsTimeRangeModel",
+    "DominantScoreModel",
+    "DominantBreakdownItemModel",
+    "DominantsModel",
 ]

--- a/kerykeion/schemas/kr_literals.py
+++ b/kerykeion/schemas/kr_literals.py
@@ -441,3 +441,25 @@ north/south of the equator and are added in v6.0.
 
 ReturnType: TypeAlias = Literal["Lunar", "Solar", "Heliocentric", "Lunar_Node_Crossing"]
 """Literal type for Return Types"""
+
+
+DominantMethod: TypeAlias = Literal["modern", "almuten_figuris", "elemental"]
+"""Literal type for the built-in dominant-calculation schools (methods).
+
+Each value selects a different, citable astrological "school" for computing the
+dominants of a chart. A custom strategy may be supplied instead of one of these
+names (see ``DominantsFactory``), in which case the resulting model reports
+``method=None``.
+
+Values:
+    - "modern": Modern weighted method (Astrotheme-style). Planetary strength is
+      accumulated from angularity, aspect activity, essential dignity and
+      rulership bonuses; the dominant signs, houses, elements, modes, polarity,
+      hemispheres and quadrants are then derived from those planetary scores.
+    - "almuten_figuris": Traditional/medieval "Lord of the Geniture". Essential
+      dignities are tallied for every classical planet over the five hylegiacal
+      places (Sun, Moon, Ascendant, Part of Fortune, prenatal Syzygy); the
+      planet with the highest total is the Almuten Figuris.
+    - "elemental": Simple elemental and modal balance, by weighted or pure count
+      of the chart's points.
+"""

--- a/kerykeion/schemas/kr_models.py
+++ b/kerykeion/schemas/kr_models.py
@@ -51,7 +51,7 @@ from kerykeion.schemas import (
     PerspectiveType,
     AspectMovementType,
 )
-from kerykeion.schemas.kr_literals import ReturnType
+from kerykeion.schemas.kr_literals import ReturnType, DominantMethod
 
 # Type alias for any astrological subject model (birth chart, composite, or return)
 AnySubjectModel = Union["AstrologicalSubjectModel", "CompositeSubjectModel", "PlanetReturnModel"]
@@ -1449,3 +1449,120 @@ class PlanetaryPhenomenaCollectionModel(SubscriptableBaseModel):
     iso_datetime: str = Field(description="ISO 8601 formatted datetime")
     julian_day: float = Field(description="Julian Day number")
     phenomena: list[PlanetaryPhenomenaModel] = Field(description="Phenomena for each planet")
+
+
+# =============================================================================
+# DOMINANTS MODELS (v6.0)
+# =============================================================================
+# Public result types for the dominants calculator (see kerykeion.dominants).
+# The shape is intentionally FIXED and school-agnostic: every category is always
+# present so the type stays stable for runtime introspection (FastAPI /
+# typing.get_type_hints). A school that does not compute a given category leaves
+# its list empty and the matching ``dominant_*`` winner ``None``.
+
+
+class DominantScoreModel(SubscriptableBaseModel):
+    """A single ranked entry within one dominant category.
+
+    The dominants calculator expresses every category (planets, signs, elements,
+    modes, houses, polarities, hemispheres, quadrants) as a list of these scored
+    entries, ordered from strongest to weakest. The representation is identical
+    regardless of the calculation school, so consumers can render any category
+    uniformly.
+
+    Attributes:
+        name: Identifier of the scored item within its category. The vocabulary
+            depends on the category, e.g. a planet/point name ("Sun"), a sign
+            code ("Ari"), an element ("Fire"), a mode ("Cardinal"), a house
+            ("First_House"), a polarity ("Yang"/"Yin"), a hemisphere
+            ("North"/"South"/"East"/"West") or a quadrant ("First_Quadrant").
+        score: Raw, school-specific strength. Values are only comparable within
+            the same category of the same result, because different schools use
+            different scales.
+        percentage: Share of the category total, normalized so a category's
+            values sum to approximately 100. Convenient for display.
+        rank: 1-based position within the category, where ``1`` is the most
+            dominant. Ties are broken deterministically by each school.
+        is_dominant: ``True`` when the entry qualifies as a dominant of its
+            category (within the top-N and/or above the school's threshold).
+    """
+
+    name: str
+    score: float
+    percentage: float
+    rank: int
+    is_dominant: bool
+
+
+class DominantBreakdownItemModel(SubscriptableBaseModel):
+    """One transparency line explaining how a score was accumulated.
+
+    Breakdown items are only populated when the caller asks for them
+    (``include_score_breakdown=True``); they let a user audit *why* a planet or
+    sign scored as it did. For the Almuten Figuris they also carry the
+    per-place / per-dignity detail (``category="place"``).
+
+    Attributes:
+        category: The scoring dimension the item belongs to (e.g. "angularity",
+            "aspect", "dignity", "rulership", "place").
+        target: The item the points were awarded to (e.g. a planet name).
+        rule: The specific rule that fired (e.g. "conjunction Ascendant",
+            "Domicile", "ruler of MC").
+        points: Signed points contributed by this rule.
+        detail: Optional human-readable context (e.g. "orb 1.2°", "Sun place").
+    """
+
+    category: str
+    target: str
+    rule: str
+    points: float
+    detail: Optional[str] = None
+
+
+class DominantsModel(SubscriptableBaseModel):
+    """Result of a dominants calculation, in a fixed, school-agnostic shape.
+
+    Every category is always present so the public type is stable for runtime
+    introspection: a school that does not compute a given category simply leaves
+    its list empty and the matching ``dominant_*`` winner ``None``. This lets one
+    response schema serve every built-in school and any user-supplied custom
+    strategy.
+
+    Attributes:
+        strategy_name: Human-readable name of the strategy that produced the
+            result (e.g. "modern", "almuten_figuris", or a custom strategy's
+            ``name``).
+        method: The built-in method identifier, or ``None`` when a custom
+            strategy was used.
+        planets: Ranked planetary/point dominants.
+        signs: Ranked sign dominants.
+        elements: Ranked element dominants (Fire/Earth/Air/Water).
+        qualities: Ranked mode/quality dominants (Cardinal/Fixed/Mutable).
+        houses: Ranked house dominants.
+        polarities: Ranked polarity dominants (Yang/Yin).
+        hemispheres: Ranked hemisphere dominants (North/South/East/West).
+        quadrants: Ranked quadrant dominants.
+        dominant_planet: Convenience winner of ``planets`` (or ``None``).
+        dominant_sign: Convenience winner of ``signs`` (or ``None``).
+        dominant_element: Convenience winner of ``elements`` (or ``None``).
+        dominant_quality: Convenience winner of ``qualities`` (or ``None``).
+        dominant_house: Convenience winner of ``houses`` (or ``None``).
+        score_breakdown: Optional audit trail of how the scores were earned.
+    """
+
+    strategy_name: str
+    method: Optional[DominantMethod] = None
+    planets: list[DominantScoreModel] = Field(default_factory=list)
+    signs: list[DominantScoreModel] = Field(default_factory=list)
+    elements: list[DominantScoreModel] = Field(default_factory=list)
+    qualities: list[DominantScoreModel] = Field(default_factory=list)
+    houses: list[DominantScoreModel] = Field(default_factory=list)
+    polarities: list[DominantScoreModel] = Field(default_factory=list)
+    hemispheres: list[DominantScoreModel] = Field(default_factory=list)
+    quadrants: list[DominantScoreModel] = Field(default_factory=list)
+    dominant_planet: Optional[str] = None
+    dominant_sign: Optional[Sign] = None
+    dominant_element: Optional[Element] = None
+    dominant_quality: Optional[Quality] = None
+    dominant_house: Optional[Houses] = None
+    score_breakdown: list[DominantBreakdownItemModel] = Field(default_factory=list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kerykeion"
-version = "6.0.0a48"
+version = "6.0.0a49"
 authors = [
     { name = "Giacomo Battaglia", email = "kerykeion.astrology@gmail.com" }
 ]

--- a/tests/core/test_dominants.py
+++ b/tests/core/test_dominants.py
@@ -318,14 +318,37 @@ def test_syzygy_gap_degrades_gracefully(john_lennon, monkeypatch):
     """An ephemeris failure drops the syzygy place without crashing the Almuten."""
     import kerykeion.dominants.utils as utils_module
 
+    # Use a non-RuntimeError, non-builtin exception to mirror the backend's real
+    # out-of-range error (libephemeris raises EphemerisRangeError — a plain
+    # Exception subclass, not a RuntimeError): the catch must be backend-agnostic.
+    class _SimulatedRangeError(Exception):
+        pass
+
     def _boom(_julian_day):
-        raise RuntimeError("simulated ephemeris gap")
+        raise _SimulatedRangeError("simulated out-of-range date")
 
     monkeypatch.setattr(utils_module, "_sun_moon_longitudes", _boom)
     assert prenatal_syzygy(john_lennon) is None
 
     # The Almuten still resolves over the remaining four places.
     result = DominantsFactory.from_subject(john_lennon, strategy="almuten_figuris")
+    assert result.dominant_planet in _CLASSICAL
+
+
+def test_prenatal_syzygy_full_moon(yoko_ono):
+    """A waning chart resolves to a Full-Moon prenatal syzygy (the other branch).
+
+    Yoko Ono is born after a Full Moon and at night, so the syzygy degree is
+    taken from the Moon (the luminary above the horizon at birth). This anchors
+    the 'Full' branch and the nocturnal sect choice, which the New-Moon Lennon
+    fixture does not exercise.
+    """
+    syzygy = prenatal_syzygy(yoko_ono)
+    assert syzygy is not None
+    assert syzygy.kind == "Full"
+    assert 0.0 <= syzygy.degree < 360.0
+    # The Almuten still resolves to a valid classical planet using the Full place.
+    result = DominantsFactory.from_subject(yoko_ono, strategy="almuten_figuris")
     assert result.dominant_planet in _CLASSICAL
 
 

--- a/tests/core/test_dominants.py
+++ b/tests/core/test_dominants.py
@@ -1,0 +1,365 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the dominants calculator (kerykeion.dominants).
+
+Covered:
+    - Almuten Figuris: a hand-verified anchor (scores derived from the static
+      Ptolemaic dignity tables), the accidental layer, and the 5-place setup.
+    - Modern weighted method: component tests of the angularity formula plus
+      integration invariants on a known chart (Aries-rising ⇒ Mars dominant).
+    - Elemental balance: parity with the library's element/quality distribution.
+    - Factory: strategy resolution, the custom-strategy plug-in seam, and errors.
+    - Public contract: get_type_hints resolvability, JSON round-trip, stable shape.
+    - Edge cases: prenatal-syzygy determinism, ephemeris-gap degradation, sidereal.
+
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+import json
+import typing
+
+import pytest
+from pytest import approx
+
+from kerykeion import (
+    AstrologicalSubjectFactory,
+    BaseDominantStrategy,
+    DominantBreakdownItemModel,
+    DominantScoreModel,
+    DominantsFactory,
+    DominantsModel,
+)
+from kerykeion.dominants.base import Category
+from kerykeion.dominants.strategies.modern import ModernDominantStrategy
+from kerykeion.dominants.utils import part_of_fortune_degree, prenatal_syzygy
+from kerykeion.schemas.kerykeion_exception import KerykeionException
+from kerykeion.utilities import get_kerykeion_point_from_degree
+
+pytestmark = pytest.mark.core
+
+_CLASSICAL = {"Sun", "Moon", "Mercury", "Venus", "Mars", "Jupiter", "Saturn"}
+_CATEGORIES = ("planets", "signs", "elements", "qualities", "houses", "polarities", "hemispheres", "quadrants")
+
+
+# =============================================================================
+# ALMUTEN FIGURIS
+# =============================================================================
+
+
+def test_almuten_essential_anchor(john_lennon):
+    """Essential-dignity tally over the five hylegiacal places (hand-verified).
+
+    The expected scores are derived purely from the published Ptolemaic tables
+    in ``kerykeion.dignities.dignity_data`` applied to Lennon's five places:
+        Sun 16°Lib · Moon 3°Aqu · Asc 19°Ari · Fortune 2°Cap · Syzygy 8°Lib (New)
+    Saturn wins (domicile in Aquarius, exaltation in Libra ×2, domicile in
+    Capricorn), ahead of Mercury (triplicity/term of Air, repeatedly).
+    """
+    result = DominantsFactory.from_subject(john_lennon, strategy="almuten_figuris")
+
+    assert result.method == "almuten_figuris"
+    assert result.dominant_planet == "Saturn"
+
+    totals = {item.name: item.score for item in result.planets}
+    assert totals == {
+        "Saturn": 19.0,
+        "Mercury": 17.0,
+        "Venus": 11.0,
+        "Mars": 9.0,
+        "Jupiter": 6.0,
+        "Sun": 5.0,
+        "Moon": 4.0,
+    }
+    # All seven classical planets are present and ranked 1..7 in descending order.
+    assert {item.name for item in result.planets} == _CLASSICAL
+    assert [item.rank for item in result.planets] == [1, 2, 3, 4, 5, 6, 7]
+
+
+def test_almuten_winner_placement_fills_convenience_fields(john_lennon):
+    """The Almuten's own sign/element/quality/house populate the winner fields."""
+    result = DominantsFactory.from_subject(john_lennon, strategy="almuten_figuris")
+    saturn = john_lennon.saturn
+    assert result.dominant_sign == saturn.sign
+    assert result.dominant_element == saturn.element
+    assert result.dominant_quality == saturn.quality
+    assert result.dominant_house == saturn.house
+
+
+def test_almuten_accidentals_change_ranking(john_lennon):
+    """The optional accidental layer (house + day ruler) shifts the winner.
+
+    Lennon was born on a Wednesday (Mercury's day) with Mercury angular, so the
+    accidental layer lifts Mercury above the essential-only winner, Saturn.
+    """
+    essential = DominantsFactory.from_subject(john_lennon, strategy="almuten_figuris")
+    accidental = DominantsFactory.from_subject(
+        john_lennon, strategy="almuten_figuris", include_accidental_dignities=True
+    )
+    assert essential.dominant_planet == "Saturn"
+    assert accidental.dominant_planet == "Mercury"
+    # Totals strictly increase (or hold) once accidental points are added.
+    essential_scores = {p.name: p.score for p in essential.planets}
+    accidental_scores = {p.name: p.score for p in accidental.planets}
+    assert all(accidental_scores[name] >= essential_scores[name] for name in _CLASSICAL)
+
+
+def test_almuten_breakdown_records_places(john_lennon):
+    """With breakdown on, every contribution is a per-place dignity line."""
+    result = DominantsFactory.from_subject(john_lennon, strategy="almuten_figuris", include_score_breakdown=True)
+    assert result.score_breakdown, "breakdown should not be empty"
+    assert all(item.category == "place" for item in result.score_breakdown)
+    # Saturn must have at least one domicile (5-point) contribution.
+    saturn_domiciles = [i for i in result.score_breakdown if i.target == "Saturn" and i.rule == "Domicile"]
+    assert saturn_domiciles and all(i.points == 5.0 for i in saturn_domiciles)
+
+
+# =============================================================================
+# MODERN WEIGHTED METHOD
+# =============================================================================
+
+
+def test_modern_angularity_falloff():
+    """Angularity is 4.0 exactly on the Ascendant, 0 at the orb edge, 2.0 on IC."""
+    point = get_kerykeion_point_from_degree(100.0, "Mars", "AstrologicalPoint")
+
+    on_ascendant = {"Ascendant": 100.0, "Medium_Coeli": None, "Descendant": None, "Imum_Coeli": None}
+    assert ModernDominantStrategy._angularity_scores([point], on_ascendant, [], False)["Mars"] == approx(4.0)
+
+    # 15° away from the only angle → outside the orb → zero.
+    far = {"Ascendant": 115.0, "Medium_Coeli": None, "Descendant": None, "Imum_Coeli": None}
+    assert ModernDominantStrategy._angularity_scores([point], far, [], False)["Mars"] == approx(0.0)
+
+    # Exactly on the IC (weight 0.5) → 4.0 * 0.5 = 2.0.
+    on_ic = {"Ascendant": None, "Medium_Coeli": None, "Descendant": None, "Imum_Coeli": 100.0}
+    assert ModernDominantStrategy._angularity_scores([point], on_ic, [], False)["Mars"] == approx(2.0)
+
+
+def test_modern_mars_dominant_for_aries_rising(john_lennon):
+    """Lennon has Aries rising, so its modern ruler Mars is a dominant planet."""
+    result = DominantsFactory.from_subject(john_lennon, strategy="modern")
+
+    assert result.method == "modern"
+    assert len(result.planets) == 10  # all ten planets present
+    assert [item.rank for item in result.planets] == list(range(1, 11))
+    dominant_names = [item.name for item in result.planets if item.is_dominant]
+    assert "Mars" in dominant_names
+    assert result.dominant_planet is not None
+    assert result.dominant_element in {"Fire", "Earth", "Air", "Water"}
+    assert result.dominant_quality in {"Cardinal", "Fixed", "Mutable"}
+
+
+def test_modern_full_category_set(john_lennon):
+    """The modern method fills the complete Astrotheme-style category set."""
+    result = DominantsFactory.from_subject(john_lennon, strategy="modern")
+    for category in _CATEGORIES:
+        assert isinstance(getattr(result, category), list)
+    # Polarity has exactly Yang and Yin; hemispheres cover the four directions.
+    assert {item.name for item in result.polarities} == {"Yang", "Yin"}
+    assert {item.name for item in result.hemispheres} == {"North", "South", "East", "West"}
+    # Each independent hemisphere axis flags exactly one winner.
+    dominant_hemispheres = {item.name for item in result.hemispheres if item.is_dominant}
+    assert len(dominant_hemispheres) == 2
+
+
+def test_modern_percentages_sum_to_100(john_lennon):
+    """Percentages are normalized to 100 within each populated category."""
+    result = DominantsFactory.from_subject(john_lennon, strategy="modern")
+    for category in ("planets", "elements", "qualities", "polarities"):
+        items = getattr(result, category)
+        assert sum(item.percentage for item in items) == approx(100.0, abs=0.5)
+
+
+# =============================================================================
+# ELEMENTAL BALANCE
+# =============================================================================
+
+
+def test_elemental_matches_distribution(john_lennon):
+    """The elemental school agrees with the library's distribution helpers."""
+    from kerykeion.charts.charts_utils import calculate_element_points, calculate_quality_points
+    from kerykeion.settings.chart_defaults import DEFAULT_CELESTIAL_POINTS_SETTINGS
+
+    for method in ("weighted", "pure_count"):
+        elements = calculate_element_points(
+            DEFAULT_CELESTIAL_POINTS_SETTINGS, john_lennon.active_points, john_lennon, method=method
+        )
+        qualities = calculate_quality_points(
+            DEFAULT_CELESTIAL_POINTS_SETTINGS, john_lennon.active_points, john_lennon, method=method
+        )
+        result = DominantsFactory.from_subject(john_lennon, strategy="elemental", distribution_method=method)
+
+        # The dominant must be one of the elements/qualities achieving the max
+        # total (ties are broken deterministically, but either is acceptable).
+        top_elements = {key for key, value in elements.items() if value == max(elements.values())}
+        top_qualities = {key for key, value in qualities.items() if value == max(qualities.values())}
+        assert result.dominant_element.lower() in top_elements
+        assert result.dominant_quality.lower() in top_qualities
+        # Elemental school scores only elements/qualities/polarities.
+        assert result.planets == []
+        assert {item.name for item in result.polarities} == {"Yang", "Yin"}
+
+
+# =============================================================================
+# FACTORY: RESOLUTION, CUSTOM STRATEGY, ERRORS
+# =============================================================================
+
+
+class _StubStrategy(BaseDominantStrategy):
+    """Minimal custom strategy used to exercise the plug-in seam."""
+
+    name = "stub_school"
+
+    def compute(self, subject, config):
+        return self.build_model(categories={"planets": Category(scores={"Sun": 99.0}, dominant={"Sun"})})
+
+
+def test_custom_strategy_plug_in(john_lennon):
+    """A custom strategy instance is accepted and drives the result."""
+    result = DominantsFactory.from_subject(john_lennon, strategy=_StubStrategy())
+    assert result.strategy_name == "stub_school"
+    assert result.method is None  # custom strategies report no built-in method
+    assert result.dominant_planet == "Sun"
+
+
+def test_unknown_method_raises(john_lennon):
+    """An unknown method name raises a clear KerykeionException."""
+    with pytest.raises(KerykeionException, match="Unknown dominant method"):
+        DominantsFactory.from_subject(john_lennon, strategy="not_a_method")
+
+
+def test_invalid_strategy_type_raises(john_lennon):
+    """A non-strategy, non-string object is rejected."""
+    with pytest.raises(KerykeionException):
+        DominantsFactory.from_subject(john_lennon, strategy=object())  # type: ignore[arg-type]
+
+
+def test_available_methods():
+    """The registry exposes exactly the three built-in schools."""
+    assert DominantsFactory.available_methods() == ["almuten_figuris", "elemental", "modern"]
+
+
+def test_from_birth_data_convenience():
+    """from_birth_data builds the subject and delegates to from_subject."""
+    result = DominantsFactory.from_birth_data(
+        "Test",
+        1990,
+        5,
+        15,
+        12,
+        0,
+        lat=41.9028,
+        lng=12.4964,
+        tz_str="Europe/Rome",
+        online=False,
+        suppress_geonames_warning=True,
+        strategy="elemental",
+    )
+    assert isinstance(result, DominantsModel)
+    assert result.dominant_element in {"Fire", "Earth", "Air", "Water"}
+
+
+# =============================================================================
+# PUBLIC CONTRACT (FastAPI introspection, serialization, stable shape)
+# =============================================================================
+
+
+def test_get_type_hints_resolves():
+    """get_type_hints must succeed on every public model (FastAPI contract)."""
+    for model in (DominantsModel, DominantScoreModel, DominantBreakdownItemModel):
+        hints = typing.get_type_hints(model)
+        assert hints  # non-empty, fully resolved
+
+
+def test_json_round_trip(john_lennon):
+    """The result serializes to JSON and rebuilds identically."""
+    result = DominantsFactory.from_subject(john_lennon, strategy="modern", include_score_breakdown=True)
+    dumped = result.model_dump()
+    json.dumps(dumped)  # must be JSON-serializable
+    rebuilt = DominantsModel(**dumped)
+    assert rebuilt.dominant_planet == result.dominant_planet
+    assert len(rebuilt.planets) == len(result.planets)
+
+
+def test_stable_shape_across_schools(john_lennon):
+    """Every school returns the same fixed set of category lists."""
+    for method in DominantsFactory.available_methods():
+        result = DominantsFactory.from_subject(john_lennon, strategy=method)
+        for category in _CATEGORIES:
+            assert isinstance(getattr(result, category), list)
+
+
+def test_breakdown_is_opt_in(john_lennon):
+    """The audit trail is empty unless explicitly requested."""
+    assert DominantsFactory.from_subject(john_lennon, strategy="modern").score_breakdown == []
+    assert DominantsFactory.from_subject(john_lennon, strategy="modern", include_score_breakdown=True).score_breakdown
+
+
+# =============================================================================
+# EDGE CASES
+# =============================================================================
+
+
+def test_prenatal_syzygy_deterministic(john_lennon):
+    """The prenatal syzygy is reproducible and correctly typed for Lennon."""
+    first = prenatal_syzygy(john_lennon)
+    second = prenatal_syzygy(john_lennon)
+    assert first is not None
+    assert first.kind == second.kind == "New"  # Lennon is waxing gibbous before birth
+    assert first.degree == approx(second.degree, abs=1e-6)
+
+
+def test_part_of_fortune_computed_when_absent(john_lennon):
+    """The Part of Fortune is derived from Asc/Sun/Moon when not pre-calculated."""
+    degree = part_of_fortune_degree(john_lennon)
+    assert degree is not None and 0.0 <= degree < 360.0
+
+
+def test_syzygy_gap_degrades_gracefully(john_lennon, monkeypatch):
+    """An ephemeris failure drops the syzygy place without crashing the Almuten."""
+    import kerykeion.dominants.utils as utils_module
+
+    def _boom(_julian_day):
+        raise RuntimeError("simulated ephemeris gap")
+
+    monkeypatch.setattr(utils_module, "_sun_moon_longitudes", _boom)
+    assert prenatal_syzygy(john_lennon) is None
+
+    # The Almuten still resolves over the remaining four places.
+    result = DominantsFactory.from_subject(john_lennon, strategy="almuten_figuris")
+    assert result.dominant_planet in _CLASSICAL
+
+
+def test_sidereal_chart_returns_valid_winner():
+    """A sidereal chart yields a valid Almuten and leaves the sect unchanged."""
+    tropical = AstrologicalSubjectFactory.from_birth_data(
+        "Lennon T",
+        1940,
+        10,
+        9,
+        18,
+        30,
+        lat=53.4084,
+        lng=-2.9916,
+        tz_str="Europe/London",
+        online=False,
+        suppress_geonames_warning=True,
+    )
+    sidereal = AstrologicalSubjectFactory.from_birth_data(
+        "Lennon S",
+        1940,
+        10,
+        9,
+        18,
+        30,
+        lat=53.4084,
+        lng=-2.9916,
+        tz_str="Europe/London",
+        online=False,
+        suppress_geonames_warning=True,
+        zodiac_type="Sidereal",
+        sidereal_mode="LAHIRI",
+    )
+    result = DominantsFactory.from_subject(sidereal, strategy="almuten_figuris")
+    assert result.dominant_planet in _CLASSICAL
+    # Sect is a horizon (not zodiac) property, so it is identical in both frames.
+    assert sidereal.is_diurnal == tropical.is_diurnal

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "kerykeion"
-version = "6.0.0a48"
+version = "6.0.0a49"
 source = { editable = "." }
 dependencies = [
     { name = "libephemeris" },


### PR DESCRIPTION
## Summary

Adds a **Dominants calculator** — the dominant planet, sign, element, modality and house of a chart — as a dedicated module (`kerykeion/dominants/`) with a factory + Pydantic model, several interchangeable calculation **"schools"** behind a **Strategy pattern**, and a first-class **custom-strategy** extension point.

```python
from kerykeion import AstrologicalSubjectFactory, DominantsFactory

subject = AstrologicalSubjectFactory.from_birth_data(
    "John Lennon", 1940, 10, 9, 18, 30,
    lat=53.4084, lng=-2.9916, tz_str="Europe/London", online=False)

dom = DominantsFactory.from_subject(subject, strategy="modern")
dom.dominant_planet, dom.dominant_element   # ('Mars', 'Earth')
```

## Schools (the "scuole di calcolo")

Selectable by the new `DominantMethod` literal, or replaceable with a custom strategy:

- **`"modern"`** — modern weighted method (*Astrotheme-style*): each planet's strength = **angularity** (orb 15°, Asc > MC > Desc > IC) + **aspect activity** (weighted by aspect type, orb exactitude, and a fast/slow speed tier so Neptune–Pluto ≪ Moon–Mars) + a **mild essential-dignity** bonus/penalty + **rulership** bonuses (Asc > MC > Sun > Moon). From the planetary scores it derives dominant **signs, houses, elements, modes, polarity, hemispheres and quadrants**. Speed/retrogradation excluded by design.
- **`"almuten_figuris"`** — the traditional **Lord of the Geniture**: essential dignities (domicile 5 · exaltation 4 · triplicity 3 · term 2 · face 1) tallied for every classical planet over the five **hylegiacal places** (Sun, Moon, Ascendant, Part of Fortune, **prenatal Syzygy**), with an optional **accidental-dignity** layer (house placement, weekday ruler). Documented on kerykeion.net.
- **`"elemental"`** — simple element/modality balance, reusing `calculate_element_points` / `calculate_quality_points`.

## Architecture

- **Strategy pattern**: `DominantStrategy` (a `runtime_checkable` Protocol) + optional `BaseDominantStrategy` (Template Method: shared ranking, percentage normalization, winner selection). A custom school is any object with a `name` and `compute(subject, config)` — **no registration step**.
- **Factory**: `DominantsFactory.from_subject(subject, strategy=...)` resolves a built-in name via a registry **or** a custom strategy instance; `from_birth_data(...)` is a convenience.
- **Stable public model**: `DominantsModel` has a fixed, school-agnostic shape (every category always present; winners optional), so the response type is stable for runtime / FastAPI introspection. New models re-exported from the package root and verified **`get_type_hints`-safe**.

## Reuse (no reinvention)

Builds on existing components: the Ptolemaic **dignity tables** and term/face helpers (`kerykeion.dignities`), the **element/quality distribution** helpers, the **aspect engine**, and the **rulership** data. The prenatal Syzygy is found with a self-contained, bracketed bisection over the Sun–Moon elongation (the periodic `compute_lunar_phase_jd` is unreliable for an unbounded backward search), accessing the ephemeris under `EPHEMERIS_LOCK`.

## Test plan

`tests/core/test_dominants.py` — **22 tests**, all green; full `tests/core` tier passes (10087 passed, 69 skipped) with no regressions. Coverage:

- **Almuten anchor**: scores hand-derived from the static Ptolemaic tables for Lennon's five places (Saturn wins, 19 pts); accidental layer flips the winner to Mercury; per-place breakdown.
- **Modern**: angularity formula component tests (4.0 on Asc, 0 at 15°, 2.0 on IC); Aries-rising ⇒ Mars dominant; full category set; percentages sum to 100.
- **Elemental**: parity with the distribution helpers under both `weighted` and `pure_count`.
- **Factory**: resolution, custom-strategy plug-in, unknown-method / invalid-type errors, `available_methods`, `from_birth_data`.
- **Contract**: `get_type_hints` resolvability, JSON round-trip, stable shape.
- **Edge**: syzygy determinism, ephemeris-gap degradation (monkeypatched), Part of Fortune fallback, sidereal chart.

Lint clean (`ruff check`), formatted with `ruff format`. CHANGELOG + version bumped to `6.0.0a49`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Introduced a chart dominants calculator accessible via `DominantsFactory` with three built-in calculation methods: Modern (weighted planet strength), Almuten Figuris (classical), and Elemental (element/quality balance). Computes and ranks dominant planets, signs, elements, qualities, houses, polarities, hemispheres, and quadrants with optional detailed score breakdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/g-battaglia/kerykeion/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->