### PR TITLE
feat: retrograde-station and sign-ingress finders

### DIFF
--- a/kerykeion/__init__.py
+++ b/kerykeion/__init__.py
@@ -71,6 +71,16 @@ from .void_of_course_moon import VoidOfCourseMoonFactory
 from .planetary_phenomena import PlanetaryPhenomenaFactory
 from .eclipses import EclipseFactory
 from .lunations import LunationFinderFactory, LunationModel, LunationsCollectionModel
+from .retrograde_stations import (
+    RetrogradeStationFactory,
+    StationModel,
+    RetrogradeStationsCollectionModel,
+)
+from .sign_ingresses import (
+    SignIngressFactory,
+    IngressModel,
+    SignIngressesCollectionModel,
+)
 from .planetary_nodes import PlanetaryNodesFactory
 from .heliacal import HeliacalFactory
 from .occultations import OccultationFactory
@@ -161,6 +171,12 @@ __all__ = [
     "LunationFinderFactory",
     "LunationModel",
     "LunationsCollectionModel",
+    "RetrogradeStationFactory",
+    "StationModel",
+    "RetrogradeStationsCollectionModel",
+    "SignIngressFactory",
+    "IngressModel",
+    "SignIngressesCollectionModel",
     "PlanetaryNodesFactory",
     "HeliacalFactory",
     "OccultationFactory",

--- a/kerykeion/retrograde_stations/__init__.py
+++ b/kerykeion/retrograde_stations/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""Retrograde/direct station finder: motion-reversal moments over a range."""
+
+from .retrograde_station_factory import (
+    RetrogradeStationFactory,
+    StationModel,
+    RetrogradeStationsCollectionModel,
+)
+
+__all__ = [
+    "RetrogradeStationFactory",
+    "StationModel",
+    "RetrogradeStationsCollectionModel",
+]

--- a/kerykeion/retrograde_stations/__init__.py
+++ b/kerykeion/retrograde_stations/__init__.py
@@ -9,6 +9,6 @@ from .retrograde_station_factory import (
 
 __all__ = [
     "RetrogradeStationFactory",
-    "StationModel",
     "RetrogradeStationsCollectionModel",
+    "StationModel",
 ]

--- a/kerykeion/retrograde_stations/retrograde_station_factory.py
+++ b/kerykeion/retrograde_stations/retrograde_station_factory.py
@@ -29,7 +29,6 @@ from kerykeion.schemas.kr_models import SubscriptableBaseModel
 from kerykeion.utilities import (
     datetime_to_julian,
     get_kerykeion_point_from_degree,
-    julian_to_datetime,
 )
 from pydantic import Field
 
@@ -83,14 +82,16 @@ def _to_utc_naive(dt: datetime) -> datetime:
 def _jd_to_iso(jd: float) -> str:
     """Convert a Julian Day (UT) to an ISO 8601 UTC string with seconds.
 
-    Lets conversion errors propagate rather than emitting an empty ``iso_utc``
-    that would look valid to downstream consumers.
+    Uses ``swe.revjul`` rather than Python ``datetime`` (limited to years
+    1..9999) so the BCE range Kerykeion supports formats correctly, with an
+    extended-year sign for negative years.
     """
-    dt = julian_to_datetime(jd)
-    return (
-        f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
-        f"T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}Z"
-    )
+    year, month, day, hour_frac = swe.revjul(jd)
+    secs = min(int(hour_frac * 3600 + 0.5), 86399)  # nearest second, no 24:00 carry
+    hours, rem = divmod(secs, 3600)
+    minutes, seconds = divmod(rem, 60)
+    year_str = f"-{abs(year):04d}" if year < 0 else f"{year:04d}"
+    return f"{year_str}-{month:02d}-{day:02d}T{hours:02d}:{minutes:02d}:{seconds:02d}Z"
 
 
 def _speed(jd: float, body: int) -> float:
@@ -179,8 +180,9 @@ class RetrogradeStationFactory:
         start_dt = _to_utc_naive(datetime.fromisoformat(start_date))
         end_dt = _to_utc_naive(datetime.fromisoformat(end_date))
         # A date-only end_date means "through the end of that UTC day"; without
-        # this it resolves to midnight and drops any station later that day.
-        if "T" not in end_date and " " not in end_date:
+        # this it resolves to midnight and drops any station later that day. Check
+        # for both T/t (fromisoformat accepts a lowercase 't') and a space.
+        if "T" not in end_date and "t" not in end_date and " " not in end_date:
             end_dt = end_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
         start_jd = datetime_to_julian(start_dt)
         end_jd = datetime_to_julian(end_dt)
@@ -207,7 +209,9 @@ class RetrogradeStationFactory:
                     f"Unknown or non-stationing planets: {', '.join(invalid)}. "
                     f"Valid: {', '.join(_PLANET_IDS)}"
                 )
-            bodies = [(name, _PLANET_IDS[name]) for name in planets]
+            # Deduplicate (preserve order): duplicates would repeat the scan and
+            # emit every event multiple times.
+            bodies = [(name, _PLANET_IDS[name]) for name in dict.fromkeys(planets)]
         else:
             bodies = list(_STATION_PLANETS)
 

--- a/kerykeion/retrograde_stations/retrograde_station_factory.py
+++ b/kerykeion/retrograde_stations/retrograde_station_factory.py
@@ -81,15 +81,16 @@ def _to_utc_naive(dt: datetime) -> datetime:
 
 
 def _jd_to_iso(jd: float) -> str:
-    """Convert a Julian Day (UT) to an ISO 8601 UTC string with seconds."""
-    try:
-        dt = julian_to_datetime(jd)
-        return (
-            f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
-            f"T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}Z"
-        )
-    except Exception:  # pragma: no cover - defensive
-        return ""
+    """Convert a Julian Day (UT) to an ISO 8601 UTC string with seconds.
+
+    Lets conversion errors propagate rather than emitting an empty ``iso_utc``
+    that would look valid to downstream consumers.
+    """
+    dt = julian_to_datetime(jd)
+    return (
+        f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
+        f"T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}Z"
+    )
 
 
 def _speed(jd: float, body: int) -> float:
@@ -243,11 +244,15 @@ class RetrogradeStationFactory:
         while jd < end_jd:
             jd_next = min(jd + _SAMPLE_STEP_DAYS, end_jd)
             next_speed = _speed(jd_next, body)
-            # Strictly opposite signs => the speed passed through zero in between.
-            if prev_speed * next_speed < 0.0:
-                jd_station = _bisect_station(body, jd, jd_next)
+            # A sign change in speed brackets a station; an endpoint speed of
+            # exactly 0.0 is the station itself. Claim a boundary zero on next
+            # (not prev) so a zero shared by two intervals is counted once.
+            crossed = prev_speed * next_speed < 0.0
+            endpoint_zero = next_speed == 0.0 and prev_speed != 0.0
+            if crossed or endpoint_zero:
+                jd_station = jd_next if endpoint_zero else _bisect_station(body, jd, jd_next)
                 # Direct -> retrograde is a retrograde station (SR); the reverse
-                # is a direct station (SD).
+                # is a direct station (SD). prev_speed is non-zero in both branches.
                 station_type = "SR" if prev_speed > 0.0 else "SD"
                 found.append(RetrogradeStationFactory._build(name, station_type, jd_station))
             prev_speed = next_speed

--- a/kerykeion/retrograde_stations/retrograde_station_factory.py
+++ b/kerykeion/retrograde_stations/retrograde_station_factory.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+"""Find planetary retrograde/direct stations over a date range.
+
+A *station* is the instant a planet's apparent longitudinal motion reverses: a
+**retrograde station** (SR) when it turns from direct to retrograde, a **direct
+station** (SD) when it turns back. At that instant the longitudinal speed passes
+through zero.
+
+There is no station primitive shared by both ephemeris backends
+(``find_station_ut`` is a libephemeris extension, absent on swisseph), so — like
+``LunationFinderFactory`` — this stays backend-agnostic: it samples the
+longitudinal speed via ``swe.calc_ut(..., FLG_SPEED)`` across the range and, on
+every sign change of that speed, bisects to the zero crossing. Speed sign changes
+are weeks apart even for Mercury, so a coarse sample step never skips one.
+
+Swiss Ephemeris / libephemeris functions used:
+    - swe.calc_ut(jd, planet_id, FLG_SWIEPH | FLG_SPEED)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
+
+from kerykeion.schemas.kr_models import SubscriptableBaseModel
+from kerykeion.utilities import (
+    datetime_to_julian,
+    get_kerykeion_point_from_degree,
+    julian_to_datetime,
+)
+from pydantic import Field
+
+logger = logging.getLogger(__name__)
+
+_EPHE_PATH = EPHE_DATA_PATH
+
+# Geocentric speed flag: the [3] element of calc_ut's first tuple is the
+# longitudinal speed in degrees/day (negative when retrograde).
+_SPEED_FLAGS = swe.FLG_SWIEPH | swe.FLG_SPEED
+
+# The Sun and Moon never station (they are always direct from Earth), so the
+# default set is the seven non-luminary classical/modern planets. Names match
+# kerykeion's AstrologicalPoint vocabulary.
+_STATION_PLANETS: List[tuple[str, int]] = [
+    ("Mercury", swe.MERCURY),
+    ("Venus", swe.VENUS),
+    ("Mars", swe.MARS),
+    ("Jupiter", swe.JUPITER),
+    ("Saturn", swe.SATURN),
+    ("Uranus", swe.URANUS),
+    ("Neptune", swe.NEPTUNE),
+    ("Pluto", swe.PLUTO),
+]
+
+_PLANET_IDS = {name: pid for name, pid in _STATION_PLANETS}
+
+# Sampling step (days). Stations of the same planet are ≥ ~3 weeks apart (even
+# Mercury), so half-day sampling never brackets two stations in one step.
+_SAMPLE_STEP_DAYS = 0.5
+# Bisection iterations: each halving of a 0.5-day bracket reaches sub-second
+# precision well before 40 steps.
+_BISECTION_ITERS = 40
+# Runaway guard (≈ 270 years at the default step).
+_MAX_SAMPLES = 200_000
+
+
+def _to_utc_naive(dt: datetime) -> datetime:
+    """Normalize an offset-aware datetime to naive UTC.
+
+    ``datetime_to_julian`` reads the wall-clock fields and ignores tzinfo, and
+    the range is documented as UTC, so an aware input must be converted rather
+    than silently treated as if its local wall-clock were UTC.
+    """
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _jd_to_iso(jd: float) -> str:
+    """Convert a Julian Day (UT) to an ISO 8601 UTC string with seconds."""
+    try:
+        dt = julian_to_datetime(jd)
+        return (
+            f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
+            f"T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}Z"
+        )
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+
+def _speed(jd: float, body: int) -> float:
+    """Longitudinal speed (deg/day) of ``body`` at ``jd``; negative = retrograde."""
+    return float(swe.calc_ut(jd, body, _SPEED_FLAGS)[0][3])
+
+
+def _bisect_station(body: int, a: float, b: float) -> float:
+    """Bisect ``[a, b]`` (speed sign differs at the ends) to the speed zero."""
+    sa = _speed(a, body)
+    for _ in range(_BISECTION_ITERS):
+        mid = (a + b) / 2.0
+        sm = _speed(mid, body)
+        if sm == 0.0:
+            return mid
+        if (sa < 0.0) != (sm < 0.0):
+            b = mid
+        else:
+            a, sa = mid, sm
+    return (a + b) / 2.0
+
+
+# =============================================================================
+# MODELS
+# =============================================================================
+
+
+class StationModel(SubscriptableBaseModel):
+    """A single planetary station (motion reversal)."""
+
+    planet: str = Field(description="Planet name (kerykeion AstrologicalPoint vocabulary)")
+    station_type: str = Field(description="SR = retrograde station, SD = direct station")
+    julian_day: float = Field(description="Julian Day (UT) of the exact station")
+    iso_utc: str = Field(description="ISO 8601 UTC datetime of the exact station")
+    sign: str = Field(description="Zodiac sign at the station")
+    sign_num: int = Field(description="Zodiac sign number (0=Aries)")
+    degree: float = Field(description="Degree within the sign (0-30)")
+    ecliptic_longitude: float = Field(description="Absolute ecliptic longitude (0-360)")
+
+
+class RetrogradeStationsCollectionModel(SubscriptableBaseModel):
+    """Ordered list of stations within a Julian Day range."""
+
+    start_jd: float
+    end_jd: float
+    stations: List[StationModel]
+
+
+# =============================================================================
+# FACTORY
+# =============================================================================
+
+
+class RetrogradeStationFactory:
+    """Find planetary retrograde/direct stations within a date range.
+
+    Example:
+        >>> from kerykeion import RetrogradeStationFactory
+        >>> result = RetrogradeStationFactory.from_iso_range("2026-01-01", "2026-12-31")
+        >>> result.stations[0].planet, result.stations[0].station_type
+    """
+
+    @staticmethod
+    def from_iso_range(
+        start_date: str,
+        end_date: str,
+        planets: Optional[List[str]] = None,
+    ) -> RetrogradeStationsCollectionModel:
+        """Find stations between two ISO date(time) strings (treated as UTC).
+
+        Args:
+            start_date: ISO date or datetime, e.g. ``"2026-01-01"``.
+            end_date: ISO date or datetime, e.g. ``"2026-12-31"``.
+            planets: Optional subset of planet names. Defaults to Mercury..Pluto.
+        """
+        start_dt = _to_utc_naive(datetime.fromisoformat(start_date))
+        end_dt = _to_utc_naive(datetime.fromisoformat(end_date))
+        # A date-only end_date means "through the end of that UTC day"; without
+        # this it resolves to midnight and drops any station later that day.
+        if "T" not in end_date and " " not in end_date:
+            end_dt = end_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+        start_jd = datetime_to_julian(start_dt)
+        end_jd = datetime_to_julian(end_dt)
+        return RetrogradeStationFactory.from_julian_day(start_jd, end_jd, planets)
+
+    @staticmethod
+    def from_julian_day(
+        start_jd: float,
+        end_jd: float,
+        planets: Optional[List[str]] = None,
+    ) -> RetrogradeStationsCollectionModel:
+        """Find all stations in ``[start_jd, end_jd]``, ordered chronologically.
+
+        Args:
+            start_jd: Julian Day (UT) range start.
+            end_jd: Julian Day (UT) range end.
+            planets: Optional subset of planet names. Defaults to Mercury..Pluto.
+        """
+        if planets:
+            invalid = sorted(set(planets) - set(_PLANET_IDS))
+            if invalid:
+                raise ValueError(
+                    f"Unknown or non-stationing planets: {', '.join(invalid)}. "
+                    f"Valid: {', '.join(_PLANET_IDS)}"
+                )
+            bodies = [(name, _PLANET_IDS[name]) for name in planets]
+        else:
+            bodies = list(_STATION_PLANETS)
+
+        swe.set_ephe_path(_EPHE_PATH)
+        stations: List[StationModel] = []
+
+        if end_jd > start_jd:
+            for name, body in bodies:
+                stations.extend(
+                    RetrogradeStationFactory._scan_planet(name, body, start_jd, end_jd)
+                )
+            stations.sort(key=lambda s: s.julian_day)
+
+        swe.close()
+        return RetrogradeStationsCollectionModel(
+            start_jd=start_jd,
+            end_jd=end_jd,
+            stations=stations,
+        )
+
+    @staticmethod
+    def _scan_planet(
+        name: str, body: int, start_jd: float, end_jd: float
+    ) -> List[StationModel]:
+        """Walk the range for one planet, bisecting each speed sign change."""
+        found: List[StationModel] = []
+        jd = start_jd
+        prev_speed = _speed(jd, body)
+        samples = 0
+        while jd < end_jd and samples < _MAX_SAMPLES:
+            jd_next = min(jd + _SAMPLE_STEP_DAYS, end_jd)
+            next_speed = _speed(jd_next, body)
+            # Strictly opposite signs => the speed passed through zero in between.
+            if prev_speed * next_speed < 0.0:
+                jd_station = _bisect_station(body, jd, jd_next)
+                # Direct -> retrograde is a retrograde station (SR); the reverse
+                # is a direct station (SD).
+                station_type = "SR" if prev_speed > 0.0 else "SD"
+                found.append(RetrogradeStationFactory._build(name, station_type, jd_station))
+            prev_speed = next_speed
+            jd = jd_next
+            samples += 1
+        return found
+
+    @staticmethod
+    def _build(name: str, station_type: str, jd: float) -> StationModel:
+        """Build a StationModel with the zodiac position at the station JD."""
+        lon = float(swe.calc_ut(jd, _PLANET_IDS[name], swe.FLG_SWIEPH)[0][0]) % 360.0
+        point = get_kerykeion_point_from_degree(lon, name, "AstrologicalPoint")
+        return StationModel(
+            planet=name,
+            station_type=station_type,
+            julian_day=jd,
+            iso_utc=_jd_to_iso(jd),
+            sign=point.sign,
+            sign_num=point.sign_num,
+            degree=round(point.position, 6),
+            ecliptic_longitude=round(lon, 6),
+        )

--- a/kerykeion/retrograde_stations/retrograde_station_factory.py
+++ b/kerykeion/retrograde_stations/retrograde_station_factory.py
@@ -23,7 +23,7 @@ import logging
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
+from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH, EPHEMERIS_LOCK
 
 from kerykeion.schemas.kr_models import SubscriptableBaseModel
 from kerykeion.utilities import (
@@ -63,8 +63,9 @@ _SAMPLE_STEP_DAYS = 0.5
 # Bisection iterations: each halving of a 0.5-day bracket reaches sub-second
 # precision well before 40 steps.
 _BISECTION_ITERS = 40
-# Runaway guard (≈ 270 years at the default step).
-_MAX_SAMPLES = 200_000
+# Backstop on samples per scan (~2700 years at the default step). Ranges that
+# would exceed it are rejected explicitly rather than silently truncated.
+_MAX_SAMPLES = 2_000_000
 
 
 def _to_utc_naive(dt: datetime) -> datetime:
@@ -109,6 +110,16 @@ def _bisect_station(body: int, a: float, b: float) -> float:
         else:
             a, sa = mid, sm
     return (a + b) / 2.0
+
+
+def _ensure_scannable(start_jd: float, end_jd: float) -> None:
+    """Reject ranges too long to scan, so a caller never receives a silently
+    truncated result whose ``end_jd`` still claims the full requested range."""
+    if (end_jd - start_jd) / _SAMPLE_STEP_DAYS > _MAX_SAMPLES:
+        raise ValueError(
+            f"Date range too large to scan at the current resolution "
+            f"(> {_MAX_SAMPLES} samples). Narrow the date range."
+        )
 
 
 # =============================================================================
@@ -187,7 +198,8 @@ class RetrogradeStationFactory:
             end_jd: Julian Day (UT) range end.
             planets: Optional subset of planet names. Defaults to Mercury..Pluto.
         """
-        if planets:
+        # None = default set; an explicit empty list = scan nothing.
+        if planets is not None:
             invalid = sorted(set(planets) - set(_PLANET_IDS))
             if invalid:
                 raise ValueError(
@@ -198,17 +210,22 @@ class RetrogradeStationFactory:
         else:
             bodies = list(_STATION_PLANETS)
 
-        swe.set_ephe_path(_EPHE_PATH)
         stations: List[StationModel] = []
-
-        if end_jd > start_jd:
-            for name, body in bodies:
-                stations.extend(
-                    RetrogradeStationFactory._scan_planet(name, body, start_jd, end_jd)
-                )
+        if end_jd > start_jd and bodies:
+            _ensure_scannable(start_jd, end_jd)
+            # Hold the lock across the whole scan: set_ephe_path / calc_ut / close
+            # mutate process-global backend state shared with chart calculations.
+            with EPHEMERIS_LOCK:
+                swe.set_ephe_path(_EPHE_PATH)
+                try:
+                    for name, body in bodies:
+                        stations.extend(
+                            RetrogradeStationFactory._scan_planet(name, body, start_jd, end_jd)
+                        )
+                finally:
+                    swe.close()
             stations.sort(key=lambda s: s.julian_day)
 
-        swe.close()
         return RetrogradeStationsCollectionModel(
             start_jd=start_jd,
             end_jd=end_jd,
@@ -223,8 +240,7 @@ class RetrogradeStationFactory:
         found: List[StationModel] = []
         jd = start_jd
         prev_speed = _speed(jd, body)
-        samples = 0
-        while jd < end_jd and samples < _MAX_SAMPLES:
+        while jd < end_jd:
             jd_next = min(jd + _SAMPLE_STEP_DAYS, end_jd)
             next_speed = _speed(jd_next, body)
             # Strictly opposite signs => the speed passed through zero in between.
@@ -236,7 +252,6 @@ class RetrogradeStationFactory:
                 found.append(RetrogradeStationFactory._build(name, station_type, jd_station))
             prev_speed = next_speed
             jd = jd_next
-            samples += 1
         return found
 
     @staticmethod

--- a/kerykeion/sign_ingresses/__init__.py
+++ b/kerykeion/sign_ingresses/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""Sign ingress finder: zodiac sign boundary crossings over a range."""
+
+from .sign_ingress_factory import (
+    SignIngressFactory,
+    IngressModel,
+    SignIngressesCollectionModel,
+)
+
+__all__ = [
+    "SignIngressFactory",
+    "IngressModel",
+    "SignIngressesCollectionModel",
+]

--- a/kerykeion/sign_ingresses/__init__.py
+++ b/kerykeion/sign_ingresses/__init__.py
@@ -8,7 +8,7 @@ from .sign_ingress_factory import (
 )
 
 __all__ = [
-    "SignIngressFactory",
     "IngressModel",
     "SignIngressesCollectionModel",
+    "SignIngressFactory",
 ]

--- a/kerykeion/sign_ingresses/sign_ingress_factory.py
+++ b/kerykeion/sign_ingresses/sign_ingress_factory.py
@@ -1,0 +1,274 @@
+# -*- coding: utf-8 -*-
+"""Find zodiac sign ingresses (a planet crossing a 30° boundary) over a range.
+
+An *ingress* is the instant a body crosses from one zodiac sign into the next —
+its ecliptic longitude passes a multiple of 30°. A retrograde planet near a sign
+boundary can cross it more than once (forward, back, forward); each crossing is a
+real ingress and is reported.
+
+``cross_ut`` (libephemeris) targets a fixed longitude directly, but it is absent
+on the swisseph backend, so — like ``LunationFinderFactory`` — this stays
+backend-agnostic: it samples longitude via ``swe.calc_ut`` across the range and,
+whenever the sign index changes between two samples, bisects to the exact 30°
+crossing. The half-day step keeps even the Moon (~13°/day) below one sign per
+step, so no boundary is skipped.
+
+Swiss Ephemeris / libephemeris functions used:
+    - swe.calc_ut(jd, planet_id, FLG_SWIEPH)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
+
+from kerykeion.schemas.kr_models import SubscriptableBaseModel
+from kerykeion.utilities import (
+    datetime_to_julian,
+    get_kerykeion_point_from_degree,
+    julian_to_datetime,
+)
+from pydantic import Field
+
+logger = logging.getLogger(__name__)
+
+_EPHE_PATH = EPHE_DATA_PATH
+
+# Default set: Sun..Pluto. The Moon is opt-in — ~13 ingresses/month is noise for
+# most use cases — but accepted when explicitly requested. Names match
+# kerykeion's AstrologicalPoint vocabulary.
+_INGRESS_PLANETS: List[tuple[str, int]] = [
+    ("Sun", swe.SUN),
+    ("Mercury", swe.MERCURY),
+    ("Venus", swe.VENUS),
+    ("Mars", swe.MARS),
+    ("Jupiter", swe.JUPITER),
+    ("Saturn", swe.SATURN),
+    ("Uranus", swe.URANUS),
+    ("Neptune", swe.NEPTUNE),
+    ("Pluto", swe.PLUTO),
+]
+
+# Valid request vocabulary includes the Moon (opt-in).
+_PLANET_IDS = {name: pid for name, pid in _INGRESS_PLANETS}
+_PLANET_IDS["Moon"] = swe.MOON
+
+# Sampling step (days). The Moon (~13°/day) advances < 7° per half-day, so a sign
+# (30°) is never jumped; slower bodies have ample margin.
+_SAMPLE_STEP_DAYS = 0.5
+_BISECTION_ITERS = 40
+# Runaway guard (≈ 270 years at the default step).
+_MAX_SAMPLES = 200_000
+
+
+def _to_utc_naive(dt: datetime) -> datetime:
+    """Normalize an offset-aware datetime to naive UTC (see lunation factory)."""
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _jd_to_iso(jd: float) -> str:
+    """Convert a Julian Day (UT) to an ISO 8601 UTC string with seconds."""
+    try:
+        dt = julian_to_datetime(jd)
+        return (
+            f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
+            f"T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}Z"
+        )
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+
+def _ang_diff(a: float, b: float) -> float:
+    """Signed smallest angular difference ``a - b`` in ``(-180, 180]``."""
+    return ((a - b + 180.0) % 360.0) - 180.0
+
+
+def _lon(jd: float, body: int) -> float:
+    """Ecliptic longitude (deg, 0-360) of ``body`` at ``jd``."""
+    return float(swe.calc_ut(jd, body, swe.FLG_SWIEPH)[0][0]) % 360.0
+
+
+def _sign_name(sign_num: int) -> str:
+    """Zodiac sign name for an index (0=Aries), via the shared degree helper."""
+    return get_kerykeion_point_from_degree(
+        (sign_num % 12) * 30 + 15, "Sun", "AstrologicalPoint"
+    ).sign
+
+
+def _bisect_ingress(body: int, a: float, b: float, boundary: float) -> float:
+    """Bisect ``[a, b]`` to the JD where longitude equals the 30° ``boundary``."""
+    fa = _ang_diff(_lon(a, body), boundary)
+    for _ in range(_BISECTION_ITERS):
+        mid = (a + b) / 2.0
+        fm = _ang_diff(_lon(mid, body), boundary)
+        if fm == 0.0:
+            return mid
+        if (fa < 0.0) != (fm < 0.0):
+            b = mid
+        else:
+            a, fa = mid, fm
+    return (a + b) / 2.0
+
+
+# =============================================================================
+# MODELS
+# =============================================================================
+
+
+class IngressModel(SubscriptableBaseModel):
+    """A single zodiac sign ingress (30° boundary crossing)."""
+
+    planet: str = Field(description="Planet name (kerykeion AstrologicalPoint vocabulary)")
+    julian_day: float = Field(description="Julian Day (UT) of the exact ingress")
+    iso_utc: str = Field(description="ISO 8601 UTC datetime of the exact ingress")
+    sign: str = Field(description="Sign being entered")
+    sign_num: int = Field(description="Entered sign number (0=Aries)")
+    from_sign: str = Field(description="Sign being left")
+    from_sign_num: int = Field(description="Left sign number (0=Aries)")
+    retrograde: bool = Field(description="True if the ingress occurs in retrograde motion")
+    ecliptic_longitude: float = Field(description="The 30° boundary crossed (0-360)")
+
+
+class SignIngressesCollectionModel(SubscriptableBaseModel):
+    """Ordered list of sign ingresses within a Julian Day range."""
+
+    start_jd: float
+    end_jd: float
+    ingresses: List[IngressModel]
+
+
+# =============================================================================
+# FACTORY
+# =============================================================================
+
+
+class SignIngressFactory:
+    """Find zodiac sign ingresses within a date range, ordered chronologically.
+
+    Example:
+        >>> from kerykeion import SignIngressFactory
+        >>> result = SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31")
+        >>> result.ingresses[0].planet, result.ingresses[0].sign
+    """
+
+    @staticmethod
+    def from_iso_range(
+        start_date: str,
+        end_date: str,
+        planets: Optional[List[str]] = None,
+    ) -> SignIngressesCollectionModel:
+        """Find ingresses between two ISO date(time) strings (treated as UTC).
+
+        Args:
+            start_date: ISO date or datetime, e.g. ``"2026-01-01"``.
+            end_date: ISO date or datetime, e.g. ``"2026-12-31"``.
+            planets: Optional subset of planet names. Defaults to Sun..Pluto
+                (Moon excluded unless explicitly requested).
+        """
+        start_dt = _to_utc_naive(datetime.fromisoformat(start_date))
+        end_dt = _to_utc_naive(datetime.fromisoformat(end_date))
+        # A date-only end_date means "through the end of that UTC day".
+        if "T" not in end_date and " " not in end_date:
+            end_dt = end_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+        start_jd = datetime_to_julian(start_dt)
+        end_jd = datetime_to_julian(end_dt)
+        return SignIngressFactory.from_julian_day(start_jd, end_jd, planets)
+
+    @staticmethod
+    def from_julian_day(
+        start_jd: float,
+        end_jd: float,
+        planets: Optional[List[str]] = None,
+    ) -> SignIngressesCollectionModel:
+        """Find all sign ingresses in ``[start_jd, end_jd]``, ordered chronologically.
+
+        Args:
+            start_jd: Julian Day (UT) range start.
+            end_jd: Julian Day (UT) range end.
+            planets: Optional subset of planet names. Defaults to Sun..Pluto.
+        """
+        if planets:
+            invalid = sorted(set(planets) - set(_PLANET_IDS))
+            if invalid:
+                raise ValueError(
+                    f"Unknown planets: {', '.join(invalid)}. "
+                    f"Valid: {', '.join(_PLANET_IDS)}"
+                )
+            bodies = [(name, _PLANET_IDS[name]) for name in planets]
+        else:
+            bodies = list(_INGRESS_PLANETS)
+
+        swe.set_ephe_path(_EPHE_PATH)
+        ingresses: List[IngressModel] = []
+
+        if end_jd > start_jd:
+            for name, body in bodies:
+                ingresses.extend(
+                    SignIngressFactory._scan_planet(name, body, start_jd, end_jd)
+                )
+            ingresses.sort(key=lambda i: i.julian_day)
+
+        swe.close()
+        return SignIngressesCollectionModel(
+            start_jd=start_jd,
+            end_jd=end_jd,
+            ingresses=ingresses,
+        )
+
+    @staticmethod
+    def _scan_planet(
+        name: str, body: int, start_jd: float, end_jd: float
+    ) -> List[IngressModel]:
+        """Walk the range for one planet, bisecting each sign-index change."""
+        found: List[IngressModel] = []
+        jd = start_jd
+        prev_lon = _lon(jd, body)
+        prev_sign = int(prev_lon // 30)
+        samples = 0
+        while jd < end_jd and samples < _MAX_SAMPLES:
+            jd_next = min(jd + _SAMPLE_STEP_DAYS, end_jd)
+            cur_lon = _lon(jd_next, body)
+            cur_sign = int(cur_lon // 30)
+            if cur_sign != prev_sign:
+                # Direction over the step decides which boundary was crossed:
+                # forward (delta>0) crosses the top of prev_sign, retrograde the
+                # bottom. The half-day step guarantees a single boundary here.
+                retro = _ang_diff(cur_lon, prev_lon) < 0.0
+                boundary = ((prev_sign * 30) if retro else ((prev_sign + 1) * 30)) % 360.0
+                jd_ingress = _bisect_ingress(body, jd, jd_next, boundary)
+                found.append(
+                    SignIngressFactory._build(
+                        name, jd_ingress, prev_sign, cur_sign, retro, boundary
+                    )
+                )
+            prev_lon, prev_sign = cur_lon, cur_sign
+            jd = jd_next
+            samples += 1
+        return found
+
+    @staticmethod
+    def _build(
+        name: str,
+        jd: float,
+        from_sign_num: int,
+        to_sign_num: int,
+        retro: bool,
+        boundary: float,
+    ) -> IngressModel:
+        """Build an IngressModel for a boundary crossing at ``jd``."""
+        return IngressModel(
+            planet=name,
+            julian_day=jd,
+            iso_utc=_jd_to_iso(jd),
+            sign=_sign_name(to_sign_num),
+            sign_num=to_sign_num % 12,
+            from_sign=_sign_name(from_sign_num),
+            from_sign_num=from_sign_num % 12,
+            retrograde=retro,
+            ecliptic_longitude=round(boundary, 6),
+        )

--- a/kerykeion/sign_ingresses/sign_ingress_factory.py
+++ b/kerykeion/sign_ingresses/sign_ingress_factory.py
@@ -78,15 +78,16 @@ def _to_utc_naive(dt: datetime) -> datetime:
 
 
 def _jd_to_iso(jd: float) -> str:
-    """Convert a Julian Day (UT) to an ISO 8601 UTC string with seconds."""
-    try:
-        dt = julian_to_datetime(jd)
-        return (
-            f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
-            f"T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}Z"
-        )
-    except Exception:  # pragma: no cover - defensive
-        return ""
+    """Convert a Julian Day (UT) to an ISO 8601 UTC string with seconds.
+
+    Lets conversion errors propagate rather than emitting an empty ``iso_utc``
+    that would look valid to downstream consumers.
+    """
+    dt = julian_to_datetime(jd)
+    return (
+        f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
+        f"T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}Z"
+    )
 
 
 def _ang_diff(a: float, b: float) -> float:

--- a/kerykeion/sign_ingresses/sign_ingress_factory.py
+++ b/kerykeion/sign_ingresses/sign_ingress_factory.py
@@ -29,7 +29,6 @@ from kerykeion.schemas.kr_models import SubscriptableBaseModel
 from kerykeion.utilities import (
     datetime_to_julian,
     get_kerykeion_point_from_degree,
-    julian_to_datetime,
 )
 from pydantic import Field
 
@@ -80,14 +79,16 @@ def _to_utc_naive(dt: datetime) -> datetime:
 def _jd_to_iso(jd: float) -> str:
     """Convert a Julian Day (UT) to an ISO 8601 UTC string with seconds.
 
-    Lets conversion errors propagate rather than emitting an empty ``iso_utc``
-    that would look valid to downstream consumers.
+    Uses ``swe.revjul`` rather than Python ``datetime`` (limited to years
+    1..9999) so the BCE range Kerykeion supports formats correctly, with an
+    extended-year sign for negative years.
     """
-    dt = julian_to_datetime(jd)
-    return (
-        f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
-        f"T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}Z"
-    )
+    year, month, day, hour_frac = swe.revjul(jd)
+    secs = min(int(hour_frac * 3600 + 0.5), 86399)  # nearest second, no 24:00 carry
+    hours, rem = divmod(secs, 3600)
+    minutes, seconds = divmod(rem, 60)
+    year_str = f"-{abs(year):04d}" if year < 0 else f"{year:04d}"
+    return f"{year_str}-{month:02d}-{day:02d}T{hours:02d}:{minutes:02d}:{seconds:02d}Z"
 
 
 def _ang_diff(a: float, b: float) -> float:
@@ -189,8 +190,9 @@ class SignIngressFactory:
         """
         start_dt = _to_utc_naive(datetime.fromisoformat(start_date))
         end_dt = _to_utc_naive(datetime.fromisoformat(end_date))
-        # A date-only end_date means "through the end of that UTC day".
-        if "T" not in end_date and " " not in end_date:
+        # A date-only end_date means "through the end of that UTC day". Check for
+        # both T/t (fromisoformat accepts a lowercase 't') and a space separator.
+        if "T" not in end_date and "t" not in end_date and " " not in end_date:
             end_dt = end_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
         start_jd = datetime_to_julian(start_dt)
         end_jd = datetime_to_julian(end_dt)
@@ -217,7 +219,9 @@ class SignIngressFactory:
                     f"Unknown planets: {', '.join(invalid)}. "
                     f"Valid: {', '.join(_PLANET_IDS)}"
                 )
-            bodies = [(name, _PLANET_IDS[name]) for name in planets]
+            # Deduplicate (preserve order): duplicates would repeat the scan and
+            # emit every event multiple times.
+            bodies = [(name, _PLANET_IDS[name]) for name in dict.fromkeys(planets)]
         else:
             bodies = list(_INGRESS_PLANETS)
 

--- a/kerykeion/sign_ingresses/sign_ingress_factory.py
+++ b/kerykeion/sign_ingresses/sign_ingress_factory.py
@@ -23,7 +23,7 @@ import logging
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH
+from kerykeion.ephemeris_backend import swe, EPHE_DATA_PATH, EPHEMERIS_LOCK
 
 from kerykeion.schemas.kr_models import SubscriptableBaseModel
 from kerykeion.utilities import (
@@ -60,8 +60,14 @@ _PLANET_IDS["Moon"] = swe.MOON
 # (30°) is never jumped; slower bodies have ample margin.
 _SAMPLE_STEP_DAYS = 0.5
 _BISECTION_ITERS = 40
-# Runaway guard (≈ 270 years at the default step).
-_MAX_SAMPLES = 200_000
+# Backstop on samples per scan (~2700 years at the default step). Ranges that
+# would exceed it are rejected explicitly rather than silently truncated.
+_MAX_SAMPLES = 2_000_000
+# A planet can cross a boundary, station, and cross back within one sampling
+# interval (both endpoints in the same sign). When the midpoint reveals a hidden
+# sign, the interval is subdivided down to this resolution to catch both hits.
+_MIN_SEGMENT_DAYS = 1.0 / 96.0  # 15 minutes
+_MAX_SUBDIVISION_DEPTH = 8
 
 
 def _to_utc_naive(dt: datetime) -> datetime:
@@ -113,6 +119,16 @@ def _bisect_ingress(body: int, a: float, b: float, boundary: float) -> float:
         else:
             a, fa = mid, fm
     return (a + b) / 2.0
+
+
+def _ensure_scannable(start_jd: float, end_jd: float) -> None:
+    """Reject ranges too long to scan, so a caller never receives a silently
+    truncated result whose ``end_jd`` still claims the full requested range."""
+    if (end_jd - start_jd) / _SAMPLE_STEP_DAYS > _MAX_SAMPLES:
+        raise ValueError(
+            f"Date range too large to scan at the current resolution "
+            f"(> {_MAX_SAMPLES} samples). Narrow the date range."
+        )
 
 
 # =============================================================================
@@ -192,7 +208,8 @@ class SignIngressFactory:
             end_jd: Julian Day (UT) range end.
             planets: Optional subset of planet names. Defaults to Sun..Pluto.
         """
-        if planets:
+        # None = default set; an explicit empty list = scan nothing.
+        if planets is not None:
             invalid = sorted(set(planets) - set(_PLANET_IDS))
             if invalid:
                 raise ValueError(
@@ -203,17 +220,22 @@ class SignIngressFactory:
         else:
             bodies = list(_INGRESS_PLANETS)
 
-        swe.set_ephe_path(_EPHE_PATH)
         ingresses: List[IngressModel] = []
-
-        if end_jd > start_jd:
-            for name, body in bodies:
-                ingresses.extend(
-                    SignIngressFactory._scan_planet(name, body, start_jd, end_jd)
-                )
+        if end_jd > start_jd and bodies:
+            _ensure_scannable(start_jd, end_jd)
+            # Hold the lock across the whole scan: set_ephe_path / calc_ut / close
+            # mutate process-global backend state shared with chart calculations.
+            with EPHEMERIS_LOCK:
+                swe.set_ephe_path(_EPHE_PATH)
+                try:
+                    for name, body in bodies:
+                        ingresses.extend(
+                            SignIngressFactory._scan_planet(name, body, start_jd, end_jd)
+                        )
+                finally:
+                    swe.close()
             ingresses.sort(key=lambda i: i.julian_day)
 
-        swe.close()
         return SignIngressesCollectionModel(
             start_jd=start_jd,
             end_jd=end_jd,
@@ -224,32 +246,62 @@ class SignIngressFactory:
     def _scan_planet(
         name: str, body: int, start_jd: float, end_jd: float
     ) -> List[IngressModel]:
-        """Walk the range for one planet, bisecting each sign-index change."""
+        """Walk the range for one planet, emitting every sign-boundary crossing."""
         found: List[IngressModel] = []
         jd = start_jd
-        prev_lon = _lon(jd, body)
-        prev_sign = int(prev_lon // 30)
-        samples = 0
-        while jd < end_jd and samples < _MAX_SAMPLES:
+        prev_sign = int(_lon(jd, body) // 30)
+        while jd < end_jd:
             jd_next = min(jd + _SAMPLE_STEP_DAYS, end_jd)
-            cur_lon = _lon(jd_next, body)
-            cur_sign = int(cur_lon // 30)
-            if cur_sign != prev_sign:
-                # Direction over the step decides which boundary was crossed:
-                # forward (delta>0) crosses the top of prev_sign, retrograde the
-                # bottom. The half-day step guarantees a single boundary here.
-                retro = _ang_diff(cur_lon, prev_lon) < 0.0
-                boundary = ((prev_sign * 30) if retro else ((prev_sign + 1) * 30)) % 360.0
-                jd_ingress = _bisect_ingress(body, jd, jd_next, boundary)
-                found.append(
-                    SignIngressFactory._build(
-                        name, jd_ingress, prev_sign, cur_sign, retro, boundary
-                    )
-                )
-            prev_lon, prev_sign = cur_lon, cur_sign
+            cur_sign = int(_lon(jd_next, body) // 30)
+            SignIngressFactory._emit_segment(name, body, jd, prev_sign, jd_next, cur_sign, found, 0)
+            prev_sign = cur_sign
             jd = jd_next
-            samples += 1
         return found
+
+    @staticmethod
+    def _emit_segment(
+        name: str,
+        body: int,
+        a: float,
+        sign_a: int,
+        b: float,
+        sign_b: int,
+        found: List[IngressModel],
+        depth: int,
+    ) -> None:
+        """Emit ingresses within ``[a, b]``, subdividing to catch crossings the
+        endpoints hide (a forward + retrograde re-crossing inside one interval)."""
+        if sign_a == sign_b:
+            # Equal endpoints can still hide a there-and-back excursion across a
+            # boundary near a station. Probe the midpoint; if it sits in another
+            # sign, two crossings are hidden here — recurse into both halves.
+            if depth >= _MAX_SUBDIVISION_DEPTH or (b - a) <= _MIN_SEGMENT_DAYS:
+                return
+            mid = (a + b) / 2.0
+            sign_mid = int(_lon(mid, body) // 30)
+            if sign_mid != sign_a:
+                SignIngressFactory._emit_segment(name, body, a, sign_a, mid, sign_mid, found, depth + 1)
+                SignIngressFactory._emit_segment(name, body, mid, sign_mid, b, sign_b, found, depth + 1)
+            return
+
+        diff = (sign_b - sign_a) % 12
+        if diff != 1 and diff != 11 and depth < _MAX_SUBDIVISION_DEPTH and (b - a) > _MIN_SEGMENT_DAYS:
+            # More than one boundary between the endpoints (a fast body, or a
+            # multi-crossing interval): split so each half resolves one boundary.
+            mid = (a + b) / 2.0
+            sign_mid = int(_lon(mid, body) // 30)
+            SignIngressFactory._emit_segment(name, body, a, sign_a, mid, sign_mid, found, depth + 1)
+            SignIngressFactory._emit_segment(name, body, mid, sign_mid, b, sign_b, found, depth + 1)
+            return
+
+        # Adjacent signs: a single boundary. diff==1 is forward (top of sign_a),
+        # diff==11 is retrograde (bottom of sign_a).
+        retro = diff == 11
+        boundary = ((sign_a * 30) if retro else ((sign_a + 1) * 30)) % 360.0
+        jd_ingress = _bisect_ingress(body, a, b, boundary)
+        found.append(
+            SignIngressFactory._build(name, jd_ingress, sign_a, sign_b, retro, boundary)
+        )
 
     @staticmethod
     def _build(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kerykeion"
-version = "6.0.0a53"
+version = "6.0.0a54"
 authors = [
     { name = "Giacomo Battaglia", email = "kerykeion.astrology@gmail.com" }
 ]

--- a/tests/core/test_retrograde_stations.py
+++ b/tests/core/test_retrograde_stations.py
@@ -73,6 +73,16 @@ class TestStationApi:
         res = RetrogradeStationFactory.from_julian_day(start, start)
         assert res.stations == []
 
+    def test_empty_planet_list_returns_nothing(self):
+        # An explicit empty list means "scan nothing", not "scan the defaults".
+        res = RetrogradeStationFactory.from_iso_range("2026-01-01", "2026-12-31", [])
+        assert res.stations == []
+
+    def test_oversized_range_raises(self):
+        # A range too long to scan is rejected, never silently truncated.
+        with pytest.raises(ValueError):
+            RetrogradeStationFactory.from_iso_range("0001-01-01", "3000-01-01")
+
     def test_from_julian_day(self):
         start = datetime_to_julian(datetime(2026, 1, 1))
         end = datetime_to_julian(datetime(2026, 12, 31))

--- a/tests/core/test_retrograde_stations.py
+++ b/tests/core/test_retrograde_stations.py
@@ -83,6 +83,21 @@ class TestStationApi:
         with pytest.raises(ValueError):
             RetrogradeStationFactory.from_iso_range("0001-01-01", "3000-01-01")
 
+    def test_bce_range_via_julian_day(self):
+        # The BCE range must not crash on JD->ISO conversion (datetime caps at
+        # year 1). Mercury stations in 100 BCE; just assert it runs and formats.
+        from kerykeion.ephemeris_backend import swe
+
+        jd0 = swe.julday(-100, 1, 1, 0.0)
+        jd1 = swe.julday(-100, 12, 31, 23.9)
+        res = RetrogradeStationFactory.from_julian_day(jd0, jd1, ["Mercury"])
+        assert all(s.iso_utc.startswith("-0100-") for s in res.stations)
+
+    def test_duplicate_planets_deduplicated(self):
+        once = RetrogradeStationFactory.from_iso_range("2026-01-01", "2026-12-31", ["Mercury"]).stations
+        twice = RetrogradeStationFactory.from_iso_range("2026-01-01", "2026-12-31", ["Mercury", "Mercury"]).stations
+        assert len(once) == len(twice)
+
     def test_from_julian_day(self):
         start = datetime_to_julian(datetime(2026, 1, 1))
         end = datetime_to_julian(datetime(2026, 12, 31))

--- a/tests/core/test_retrograde_stations.py
+++ b/tests/core/test_retrograde_stations.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Retrograde Station Factory."""
+
+import pytest
+
+from kerykeion.retrograde_stations import RetrogradeStationFactory
+from kerykeion.utilities import datetime_to_julian
+from datetime import datetime
+
+
+class TestMercuryStations2026:
+    """Mercury's three 2026 retrograde periods are well-documented anchors."""
+
+    def test_six_stations_alternating(self):
+        res = RetrogradeStationFactory.from_iso_range(
+            "2026-01-01", "2026-12-31", ["Mercury"]
+        )
+        # Three retrograde periods => three SR + three SD, strictly alternating.
+        assert len(res.stations) == 6
+        types = [s.station_type for s in res.stations]
+        assert types == ["SR", "SD", "SR", "SD", "SR", "SD"]
+
+    def test_first_station_is_late_february_in_pisces(self):
+        res = RetrogradeStationFactory.from_iso_range(
+            "2026-01-01", "2026-12-31", ["Mercury"]
+        )
+        first = res.stations[0]
+        assert first.station_type == "SR"
+        assert first.iso_utc.startswith("2026-02-26")
+        assert first.sign == "Pis"
+
+    def test_chronological_and_within_sign_pairs(self):
+        res = RetrogradeStationFactory.from_iso_range(
+            "2026-01-01", "2026-12-31", ["Mercury"]
+        )
+        jds = [s.julian_day for s in res.stations]
+        assert jds == sorted(jds)
+        # Each SR/SD pair brackets one retrograde period (~3 weeks long).
+        for sr, sd in zip(res.stations[0::2], res.stations[1::2]):
+            assert sr.station_type == "SR" and sd.station_type == "SD"
+            assert 15.0 < (sd.julian_day - sr.julian_day) < 30.0
+
+
+class TestStationApi:
+    """Factory entry points, defaults, and validation."""
+
+    def test_default_planet_set_excludes_luminaries(self):
+        res = RetrogradeStationFactory.from_iso_range("2026-01-01", "2026-12-31")
+        planets = {s.planet for s in res.stations}
+        assert "Sun" not in planets and "Moon" not in planets
+        # Every station is a real motion reversal of a non-luminary planet.
+        assert all(s.station_type in ("SR", "SD") for s in res.stations)
+        assert res.stations == sorted(res.stations, key=lambda s: s.julian_day)
+
+    def test_luminaries_rejected(self):
+        with pytest.raises(ValueError):
+            RetrogradeStationFactory.from_iso_range("2026-01-01", "2026-12-31", ["Sun"])
+        with pytest.raises(ValueError):
+            RetrogradeStationFactory.from_iso_range("2026-01-01", "2026-12-31", ["Moon"])
+
+    def test_zodiac_fields_consistent(self):
+        res = RetrogradeStationFactory.from_iso_range(
+            "2026-01-01", "2026-12-31", ["Mercury"]
+        )
+        for s in res.stations:
+            assert 0 <= s.sign_num <= 11
+            assert 0.0 <= s.degree < 30.0
+            assert 0.0 <= s.ecliptic_longitude < 360.0
+            assert "T" in s.iso_utc and s.iso_utc.endswith("Z")
+
+    def test_empty_range(self):
+        start = datetime_to_julian(datetime(2026, 1, 1))
+        res = RetrogradeStationFactory.from_julian_day(start, start)
+        assert res.stations == []
+
+    def test_from_julian_day(self):
+        start = datetime_to_julian(datetime(2026, 1, 1))
+        end = datetime_to_julian(datetime(2026, 12, 31))
+        res = RetrogradeStationFactory.from_julian_day(start, end, ["Mercury"])
+        assert len(res.stations) == 6
+        assert res.start_jd == start and res.end_jd == end

--- a/tests/core/test_sign_ingresses.py
+++ b/tests/core/test_sign_ingresses.py
@@ -59,6 +59,19 @@ class TestRetrogradeIngresses:
         assert last.iso_utc.startswith("2024-11-19")
         assert last.sign == "Aqu" and not last.retrograde
 
+    def test_double_crossing_within_one_interval(self):
+        # Mercury crossed into Aquarius ~04:20 UTC and retrograded back into
+        # Capricorn ~11:59 UTC on 1970-01-04 — both inside a single sampling
+        # interval. Endpoint-only detection misses both; the midpoint probe
+        # recovers them.
+        res = SignIngressFactory.from_iso_range("1970-01-03", "1970-01-06", ["Mercury"])
+        assert len(res.ingresses) == 2
+        first, second = res.ingresses
+        assert first.from_sign == "Cap" and first.sign == "Aqu" and not first.retrograde
+        assert second.from_sign == "Aqu" and second.sign == "Cap" and second.retrograde
+        assert first.iso_utc.startswith("1970-01-04")
+        assert second.iso_utc.startswith("1970-01-04")
+
 
 class TestIngressApi:
     """Factory entry points, defaults, and validation."""
@@ -85,6 +98,16 @@ class TestIngressApi:
         start = datetime_to_julian(datetime(2026, 1, 1))
         res = SignIngressFactory.from_julian_day(start, start)
         assert res.ingresses == []
+
+    def test_empty_planet_list_returns_nothing(self):
+        # An explicit empty list means "scan nothing", not "scan the defaults".
+        res = SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31", [])
+        assert res.ingresses == []
+
+    def test_oversized_range_raises(self):
+        # A range too long to scan is rejected, never silently truncated.
+        with pytest.raises(ValueError):
+            SignIngressFactory.from_iso_range("0001-01-01", "3000-01-01")
 
     def test_from_julian_day(self):
         start = datetime_to_julian(datetime(2026, 1, 1))

--- a/tests/core/test_sign_ingresses.py
+++ b/tests/core/test_sign_ingresses.py
@@ -109,6 +109,29 @@ class TestIngressApi:
         with pytest.raises(ValueError):
             SignIngressFactory.from_iso_range("0001-01-01", "3000-01-01")
 
+    def test_bce_range_via_julian_day(self):
+        # The BCE range Kerykeion supports must not crash on JD->ISO conversion
+        # (Python datetime caps at year 1). Year -100 has 12 solar ingresses.
+        from kerykeion.ephemeris_backend import swe
+
+        jd0 = swe.julday(-100, 1, 1, 0.0)
+        jd1 = swe.julday(-100, 12, 31, 23.9)
+        res = SignIngressFactory.from_julian_day(jd0, jd1, ["Sun"])
+        assert len(res.ingresses) == 12
+        assert res.ingresses[0].iso_utc.startswith("-0100-")
+
+    def test_lowercase_t_end_not_extended(self):
+        # fromisoformat accepts a lowercase 't'; it must be read as a datetime,
+        # not widened to end-of-day. The Sun enters Aries 2026-03-20T14:45Z, so a
+        # 't00:00:00' end on that day must exclude it.
+        res = SignIngressFactory.from_iso_range("2026-03-19", "2026-03-20t00:00:00", ["Sun"])
+        assert all(x.sign != "Ari" for x in res.ingresses)
+
+    def test_duplicate_planets_deduplicated(self):
+        once = SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31", ["Sun"]).ingresses
+        twice = SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31", ["Sun", "Sun"]).ingresses
+        assert len(once) == len(twice)
+
     def test_from_julian_day(self):
         start = datetime_to_julian(datetime(2026, 1, 1))
         end = datetime_to_julian(datetime(2026, 12, 31))

--- a/tests/core/test_sign_ingresses.py
+++ b/tests/core/test_sign_ingresses.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Sign Ingress Factory."""
+
+import pytest
+
+from kerykeion.sign_ingresses import SignIngressFactory
+from kerykeion.utilities import datetime_to_julian
+from datetime import datetime
+
+
+class TestSunIngresses2026:
+    """The Sun's ingresses are the equinoxes/solstices — exact known anchors."""
+
+    def test_twelve_ingresses_never_retrograde(self):
+        res = SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31", ["Sun"])
+        assert len(res.ingresses) == 12
+        assert all(not x.retrograde for x in res.ingresses)
+        # Each ingress lands on a 30° boundary.
+        assert all(x.ecliptic_longitude % 30 == 0 for x in res.ingresses)
+
+    def test_spring_equinox_into_aries(self):
+        res = SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31", ["Sun"])
+        aries = [x for x in res.ingresses if x.sign == "Ari"][0]
+        assert aries.iso_utc.startswith("2026-03-20")
+        assert aries.from_sign == "Pis"
+        assert aries.ecliptic_longitude == 0.0
+
+    def test_summer_solstice_into_cancer(self):
+        res = SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31", ["Sun"])
+        cancer = [x for x in res.ingresses if x.sign == "Can"][0]
+        assert cancer.iso_utc.startswith("2026-06-21")
+        assert cancer.ecliptic_longitude == 90.0
+
+    def test_chronological_and_adjacent_signs(self):
+        res = SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31", ["Sun"])
+        jds = [x.julian_day for x in res.ingresses]
+        assert jds == sorted(jds)
+        # Forward motion: each entered sign is the one after the sign left.
+        for x in res.ingresses:
+            assert x.sign_num == (x.from_sign_num + 1) % 12
+
+
+class TestRetrogradeIngresses:
+    """Pluto's 2023-2024 Capricorn<->Aquarius dance is a documented anchor."""
+
+    def test_pluto_retrograde_reentry_into_capricorn(self):
+        res = SignIngressFactory.from_iso_range("2023-01-01", "2024-12-31", ["Pluto"])
+        # The retrograde step back into Capricorn on 11 Jun 2023.
+        retro = [x for x in res.ingresses if x.retrograde]
+        assert retro, "expected at least one retrograde ingress"
+        first_retro = retro[0]
+        assert first_retro.iso_utc.startswith("2023-06-11")
+        assert first_retro.from_sign == "Aqu" and first_retro.sign == "Cap"
+        assert first_retro.ecliptic_longitude == 300.0
+
+    def test_pluto_final_ingress_into_aquarius_nov_2024(self):
+        res = SignIngressFactory.from_iso_range("2023-01-01", "2024-12-31", ["Pluto"])
+        last = res.ingresses[-1]
+        assert last.iso_utc.startswith("2024-11-19")
+        assert last.sign == "Aqu" and not last.retrograde
+
+
+class TestIngressApi:
+    """Factory entry points, defaults, and validation."""
+
+    def test_default_excludes_moon(self):
+        res = SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31")
+        assert all(x.planet != "Moon" for x in res.ingresses)
+
+    def test_moon_is_opt_in_and_frequent(self):
+        res = SignIngressFactory.from_iso_range(
+            "2026-01-01", "2026-12-31", ["Moon"]
+        )
+        # The Moon changes sign every ~2.3 days => ~150+ ingresses a year.
+        assert len(res.ingresses) > 140
+        assert all(x.planet == "Moon" for x in res.ingresses)
+
+    def test_unknown_planet_raises(self):
+        with pytest.raises(ValueError):
+            SignIngressFactory.from_iso_range(
+                "2026-01-01", "2026-12-31", ["Sun", "Nibiru"]
+            )
+
+    def test_empty_range(self):
+        start = datetime_to_julian(datetime(2026, 1, 1))
+        res = SignIngressFactory.from_julian_day(start, start)
+        assert res.ingresses == []
+
+    def test_from_julian_day(self):
+        start = datetime_to_julian(datetime(2026, 1, 1))
+        end = datetime_to_julian(datetime(2026, 12, 31))
+        res = SignIngressFactory.from_julian_day(start, end, ["Sun"])
+        assert len(res.ingresses) == 12
+        assert res.start_jd == start and res.end_jd == end


### PR DESCRIPTION
## Summary

Two new backend-agnostic factories that scan a date range for sky-wide events, modelled on `LunationFinderFactory` / `EclipseFactory`:

- **`RetrogradeStationFactory`** — planetary retrograde/direct stations (motion reversals), with the zodiac position at each station. Sun/Moon excluded (they never station).
- **`SignIngressFactory`** — zodiac sign ingresses (30° boundary crossings), with from/to signs and a retrograde flag for re-entries. Moon is opt-in.

Both sample `swe.calc_ut` and bisect the crossing — no libephemeris-only crossing primitives, so they work on the swisseph backend too.

## Validation

Verified against known anchors:
- the three 2026 Mercury retrograde windows (SR→SD)
- the solar equinoxes/solstices (Sun ingresses)
- the 2023–2024 Pluto Capricorn↔Aquarius ingress dance, including retrograde re-entries

## Correctness fixes (from review)

- Hold `EPHEMERIS_LOCK` across the whole scan (process-global backend state shared with chart calculations).
- Detect multiple ingresses within one sampling interval via a recursive midpoint probe (e.g. Mercury 1970-01-04: in, station, back out within ~8h).
- Reject ranges too long to scan with `ValueError` instead of silently truncating.
- Treat `planets=[]` as "scan nothing" (`None` is the default sentinel).

## Tests

24 passing (`tests/core/test_retrograde_stations.py`, `tests/core/test_sign_ingresses.py`) — one per behaviour above.

Bumps version to `6.0.0a54`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added retrograde and direct station detection for tracking planetary motion transitions
  - Added zodiac sign ingress detection for monitoring boundary crossings
  - New analysis capabilities now integrated into the core package API

* **Tests**
  - Added comprehensive test coverage for retrograde station detection
  - Added comprehensive test coverage for sign ingress detection

* **Chores**
  - Version updated to 6.0.0a54

<!-- end of auto-generated comment: release notes by coderabbit.ai -->