### PR TITLE
fix(fixed-stars): dedupe star discovery by identity, not rounded longitude (6.0.0a57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## 6.0.0a57
+
+_2026-06-16_
+
+### Fixed
+
+- **Fixed-star discovery no longer drops bright stars to a position collision** —
+  `FixedStarDiscoveryFactory.find_prominent_stars` deduplicated candidates by
+  ecliptic longitude rounded to two decimals (`round(deg, 2)`). With the small
+  curated catalog this was harmless, but libephemeris 3's 1447-star catalog packs
+  many physically distinct stars within 0.01° of longitude, so the second star in
+  catalog order was silently discarded — and catalog order is not magnitude order.
+  This suppressed astrologically relevant bright stars in favour of faint
+  neighbours (e.g. Nunki, σ Sgr mag 2.02, lost to Beta Scuti mag 4.22, both at
+  282.26°). Deduplication is now by star identity (`entry.name`) instead of
+  position, so every distinct star within orb is reported. Discovery results grow
+  accordingly (more conjunct stars returned for a given orb).
+
 ## 6.0.0a56
 
 _2026-06-16_

--- a/kerykeion/fixed_stars/discovery_factory.py
+++ b/kerykeion/fixed_stars/discovery_factory.py
@@ -152,7 +152,7 @@ class FixedStarDiscoveryFactory:
         jd = subject.julian_day
 
         prominent: list[KerykeionPointModel] = []
-        seen_positions: set[float] = set()
+        seen_names: set[str] = set()
         with ephemeris_session(
             zodiac_type=getattr(subject, "zodiac_type", None),
             sidereal_mode=getattr(subject, "sidereal_mode", None),
@@ -161,6 +161,17 @@ class FixedStarDiscoveryFactory:
         ) as scan_iflag:
             for entry in catalog:
                 star_name = entry.name
+                # Each catalog entry is a physically distinct star (unique by
+                # name/hip_number), so we dedupe by identity only — guarding
+                # against duplicate catalog entries, NOT by position. Two
+                # different stars sharing a rounded ecliptic longitude (e.g.
+                # Beta Scuti and Nunki, ~0.005° apart) must both be reported;
+                # a position-based dedupe would silently drop the second one,
+                # which after libephemeris 3.0's 1447-star catalog suppressed
+                # bright/important stars in favour of fainter catalog neighbours.
+                if star_name in seen_names:
+                    continue
+                seen_names.add(star_name)
                 try:
                     pos_ecl = ephe.fixstar_ut(star_name, jd, scan_iflag)[0]
                     star_deg = pos_ecl[0]
@@ -168,11 +179,6 @@ class FixedStarDiscoveryFactory:
                     nearest = _nearest_conjunction(star_deg, planet_positions, orb)
                     if nearest is None:
                         continue
-
-                    rounded_pos = round(star_deg, 2)
-                    if rounded_pos in seen_positions:
-                        continue
-                    seen_positions.add(rounded_pos)
 
                     # Declination is zodiac-independent; drop FLG_SIDEREAL so the
                     # equatorial fetch is identical for tropical and sidereal charts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kerykeion"
-version = "6.0.0a56"
+version = "6.0.0a57"
 authors = [
     { name = "Giacomo Battaglia", email = "kerykeion.astrology@gmail.com" }
 ]

--- a/tests/core/test_dynamic_fixed_stars.py
+++ b/tests/core/test_dynamic_fixed_stars.py
@@ -225,6 +225,19 @@ class TestFixedStarDiscovery:
         assert len(mags) >= 2, "A 3-degree orb should discover at least 2 stars with magnitude data"
         assert mags == sorted(mags), "Stars should be sorted by magnitude (brightest first)"
 
+    def test_close_longitude_stars_not_position_deduplicated(self, subject_default_stars):
+        """Regression (a57): physically distinct stars sharing a rounded ecliptic
+        longitude must both be discovered. The old ``round(deg, 2)`` position dedupe
+        dropped the second star in catalog order regardless of magnitude, so after
+        libephemeris 3.0's 1447-star catalog bright stars were suppressed by fainter
+        neighbours — e.g. Nunki (sigma Sgr, mag 2.02) lost to Beta Scuti (mag 4.22),
+        both rounding to 282.26 deg. Nunki sits at orb ~1.46 here and must appear."""
+        names = {
+            s.name
+            for s in FixedStarDiscoveryFactory.find_prominent_stars(subject_default_stars, orb=2.0)
+        }
+        assert "Nunki" in names, f"Nunki should be discovered within orb 2.0; got {sorted(names)}"
+
 
 class TestFixedStarSiderealFrameConsistency:
     """v6 pre-beta fix: star discovery must run in the subject's zodiac frame.

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "kerykeion"
-version = "6.0.0a56"
+version = "6.0.0a57"
 source = { editable = "." }
 dependencies = [
     { name = "libephemeris" },


### PR DESCRIPTION
## Problema

`FixedStarDiscoveryFactory.find_prominent_stars` deduplicava i candidati per **longitudine eclittica arrotondata a 2 decimali** (`round(deg, 2)`). Con il catalogo curato piccolo era innocuo, ma il catalogo a **1447 stelle** di libephemeris 3 impacchetta molte stelle fisicamente distinte entro 0.01° di longitudine, così la seconda stella in ordine di catalogo veniva scartata silenziosamente — e l'ordine di catalogo **non** è l'ordine di magnitudine.

Risultato: stelle luminose astrologicamente rilevanti venivano soppresse a favore di vicine più deboli. Esempio: **Nunki** (σ Sgr, mag 2.02) persa per **Beta Scuti** (mag 4.22), entrambe a 282.26°.

## Fix

Deduplicazione per **identità della stella** (`entry.name`) invece che per posizione. Ogni catalog entry è una stella fisicamente distinta (unica per nome/hip_number), quindi il guard serve solo contro entry duplicate, non contro la posizione. Ora ogni stella distinta entro orb viene riportata.

## Impatto

- I risultati di discovery crescono (più stelle congiunte ritornate per un dato orb) — è il comportamento corretto.
- Nessun impatto su type hints / introspezione runtime.
- Bump `6.0.0a56` → `6.0.0a57`.

## Test

- Nuovo test di regressione `test_close_longitude_stars_not_position_deduplicated`: verifica che Nunki sia scoperta entro orb 2.0.
- Suite `tests/core/test_dynamic_fixed_stars.py` verde (20 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fixed-star discovery deduplication to properly identify distinct stars. Previously, stars in dense catalogs with similar rounded positions were incorrectly omitted. The algorithm now uses star identity for deduplication, ensuring all separate stars within the search orb are correctly reported. Discovery results may expand accordingly.

* **Tests**
  * Added regression test to verify fixed-star discovery correctly handles nearby catalog stars with similar ecliptic longitudes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->