### PR TITLE
feat: civil/nautical/astronomical twilight in SunTimesFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 6.0.0a50
+
+_2026-05-29_
+
+`SunTimesFactory` now also reports civil, nautical and astronomical twilight.
+
+### Added
+
+- **Twilight on `SunTimesModel`** — six new optional fields: `civil_dawn` /
+  `civil_dusk` (Sun at -6°), `nautical_dawn` / `nautical_dusk` (-12°) and
+  `astronomical_dawn` / `astronomical_dusk` (-18°). Computed by
+  `compute_twilight_events` via the active ephemeris backend's `rise_trans`
+  twilight bits (geometric, no refraction); each is `None` when that twilight
+  does not occur on the civil day (polar / high-latitude geometry).
+
 ## 6.0.0a49
 
 _2026-05-29_

--- a/kerykeion/schemas/kr_models.py
+++ b/kerykeion/schemas/kr_models.py
@@ -378,6 +378,9 @@ class SunTimesModel(SubscriptableBaseModel):
         day_length: Duration from sunrise to a later paired sunset, or ``None``.
         is_polar_day: ``True`` when the Sun stays above the horizon all day.
         is_polar_night: ``True`` when the Sun stays below the horizon all day.
+        civil_dawn / civil_dusk: Sun at -6 degrees (morning / evening), or ``None``.
+        nautical_dawn / nautical_dusk: Sun at -12 degrees, or ``None``.
+        astronomical_dawn / astronomical_dusk: Sun at -18 degrees, or ``None``.
     """
 
     date: str
@@ -390,6 +393,12 @@ class SunTimesModel(SubscriptableBaseModel):
     day_length: Optional[timedelta] = None
     is_polar_day: bool = False
     is_polar_night: bool = False
+    civil_dawn: Optional[datetime] = None
+    civil_dusk: Optional[datetime] = None
+    nautical_dawn: Optional[datetime] = None
+    nautical_dusk: Optional[datetime] = None
+    astronomical_dawn: Optional[datetime] = None
+    astronomical_dusk: Optional[datetime] = None
 
 
 class PlanetaryHourModel(SubscriptableBaseModel):

--- a/kerykeion/sun_times/factory.py
+++ b/kerykeion/sun_times/factory.py
@@ -6,7 +6,7 @@ This is part of Kerykeion (C) 2025 Giacomo Battaglia
 from __future__ import annotations
 
 from kerykeion.schemas.kr_models import SunTimesModel
-from kerykeion.sun_times.utils import compute_sun_events, resolve_timezone
+from kerykeion.sun_times.utils import compute_sun_events, compute_twilight_events, resolve_timezone
 
 
 class SunTimesFactory:
@@ -64,6 +64,7 @@ class SunTimesFactory:
         """
         tz = resolve_timezone(tz_str)
         events = compute_sun_events(year, month, day, latitude, longitude, tz)
+        twilight = compute_twilight_events(year, month, day, latitude, longitude, tz)
 
         return SunTimesModel(
             date=f"{year:04d}-{month:02d}-{day:02d}",
@@ -76,4 +77,10 @@ class SunTimesFactory:
             day_length=events.day_length,
             is_polar_day=events.is_polar_day,
             is_polar_night=events.is_polar_night,
+            civil_dawn=twilight.civil_dawn,
+            civil_dusk=twilight.civil_dusk,
+            nautical_dawn=twilight.nautical_dawn,
+            nautical_dusk=twilight.nautical_dusk,
+            astronomical_dawn=twilight.astronomical_dawn,
+            astronomical_dusk=twilight.astronomical_dusk,
         )

--- a/kerykeion/sun_times/factory.py
+++ b/kerykeion/sun_times/factory.py
@@ -57,7 +57,8 @@ class SunTimesFactory:
             tz_str: IANA timezone identifier the civil date is anchored to.
 
         Returns:
-            SunTimesModel: sunrise, sunset, solar noon, day length and polar flags.
+            SunTimesModel: sunrise, sunset, solar noon, day length, polar flags
+            and civil/nautical/astronomical twilight.
 
         Raises:
             KerykeionException: If ``tz_str`` is invalid or the civil date is unsupported.

--- a/kerykeion/sun_times/utils.py
+++ b/kerykeion/sun_times/utils.py
@@ -6,13 +6,16 @@ The heavy astronomical work — locating sunrise and sunset with atmospheric
 refraction — is delegated to the well-tested
 :func:`kerykeion.moon_phase_details.utils.compute_sun_rise_set_swe`, which calls
 the active ephemeris backend's ``rise_trans`` routine. This module adds the thin
-layer on top: timezone/Julian-Day bookkeeping, solar noon, day length, and the
-polar day / polar night discriminator. No full astrological subject is built, so
-the computation is cheap (two ``rise_trans`` calls plus one position lookup).
+layer on top: timezone/Julian-Day bookkeeping, solar noon, day length, the polar
+day / polar night discriminator, and civil/nautical/astronomical twilight. No
+full astrological subject is built, so the computation stays cheap: two
+``rise_trans`` calls for sunrise/sunset (plus one position lookup) and up to six
+more for the twilight crossings.
 """
 
 from __future__ import annotations
 
+import logging
 import math
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
@@ -29,6 +32,7 @@ from kerykeion.moon_phase_details.utils import (
 from kerykeion.schemas.kerykeion_exception import KerykeionException
 from kerykeion.utilities import datetime_to_julian, julian_to_datetime
 
+logger = logging.getLogger(__name__)
 
 _APPARENT_UPPER_LIMB_HORIZON_DEGREES = -0.833
 
@@ -144,6 +148,21 @@ def julian_day_to_utc(jd: float) -> datetime:
     return julian_to_datetime(jd).replace(tzinfo=timezone.utc)
 
 
+def _civil_day_bounds(year: int, month: int, day: int, tz: pytz.BaseTzInfo) -> tuple[float, float]:
+    """Julian Days (UT) of the local midnights opening and closing the civil day.
+
+    Returns ``(jd_midnight, jd_next_midnight)``; the upper bound falls back to
+    ``jd_midnight + 1`` when the following date overflows the supported range.
+    """
+    jd_midnight = local_midnight_julian_day(year, month, day, tz)
+    try:
+        next_day = date(year, month, day) + timedelta(days=1)
+        jd_next_midnight = local_midnight_julian_day(next_day.year, next_day.month, next_day.day, tz)
+    except OverflowError:
+        jd_next_midnight = jd_midnight + 1.0
+    return jd_midnight, jd_next_midnight
+
+
 def _polar_state(jd_noon: float, latitude: float) -> tuple[bool, bool]:
     """Classify a no-rise/no-set day as polar day or polar night.
 
@@ -197,12 +216,7 @@ def compute_sun_events(
             rise/set while the geometry is not polar (e.g. a date/location outside
             the backend's supported rise/set range).
     """
-    jd_midnight = local_midnight_julian_day(year, month, day, tz)
-    try:
-        next_day = date(year, month, day) + timedelta(days=1)
-        jd_next_midnight = local_midnight_julian_day(next_day.year, next_day.month, next_day.day, tz)
-    except OverflowError:
-        jd_next_midnight = jd_midnight + 1.0
+    jd_midnight, jd_next_midnight = _civil_day_bounds(year, month, day, tz)
 
     with EPHEMERIS_LOCK:
         sunrise_jd, sunset_jd = compute_sun_rise_set_swe(jd_midnight, latitude, longitude)
@@ -262,10 +276,13 @@ def _next_event_jd(
     """
     try:
         result = swe.rise_trans(jd_start, swe.SUN, rsmi, geopos, atpress=0.0, attemp=0.0, flags=iflag)
-    except (RuntimeError, AttributeError, TypeError, IndexError, ValueError, OverflowError):
-        # Circumpolar / edge geometry: the backend may raise instead of returning a
-        # no-event status. A missing twilight crossing is normal at high latitudes,
-        # so degrade to None rather than failing the whole sun-times computation.
+    except RuntimeError as exc:
+        # Expected at high latitudes: circumpolar at the depression angle (the Sun
+        # never reaches it). A missing twilight crossing is normal, so degrade to None.
+        logger.debug("Twilight rise/set unavailable (expected for polar geometry): %s", exc)
+        return None
+    except (AttributeError, TypeError, IndexError, ValueError, OverflowError) as exc:  # pragma: no cover
+        logger.error("Unexpected error in twilight rise/set calculation: %s", exc, exc_info=True)
         return None
     if not isinstance(result, tuple) or len(result) < 2:
         return None
@@ -283,9 +300,11 @@ def compute_twilight_events(
     """Compute civil, nautical and astronomical dawn/dusk for a civil day.
 
     Dawn is the morning crossing (Sun ascending to the depression angle) and dusk
-    the evening crossing (descending past it), at -6 / -12 / -18 degrees. Results
-    are timezone-aware UTC instants bounded to the requested civil day, or ``None``
-    when the twilight does not occur that day (polar / high-latitude geometry).
+    the evening crossing (descending past it), at -6 / -12 / -18 degrees. Dawn is
+    sought from local midnight, dusk from local noon so it is the evening crossing;
+    an evening dusk can therefore land in the small hours of the next civil date
+    (as the paired sunset can). Each instant is a timezone-aware UTC ``datetime``,
+    or ``None`` when that twilight does not occur (polar / high-latitude geometry).
 
     Args:
         year, month, day: Civil date in the supplied timezone.
@@ -297,12 +316,7 @@ def compute_twilight_events(
         A :class:`TwilightEvents` with the six dawn/dusk instants (each ``None``
         when the corresponding twilight does not occur on the civil day).
     """
-    jd_midnight = local_midnight_julian_day(year, month, day, tz)
-    try:
-        next_day = date(year, month, day) + timedelta(days=1)
-        jd_next_midnight = local_midnight_julian_day(next_day.year, next_day.month, next_day.day, tz)
-    except OverflowError:
-        jd_next_midnight = jd_midnight + 1.0
+    jd_midnight, jd_next_midnight = _civil_day_bounds(year, month, day, tz)
 
     # Backend flag shims (libephemeris exposes these; swisseph uses the SE_ prefix).
     calc_rise = getattr(swe, "CALC_RISE", getattr(swe, "SE_CALC_RISE", 1))
@@ -315,17 +329,27 @@ def compute_twilight_events(
     with EPHEMERIS_LOCK:
         iflag = configure_ephemeris_path()
 
-        def event(rsmi: int) -> Optional[datetime]:
+        jd_noon = jd_midnight + 0.5
+
+        def dawn(rsmi: int) -> Optional[datetime]:
+            # Morning ascending crossing, within the civil day.
             jd = _next_event_jd(jd_midnight, geopos, rsmi, iflag)
-            if jd is None or jd >= jd_next_midnight:
-                return None
-            return julian_day_to_utc(jd)
+            return julian_day_to_utc(jd) if jd is not None and jd < jd_next_midnight else None
+
+        def dusk(rsmi: int) -> Optional[datetime]:
+            # Evening descending crossing: searching from local noon makes the first
+            # descent found the evening one (not a pre-dawn small-hours crossing). Like
+            # the paired sunset it may fall in the small hours of the next civil date,
+            # so the bound runs to the following local noon (rejecting far-future
+            # crossings during polar day).
+            jd = _next_event_jd(jd_noon, geopos, rsmi, iflag)
+            return julian_day_to_utc(jd) if jd is not None and jd < jd_next_midnight + 0.5 else None
 
         return TwilightEvents(
-            civil_dawn=event(calc_rise | civil_bit),
-            civil_dusk=event(calc_set | civil_bit),
-            nautical_dawn=event(calc_rise | nautic_bit),
-            nautical_dusk=event(calc_set | nautic_bit),
-            astronomical_dawn=event(calc_rise | astro_bit),
-            astronomical_dusk=event(calc_set | astro_bit),
+            civil_dawn=dawn(calc_rise | civil_bit),
+            civil_dusk=dusk(calc_set | civil_bit),
+            nautical_dawn=dawn(calc_rise | nautic_bit),
+            nautical_dusk=dusk(calc_set | nautic_bit),
+            astronomical_dawn=dawn(calc_rise | astro_bit),
+            astronomical_dusk=dusk(calc_set | astro_bit),
         )

--- a/kerykeion/sun_times/utils.py
+++ b/kerykeion/sun_times/utils.py
@@ -50,6 +50,25 @@ class SunEvents:
     is_polar_night: bool
 
 
+@dataclass(frozen=True)
+class TwilightEvents:
+    """Civil/nautical/astronomical dawn and dusk for one civil day at a location.
+
+    Each instant is a timezone-aware UTC ``datetime`` marking when the Sun's
+    centre crosses the corresponding depression angle (-6 / -12 / -18 degrees) on
+    the requested civil day, or ``None`` when that twilight does not occur — e.g.
+    high-latitude summer where the Sun never sinks to -18 degrees, or polar day.
+    Dawn is the morning (ascending) crossing, dusk the evening (descending) one.
+    """
+
+    civil_dawn: Optional[datetime]
+    civil_dusk: Optional[datetime]
+    nautical_dawn: Optional[datetime]
+    nautical_dusk: Optional[datetime]
+    astronomical_dawn: Optional[datetime]
+    astronomical_dusk: Optional[datetime]
+
+
 def resolve_timezone(tz_str: str) -> pytz.BaseTzInfo:
     """Resolve an IANA timezone string, raising ``KerykeionException`` if invalid.
 
@@ -225,3 +244,88 @@ def compute_sun_events(
     day_length = sunset - sunrise
     solar_noon = sunrise + day_length / 2
     return SunEvents(sunrise, sunset, solar_noon, day_length, False, False)
+
+
+def _next_event_jd(
+    jd_start: float, geopos: tuple[float, float, float], rsmi: int, iflag: int
+) -> Optional[float]:
+    """Julian Day (UT) of the next ``rise_trans`` event, or ``None`` if none found.
+
+    Thin wrapper used for twilight crossings. The twilight bits make the backend
+    search for the Sun's centre at a fixed geometric depression angle (no
+    refraction), so no pressure/temperature is supplied. Only a clean ``res == 0``
+    result is accepted; circumpolar / no-event results map to ``None``.
+
+    Note:
+        Mutates global ephemeris state via the backend; the caller must hold
+        :data:`EPHEMERIS_LOCK`.
+    """
+    try:
+        result = swe.rise_trans(jd_start, swe.SUN, rsmi, geopos, atpress=0.0, attemp=0.0, flags=iflag)
+    except (RuntimeError, AttributeError, TypeError, IndexError, ValueError, OverflowError):
+        # Circumpolar / edge geometry: the backend may raise instead of returning a
+        # no-event status. A missing twilight crossing is normal at high latitudes,
+        # so degrade to None rather than failing the whole sun-times computation.
+        return None
+    if not isinstance(result, tuple) or len(result) < 2:
+        return None
+    res, tret = result[0], result[1]
+    if not isinstance(res, int) or res != 0:
+        return None
+    if not isinstance(tret, (list, tuple)) or not tret or not isinstance(tret[0], (float, int)):
+        return None
+    return float(tret[0])
+
+
+def compute_twilight_events(
+    year: int, month: int, day: int, latitude: float, longitude: float, tz: pytz.BaseTzInfo
+) -> TwilightEvents:
+    """Compute civil, nautical and astronomical dawn/dusk for a civil day.
+
+    Dawn is the morning crossing (Sun ascending to the depression angle) and dusk
+    the evening crossing (descending past it), at -6 / -12 / -18 degrees. Results
+    are timezone-aware UTC instants bounded to the requested civil day, or ``None``
+    when the twilight does not occur that day (polar / high-latitude geometry).
+
+    Args:
+        year, month, day: Civil date in the supplied timezone.
+        latitude: Observer latitude in degrees (north positive).
+        longitude: Observer longitude in degrees (east positive).
+        tz: Resolved ``pytz`` timezone the civil date is anchored to.
+
+    Returns:
+        A :class:`TwilightEvents` with the six dawn/dusk instants (each ``None``
+        when the corresponding twilight does not occur on the civil day).
+    """
+    jd_midnight = local_midnight_julian_day(year, month, day, tz)
+    try:
+        next_day = date(year, month, day) + timedelta(days=1)
+        jd_next_midnight = local_midnight_julian_day(next_day.year, next_day.month, next_day.day, tz)
+    except OverflowError:
+        jd_next_midnight = jd_midnight + 1.0
+
+    # Backend flag shims (libephemeris exposes these; swisseph uses the SE_ prefix).
+    calc_rise = getattr(swe, "CALC_RISE", getattr(swe, "SE_CALC_RISE", 1))
+    calc_set = getattr(swe, "CALC_SET", getattr(swe, "SE_CALC_SET", 2))
+    civil_bit = getattr(swe, "BIT_CIVIL_TWILIGHT", 1024)
+    nautic_bit = getattr(swe, "BIT_NAUTIC_TWILIGHT", 2048)
+    astro_bit = getattr(swe, "BIT_ASTRO_TWILIGHT", 4096)
+    geopos = (float(longitude), float(latitude), 0.0)
+
+    with EPHEMERIS_LOCK:
+        iflag = configure_ephemeris_path()
+
+        def event(rsmi: int) -> Optional[datetime]:
+            jd = _next_event_jd(jd_midnight, geopos, rsmi, iflag)
+            if jd is None or jd >= jd_next_midnight:
+                return None
+            return julian_day_to_utc(jd)
+
+        return TwilightEvents(
+            civil_dawn=event(calc_rise | civil_bit),
+            civil_dusk=event(calc_set | civil_bit),
+            nautical_dawn=event(calc_rise | nautic_bit),
+            nautical_dusk=event(calc_set | nautic_bit),
+            astronomical_dawn=event(calc_rise | astro_bit),
+            astronomical_dusk=event(calc_set | astro_bit),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kerykeion"
-version = "6.0.0a49"
+version = "6.0.0a50"
 authors = [
     { name = "Giacomo Battaglia", email = "kerykeion.astrology@gmail.com" }
 ]

--- a/tests/core/test_sun_times_factory.py
+++ b/tests/core/test_sun_times_factory.py
@@ -162,3 +162,33 @@ def test_twilight_extreme_latitude_does_not_raise():
     assert s.is_polar_day is True
     assert s.civil_dawn is None and s.nautical_dawn is None and s.astronomical_dawn is None
     assert s.civil_dusk is None and s.nautical_dusk is None and s.astronomical_dusk is None
+
+
+def test_twilight_dusk_crosses_midnight_high_latitude():
+    # Near the solstice at ~43-48N the astronomical "night" falls in the small hours,
+    # so the evening dusk lands on the next civil date. Searching dusk from local noon
+    # keeps it the evening crossing (dawn < dusk, ~a full day after dawn); a
+    # midnight-anchored search would instead return a pre-dawn value (dusk < dawn).
+    import pytz
+
+    s = SunTimesFactory.from_date(2026, 6, 21, latitude=48.0, longitude=2.35, tz_str="Europe/Paris")
+    assert s.astronomical_dawn is not None and s.astronomical_dusk is not None
+    assert s.astronomical_dawn < s.astronomical_dusk
+    assert (s.astronomical_dusk - s.astronomical_dawn).total_seconds() > 12 * 3600
+    assert s.sunset < s.civil_dusk < s.nautical_dusk < s.astronomical_dusk
+    # The evening astronomical dusk spills past local midnight onto the next date.
+    paris = pytz.timezone("Europe/Paris")
+    assert s.astronomical_dusk.astimezone(paris).date() > s.sunset.astimezone(paris).date()
+
+
+def test_twilight_during_polar_night():
+    # Polar night is not the same as no twilight: at Svalbard in midwinter the Sun
+    # still climbs above the deeper depression angles around local noon, so nautical
+    # and astronomical twilight exist even though sunrise/sunset (and the shallower
+    # civil twilight) are None.
+    s = SunTimesFactory.from_date(2026, 12, 21, latitude=78.22, longitude=15.65, tz_str="Arctic/Longyearbyen")
+    assert s.is_polar_night is True
+    assert s.sunrise is None and s.sunset is None
+    assert s.civil_dawn is None and s.civil_dusk is None
+    assert s.nautical_dawn is not None and s.nautical_dusk is not None
+    assert s.astronomical_dawn is not None and s.astronomical_dusk is not None

--- a/tests/core/test_sun_times_factory.py
+++ b/tests/core/test_sun_times_factory.py
@@ -109,3 +109,56 @@ def test_polar_state_backend_failure_raises(monkeypatch):
     monkeypatch.setattr(sun_times_utils, "_polar_state", _raise)
     with pytest.raises(KerykeionException):
         SunTimesFactory.from_date(2026, 6, 21, **TROMSO)
+
+
+def test_twilight_ordering_rome():
+    # Civil/nautical/astronomical dawn precede sunrise (deepest depression first),
+    # and the dusks follow sunset in the mirror order — a strictly increasing run.
+    s = SunTimesFactory.from_date(2026, 5, 28, **ROME)
+    sequence = [
+        s.astronomical_dawn,
+        s.nautical_dawn,
+        s.civil_dawn,
+        s.sunrise,
+        s.sunset,
+        s.civil_dusk,
+        s.nautical_dusk,
+        s.astronomical_dusk,
+    ]
+    assert all(moment is not None for moment in sequence)
+    assert all(earlier < later for earlier, later in zip(sequence, sequence[1:]))
+    # Twilight instants are timezone-aware UTC, like the rest of the model.
+    assert s.civil_dawn.utcoffset().total_seconds() == 0
+
+
+def test_twilight_none_on_polar_day():
+    # On polar day the Sun never crosses any depression angle, so every twilight
+    # boundary is None (matching the None sunrise/sunset).
+    s = SunTimesFactory.from_date(2026, 6, 21, **TROMSO)
+    assert s.is_polar_day is True
+    assert s.civil_dawn is None and s.civil_dusk is None
+    assert s.nautical_dawn is None and s.nautical_dusk is None
+    assert s.astronomical_dawn is None and s.astronomical_dusk is None
+
+
+def test_twilight_partial_high_latitude():
+    # London at the summer solstice has no astronomical night (the Sun never sinks
+    # to -18 degrees), so astronomical dawn/dusk are None while civil and nautical
+    # twilight still occur. The day is not polar.
+    s = SunTimesFactory.from_date(2026, 6, 21, latitude=51.5074, longitude=-0.1278, tz_str="Europe/London")
+    assert not s.is_polar_day and not s.is_polar_night
+    assert s.civil_dawn is not None and s.civil_dusk is not None
+    assert s.nautical_dawn is not None and s.nautical_dusk is not None
+    assert s.astronomical_dawn is None and s.astronomical_dusk is None
+    # Deeper twilight begins earlier in the morning.
+    assert s.nautical_dawn < s.civil_dawn
+
+
+def test_twilight_extreme_latitude_does_not_raise():
+    # Deep in the Arctic on polar day the backend can refuse a twilight crossing
+    # (circumpolar at the depression angle); the factory must degrade to None
+    # rather than propagate a backend error.
+    s = SunTimesFactory.from_date(2026, 6, 21, latitude=78.22, longitude=15.65, tz_str="Arctic/Longyearbyen")
+    assert s.is_polar_day is True
+    assert s.civil_dawn is None and s.nautical_dawn is None and s.astronomical_dawn is None
+    assert s.civil_dusk is None and s.nautical_dusk is None and s.astronomical_dusk is None

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "kerykeion"
-version = "6.0.0a49"
+version = "6.0.0a50"
 source = { editable = "." }
 dependencies = [
     { name = "libephemeris" },


### PR DESCRIPTION
## Summary
Adds civil, nautical and astronomical twilight to `SunTimesFactory` / `SunTimesModel`.

- New `compute_twilight_events` (`kerykeion/sun_times/utils.py`) drives the active ephemeris backend's `rise_trans` twilight bits (`BIT_CIVIL/NAUTIC/ASTRO_TWILIGHT`, −6 / −12 / −18°), geometric (no refraction), reusing the existing JD / `EPHEMERIS_LOCK` infrastructure.
- `SunTimesModel` gains six `Optional[datetime]` UTC fields: `civil_dawn`/`civil_dusk`, `nautical_dawn`/`nautical_dusk`, `astronomical_dawn`/`astronomical_dusk`.
- Each is `None` when the twilight does not occur on the civil day (polar day, or no astronomical night at high latitude). A defensive guard degrades circumpolar backend errors to `None` rather than raising.
- Version bumped to `6.0.0a50`.

## Tests
`tests/core/test_sun_times_factory.py` — 4 new tests:
- ordering at mid latitude (astro < naut < civil < sunrise, mirrored at dusk), UTC-aware
- all `None` on polar day (Tromsø)
- partial twilight at high latitude (London solstice: civil/nautical present, astronomical `None`)
- extreme latitude does not raise (Svalbard polar day → all `None`)

`pytest tests/core/test_sun_times_factory.py` → **15 passed**.

## Notes
Uses only the pluggable ephemeris backend (libephemeris by default); no swisseph-specific code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sun times calculations now include twilight events. Civil, nautical, and astronomical dawn and dusk times are now available as optional fields in addition to sunrise, sunset, and solar noon. These values are computed for any geographic location and civil day, returning `None` when twilight does not occur.

* **Chores**
  * Bumped version to 6.0.0a50.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/g-battaglia/kerykeion/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->