### PR TITLE
feat: lunation finder + eclipse enrichment (6.0.0a52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 6.0.0a52
+
+_2026-06-03_
+
+Adds a lunation-calendar finder and enriches eclipse search with zodiac
+position plus Saros/Inex/gamma/duration metadata. Raises the libephemeris
+floor to 2.0.2.
+
+### Added
+
+- **`LunationFinderFactory`** (`kerykeion.lunations`) — finds New Moon, First
+  Quarter, Full Moon and Last Quarter across a date or Julian-Day range
+  (`from_iso_range` / `from_julian_day`) via `compute_lunar_phase_jd`, iterating
+  each phase independently at a half-synodic step so the binary-search solver
+  never degenerates on adjacent phases. Returns a `LunationsCollectionModel`
+  whose items carry the phase name, UTC timestamp, Julian Day and the Sun/Moon
+  `KerykeionPointModel`. Re-exported from the package root
+  (`LunationFinderFactory`, `LunationModel`, `LunationsCollectionModel`).
+- **Eclipse zodiac + physical metadata** — `SolarEclipseModel` /
+  `LunarEclipseModel` gain optional `ecliptic_longitude`, `sign`, `sign_num`
+  and `degree` of the luminary at maximum, plus `saros` / `inex` (and, for
+  solar eclipses, `gamma` and `duration_minutes`). The values come from the
+  libephemeris extensions, guarded with `hasattr`, so they are `None` on the
+  swisseph backend — additive and backward compatible.
+
+### Changed
+
+- **`libephemeris` pinned to `==2.0.2`** — picks up the fix for global
+  lunar-occultation search under the `extended` (DE441) precision tier
+  (`lun_occult_when_glob` previously clamped post-1969 searches to the DE441
+  segment split and returned no events).
+
 ## 6.0.0a51
 
 _2026-05-29_

--- a/kerykeion/__init__.py
+++ b/kerykeion/__init__.py
@@ -70,6 +70,7 @@ from .void_of_course_moon import VoidOfCourseMoonFactory
 # =============================================================================
 from .planetary_phenomena import PlanetaryPhenomenaFactory
 from .eclipses import EclipseFactory
+from .lunations import LunationFinderFactory, LunationModel, LunationsCollectionModel
 from .planetary_nodes import PlanetaryNodesFactory
 from .heliacal import HeliacalFactory
 from .occultations import OccultationFactory
@@ -154,6 +155,9 @@ __all__ = [
     # Standalone Factories
     "PlanetaryPhenomenaFactory",
     "EclipseFactory",
+    "LunationFinderFactory",
+    "LunationModel",
+    "LunationsCollectionModel",
     "PlanetaryNodesFactory",
     "HeliacalFactory",
     "OccultationFactory",

--- a/kerykeion/eclipses/eclipse_factory.py
+++ b/kerykeion/eclipses/eclipse_factory.py
@@ -19,6 +19,7 @@ from typing import List, Optional
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
 
 from kerykeion.schemas.kr_models import SubscriptableBaseModel
+from kerykeion.utilities import get_kerykeion_point_from_degree
 from pydantic import Field
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,74 @@ def _classify_lunar_eclipse(retflags: int) -> str:
     return "unknown"
 
 
+def _zodiac_fields(jd: float, body: int, name: str) -> dict:
+    """Ecliptic sign/degree of a luminary at the eclipse maximum.
+
+    Backend-agnostic (uses ``swe.calc_ut``). For a solar eclipse the eclipse
+    degree is the Sun/Moon conjunction longitude; for a lunar eclipse it is the
+    Moon's longitude (the Full Moon point).
+    """
+    try:
+        lon = float(swe.calc_ut(jd, body, swe.FLG_SWIEPH)[0][0]) % 360.0
+        point = get_kerykeion_point_from_degree(lon, name, "AstrologicalPoint")
+        return {
+            "ecliptic_longitude": round(lon, 6),
+            "sign": point.sign,
+            "sign_num": point.sign_num,
+            "degree": round(point.position, 6),
+        }
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Eclipse zodiac enrichment failed: %s", exc)
+        return {}
+
+
+def _saros_inex(jd: float, kind: str) -> dict:
+    """Saros/Inex series numbers (libephemeris extensions; hasattr-guarded).
+
+    Returns an empty dict on the swisseph backend (functions absent) so the
+    extra fields simply stay ``None``.
+    """
+    out: dict = {}
+    saros_fn = getattr(swe, "get_saros_number", None)
+    if saros_fn is not None:
+        try:
+            out["saros"] = int(saros_fn(jd, kind))
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Saros lookup failed: %s", exc)
+    inex_fn = getattr(swe, "get_inex_number", None)
+    if inex_fn is not None:
+        try:
+            out["inex"] = int(inex_fn(jd, kind))
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Inex lookup failed: %s", exc)
+    return out
+
+
+def _solar_gamma_duration(jd: float) -> dict:
+    """Solar gamma + central-phase duration (libephemeris extensions; guarded).
+
+    ``sol_eclipse_max_time`` returns ``(jd_max, gamma)`` in global mode (gamma in
+    Earth radii); ``calc_solar_eclipse_duration`` returns the totality/annularity
+    duration in minutes (0.0 for partial eclipses).
+    """
+    out: dict = {}
+    gamma_fn = getattr(swe, "sol_eclipse_max_time", None)
+    if gamma_fn is not None:
+        try:
+            _, gamma = gamma_fn(jd)
+            out["gamma"] = round(float(gamma), 6)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Gamma lookup failed: %s", exc)
+    dur_fn = getattr(swe, "calc_solar_eclipse_duration", None)
+    if dur_fn is not None:
+        try:
+            minutes = float(dur_fn(jd))
+            out["duration_minutes"] = round(minutes, 4) if minutes > 0 else None
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Duration lookup failed: %s", exc)
+    return out
+
+
 # =============================================================================
 # MODELS
 # =============================================================================
@@ -81,6 +150,16 @@ class SolarEclipseModel(SubscriptableBaseModel):
     magnitude: float = Field(description="Fraction of solar diameter covered")
     obscuration: float = Field(description="Fraction of solar disk area covered")
     sun_altitude: Optional[float] = Field(default=None, description="Sun altitude at maximum (degrees)")
+    # Zodiac position of the eclipse (Sun/Moon conjunction longitude at maximum).
+    ecliptic_longitude: Optional[float] = Field(default=None, description="Ecliptic longitude at maximum (0-360)")
+    sign: Optional[str] = Field(default=None, description="Zodiac sign of the eclipse")
+    sign_num: Optional[int] = Field(default=None, description="Zodiac sign number (0=Aries)")
+    degree: Optional[float] = Field(default=None, description="Degree within the sign (0-30)")
+    # Catalogued series + geometry (libephemeris extensions; None on swisseph backend).
+    saros: Optional[int] = Field(default=None, description="Saros series number")
+    inex: Optional[int] = Field(default=None, description="Inex series number")
+    gamma: Optional[float] = Field(default=None, description="Gamma: shadow-axis distance from Earth's centre (Earth radii)")
+    duration_minutes: Optional[float] = Field(default=None, description="Central (total/annular) duration in minutes; None if partial")
 
 
 class LunarEclipseModel(SubscriptableBaseModel):
@@ -90,6 +169,14 @@ class LunarEclipseModel(SubscriptableBaseModel):
     datestamp: str = Field(description="ISO 8601 formatted datetime of maximum")
     magnitude_umbral: Optional[float] = Field(default=None, description="Umbral magnitude")
     magnitude_penumbral: Optional[float] = Field(default=None, description="Penumbral magnitude")
+    # Zodiac position of the eclipse (Moon longitude / Full Moon point at maximum).
+    ecliptic_longitude: Optional[float] = Field(default=None, description="Ecliptic longitude at maximum (0-360)")
+    sign: Optional[str] = Field(default=None, description="Zodiac sign of the eclipse")
+    sign_num: Optional[int] = Field(default=None, description="Zodiac sign number (0=Aries)")
+    degree: Optional[float] = Field(default=None, description="Degree within the sign (0-30)")
+    # Catalogued series (libephemeris extensions; None on swisseph backend).
+    saros: Optional[int] = Field(default=None, description="Saros series number")
+    inex: Optional[int] = Field(default=None, description="Inex series number")
 
 
 class EclipseSearchResultModel(SubscriptableBaseModel):
@@ -194,6 +281,9 @@ class EclipseFactory:
                     magnitude=round(attr[0], 6) if len(attr) > 0 else 0.0,
                     obscuration=round(attr[2], 6) if len(attr) > 2 else 0.0,
                     sun_altitude=round(attr[5], 4) if len(attr) > 5 else None,
+                    **_zodiac_fields(max_jd, swe.SUN, "Sun"),
+                    **_saros_inex(max_jd, "solar"),
+                    **_solar_gamma_duration(max_jd),
                 ))
                 jd = max_jd + 10  # Skip ahead
             except Exception as e:
@@ -218,6 +308,9 @@ class EclipseFactory:
                     datestamp=_jd_to_iso(max_jd),
                     magnitude=0.0,
                     obscuration=0.0,
+                    **_zodiac_fields(max_jd, swe.SUN, "Sun"),
+                    **_saros_inex(max_jd, "solar"),
+                    **_solar_gamma_duration(max_jd),
                 ))
                 jd = max_jd + 10
             except Exception as e:
@@ -242,6 +335,8 @@ class EclipseFactory:
                     datestamp=_jd_to_iso(max_jd),
                     magnitude_umbral=round(attr[0], 6) if len(attr) > 0 else None,
                     magnitude_penumbral=round(attr[1], 6) if len(attr) > 1 else None,
+                    **_zodiac_fields(max_jd, swe.MOON, "Moon"),
+                    **_saros_inex(max_jd, "lunar"),
                 ))
                 jd = max_jd + 10
             except Exception as e:
@@ -264,6 +359,8 @@ class EclipseFactory:
                     type=_classify_lunar_eclipse(retflags),
                     maximum_jd=max_jd,
                     datestamp=_jd_to_iso(max_jd),
+                    **_zodiac_fields(max_jd, swe.MOON, "Moon"),
+                    **_saros_inex(max_jd, "lunar"),
                 ))
                 jd = max_jd + 10
             except Exception as e:

--- a/kerykeion/eclipses/eclipse_factory.py
+++ b/kerykeion/eclipses/eclipse_factory.py
@@ -283,7 +283,9 @@ class EclipseFactory:
                     sun_altitude=round(attr[5], 4) if len(attr) > 5 else None,
                     **_zodiac_fields(max_jd, swe.SUN, "Sun"),
                     **_saros_inex(max_jd, "solar"),
-                    **_solar_gamma_duration(max_jd),
+                    # gamma / duration are global central-line properties; max_jd
+                    # here is the observer's local maximum, so they are omitted
+                    # (the global search reports them from the global maximum).
                 ))
                 jd = max_jd + 10  # Skip ahead
             except Exception as e:

--- a/kerykeion/lunations/__init__.py
+++ b/kerykeion/lunations/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""Lunation finder: New/First Quarter/Full/Last Quarter moments over a range."""
+
+from .lunation_factory import (
+    LunationFinderFactory,
+    LunationModel,
+    LunationsCollectionModel,
+)
+
+__all__ = [
+    "LunationFinderFactory",
+    "LunationModel",
+    "LunationsCollectionModel",
+]

--- a/kerykeion/lunations/lunation_factory.py
+++ b/kerykeion/lunations/lunation_factory.py
@@ -18,7 +18,7 @@ Swiss Ephemeris / libephemeris functions used (via ``compute_lunar_phase_jd``):
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
@@ -53,6 +53,32 @@ _SEARCH_ADVANCE_DAYS = 15.0
 
 # Hard cap on iterations per phase as a runaway guard (≈ enough for millennia).
 _MAX_ITERATIONS = 200_000
+
+# Max angular error (deg) for a solver hit to count as a real phase. A genuine
+# hit converges to <0.001°; a degenerate echo of the search start is degrees off.
+_PHASE_ANGLE_TOL = 0.01
+
+
+def _to_utc_naive(dt: datetime) -> datetime:
+    """Normalize an offset-aware datetime to naive UTC.
+
+    ``datetime_to_julian`` reads the wall-clock fields and ignores tzinfo, and
+    the lunation range is documented as UTC, so an aware input must be converted
+    rather than silently treated as if its local wall-clock were UTC.
+    """
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _phase_angle_error(jd: float, target_angle: float) -> float:
+    """Absolute error (deg) between the actual Sun-Moon separation at ``jd`` and
+    ``target_angle``. Used to reject degenerate ``compute_lunar_phase_jd`` echoes
+    that return the search start instead of a real syzygy."""
+    sun = float(swe.calc_ut(jd, swe.SUN, swe.FLG_SWIEPH)[0][0]) % 360.0
+    moon = float(swe.calc_ut(jd, swe.MOON, swe.FLG_SWIEPH)[0][0]) % 360.0
+    diff = (moon - sun - target_angle) % 360.0
+    return min(diff, 360.0 - diff)
 
 
 def _jd_to_iso(jd: float) -> str:
@@ -117,8 +143,8 @@ class LunationFinderFactory:
             end_date: ISO date or datetime, e.g. ``"2026-12-31"``.
             phases: Optional subset of ``new``/``first_quarter``/``full``/``last_quarter``.
         """
-        start_dt = datetime.fromisoformat(start_date)
-        end_dt = datetime.fromisoformat(end_date)
+        start_dt = _to_utc_naive(datetime.fromisoformat(start_date))
+        end_dt = _to_utc_naive(datetime.fromisoformat(end_date))
         # A date-only end_date means "through the end of that UTC day"; without
         # this it resolves to midnight and drops any lunation later that day.
         if "T" not in end_date and " " not in end_date:
@@ -162,7 +188,11 @@ class LunationFinderFactory:
                     hit = compute_lunar_phase_jd(jd, angle, forward=True)
                     if hit is None or hit > end_jd:
                         break
-                    lunations.append(LunationFinderFactory._build(phase_name, hit))
+                    # compute_lunar_phase_jd can echo its own start (a tiny step
+                    # past jd) when called just after a phase, reporting an event
+                    # whose true angle is not the target. Record only genuine hits.
+                    if _phase_angle_error(hit, angle) <= _PHASE_ANGLE_TOL:
+                        lunations.append(LunationFinderFactory._build(phase_name, hit))
                     jd = hit + _SEARCH_ADVANCE_DAYS
 
             lunations.sort(key=lambda lun: lun.julian_day)

--- a/kerykeion/lunations/lunation_factory.py
+++ b/kerykeion/lunations/lunation_factory.py
@@ -117,8 +117,14 @@ class LunationFinderFactory:
             end_date: ISO date or datetime, e.g. ``"2026-12-31"``.
             phases: Optional subset of ``new``/``first_quarter``/``full``/``last_quarter``.
         """
-        start_jd = datetime_to_julian(datetime.fromisoformat(start_date))
-        end_jd = datetime_to_julian(datetime.fromisoformat(end_date))
+        start_dt = datetime.fromisoformat(start_date)
+        end_dt = datetime.fromisoformat(end_date)
+        # A date-only end_date means "through the end of that UTC day"; without
+        # this it resolves to midnight and drops any lunation later that day.
+        if "T" not in end_date and " " not in end_date:
+            end_dt = end_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+        start_jd = datetime_to_julian(start_dt)
+        end_jd = datetime_to_julian(end_dt)
         return LunationFinderFactory.from_julian_day(start_jd, end_jd, phases)
 
     @staticmethod
@@ -137,7 +143,10 @@ class LunationFinderFactory:
         swe.set_ephe_path(_EPHE_PATH)
 
         if phases:
-            targets = {k: v for k, v in _PHASE_ANGLES.items() if k in phases}
+            invalid = sorted(set(phases) - set(_PHASE_ANGLES))
+            if invalid:
+                raise ValueError(f"Unknown phase names: {', '.join(invalid)}")
+            targets = {k: _PHASE_ANGLES[k] for k in phases}
         else:
             targets = dict(_PHASE_ANGLES)
 

--- a/kerykeion/lunations/lunation_factory.py
+++ b/kerykeion/lunations/lunation_factory.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+"""Find lunation moments (New, First Quarter, Full, Last Quarter) over a range.
+
+There is no dedicated lunation-list primitive in libephemeris/swisseph: the
+crossing helpers (``solcross_ut``/``mooncross_ut``) target a *fixed* longitude,
+not the moving Sun, so they cannot locate syzygies directly. Instead we build on
+``compute_lunar_phase_jd`` (binary search on the Sun-Moon ecliptic separation,
+~1 second precision, backend-agnostic) and iterate it across the range.
+
+On each step we find the *soonest* upcoming phase across all requested angles
+and advance just past it, so consecutive lunations (~7.4 days apart) are never
+skipped regardless of the solver's internal search window.
+
+Swiss Ephemeris / libephemeris functions used (via ``compute_lunar_phase_jd``):
+    - swe.calc_ut(jd, swe.SUN/swe.MOON, flags)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import List, Optional
+
+from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
+
+from kerykeion.moon_phase_details.utils import compute_lunar_phase_jd
+from kerykeion.schemas.kr_models import KerykeionPointModel, SubscriptableBaseModel
+from kerykeion.utilities import (
+    datetime_to_julian,
+    get_kerykeion_point_from_degree,
+    julian_to_datetime,
+)
+from pydantic import Field
+
+logger = logging.getLogger(__name__)
+
+_EPHE_PATH = EPHE_DATA_PATH
+
+# Phase name -> Sun-Moon ecliptic separation angle (degrees).
+_PHASE_ANGLES = {
+    "new": 0.0,
+    "first_quarter": 90.0,
+    "full": 180.0,
+    "last_quarter": 270.0,
+}
+
+# After finding an occurrence of a phase, advance half a synodic month before
+# searching for the next one of the SAME phase. This keeps the search base well
+# clear of the just-found event (``compute_lunar_phase_jd`` degenerates and
+# returns its own start if called <~1 day after a phase) while staying below the
+# ~29.53-day recurrence so the next occurrence is never skipped.
+_SEARCH_ADVANCE_DAYS = 15.0
+
+# Hard cap on iterations per phase as a runaway guard (≈ enough for millennia).
+_MAX_ITERATIONS = 200_000
+
+
+def _jd_to_iso(jd: float) -> str:
+    """Convert a Julian Day (UT) to an ISO 8601 UTC string with seconds."""
+    try:
+        dt = julian_to_datetime(jd)
+        return (
+            f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
+            f"T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}Z"
+        )
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+
+# =============================================================================
+# MODELS
+# =============================================================================
+
+
+class LunationModel(SubscriptableBaseModel):
+    """A single lunation (New/First Quarter/Full/Last Quarter)."""
+
+    phase: str = Field(description="new | first_quarter | full | last_quarter")
+    julian_day: float = Field(description="Julian Day (UT) of the exact phase")
+    iso_utc: str = Field(description="ISO 8601 UTC datetime of the exact phase")
+    sun: KerykeionPointModel = Field(description="Sun position at the phase")
+    moon: KerykeionPointModel = Field(description="Moon position at the phase")
+
+
+class LunationsCollectionModel(SubscriptableBaseModel):
+    """Ordered list of lunations within a Julian Day range."""
+
+    start_jd: float
+    end_jd: float
+    lunations: List[LunationModel]
+
+
+# =============================================================================
+# FACTORY
+# =============================================================================
+
+
+class LunationFinderFactory:
+    """Find lunations within a date range, ordered chronologically.
+
+    Example:
+        >>> from kerykeion import LunationFinderFactory
+        >>> result = LunationFinderFactory.from_iso_range("2026-01-01", "2026-12-31")
+        >>> result.lunations[0].phase, result.lunations[0].iso_utc
+    """
+
+    @staticmethod
+    def from_iso_range(
+        start_date: str,
+        end_date: str,
+        phases: Optional[List[str]] = None,
+    ) -> LunationsCollectionModel:
+        """Find lunations between two ISO date(time) strings (treated as UTC).
+
+        Args:
+            start_date: ISO date or datetime, e.g. ``"2026-01-01"``.
+            end_date: ISO date or datetime, e.g. ``"2026-12-31"``.
+            phases: Optional subset of ``new``/``first_quarter``/``full``/``last_quarter``.
+        """
+        start_jd = datetime_to_julian(datetime.fromisoformat(start_date))
+        end_jd = datetime_to_julian(datetime.fromisoformat(end_date))
+        return LunationFinderFactory.from_julian_day(start_jd, end_jd, phases)
+
+    @staticmethod
+    def from_julian_day(
+        start_jd: float,
+        end_jd: float,
+        phases: Optional[List[str]] = None,
+    ) -> LunationsCollectionModel:
+        """Find all requested lunations in ``[start_jd, end_jd]``.
+
+        Args:
+            start_jd: Julian Day (UT) range start.
+            end_jd: Julian Day (UT) range end.
+            phases: Optional subset of phase names. Defaults to all four.
+        """
+        swe.set_ephe_path(_EPHE_PATH)
+
+        if phases:
+            targets = {k: v for k, v in _PHASE_ANGLES.items() if k in phases}
+        else:
+            targets = dict(_PHASE_ANGLES)
+
+        lunations: List[LunationModel] = []
+
+        if targets and end_jd > start_jd:
+            # Iterate each phase independently. Stepping by half a synodic month
+            # after each hit keeps the search base clear of the just-found event
+            # (avoiding solver degeneracy) without skipping the next occurrence.
+            for phase_name, angle in targets.items():
+                jd = start_jd
+                for _ in range(_MAX_ITERATIONS):
+                    hit = compute_lunar_phase_jd(jd, angle, forward=True)
+                    if hit is None or hit > end_jd:
+                        break
+                    lunations.append(LunationFinderFactory._build(phase_name, hit))
+                    jd = hit + _SEARCH_ADVANCE_DAYS
+
+            lunations.sort(key=lambda lun: lun.julian_day)
+
+        swe.close()
+        return LunationsCollectionModel(
+            start_jd=start_jd,
+            end_jd=end_jd,
+            lunations=lunations,
+        )
+
+    @staticmethod
+    def _build(phase_name: str, jd: float) -> LunationModel:
+        """Build a LunationModel with Sun/Moon positions at the exact phase JD."""
+        iflag = swe.FLG_SWIEPH
+        sun_lon = float(swe.calc_ut(jd, swe.SUN, iflag)[0][0]) % 360.0
+        moon_lon = float(swe.calc_ut(jd, swe.MOON, iflag)[0][0]) % 360.0
+        return LunationModel(
+            phase=phase_name,
+            julian_day=jd,
+            iso_utc=_jd_to_iso(jd),
+            sun=get_kerykeion_point_from_degree(sun_lon, "Sun", "AstrologicalPoint"),
+            moon=get_kerykeion_point_from_degree(moon_lon, "Moon", "AstrologicalPoint"),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kerykeion"
-version = "6.0.0a51"
+version = "6.0.0a52"
 authors = [
     { name = "Giacomo Battaglia", email = "kerykeion.astrology@gmail.com" }
 ]
@@ -45,7 +45,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "libephemeris==2.0.1",
+    "libephemeris==2.0.2",
     "pydantic>=2.5",
     "svg-polish>=1.0.0",
     "requests-cache>=1.2.1",

--- a/tests/core/test_eclipses.py
+++ b/tests/core/test_eclipses.py
@@ -57,6 +57,17 @@ class TestLocalSearch:
         )
         assert len(result.solar_eclipses) > 0
 
+    def test_local_solar_omits_global_gamma_duration(self):
+        # gamma and central duration are global central-line properties; local
+        # results (max_jd = observer maximum) must not carry them.
+        result = EclipseFactory.search_from_location(
+            lat=41.9, lng=12.5, start_year=2020, count=3
+        )
+        assert result.solar_eclipses
+        for e in result.solar_eclipses:
+            assert e.gamma is None
+            assert e.duration_minutes is None
+
     def test_finds_local_lunar_eclipses(self):
         result = EclipseFactory.search_from_location(
             lat=41.9, lng=12.5, start_year=2020, count=3

--- a/tests/core/test_eclipses.py
+++ b/tests/core/test_eclipses.py
@@ -293,6 +293,6 @@ class TestEclipseEnrichment:
         from unittest.mock import patch
         from kerykeion.eclipses import eclipse_factory as ef
 
-        with patch.object(ef.swe, "get_saros_number", None), \
-             patch.object(ef.swe, "get_inex_number", None):
+        with patch.object(ef.swe, "get_saros_number", None, create=True), \
+             patch.object(ef.swe, "get_inex_number", None, create=True):
             assert ef._saros_inex(2451545.0, "solar") == {}

--- a/tests/core/test_eclipses.py
+++ b/tests/core/test_eclipses.py
@@ -246,3 +246,53 @@ class TestSweRegressionEclipses:
         assert abs(factory_lunar_max_jd - swe_lunar_max_jd) < 0.01, (
             f"Factory lunar JD {factory_lunar_max_jd} != swe JD {swe_lunar_max_jd}"
         )
+
+
+class TestEclipseEnrichment:
+    """Zodiac position + catalogued series/geometry enrichment fields."""
+
+    def test_solar_has_zodiac_position(self):
+        result = EclipseFactory.search_global(start_year=2026, count=2)
+        ecl = result.solar_eclipses[0]
+        assert ecl.sign is not None
+        assert 0 <= ecl.sign_num <= 11
+        assert 0.0 <= ecl.degree < 30.0
+        assert 0.0 <= ecl.ecliptic_longitude < 360.0
+
+    def test_lunar_has_zodiac_position(self):
+        result = EclipseFactory.search_global(start_year=2026, count=2)
+        ecl = result.lunar_eclipses[0]
+        assert ecl.sign is not None
+        assert 0 <= ecl.sign_num <= 11
+
+    def test_aug_2026_total_solar_in_leo(self):
+        """The 12 Aug 2026 total solar eclipse falls at ~20 deg Leo, Saros 126."""
+        result = EclipseFactory.search_global(start_year=2026, count=2)
+        totals = [e for e in result.solar_eclipses if e.type == "total"]
+        assert totals, "expected a total solar eclipse in 2026"
+        ecl = totals[0]
+        assert ecl.sign == "Leo"
+        assert 19.0 <= ecl.degree <= 21.0
+        if hasattr(swe, "get_saros_number"):
+            assert ecl.saros == 126
+
+    def test_solar_gamma_and_duration_when_available(self):
+        result = EclipseFactory.search_global(start_year=2026, count=2)
+        central = [e for e in result.solar_eclipses if e.type in ("total", "annular")]
+        assert central
+        ecl = central[0]
+        if hasattr(swe, "sol_eclipse_max_time"):
+            assert ecl.gamma is not None
+            assert -1.6 < ecl.gamma < 1.6
+        if hasattr(swe, "calc_solar_eclipse_duration"):
+            # Central eclipses have a positive duration; partial -> None.
+            assert ecl.duration_minutes is None or ecl.duration_minutes > 0
+
+    def test_swisseph_guard_returns_none(self):
+        """When libephemeris extensions are absent, series fields stay empty."""
+        from unittest.mock import patch
+        from kerykeion.eclipses import eclipse_factory as ef
+
+        with patch.object(ef.swe, "get_saros_number", None), \
+             patch.object(ef.swe, "get_inex_number", None):
+            assert ef._saros_inex(2451545.0, "solar") == {}

--- a/tests/core/test_lunations.py
+++ b/tests/core/test_lunations.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Lunation Finder Factory."""
+
+from datetime import datetime
+
+from kerykeion.lunations import LunationFinderFactory
+from kerykeion.utilities import datetime_to_julian
+
+
+class TestLunationsRange:
+    """Find lunations across a calendar year."""
+
+    def test_year_count(self):
+        res = LunationFinderFactory.from_iso_range("2026-01-01", "2026-12-31")
+        # A calendar year holds ~49-50 lunations (12-13 of each phase).
+        assert 48 <= len(res.lunations) <= 51
+
+    def test_phase_distribution(self):
+        res = LunationFinderFactory.from_iso_range("2026-01-01", "2026-12-31")
+        counts: dict = {}
+        for lun in res.lunations:
+            counts[lun.phase] = counts.get(lun.phase, 0) + 1
+        for phase in ("new", "first_quarter", "full", "last_quarter"):
+            assert 11 <= counts.get(phase, 0) <= 14
+
+    def test_chronological_no_duplicates(self):
+        res = LunationFinderFactory.from_iso_range("2026-01-01", "2026-12-31")
+        jds = [lun.julian_day for lun in res.lunations]
+        assert jds == sorted(jds)
+        # Consecutive lunations are ~7.4 days apart; never closer than 2 days.
+        for earlier, later in zip(jds, jds[1:]):
+            assert (later - earlier) > 2.0
+
+    def test_phase_filter(self):
+        res = LunationFinderFactory.from_iso_range(
+            "2026-01-01", "2026-12-31", phases=["new"]
+        )
+        assert res.lunations
+        assert all(lun.phase == "new" for lun in res.lunations)
+        assert 11 <= len(res.lunations) <= 13
+
+
+class TestLunationGeometry:
+    """Sun/Moon geometry at each phase."""
+
+    def test_new_moon_conjunction(self):
+        res = LunationFinderFactory.from_iso_range(
+            "2026-01-01", "2026-03-31", phases=["new"]
+        )
+        lun = res.lunations[0]
+        sep = abs(lun.sun.abs_pos - lun.moon.abs_pos) % 360.0
+        sep = min(sep, 360.0 - sep)
+        assert sep < 0.5
+
+    def test_full_moon_opposition(self):
+        res = LunationFinderFactory.from_iso_range(
+            "2026-01-01", "2026-03-31", phases=["full"]
+        )
+        lun = res.lunations[0]
+        sep = abs(lun.sun.abs_pos - lun.moon.abs_pos) % 360.0
+        sep = min(sep, 360.0 - sep)
+        assert abs(sep - 180.0) < 0.5
+
+    def test_known_new_moon_aug_2026_in_leo(self):
+        """The New Moon of 12 Aug 2026 (the total solar eclipse) is ~20 deg Leo."""
+        res = LunationFinderFactory.from_iso_range(
+            "2026-08-01", "2026-08-31", phases=["new"]
+        )
+        assert len(res.lunations) == 1
+        lun = res.lunations[0]
+        assert lun.iso_utc.startswith("2026-08-12")
+        assert lun.sun.sign == "Leo"
+        assert 19.0 <= lun.sun.position <= 21.0
+
+
+class TestLunationApi:
+    """Factory entry points and edge cases."""
+
+    def test_iso_utc_format(self):
+        res = LunationFinderFactory.from_iso_range("2026-01-01", "2026-02-01")
+        for lun in res.lunations:
+            assert "T" in lun.iso_utc and lun.iso_utc.endswith("Z")
+
+    def test_empty_range(self):
+        res = LunationFinderFactory.from_iso_range("2026-01-01", "2026-01-01")
+        assert res.lunations == []
+
+    def test_from_julian_day(self):
+        start = datetime_to_julian(datetime(2026, 1, 1))
+        end = datetime_to_julian(datetime(2026, 4, 1))
+        res = LunationFinderFactory.from_julian_day(start, end)
+        assert res.lunations
+        assert res.start_jd == start
+        assert res.end_jd == end

--- a/tests/core/test_lunations.py
+++ b/tests/core/test_lunations.py
@@ -55,6 +55,23 @@ class TestLunationsRange:
         # ~1 full day (end-of-day), not 0 as a bare midnight end_date would give.
         assert 0.99 < span <= 1.0
 
+    def test_no_phantom_lunation_at_range_start(self):
+        # A range beginning just after a new moon (12 Aug 2026) must not report a
+        # phantom new moon echoed at the range start.
+        res = LunationFinderFactory.from_iso_range(
+            "2026-08-13", "2026-08-13", phases=["new"]
+        )
+        assert res.lunations == []
+
+    def test_offset_aware_input_normalized_to_utc(self):
+        from datetime import datetime
+        from kerykeion.lunations.lunation_factory import _to_utc_naive
+
+        # +02:00 wall-clock midnight is 22:00 UTC on the previous day.
+        naive = _to_utc_naive(datetime.fromisoformat("2026-01-01T00:00:00+02:00"))
+        assert naive.tzinfo is None
+        assert (naive.year, naive.month, naive.day, naive.hour) == (2025, 12, 31, 22)
+
 
 class TestLunationGeometry:
     """Sun/Moon geometry at each phase."""

--- a/tests/core/test_lunations.py
+++ b/tests/core/test_lunations.py
@@ -39,6 +39,22 @@ class TestLunationsRange:
         assert all(lun.phase == "new" for lun in res.lunations)
         assert 11 <= len(res.lunations) <= 13
 
+    def test_unknown_phase_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            LunationFinderFactory.from_iso_range(
+                "2026-01-01", "2026-12-31", phases=["full", "waxing"]
+            )
+
+    def test_date_only_end_covers_full_day(self):
+        # A date-only end_date must span through the end of that UTC day, not
+        # stop at midnight (which would drop a lunation later on the last day).
+        res = LunationFinderFactory.from_iso_range("2026-01-01", "2026-01-01")
+        span = res.end_jd - res.start_jd
+        # ~1 full day (end-of-day), not 0 as a bare midnight end_date would give.
+        assert 0.99 < span <= 1.0
+
 
 class TestLunationGeometry:
     """Sun/Moon geometry at each phase."""

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "kerykeion"
-version = "6.0.0a51"
+version = "6.0.0a52"
 source = { editable = "." }
 dependencies = [
     { name = "libephemeris" },
@@ -546,7 +546,7 @@ wheels = [
 
 [[package]]
 name = "libephemeris"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "../libephemeris" }
 dependencies = [
     { name = "astroquery" },


### PR DESCRIPTION
## Summary

Two additive features for the Eclipses & Cycles work, plus a libephemeris floor bump. Cuts release **6.0.0a52**.

### Added — `LunationFinderFactory` (`kerykeion.lunations`)
Finds New Moon / First Quarter / Full Moon / Last Quarter across a date or Julian-Day range (`from_iso_range` / `from_julian_day`), built on `compute_lunar_phase_jd`. Each phase is iterated independently at a half-synodic step so the binary-search solver never degenerates on adjacent phases. Returns a `LunationsCollectionModel`; items carry the phase name, UTC timestamp, Julian Day and the Sun/Moon `KerykeionPointModel`. Re-exported from the package root.

### Added — eclipse zodiac + physical metadata
`SolarEclipseModel` / `LunarEclipseModel` gain optional `ecliptic_longitude`, `sign`, `sign_num`, `degree` of the luminary at maximum, plus `saros` / `inex` (and `gamma` / `duration_minutes` for solar eclipses). Values come from the libephemeris extensions, guarded with `hasattr`, so they are `None` on the swisseph backend — fully additive, existing consumers unaffected.

### Changed
- `libephemeris` pinned to `==2.0.2` — picks up the fix for global lunar-occultation search under the `extended` (DE441) tier (`lun_occult_when_glob` previously clamped post-1969 searches to the DE441 segment split and returned no events).
- Version → `6.0.0a52`, CHANGELOG updated.

## Tests
`tests/core/test_lunations.py` (new) + `tests/core/test_eclipses.py` (enrichment cases): **40 passed**, including the Aug 12 2026 total solar eclipse landing in Leo and the swisseph-backend `None` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lunar phase finder: search lunar phases within date ranges with precise UTC timestamps and Sun/Moon positions
  * Enhanced eclipse data: solar and lunar results now include ecliptic longitude, zodiac sign/degree, Saros/Inex series when available, and global solar results may include gamma and duration

* **Tests**
  * Added coverage for lunation searches, geometry/formatting, enrichment fields, and regression checks for local vs global eclipse properties

* **Chores**
  * Bumped libephemeris to 2.0.2
<!-- end of auto-generated comment: release notes by coderabbit.ai -->