### PR TITLE
chore: governance & contributor files; CLA hardening; draft licensing docs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,14 @@
+# Consolidate the maintainer's many commit identities under one canonical
+# name + email, so `git shortlog`/`git blame` and any chain-of-title review
+# show a single natural person.
+#
+# External human contributors and AI-assist ("Claude") commits are
+# intentionally NOT collapsed here.
+
+Giacomo Battaglia <kerykeion.astrology@gmail.com> <battaglia.giacomo@icloud.com>
+Giacomo Battaglia <kerykeion.astrology@gmail.com> <battaglia.giacomo@yahoo.it>
+Giacomo Battaglia <kerykeion.astrology@gmail.com> <66565007+g-battaglia@users.noreply.github.com>
+Giacomo Battaglia <kerykeion.astrology@gmail.com> <giacomo@MacBook-Pro-di-Giacomo.local>
+Giacomo Battaglia <kerykeion.astrology@gmail.com> <giacomo@mbp-di-giacomo.homenet.telecomitalia.it>
+Giacomo Battaglia <kerykeion.astrology@gmail.com> <giacomobattaglia@Air-di-Giacomo.wind3.hub>
+Giacomo Battaglia <kerykeion.astrology@gmail.com> <kerykeion.astrology@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,11 +5,16 @@ Created and maintained by:
 
   Giacomo Battaglia <kerykeion.astrology@gmail.com>
 
-Copyright in the project is held by the maintainer. Under the Contributor
-License Agreement (see CONTRIBUTING.md), contributors assign the copyright in
-their contributions to the maintainer; this centralized ownership is what
-enables the project's dual-licensing model. Assignment does not remove
-authorship credit, which is preserved here and in the Git history.
+Copyright in the project is held by the maintainer. Contributions made under
+the Contributor License Agreement (see CONTRIBUTING.md) are assigned to the
+maintainer; once a contributor agrees to the CLA it covers their past,
+present, and future contributions, and this centralized ownership is what
+enables the project's dual-licensing model. The CLA and its bot check were
+introduced on 2026-02-24; contributions predating it, or by contributors who
+have not (yet) agreed to it, remain available to the project under their
+original inbound license (AGPL-3.0) unless a separate assignment is on record.
+Assignment does not remove authorship credit, which is preserved here and in
+the Git history.
 
 With thanks to the contributors (alphabetical):
 
@@ -26,6 +31,7 @@ With thanks to the contributors (alphabetical):
   fkostadinov
   gaycodegal
   jack
+  nasik
   ourania-entoli
   paracosm17
   tomshaffner

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,35 @@
+Kerykeion — Authors & Contributors
+==================================
+
+Created and maintained by:
+
+  Giacomo Battaglia <kerykeion.astrology@gmail.com>
+
+Copyright in the project is held by the maintainer. Under the Contributor
+License Agreement (see CONTRIBUTING.md), contributors assign the copyright in
+their contributions to the maintainer; this centralized ownership is what
+enables the project's dual-licensing model. Assignment does not remove
+authorship credit, which is preserved here and in the Git history.
+
+With thanks to the contributors (alphabetical):
+
+  Alexandre Heitor Schmidt
+  Claudio Paladini
+  Daniel Kogan
+  E-werd
+  IvoR
+  Kelvin Ng
+  Konstantin Gavrilov
+  Martynas Jankauskas
+  Mateusz
+  adrien-vinet (gallica-lupus)
+  fkostadinov
+  gaycodegal
+  jack
+  ourania-entoli
+  paracosm17
+  tomshaffner
+
+AI-assisted development: some changes were produced with AI coding assistants
+under the maintainer's direction; any rights in such output vest in the
+maintainer.

--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -1,0 +1,49 @@
+> **Status: DRAFT.** Not legally effective until reviewed and signed by a
+> qualified IP / open-source attorney. The terms below are a starting point for
+> negotiation, not a binding offer, and not legal advice.
+
+# Kerykeion Commercial License
+
+Kerykeion is dual-licensed. The default public grant is **AGPL-3.0** (see
+[LICENSE](LICENSE) and [LICENSING.md](LICENSING.md)). Organizations that cannot
+or do not want to comply with the AGPL — for example, embedding Kerykeion in a
+closed-source product, or running a SaaS without source disclosure — can instead
+obtain a commercial license.
+
+## How to obtain a commercial license
+
+Commercial-licensing terms are arranged **directly with the copyright holder**.
+There is no online purchase or self-serve form — please get in touch and we will
+work out the terms for your use case:
+
+- **Licensor:** Giacomo Battaglia
+- **Contact:** <kerykeion.astrology@gmail.com>
+
+A commercial license typically covers the right to use, modify, and redistribute
+Kerykeion in object or source form as part of your products without the AGPL's
+source-disclosure obligations, scoped to your distribution model (per product /
+per organization, distributed software vs. SaaS). Because the offering runs under
+the commercial grant, AGPL §13 (network source disclosure) does not attach.
+
+## What the grant covers
+
+- The Kerykeion code owned by the Licensor at the identified reference tag.
+- A **pass-through** commercial grant for the default runtime backend,
+  `libephemeris` (also the Licensor's project), so a commercial customer is not
+  left subject to libephemeris's AGPL — see
+  [LIBEPHEMERIS-COMMERCIAL-GRANT.md](LIBEPHEMERIS-COMMERCIAL-GRANT.md).
+
+## What the grant does not cover
+
+- Bundled glyph assets keep their own terms: public-domain (Symbola) and SIL OFL
+  1.1 (Noto Sans Symbols 2); the OFL notice must accompany distributions (see
+  [NOTICE](NOTICE)).
+- The optional Swiss Ephemeris backend (`pyswisseph` / Astrodienst AG): a
+  closed-source product using that backend needs a separate license from
+  Astrodienst. It is never installed or used on Kerykeion's default path.
+
+## Provenance
+
+The chart-rendering subsystem uses original / clean-room and permissively
+licensed glyph artwork and an independently authored drawing engine; provenance
+is recorded in [NOTICE](NOTICE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,19 +54,23 @@ This project is licensed under the **GNU Affero General Public License v3.0 (AGP
 
 ## Contributor License Agreement (CLA) — Copyright Assignment
 
-By submitting a pull request or any other contribution to this repository, you agree to the following terms:
+By submitting a pull request or any other contribution to this repository, you agree to the following terms in respect of every contribution you have made and will make to the project:
 
-1. **Copyright Assignment.** You assign all right, title, and interest in the copyright of your contribution to the project maintainer, **Giacomo Battaglia** ("Maintainer").
+1. **Copyright Assignment.** You hereby irrevocably assign to the project maintainer, **Giacomo Battaglia** ("Maintainer"), all right, title, and interest in the copyright of your past, present, and future contributions to this repository. To the extent any such assignment is not effective under applicable law, you instead grant the Maintainer a worldwide, perpetual, irrevocable, royalty-free, exclusive licence to use, reproduce, modify, distribute, sublicense, and re-license those contributions, with the right to grant sublicenses through multiple tiers. The Maintainer in turn grants you a perpetual, worldwide, non-exclusive, royalty-free licence to use and re-license your own contribution for any purpose, so this assignment does not stop you from reusing your own work.
 
-2. **Re-licensing.** The Maintainer reserves the right to re-license the project — or any part of it, including your contribution — under any other license, whether open-source or proprietary, at their sole discretion.
+2. **Re-licensing.** The Maintainer may re-license the project — or any part of it, including your contribution — under any other license, whether open-source or proprietary, at their sole discretion.
 
 3. **AGPL Availability.** The project will continue to be publicly available under the AGPL-3.0 license. The copyright assignment enables dual-licensing and commercial offerings that help sustain long-term development.
 
-4. **Attribution.** Your authorship is acknowledged in the Git commit history and, where appropriate, in release notes. Copyright assignment does not erase your credit as the original author of your contribution.
+4. **Moral rights.** To the fullest extent permitted by applicable law, you agree not to assert or enforce, against the Maintainer or its licensees, any moral rights you may hold in your contributions; where such rights are waivable, you waive them. Some jurisdictions (including Italy) treat certain moral rights as inalienable; this clause applies only as far as the law allows.
 
-5. **Originality.** You represent that each contribution is your original work and that you have the right to assign its copyright. If any part of your contribution is subject to a third-party license, you must clearly state this in the pull request.
+5. **Attribution.** Your authorship is acknowledged in the Git commit history, in the AUTHORS file, and, where appropriate, in release notes. Copyright assignment does not erase your credit as the original author of your contribution.
 
-A CLA-bot automatically checks every pull request. If you have not yet been added to the approved contributors list, the bot will comment on your PR with instructions. Once you have confirmed your agreement (typically by being added to the list), all future PRs will pass the check automatically.
+6. **Originality & authority.** You represent that each contribution is your original work, that you have the right to assign its copyright (and, where you contribute in the course of employment, that you have your employer's authorization to do so), and that the contribution does not knowingly infringe any third party's rights. If any part of your contribution is subject to a third-party license, you must clearly state this in the pull request.
+
+7. **Governing law.** This agreement is governed by the laws of Italy, without regard to its conflict-of-laws rules, and the courts of the Maintainer's place of residence shall have jurisdiction, without prejudice to any mandatory protections available to you under your local law.
+
+Your agreement is given by your own act of submitting a contribution (as stated above). On GitHub, a CLA-bot additionally checks each pull request and comments with instructions if your account is not yet recorded as having agreed; this automated check runs on GitHub only (it does not run on any mirror).
 
 ## Questions?
 

--- a/LIBEPHEMERIS-COMMERCIAL-GRANT.md
+++ b/LIBEPHEMERIS-COMMERCIAL-GRANT.md
@@ -1,0 +1,43 @@
+> **Status: DRAFT internal memorandum.** Not legally effective until reviewed,
+> dated, and signed. Not legal advice.
+
+# libephemeris commercial-grant election for the Kerykeion commercial edition
+
+## Purpose
+
+Kerykeion's default ephemeris backend is **libephemeris**, pinned in
+`pyproject.toml`. libephemeris is published under the SPDX expression
+`AGPL-3.0-only OR LicenseRef-LibEphemeris-Commercial` and is authored by the same
+copyright holder as Kerykeion. This memo records the election of the commercial
+grant for the Kerykeion commercial edition, and the pass-through of that grant to
+Kerykeion commercial customers, so that a closed-source or SaaS deployment of
+Kerykeion does not inherit libephemeris's AGPL obligations (including AGPL §13
+network source disclosure).
+
+## Election
+
+I, Giacomo Battaglia, sole copyright holder of both Kerykeion and libephemeris,
+elect the `LicenseRef-LibEphemeris-Commercial` grant for libephemeris as
+incorporated in the Kerykeion commercial edition, covering both distributed
+software and SaaS use; and I grant each Kerykeion commercial licensee a
+pass-through libephemeris commercial license for the same scope as their
+Kerykeion commercial license.
+
+## Conditions / open items (pre-GA)
+
+- **Pin a final release.** Kerykeion currently pins `libephemeris==3.0.0rc1` (a
+  release candidate). Before commercial GA, repin to the final
+  `libephemeris==3.0.0` once published. Note that the dual-license election is
+  declared in libephemeris's bundled license files (`LICENSING.md` / `NOTICE.md`):
+  the PEP 639 `License-Expression` metadata field carries the single
+  `AGPL-3.0-only` term, while the `OR LicenseRef-LibEphemeris-Commercial` election
+  lives in those files — confirm both on repin. *(As of this draft no final 3.0.0
+  exists on PyPI — the latest is `3.0.0rc1`; re-check before GA.)*
+- **Title check.** libephemeris's own provenance supports this grant: sole human
+  author; only permissive (MIT) vendored components; JPL DE440/DE441 public-domain
+  data; the last copyleft module retired by a June-2026 clean-room rewrite. Keep
+  its `NOTICE.md` / `THIRD_PARTY_NOTICES.md` on file as the provenance record.
+
+## Signature
+
+    Giacomo Battaglia   ___________________________   Date: ______________

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,62 @@
+> **Status: DRAFT.** Not legally effective until reviewed and signed by a
+> qualified IP / open-source attorney. This describes an *intended*
+> dual-licensing model for Kerykeion; it is not legal advice or a binding offer.
+
+# Licensing
+
+Kerykeion is intended to be **dual-licensed**: the same codebase is offered
+under two alternative grants, and you choose the one you use it under.
+
+## 1. Open source — AGPL-3.0
+
+The default license is the [GNU Affero General Public License v3](LICENSE)
+(AGPL-3.0). It is free for any use — including commercial use — as long as you
+comply with its terms, most notably: if you distribute the software, or make a
+modified version available to users over a network, you must make the
+corresponding source code available under the AGPL.
+
+The packages published on PyPI are AGPL-3.0.
+
+## 2. Commercial license
+
+Organizations that cannot or do not want to comply with the AGPL — for example,
+embedding Kerykeion in a closed-source product, or running a SaaS without source
+disclosure — can obtain a commercial license from the copyright holder instead.
+See [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md).
+
+- Contact: Giacomo Battaglia — <kerykeion.astrology@gmail.com>
+
+## How the dual license works
+
+- Giacomo Battaglia is the copyright holder of Kerykeion. External contributions
+  are assigned to the maintainer under the CLA (see [CONTRIBUTING.md](CONTRIBUTING.md)),
+  which is what enables the dual grant.
+- **Scope of the commercial grant.** The commercial license applies to the state
+  of the code at an identified reference tag/commit of this repository — not to
+  the Git history, and not to previously published AGPL releases.
+- **Past AGPL releases stay AGPL.** Versions already published under AGPL-3.0
+  remain available under AGPL-3.0; those grants are irrevocable. This is the
+  standard dual-license model (cf. Qt, MySQL): old releases stay open, while the
+  current and future code may additionally be offered commercially.
+- **Bundled assets.** The chart glyphs bundled in the package are public-domain
+  (Symbola), SIL OFL 1.1 (Noto Sans Symbols 2), or clean-room originals; see
+  [NOTICE](NOTICE). The OFL components require their notice to travel with any
+  distribution, including the commercial edition.
+- **Runtime backend.** The default ephemeris backend, `libephemeris`, is itself
+  dual-licensed (`AGPL-3.0-only OR LicenseRef-LibEphemeris-Commercial`) and is
+  authored by the same maintainer; the commercial edition elects its commercial
+  grant — see [LIBEPHEMERIS-COMMERCIAL-GRANT.md](LIBEPHEMERIS-COMMERCIAL-GRANT.md).
+  The optional Swiss Ephemeris backend (`pyswisseph`) is never used on the
+  default path and requires a separate license from Astrodienst AG for closed use.
+
+## Commercial delivery
+
+A commercial recipient receives a snapshot of the tree at the reference tag
+(e.g. via `git archive` of the tag, **without** the `.git` history). Note that
+the public repository is mirrored on both GitHub and GitLab.
+
+## Contributions
+
+External contributions are accepted only under the CLA in
+[CONTRIBUTING.md](CONTRIBUTING.md), which assigns copyright to the maintainer so
+the contribution can be distributed under **both** grants.

--- a/NOTICE
+++ b/NOTICE
@@ -46,3 +46,27 @@ fonts themselves are not redistributed by this project.
    (conjunction, opposition, square, trine, sextile, semi-sextile, semi-square,
    sesquiquadrate, quintile, biquintile, quincunx). The Ascendant / MC /
    Descendant / Imum Coeli markers are plain text labels.
+
+--------------------------------------------------------------------------------
+Runtime dependencies (installed from PyPI, not bundled in this package)
+--------------------------------------------------------------------------------
+
+Kerykeion installs the following packages at runtime. They are NOT vendored
+into this package; their licenses are listed here as a courtesy.
+
+  libephemeris         AGPL-3.0-only — default ephemeris backend; dual-licensed,
+                       a commercial grant is available from the same maintainer
+  pydantic             MIT
+  svg-polish           Apache-2.0 (maintained by the same author)
+  requests             Apache-2.0
+  requests-cache       BSD-2-Clause
+  simple-ascii-tables  MIT (maintained by the same author)
+  pytz                 MIT
+  typing-extensions    PSF-2.0
+  certifi (transitive) MPL-2.0
+
+Optional Swiss Ephemeris backend — only with the `swiss` / `all` extras, never
+installed or used on the default path:
+
+  pyswisseph           Swiss Ephemeris by Astrodienst AG — AGPL-3.0, or a
+                       separate commercial license obtained from Astrodienst.

--- a/site/examples/theming.md
+++ b/site/examples/theming.md
@@ -10,7 +10,7 @@ order: 11
 
 The theming functionality allows you to customize the look and feel of your astrological charts. You can choose from four unique themes to enhance your charting experience:
 
-1. **Classic**: The default theme with a classic OpenAstro like color scheme.
+1. **Classic**: The default theme with a classic, traditional color scheme.
 2. **Dark**: A dark theme that is easy on the eyes, especially in low-light environments.
 3. **Dark High Contrast**: A dark theme with high contrast for better visibility.
 4. **Light**: A light theme with a clean and bright appearance.


### PR DESCRIPTION
## Summary

Adds project governance files, strengthens the contributor agreement, and includes **draft** dual-licensing documents (clearly marked *not legally effective* pending attorney review). Docs/text only — no code or runtime changes.

- `.mailmap` — consolidate the maintainer's commit identities under one canonical name/email (external contributors and AI-assist left distinct)
- `AUTHORS` — credit contributors; record that copyright vests in the maintainer
- `CONTRIBUTING.md` — strengthen the CLA: present assignment, present + future contributions, a non-exclusive **licence-back** to the contributor, moral-rights handling, originality/authority, governing law; clarify the consent mechanism (and that the CLA-bot check is GitHub-only)
- `NOTICE` — add a runtime-dependencies section
- `LICENSING.md`, `COMMERCIAL-LICENSE.md`, `LIBEPHEMERIS-COMMERCIAL-GRANT.md` — **DRAFT** dual-licensing documents, each headed with a visible "Status: DRAFT — not legally effective" notice
- `site/examples/theming.md` — tidy a theme description

## Notes

- The licensing documents are **drafts for attorney review**, carry a visible DRAFT banner, and are not binding offers.
- No code changes; test baselines untouched; `ruff check` clean.
- Dependency licenses in `NOTICE` were verified against the installed package metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YYxsHWaXchWqNAWfB17J7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and updated licensing and contributor documents to clarify project licensing, contribution terms, and third-party dependency notices.
  * Added a contributor list and updated project attribution details.
  * Updated theme documentation wording for the Classic theme.
* **Chores**
  * Added identity mapping for contributor records to keep author attribution consistent across commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->