### PR TITLE
feat(zodiacal-releasing): add Zodiacal Releasing factory (aphesis)

### DIFF
--- a/kerykeion/__init__.py
+++ b/kerykeion/__init__.py
@@ -96,6 +96,7 @@ from .aspects import AspectsFactory
 from .relationship_score_factory import RelationshipScoreFactory
 from .house_comparison.house_comparison_factory import HouseComparisonFactory
 from .dominants import DominantsFactory, DominantStrategy, BaseDominantStrategy
+from .zodiacal_releasing import ZodiacalReleasingFactory
 
 # =============================================================================
 # VISUALIZATION
@@ -124,6 +125,8 @@ from .schemas.kr_models import (
     DominantsModel,
     DominantScoreModel,
     DominantBreakdownItemModel,
+    ZodiacalReleasingModel,
+    ZRPeriodModel,
 )
 from .schemas.kr_literals import DominantMethod
 
@@ -182,6 +185,7 @@ __all__ = [
     "DominantsFactory",
     "DominantStrategy",
     "BaseDominantStrategy",
+    "ZodiacalReleasingFactory",
     # Visualization
     "ChartDrawer",
     "ReportGenerator",
@@ -203,6 +207,8 @@ __all__ = [
     "DominantsModel",
     "DominantScoreModel",
     "DominantBreakdownItemModel",
+    "ZodiacalReleasingModel",
+    "ZRPeriodModel",
     "DominantMethod",
     # Settings and Utilities
     "KerykeionSettingsModel",

--- a/kerykeion/schemas/kr_models.py
+++ b/kerykeion/schemas/kr_models.py
@@ -1577,3 +1577,56 @@ class DominantsModel(SubscriptableBaseModel):
     dominant_quality: Optional[Quality] = None
     dominant_house: Optional[Houses] = None
     score_breakdown: list[DominantBreakdownItemModel] = Field(default_factory=list)
+
+
+class ZRPeriodModel(SubscriptableBaseModel):
+    """One zodiacal-releasing period at a given level of subdivision.
+
+    Periods nest: an L1 (years) period contains L2 (months) sub-periods, each of
+    which may contain L3 sub-periods, and so on. Deeper levels are only populated
+    along the period that contains the requested target date, to keep the tree
+    bounded.
+
+    Attributes:
+        sign: Three-letter sign code ruling the period.
+        ruler: Traditional (domicile) ruler of the sign.
+        level: Subdivision level (1 = years, 2 = months, 3 = days, …).
+        start: Start date (ISO ``YYYY-MM-DD``).
+        end: End date (ISO ``YYYY-MM-DD``).
+        years: Nominal length in years at this level (the sign's general years
+            divided by ``12 ** (level - 1)``).
+        is_angular: ``True`` when the sign is angular from the lot (1st/4th/7th/
+            10th) — the peak periods.
+        is_loosing_the_bond: ``True`` when this period begins after a "loosing of
+            the bond" jump to the opposite sign.
+        subperiods: Nested sub-periods one level deeper (possibly empty).
+    """
+
+    sign: Sign
+    ruler: Optional[str] = None
+    level: int
+    start: str
+    end: str
+    years: float
+    is_angular: bool = False
+    is_loosing_the_bond: bool = False
+    subperiods: "list[ZRPeriodModel]" = Field(default_factory=list)
+
+
+class ZodiacalReleasingModel(SubscriptableBaseModel):
+    """Result of a zodiacal-releasing calculation from a lot.
+
+    Attributes:
+        lot: The lot the release is measured from ("fortune" or "spirit").
+        lot_sign: Sign of the lot — the first L1 period starts here.
+        lot_degree: Absolute longitude of the lot in the subject's zodiac.
+        periods: The top-level (L1) periods, each with nested sub-periods.
+        current_path: The chain of periods containing the target date, from L1
+            down to the deepest computed level (empty when no target date given).
+    """
+
+    lot: str
+    lot_sign: Sign
+    lot_degree: float
+    periods: list[ZRPeriodModel] = Field(default_factory=list)
+    current_path: list[ZRPeriodModel] = Field(default_factory=list)

--- a/kerykeion/zodiacal_releasing/__init__.py
+++ b/kerykeion/zodiacal_releasing/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+Zodiacal Releasing (aphesis)
+============================
+
+Compute the Hellenistic time-lord technique of zodiacal releasing from a lot
+(Fortune or Spirit). Life unfolds as a sequence of planetary periods beginning
+at the lot's sign, each sign ruling for its general years and subdividing into
+months, days and finer levels, with the "loosing of the bond" applied as the
+sequence circles back to its starting sign.
+
+Quick start:
+    >>> from kerykeion import AstrologicalSubjectFactory, ZodiacalReleasingFactory
+    >>> subject = AstrologicalSubjectFactory.from_birth_data(
+    ...     "Jane", 1990, 6, 15, 12, 0,
+    ...     lat=41.9, lng=12.5, tz_str="Europe/Rome", online=False)
+    >>> zr = ZodiacalReleasingFactory.from_subject(
+    ...     subject, lot="fortune", target_date="2026-06-04")
+    >>> zr.lot_sign, len(zr.periods) > 0
+    (..., True)
+"""
+
+from .factory import ZodiacalReleasingFactory
+
+__all__ = ["ZodiacalReleasingFactory"]

--- a/kerykeion/zodiacal_releasing/factory.py
+++ b/kerykeion/zodiacal_releasing/factory.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+"""
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Iterator, List, Literal, Optional
+
+from kerykeion.dominants.utils import part_of_fortune_degree
+from kerykeion.schemas.kerykeion_exception import KerykeionException
+from kerykeion.schemas.kr_literals import SIGN_CODES, Sign
+from kerykeion.schemas.kr_models import (
+    AstrologicalSubjectModel,
+    ZodiacalReleasingModel,
+    ZRPeriodModel,
+)
+
+# General years per sign (Vettius Valens). These drive every level: L1 counts
+# them as years, L2 as months (years / 12), L3 a further twelfth, and so on.
+GENERAL_YEARS: dict[Sign, int] = {
+    "Ari": 15,
+    "Tau": 8,
+    "Gem": 20,
+    "Can": 25,
+    "Leo": 19,
+    "Vir": 20,
+    "Lib": 8,
+    "Sco": 15,
+    "Sag": 12,
+    "Cap": 27,
+    "Aqu": 30,
+    "Pis": 12,
+}
+
+# Traditional (domicile) ruler of each sign, for display alongside each period.
+TRADITIONAL_RULERS: dict[Sign, str] = {
+    "Ari": "Mars",
+    "Tau": "Venus",
+    "Gem": "Mercury",
+    "Can": "Moon",
+    "Leo": "Sun",
+    "Vir": "Mercury",
+    "Lib": "Venus",
+    "Sco": "Mars",
+    "Sag": "Jupiter",
+    "Cap": "Saturn",
+    "Aqu": "Saturn",
+    "Pis": "Jupiter",
+}
+
+# Length of a year in days. The tropical year matches the Hellenistic convention
+# used by modern zodiacal-releasing implementations.
+TROPICAL_YEAR_DAYS = 365.2422
+
+# Default cap on how far the L1 timeline is built, in years of life.
+DEFAULT_LIFE_CAP_YEARS = 100
+
+LotName = Literal["fortune", "spirit"]
+
+
+def _lot_degree(subject: AstrologicalSubjectModel, lot: LotName) -> Optional[float]:
+    """Return the absolute longitude of the chosen lot.
+
+    The Part of Fortune reuses kerykeion's sect-sensitive helper. The Part of
+    Spirit is its mirror: ``Asc + Sun - Moon`` by day, ``Asc + Moon - Sun`` by
+    night.
+    """
+    if lot == "fortune":
+        return part_of_fortune_degree(subject)
+
+    ascendant, sun, moon = subject.ascendant, subject.sun, subject.moon
+    if ascendant is None or sun is None or moon is None:
+        return None
+    if bool(getattr(subject, "is_diurnal", True)):
+        degree = ascendant.abs_pos + sun.abs_pos - moon.abs_pos
+    else:
+        degree = ascendant.abs_pos + moon.abs_pos - sun.abs_pos
+    return degree % 360.0
+
+
+def _lob_sequence(start: int) -> Iterator[tuple[int, bool]]:
+    """Yield ``(sign_num, is_loosing_the_bond)`` indefinitely from ``start``.
+
+    Sub-periods proceed in zodiacal order. When the sequence would return to the
+    sign that began the current revolution, it instead "looses the bond" and
+    jumps to the opposite sign, flagged ``True``.
+    """
+    revolution_start = start
+    current = start
+    yield current, False
+    while True:
+        nxt = (current + 1) % 12
+        is_lob = False
+        if nxt == revolution_start:
+            nxt = (revolution_start + 6) % 12
+            revolution_start = nxt
+            is_lob = True
+        current = nxt
+        yield current, is_lob
+
+
+def _build_level(
+    start_sign: int,
+    start_dt: datetime,
+    duration_days: Optional[float],
+    level: int,
+    levels: int,
+    target_dt: Optional[datetime],
+    lot_sign: int,
+    life_cap_days: float,
+) -> List[ZRPeriodModel]:
+    """Build the periods filling one parent span at ``level``.
+
+    ``duration_days`` is ``None`` for L1 (filled up to ``life_cap_days``);
+    otherwise periods are produced until the parent span is filled, truncating
+    the last one. Children are expanded for every L2 period, but for L3+ only
+    along the period that contains ``target_dt`` — keeping the tree bounded.
+    """
+    periods: List[ZRPeriodModel] = []
+    unit_days = TROPICAL_YEAR_DAYS / (12 ** (level - 1))
+    cursor = start_dt
+    produced = 0.0
+
+    for sign_num, is_lob in _lob_sequence(start_sign):
+        sign = SIGN_CODES[sign_num]
+        full = GENERAL_YEARS[sign] * unit_days
+        if duration_days is None:
+            dur = full
+        else:
+            dur = min(full, duration_days - produced)
+        if dur <= 0:
+            break
+
+        end = cursor + timedelta(days=dur)
+        contains_target = target_dt is not None and cursor <= target_dt < end
+
+        children: List[ZRPeriodModel] = []
+        if level < levels and (level < 2 or contains_target):
+            children = _build_level(
+                sign_num, cursor, dur, level + 1, levels, target_dt, lot_sign, life_cap_days
+            )
+
+        periods.append(
+            ZRPeriodModel(
+                sign=sign,
+                ruler=TRADITIONAL_RULERS[sign],
+                level=level,
+                start=cursor.date().isoformat(),
+                end=end.date().isoformat(),
+                years=GENERAL_YEARS[sign] / (12 ** (level - 1)),
+                is_angular=((sign_num - lot_sign) % 12) in (0, 3, 6, 9),
+                is_loosing_the_bond=is_lob,
+                subperiods=children,
+            )
+        )
+
+        cursor = end
+        produced += dur
+        if duration_days is None:
+            if (cursor - start_dt).days >= life_cap_days:
+                break
+        elif produced >= duration_days - 1e-6:
+            break
+
+    return periods
+
+
+def _current_path(periods: List[ZRPeriodModel], target_dt: datetime) -> List[ZRPeriodModel]:
+    """Walk the tree to collect the periods containing ``target_dt``, L1 → deepest."""
+    path: List[ZRPeriodModel] = []
+    nodes = periods
+    while nodes:
+        match = None
+        for p in nodes:
+            start = datetime.fromisoformat(p.start)
+            end = datetime.fromisoformat(p.end)
+            if start <= target_dt < end:
+                match = p
+                break
+        if match is None:
+            break
+        path.append(match)
+        nodes = match.subperiods
+    return path
+
+
+class ZodiacalReleasingFactory:
+    """Compute zodiacal releasing (aphesis) from a lot.
+
+    Periods unfold from the lot's sign in zodiacal order, each sign ruling for
+    its general years, subdividing into months, days, and finer levels, with the
+    "loosing of the bond" jump applied as the sequence circles back.
+
+    Example:
+        >>> from kerykeion import AstrologicalSubjectFactory, ZodiacalReleasingFactory
+        >>> subject = AstrologicalSubjectFactory.from_birth_data(
+        ...     "Jane", 1990, 6, 15, 12, 0, lat=41.9, lng=12.5, tz_str="Europe/Rome")
+        >>> zr = ZodiacalReleasingFactory.from_subject(subject, lot="fortune", target_date="2026-06-04")
+        >>> zr.lot_sign, len(zr.periods) > 0
+        (..., True)
+    """
+
+    @classmethod
+    def from_subject(
+        cls,
+        subject: AstrologicalSubjectModel,
+        *,
+        lot: LotName = "fortune",
+        levels: int = 2,
+        target_date: Optional[str] = None,
+        life_cap_years: int = DEFAULT_LIFE_CAP_YEARS,
+    ) -> ZodiacalReleasingModel:
+        """Build the zodiacal-releasing periods for a subject.
+
+        Args:
+            subject: The natal chart. Requires a known birth time (Ascendant).
+            lot: ``"fortune"`` or ``"spirit"``.
+            levels: How many subdivision levels to compute (1-4). L1 and L2 are
+                built in full; deeper levels only along the target-date path.
+            target_date: ISO date (``YYYY-MM-DD``) used to mark the current
+                period chain. When omitted, no current path is reported and only
+                full levels (≤ 2) are built.
+            life_cap_years: How far the L1 timeline extends, in years of life.
+
+        Returns:
+            A :class:`ZodiacalReleasingModel`.
+
+        Raises:
+            KerykeionException: For an unknown ``lot``, an unresolvable lot
+                (missing birth time), or an unparseable ``target_date``.
+        """
+        if lot not in ("fortune", "spirit"):
+            raise KerykeionException(f"Unknown lot: {lot!r} (expected 'fortune' or 'spirit').")
+
+        levels = max(1, min(4, levels))
+
+        degree = _lot_degree(subject, lot)
+        if degree is None:
+            raise KerykeionException(
+                "Cannot compute the lot: the Ascendant, Sun or Moon is unavailable "
+                "(zodiacal releasing requires a known birth time)."
+            )
+        lot_sign_num = int(degree % 360.0 // 30)
+
+        try:
+            birth_dt = datetime(
+                subject.year, subject.month, subject.day, subject.hour, subject.minute
+            )
+        except (TypeError, ValueError) as exc:
+            raise KerykeionException(f"Invalid birth date on subject: {exc}") from exc
+
+        target_dt: Optional[datetime] = None
+        if target_date is not None:
+            try:
+                target_dt = datetime.fromisoformat(target_date)
+            except ValueError as exc:
+                raise KerykeionException(
+                    f"Invalid target_date {target_date!r} (expected ISO YYYY-MM-DD)."
+                ) from exc
+
+        # Extend the L1 timeline far enough to cover the target date plus a margin.
+        life_cap_days = life_cap_years * TROPICAL_YEAR_DAYS
+        if target_dt is not None:
+            span = (target_dt - birth_dt).days + 10 * TROPICAL_YEAR_DAYS
+            life_cap_days = max(life_cap_days, span)
+
+        periods = _build_level(
+            lot_sign_num, birth_dt, None, 1, levels, target_dt, lot_sign_num, life_cap_days
+        )
+
+        current_path = _current_path(periods, target_dt) if target_dt is not None else []
+
+        return ZodiacalReleasingModel(
+            lot=lot,
+            lot_sign=SIGN_CODES[lot_sign_num],
+            lot_degree=degree % 360.0,
+            periods=periods,
+            current_path=current_path,
+        )

--- a/kerykeion/zodiacal_releasing/factory.py
+++ b/kerykeion/zodiacal_releasing/factory.py
@@ -109,16 +109,22 @@ def _build_level(
     levels: int,
     target_dt: Optional[datetime],
     lot_sign: int,
-    life_cap_days: float,
-) -> List[ZRPeriodModel]:
+) -> "tuple[List[ZRPeriodModel], List[ZRPeriodModel]]":
     """Build the periods filling one parent span at ``level``.
 
-    ``duration_days`` is ``None`` for L1 (filled up to ``life_cap_days``);
-    otherwise periods are produced until the parent span is filled, truncating
-    the last one. Children are expanded for every L2 period, but for L3+ only
-    along the period that contains ``target_dt`` — keeping the tree bounded.
+    ``duration_days`` bounds the span to fill — for L1 it is the life cap, so the
+    L1 horizon is honoured up front rather than overshot by a full sign period.
+    The last period is truncated to fit. Children are expanded for every L2
+    period, but for L3+ only along the period that contains ``target_dt`` —
+    keeping the tree bounded.
+
+    Returns ``(periods, current_path)``. The current path is computed here from
+    the exact cursor datetimes (not the day-truncated display strings), so a
+    target falling on a boundary date for a non-midnight birth still resolves to
+    the period the deeper levels were actually built under.
     """
     periods: List[ZRPeriodModel] = []
+    current_path: List[ZRPeriodModel] = []
     unit_days = TROPICAL_YEAR_DAYS / (12 ** (level - 1))
     cursor = start_dt
     produced = 0.0
@@ -126,64 +132,41 @@ def _build_level(
     for sign_num, is_lob in _lob_sequence(start_sign):
         sign = SIGN_CODES[sign_num]
         full = GENERAL_YEARS[sign] * unit_days
-        if duration_days is None:
-            dur = full
-        else:
-            dur = min(full, duration_days - produced)
-        if dur <= 0:
+        dur = min(full, duration_days - produced)
+        if dur <= 1e-9:
             break
 
         end = cursor + timedelta(days=dur)
         contains_target = target_dt is not None and cursor <= target_dt < end
 
         children: List[ZRPeriodModel] = []
+        child_path: List[ZRPeriodModel] = []
         if level < levels and (level < 2 or contains_target):
-            children = _build_level(
-                sign_num, cursor, dur, level + 1, levels, target_dt, lot_sign, life_cap_days
+            children, child_path = _build_level(
+                sign_num, cursor, dur, level + 1, levels, target_dt, lot_sign
             )
 
-        periods.append(
-            ZRPeriodModel(
-                sign=sign,
-                ruler=TRADITIONAL_RULERS[sign],
-                level=level,
-                start=cursor.date().isoformat(),
-                end=end.date().isoformat(),
-                years=GENERAL_YEARS[sign] / (12 ** (level - 1)),
-                is_angular=((sign_num - lot_sign) % 12) in (0, 3, 6, 9),
-                is_loosing_the_bond=is_lob,
-                subperiods=children,
-            )
+        period = ZRPeriodModel(
+            sign=sign,
+            ruler=TRADITIONAL_RULERS[sign],
+            level=level,
+            start=cursor.date().isoformat(),
+            end=end.date().isoformat(),
+            years=GENERAL_YEARS[sign] / (12 ** (level - 1)),
+            is_angular=((sign_num - lot_sign) % 12) in (0, 3, 6, 9),
+            is_loosing_the_bond=is_lob,
+            subperiods=children,
         )
+        periods.append(period)
+        if contains_target:
+            current_path = [period, *child_path]
 
         cursor = end
         produced += dur
-        if duration_days is None:
-            if (cursor - start_dt).days >= life_cap_days:
-                break
-        elif produced >= duration_days - 1e-6:
+        if produced >= duration_days - 1e-6:
             break
 
-    return periods
-
-
-def _current_path(periods: List[ZRPeriodModel], target_dt: datetime) -> List[ZRPeriodModel]:
-    """Walk the tree to collect the periods containing ``target_dt``, L1 → deepest."""
-    path: List[ZRPeriodModel] = []
-    nodes = periods
-    while nodes:
-        match = None
-        for p in nodes:
-            start = datetime.fromisoformat(p.start)
-            end = datetime.fromisoformat(p.end)
-            if start <= target_dt < end:
-                match = p
-                break
-        if match is None:
-            break
-        path.append(match)
-        nodes = match.subperiods
-    return path
+    return periods, current_path
 
 
 class ZodiacalReleasingFactory:
@@ -259,6 +242,13 @@ class ZodiacalReleasingFactory:
                 raise KerykeionException(
                     f"Invalid target_date {target_date!r} (expected ISO YYYY-MM-DD)."
                 ) from exc
+            # Birth datetimes are naive; a timezone-aware target would raise a raw
+            # TypeError in the date math below. Reject it with a clear message.
+            if target_dt.tzinfo is not None:
+                raise KerykeionException(
+                    f"target_date {target_date!r} must be timezone-naive "
+                    "(pass a bare ISO date, e.g. '2026-06-04')."
+                )
 
         # Extend the L1 timeline far enough to cover the target date plus a margin.
         life_cap_days = life_cap_years * TROPICAL_YEAR_DAYS
@@ -266,11 +256,12 @@ class ZodiacalReleasingFactory:
             span = (target_dt - birth_dt).days + 10 * TROPICAL_YEAR_DAYS
             life_cap_days = max(life_cap_days, span)
 
-        periods = _build_level(
-            lot_sign_num, birth_dt, None, 1, levels, target_dt, lot_sign_num, life_cap_days
+        # L1 fills exactly the life cap (the last period is truncated to it), so
+        # the documented horizon is honoured instead of overshot. The current
+        # path is returned alongside, computed from exact datetimes.
+        periods, current_path = _build_level(
+            lot_sign_num, birth_dt, life_cap_days, 1, levels, target_dt, lot_sign_num
         )
-
-        current_path = _current_path(periods, target_dt) if target_dt is not None else []
 
         return ZodiacalReleasingModel(
             lot=lot,

--- a/kerykeion/zodiacal_releasing/factory.py
+++ b/kerykeion/zodiacal_releasing/factory.py
@@ -73,7 +73,7 @@ def _lot_degree(subject: AstrologicalSubjectModel, lot: LotName) -> Optional[flo
     ascendant, sun, moon = subject.ascendant, subject.sun, subject.moon
     if ascendant is None or sun is None or moon is None:
         return None
-    if bool(getattr(subject, "is_diurnal", True)):
+    if getattr(subject, "is_diurnal", True):
         degree = ascendant.abs_pos + sun.abs_pos - moon.abs_pos
     else:
         degree = ascendant.abs_pos + moon.abs_pos - sun.abs_pos

--- a/tests/core/test_zodiacal_releasing.py
+++ b/tests/core/test_zodiacal_releasing.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the zodiacal releasing calculator (kerykeion.zodiacal_releasing).
+
+Structural invariants are checked against the John Lennon reference chart
+(Part of Fortune ~2° Capricorn, per the dominants anchor): the L1 sequence
+starts at the lot's sign, periods are contiguous and last their general years,
+angular/peak periods sit 1/4/7/10 from the lot, the loosing-of-the-bond jump
+fires, and the current-path tracks a target date.
+
+This is part of Kerykeion (C) 2025 Giacomo Battaglia
+"""
+
+from datetime import datetime
+
+import pytest
+from pytest import approx
+
+from kerykeion import AstrologicalSubjectFactory, ZodiacalReleasingFactory
+from kerykeion.schemas.kerykeion_exception import KerykeionException
+from kerykeion.zodiacal_releasing.factory import GENERAL_YEARS, TROPICAL_YEAR_DAYS
+
+pytestmark = pytest.mark.core
+
+
+def _days(start: str, end: str) -> float:
+    return (datetime.fromisoformat(end) - datetime.fromisoformat(start)).days
+
+
+def test_fortune_lot_sign(john_lennon):
+    """Lennon's Part of Fortune falls in Capricorn — the L1 release starts there."""
+    zr = ZodiacalReleasingFactory.from_subject(john_lennon, lot="fortune")
+    assert zr.lot == "fortune"
+    assert zr.lot_sign == "Cap"
+    assert zr.periods[0].sign == "Cap"
+
+
+def test_l1_contiguous_and_correct_lengths(john_lennon):
+    """L1 periods abut one another and last their sign's general years."""
+    zr = ZodiacalReleasingFactory.from_subject(john_lennon, lot="fortune")
+    periods = zr.periods
+    assert len(periods) >= 2
+
+    for prev, nxt in zip(periods, periods[1:]):
+        assert prev.end == nxt.start  # contiguous
+
+    # First (non-truncated) period spans its general years.
+    first = periods[0]
+    assert _days(first.start, first.end) == approx(GENERAL_YEARS["Cap"] * TROPICAL_YEAR_DAYS, abs=2)
+
+
+def test_angular_periods_are_pivots_from_lot(john_lennon):
+    """Angular (peak) periods are 1st/4th/7th/10th from the lot sign."""
+    zr = ZodiacalReleasingFactory.from_subject(john_lennon, lot="fortune")
+    # Capricorn lot → angular signs are Cap, Ari, Can, Lib.
+    angular_signs = {p.sign for p in zr.periods if p.is_angular}
+    assert angular_signs <= {"Cap", "Ari", "Can", "Lib"}
+    assert "Cap" in angular_signs
+
+
+def test_current_path_tracks_target_date(john_lennon):
+    """With a target date, the current path is reported from L1 down."""
+    zr = ZodiacalReleasingFactory.from_subject(
+        john_lennon, lot="fortune", levels=3, target_date="2000-01-01"
+    )
+    assert zr.current_path, "expected a non-empty current path"
+    target = datetime(2000, 1, 1)
+
+    # Each step in the path actually contains the target date and descends levels.
+    for depth, period in enumerate(zr.current_path, start=1):
+        assert period.level == depth
+        assert datetime.fromisoformat(period.start) <= target < datetime.fromisoformat(period.end)
+
+
+def test_loosing_of_the_bond_fires_in_subperiods(john_lennon):
+    """A long L1 period is filled by L2 sub-periods that loose the bond."""
+    zr = ZodiacalReleasingFactory.from_subject(john_lennon, lot="fortune", levels=2)
+    # Aquarius (30y) is the longest period; its L2 chain must wrap and jump.
+    flagged = any(
+        sub.is_loosing_the_bond for period in zr.periods for sub in period.subperiods
+    )
+    assert flagged
+
+
+def test_spirit_lot_differs(john_lennon):
+    """The Spirit lot is the mirror of Fortune and generally starts elsewhere."""
+    fortune = ZodiacalReleasingFactory.from_subject(john_lennon, lot="fortune")
+    spirit = ZodiacalReleasingFactory.from_subject(john_lennon, lot="spirit")
+    assert spirit.lot == "spirit"
+    assert spirit.lot_sign != fortune.lot_sign
+
+
+def test_unknown_lot_raises(john_lennon):
+    with pytest.raises(KerykeionException):
+        ZodiacalReleasingFactory.from_subject(john_lennon, lot="ascendant")  # type: ignore[arg-type]
+
+
+def test_levels_are_bounded_off_path(john_lennon):
+    """L2 is built for every L1 period; L3 only along the target path."""
+    zr = ZodiacalReleasingFactory.from_subject(
+        john_lennon, lot="fortune", levels=3, target_date="2000-01-01"
+    )
+    # Every L1 period has L2 children.
+    assert all(p.subperiods for p in zr.periods)
+
+    # L3 exists only under the current path, not under every L2 period.
+    current_l1 = zr.current_path[0]
+    l2_with_children = [s for s in current_l1.subperiods if s.subperiods]
+    assert l2_with_children, "current L1 should contain at least one L2 with L3 children"

--- a/tests/core/test_zodiacal_releasing.py
+++ b/tests/core/test_zodiacal_releasing.py
@@ -12,6 +12,7 @@ This is part of Kerykeion (C) 2025 Giacomo Battaglia
 """
 
 from datetime import datetime
+from itertools import pairwise
 
 import pytest
 from pytest import approx
@@ -23,7 +24,7 @@ from kerykeion.zodiacal_releasing.factory import GENERAL_YEARS, TROPICAL_YEAR_DA
 pytestmark = pytest.mark.core
 
 
-def _days(start: str, end: str) -> float:
+def _days(start: str, end: str) -> int:
     return (datetime.fromisoformat(end) - datetime.fromisoformat(start)).days
 
 
@@ -41,7 +42,7 @@ def test_l1_contiguous_and_correct_lengths(john_lennon):
     periods = zr.periods
     assert len(periods) >= 2
 
-    for prev, nxt in zip(periods, periods[1:]):
+    for prev, nxt in pairwise(periods):
         assert prev.end == nxt.start  # contiguous
 
     # First (non-truncated) period spans its general years.

--- a/tests/core/test_zodiacal_releasing.py
+++ b/tests/core/test_zodiacal_releasing.py
@@ -108,3 +108,30 @@ def test_levels_are_bounded_off_path(john_lennon):
     current_l1 = zr.current_path[0]
     l2_with_children = [s for s in current_l1.subperiods if s.subperiods]
     assert l2_with_children, "current L1 should contain at least one L2 with L3 children"
+
+
+def test_life_cap_is_honored(john_lennon):
+    """A small life_cap_years bounds the L1 horizon (last period truncated)."""
+    cap_years = 5
+    zr = ZodiacalReleasingFactory.from_subject(
+        john_lennon, lot="fortune", levels=1, life_cap_years=cap_years
+    )
+    total = _days(zr.periods[0].start, zr.periods[-1].end)
+    assert total <= cap_years * TROPICAL_YEAR_DAYS + 1
+
+
+def test_timezone_aware_target_raises(john_lennon):
+    """A timezone-aware target_date is rejected with KerykeionException, not TypeError."""
+    with pytest.raises(KerykeionException):
+        ZodiacalReleasingFactory.from_subject(
+            john_lennon, lot="fortune", target_date="2026-06-04T00:00:00+02:00"
+        )
+
+
+def test_current_path_is_internally_consistent(john_lennon):
+    """Each step of the current path is a real child of the previous one."""
+    zr = ZodiacalReleasingFactory.from_subject(
+        john_lennon, lot="fortune", levels=3, target_date="2000-01-01"
+    )
+    for parent, child in pairwise(zr.current_path):
+        assert child in parent.subperiods


### PR DESCRIPTION
## Summary
Adds `ZodiacalReleasingFactory` — the Hellenistic time-lord technique (aphesis) released from the Lot of Fortune or Spirit.

- Periods unfold from the lot's sign in zodiacal order, each sign ruling for its general years (Valens), subdividing into months/days/finer levels
- **Loosing of the bond**: the sequence jumps to the opposite sign when it would circle back to the period's starting sign
- **Angular/peak** detection (signs 1st/4th/7th/10th from the lot) and **current-period** tracking for a target date
- Reuses `part_of_fortune_degree` / `zodiac_breakdown`; adds the mirrored Spirit lot
- New `ZodiacalReleasingModel` / `ZRPeriodModel`, exported from the package

## Bounding
L1 and L2 are built in full; deeper levels (L3/L4) are expanded only along the target-date path, keeping the payload bounded.

## Test
8 structural tests (`tests/core/test_zodiacal_releasing.py`), all green:
- L1 starts at the lot sign, periods contiguous, lengths = general years
- angular periods are the pivots from the lot
- loosing-of-the-bond fires in long sub-period chains
- current path tracks a target date and descends levels
- Spirit lot differs; unknown lot raises

Validated on the John Lennon reference (Fortune in Capricorn 272.5°, correct L1 lengths and current path).

## Note
GitLab is a mirror only — this is the GitHub source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Zodiacal Releasing (aphesis) calculation functionality for computing astrological releasing periods from lots (Fortune, Spirit, etc.)
  * Supports multiple subdivision levels and optional target date tracking to identify current period chains
  * Enables comprehensive period analysis including sign rulers and duration calculations

* **Tests**
  * Added comprehensive test suite validating zodiacal releasing calculation correctness and invariants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->