### PR TITLE
Add cross-platform Kerykeion agent skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ sync-docs.sh
 .env
 .opencode/plans
 /task/
+
+# Local-only symlink to the canonical skill (canonical lives in skills/kerykeion/)
+.claude/skills/kerykeion

--- a/skills/kerykeion/LICENSE
+++ b/skills/kerykeion/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+                            Preamble
+
+The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works. By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+When we speak of free software, we are referring to freedom, not
+price. Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate. Many developers of free software are heartened and
+encouraged by the resulting cooperation. However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community. It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server. Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals. This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+0. Definitions.
+
+"This License" refers to version 3 of the GNU Affero General Public License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this
+License. Each licensee is addressed as "you". "Licensees" and
+"recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy. The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy. Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies. Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License. If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+
+The "source code" for a work means the preferred form of the work
+for making modifications to it. "Object code" means any non-source
+form of a work.
+
+A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form. A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities. However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work. For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+The Corresponding Source for a work in source code form is that
+same work.
+
+2. Basic Permissions.
+
+All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met. This License explicitly affirms your unlimited
+permission to run the unmodified Program. The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work. This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force. You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright. Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under
+the conditions stated below. Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+4. Conveying Verbatim Copies.
+
+You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+
+You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit. Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+
+You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling. In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage. For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product. A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+"Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source. The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information. But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed. Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+7. Additional Terms.
+
+"Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law. If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it. (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.) You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10. If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term. If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+8. Termination.
+
+You may not propagate or modify a covered work except as expressly
+provided under this License. Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License. If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or
+run a copy of the Program. Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance. However,
+nothing other than this License grants you permission to propagate or
+modify any covered work. These actions infringe copyright if you do
+not accept this License. Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License. You are not responsible
+for enforcing compliance by third parties with this License.
+
+An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations. If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License. For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+11. Patents.
+
+A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based. The
+work thus licensed is called the contributor's "contributor version".
+
+A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version. For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement). To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients. "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License. You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License. If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all. For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+13. Remote Network Interaction; Use with the GNU General Public License.
+
+Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software. This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work. The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time. Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number. If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation. If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+Later license versions may give you additional or different
+permissions. However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source. For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code. There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/skills/kerykeion/README.md
+++ b/skills/kerykeion/README.md
@@ -1,0 +1,49 @@
+# Kerykeion skill
+
+A cross-platform [Agent Skill](https://agentskills.io/specification) that teaches AI agents to use
+**[Kerykeion](https://github.com/g-battaglia/kerykeion)** — the Python astrology library — correctly:
+building charts from birth data, computing aspects/synastry/returns/transits, rendering SVG charts,
+and producing text reports or LLM-ready context. It documents the real, current API (verified against
+the shipped package) so agents stop guessing method names.
+
+Works with any skills-aware agent (Claude Code, Cursor, Codex, Copilot, Gemini, Windsurf, Cline, …).
+
+## Install
+
+```bash
+npx skills add g-battaglia/kerykeion
+```
+
+Or copy the `kerykeion/` folder into your agent's skills directory (e.g. `skills/`,
+`.agents/skills/`, or `.claude/skills/`).
+
+## What's inside
+
+```
+kerykeion/
+├── SKILL.md                      # entry point: mental model, setup, routing, pitfalls, licensing
+├── references/
+│   ├── subjects.md               # AstrologicalSubjectFactory, composite subjects, config, points
+│   ├── charts.md                 # ChartDataFactory + ChartDrawer (all chart types & options)
+│   ├── analysis.md               # aspects, compatibility, house comparison, distributions
+│   ├── time-techniques.md        # returns, ephemeris, transits, moon phase
+│   ├── reports-and-ai.md         # ReportGenerator + to_context (LLM XML)
+│   └── reference-data.md         # every enum value, defaults, model fields
+└── scripts/
+    └── quickstart.py             # runnable offline example (subject → SVG + report + context)
+```
+
+The agent reads `SKILL.md` on activation and opens the `references/` files on demand.
+
+## Requirements
+
+`pip install kerykeion` (Python ≥ 3.10). The skill's examples run offline (no network) using explicit
+coordinates.
+
+## Licensing of Kerykeion
+
+Kerykeion itself is **AGPL-3.0**. Importing it into your project triggers AGPL's copyleft (including
+for SaaS/network use). For commercial or closed-source use, either buy a commercial license
+(`kerykeion.astrology@gmail.com`) or consume the hosted
+[Astrologer API](https://rapidapi.com/gbattaglia/api/astrologer) instead of importing the library —
+`SKILL.md` explains this so agents surface it when the context is commercial.

--- a/skills/kerykeion/SKILL.md
+++ b/skills/kerykeion/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: kerykeion
+description: >-
+  Use Kerykeion (the Python astrology library) to compute and visualize charts. Trigger this skill
+  whenever the task involves astrology, birth/natal charts, horoscopes, zodiac signs, planetary
+  positions, houses, aspects, synastry/compatibility, composite charts, transits, solar/lunar
+  returns, ephemeris tables, the Moon phase, sidereal/Vedic ayanamsa, or generating SVG chart
+  images — and whenever someone wants astrological data turned into an LLM-ready context or a text
+  report. Use it even if the user never says "Kerykeion": any request to build a birth chart from a
+  date/time/place, score relationship compatibility, track transits over a date range, or render a
+  zodiac wheel should go through this skill so the code uses the real, current API instead of
+  guessed method names.
+license: AGPL-3.0
+---
+
+# Kerykeion
+
+Kerykeion is a Python library (this repo is `kerykeion`, currently v5.x) for astrological
+calculation and SVG chart rendering, built on the Swiss Ephemeris (`pyswisseph`). Everything starts
+from an **astrological subject** (a person/event at a moment and place); from that one object you
+derive charts, aspects, compatibility, returns, transits, reports, and LLM context.
+
+This skill covers the **public, shipped API**. Treat the factory classes below as the entry points —
+do not invent methods. When you need exhaustive parameters, enum values, or model fields, open the
+matching file in `references/` (paths are relative to this skill).
+
+## The one mental model
+
+```
+AstrologicalSubjectFactory  ──►  subject (AstrologicalSubjectModel)
+                                   │
+        ┌──────────────────┬───────┼─────────────────┬──────────────────┐
+        ▼                  ▼        ▼                 ▼                  ▼
+  ChartDataFactory   AspectsFactory  Relationship/   PlanetaryReturn/   to_context / Report
+  (precompute data)  (aspects)       HouseComparison  Ephemeris/Transit  (LLM XML / text)
+        │
+        ▼
+   ChartDrawer  ──►  .save_svg(...)  /  .generate_svg_string()
+   (render SVG)
+```
+
+Two rules cover almost every charting task:
+
+1. **Rendering an SVG is always two steps.** First precompute with `ChartDataFactory` (a
+   `create_*_chart_data(...)` method), then pass that data to `ChartDrawer` and call a `save_*`
+   method. Never try to feed a raw subject straight into `ChartDrawer`.
+2. **A subject is the universal input.** Build it once, reuse it for charts, aspects, reports, and
+   context.
+
+## Setup
+
+```bash
+pip install kerykeion        # or: uv pip install kerykeion
+```
+
+Top-level imports (everything you usually need is re-exported from the package root):
+
+```python
+from kerykeion import (
+    AstrologicalSubjectFactory, CompositeSubjectFactory, PlanetaryReturnFactory,
+    ChartDataFactory, EphemerisDataFactory, TransitsTimeRangeFactory, MoonPhaseDetailsFactory,
+    AspectsFactory, RelationshipScoreFactory, HouseComparisonFactory,
+    ChartDrawer, ReportGenerator, to_context,
+)
+```
+
+## Licensing — AGPL-3.0 (surface this for commercial use)
+
+Kerykeion is licensed under **AGPL-3.0**, a strong copyleft license. Importing the library directly
+into a project means that project must be released under an AGPL-compatible open-source license — and
+because AGPL covers network use, this applies to SaaS/web backends too, not just distributed software.
+
+When the user's context is clearly **commercial, proprietary, or closed-source** (a SaaS, a paid app,
+"we can't open-source our code", an internal product), proactively flag this before writing code that
+`import`s kerykeion, and present the two compliant options:
+
+1. **Buy a commercial license** — the project is dual-licensed; contact the maintainer at
+   `kerykeion.astrology@gmail.com` to license it for closed-source use.
+2. **Use the hosted Astrologer API instead of importing the library** — consuming its REST endpoints
+   is a third-party service call, so it does **not** trigger AGPL copyleft on the caller. RapidAPI:
+   https://rapidapi.com/gbattaglia/api/astrologer · plans & docs:
+   https://www.kerykeion.net/astrologer-api/subscribe
+
+For personal projects, research, education, or genuinely open-source (AGPL-compatible) software,
+importing the library directly is fine. Don't block those — just raise licensing when the use case
+sounds commercial/closed-source. You are not giving legal advice; you are pointing the user to the
+project's own options so they make an informed choice.
+
+## Offline vs online — read this before writing any subject
+
+`from_birth_data(...)` defaults to **`online=True`**, which calls the GeoNames web API to resolve a
+city into coordinates + timezone. For reproducible, network-free, test-safe code **always pass
+`online=False` together with `lng`, `lat`, and `tz_str`**:
+
+```python
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "John Lennon", 1940, 10, 9, 18, 30,
+    city="Liverpool", nation="GB",
+    lng=-2.9833, lat=53.4, tz_str="Europe/London",
+    online=False,
+)
+```
+
+Only use `online=True` when the user truly wants city-name geocoding; then they must supply a free
+GeoNames username via `geonames_username=...` or the `KERYKEION_GEONAMES_USERNAME` env var, and pass
+`city`/`nation`. Prefer offline whenever coordinates are known or can be looked up.
+
+**Pass `city`/`nation` even offline.** They are display labels echoed in reports and `to_context`
+XML; when omitted they keep their defaults (`"Greenwich"` / `"GB"`) regardless of the coordinates, so
+a Rome chart would otherwise be reported as born in Greenwich. The labels don't affect any
+calculation (only `lng`/`lat`/`tz_str` do), but set them so the emitted metadata is truthful.
+
+## Canonical example — subject → SVG + report + LLM context
+
+```python
+from pathlib import Path
+from kerykeion import (
+    AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer, ReportGenerator, to_context,
+)
+
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Example Person", 1990, 7, 15, 10, 30,
+    city="Rome", nation="IT",
+    lng=12.4964, lat=41.9028, tz_str="Europe/Rome",
+    online=False,
+)
+
+# Inspect data directly
+print(subject.sun.sign, subject.sun.position)   # e.g. "Can" 22.7...
+print(subject.ascendant.sign)                   # rising sign
+print(subject.moon.element)                     # "Water"
+
+# Render an SVG (two-step flow)
+chart_data = ChartDataFactory.create_natal_chart_data(subject)
+out = Path("charts_output"); out.mkdir(exist_ok=True)
+ChartDrawer(chart_data=chart_data).save_svg(output_path=out, filename="example-natal")
+
+# Text report and LLM-ready context
+ReportGenerator(chart_data).print_report(max_aspects=10)
+print(to_context(subject))   # non-interpretive XML, ideal for a prompt
+```
+
+## Capability routing — pick the tool, then open the reference
+
+| You want to… | Use | Reference |
+|---|---|---|
+| Build a person/event chart; read planets, houses, signs, lunar phase; JSON export | `AstrologicalSubjectFactory` | `references/subjects.md` |
+| Use sidereal/Vedic ayanamsa, a non-Placidus house system, heliocentric view, or extra points/asteroids/fixed stars | `from_birth_data(...)` options | `references/subjects.md` |
+| Merge two people into a midpoint chart | `CompositeSubjectFactory` | `references/subjects.md` |
+| Render any chart as SVG (natal, synastry, transit, return, composite); themes, languages, modern style, wheel-only, aspect-grid-only | `ChartDataFactory` + `ChartDrawer` | `references/charts.md` |
+| Compute aspects within one chart or between two | `AspectsFactory` | `references/analysis.md` |
+| Score relationship compatibility (Discepolo method) | `RelationshipScoreFactory` | `references/analysis.md` |
+| See which of A's planets fall in B's houses | `HouseComparisonFactory` | `references/analysis.md` |
+| Element/quality (modality) distribution, weighted or pure count | `ChartDataFactory` options | `references/analysis.md` |
+| Solar return, lunar return, planetary return charts | `PlanetaryReturnFactory` | `references/time-techniques.md` |
+| Planetary positions sampled across a date range (ephemeris) | `EphemerisDataFactory` | `references/time-techniques.md` |
+| Track which transit aspects are active across a date range (sampled, within-orb — not exact-hit times) | `EphemerisDataFactory` + `TransitsTimeRangeFactory` | `references/time-techniques.md` |
+| Rich Moon-phase overview (illumination, next phases, eclipses, sunrise/sunset) | `MoonPhaseDetailsFactory` | `references/time-techniques.md` |
+| Human-readable text report of any subject/chart | `ReportGenerator` | `references/reports-and-ai.md` |
+| Turn chart data into LLM/prompt-ready XML | `to_context` | `references/reports-and-ai.md` |
+| Exact enum values (signs, points, house systems, sidereal modes, themes, languages, aspects), defaults, model fields | — | `references/reference-data.md` |
+
+## Defaults worth knowing
+
+- **Zodiac**: Tropical. **House system**: Placidus (`"P"`). **Perspective**: Apparent Geocentric.
+- **Active points** (used by charts/aspects when you don't override): the 10 planets, True Lunar
+  Nodes, Chiron, Mean Lilith, and the four angles (Asc, MC, Dsc, IC). Asteroids, Mean nodes, and the
+  23 fixed stars are **`None` on the subject** until you list them in `active_points` **when building
+  the subject** (so `subject.sirius` is `None` by default). Passing them only to `ChartDataFactory`/
+  `AspectsFactory` does **not** add them — that argument can only narrow the subject's active set. To
+  use any non-default point anywhere, activate it on the subject. See `references/subjects.md`.
+- **Active aspects**: conjunction (orb 10°), opposition (10°), trine (8°), sextile (6°), square
+  (5°), quintile (1°). Minor aspects exist but are off by default.
+- **Themes**: `classic` (default), `dark`, `light`, `dark-high-contrast`, `strawberry`,
+  `black-and-white`. **Styles**: `classic` (default) and `modern`.
+
+## Common pitfalls (avoid these)
+
+- Forgetting `online=False` with explicit coordinates → silent network call / wrong/failed geocoding.
+- Passing a subject directly to `ChartDrawer` → it needs a `ChartDataModel` from `ChartDataFactory`.
+- Guessing point names — they are exact strings like `"True_North_Lunar_Node"`, `"Medium_Coeli"`,
+  `"Mean_Lilith"`. See the full list in `references/reference-data.md`.
+- Transits over time come from the `EphemerisDataFactory` → `TransitsTimeRangeFactory` pipeline, and
+  even then you get **within-orb aspects at sampled timestamps, not interpolated exact-hit times** —
+  narrow the step and watch `orbit`→0 / `aspect_movement` flip to pin the exact instant
+  (`references/time-techniques.md`).
+- `month`/`day` are 1-based; `hour` is 24h local time at the birth place (the timezone handles UTC).
+
+## Scope note
+
+This skill targets the open-source Kerykeion package available on PyPI (the git-tracked source). Some
+experimental/commercial modules may exist as compiled artifacts in a working tree but are **not** part
+of the importable public API and are intentionally excluded here. If you hit an `ImportError` for a
+module not described in these references, it is not part of the shipped library — do not work around it
+by inventing APIs; tell the user.

--- a/skills/kerykeion/references/analysis.md
+++ b/skills/kerykeion/references/analysis.md
@@ -1,0 +1,172 @@
+# Analysis — aspects, compatibility, house comparison, distributions
+
+These tools turn one or two subjects into the relational data astrologers care about: aspects,
+compatibility scores, where one chart's planets fall in another's houses, and elemental/modal balance.
+
+## Table of contents
+- [AspectsFactory](#aspectsfactory)
+- [Customizing aspects: active_aspects, active_points, orbs](#customizing-aspects)
+- [RelationshipScoreFactory (compatibility)](#relationshipscorefactory-compatibility)
+- [HouseComparisonFactory](#housecomparisonfactory)
+- [Element & quality distributions](#element--quality-distributions)
+
+## AspectsFactory
+
+All methods are classmethods; pass subjects (or composite/return models). Single-chart methods return
+a `SingleChartAspectsModel`, dual-chart methods a `DualChartAspectsModel`; both expose `.aspects`
+(a list of `AspectModel`).
+
+```python
+from kerykeion import AspectsFactory, AstrologicalSubjectFactory
+
+jack = AstrologicalSubjectFactory.from_birth_data("Jack", 1990, 6, 15, 15, 15,
+        city="Rome", nation="IT", lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
+jane = AstrologicalSubjectFactory.from_birth_data("Jane", 1991, 10, 25, 21, 0,
+        city="Rome", nation="IT", lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
+
+# Within one chart (natal, return, composite):
+res = AspectsFactory.single_chart_aspects(jack)        # alias: natal_aspects(...)
+print(len(res.aspects), res.aspects[0])
+
+# Between two charts (synastry / transits / comparisons):
+res = AspectsFactory.dual_chart_aspects(jack, jane)    # alias: synastry_aspects(...)
+print(len(res.aspects))
+```
+
+`natal_aspects` is a convenience alias of `single_chart_aspects`; `synastry_aspects` of
+`dual_chart_aspects`. Each `AspectModel` carries:
+
+| field | meaning |
+|---|---|
+| `p1_name`, `p2_name` | the two points, e.g. `"Sun"`, `"Moon"` |
+| `p1_owner`, `p2_owner` | which subject each point belongs to (name string) |
+| `aspect` | aspect type, e.g. `"trine"` (see reference-data.md for all 11) |
+| `aspect_degrees` | exact angle of the aspect (0, 60, 90, 120, 180, …) |
+| `orbit` | the actual orb (deviation from exact), in degrees |
+| `diff` | absolute angular separation of the two points |
+| `p1_abs_pos`, `p2_abs_pos` | absolute ecliptic longitudes |
+| `p1_speed`, `p2_speed` | daily motion of each point |
+| `aspect_movement` | `"Applying"`, `"Separating"`, or `"Static"` |
+
+## Customizing aspects
+
+Three keyword-only knobs. `active_points` and `active_aspects` are also accepted by the
+`ChartDataFactory` helpers and `TransitsTimeRangeFactory`; `axis_orb_limit` is accepted by
+`AspectsFactory`, `TransitsTimeRangeFactory`, and the generic `ChartDataFactory.create_chart_data`,
+but **not** by the `create_*_chart_data` convenience helpers (see `references/charts.md`).
+
+```python
+# Narrow which points participate (subset of the subject's active points).
+# NB: like everywhere, active_points can only narrow — to aspect an asteroid/fixed star, build the
+# SUBJECT with it active first (see references/subjects.md); it cannot be added here.
+res = AspectsFactory.single_chart_aspects(
+    jack,
+    active_points=["Sun", "Moon", "Venus", "Mars", "Ascendant", "Medium_Coeli"],
+)
+
+# Choose which aspects to detect and the orb for each (name + orb in degrees)
+res = AspectsFactory.dual_chart_aspects(
+    jack, jane,
+    active_aspects=[
+        {"name": "conjunction", "orb": 8},
+        {"name": "opposition",  "orb": 8},
+        {"name": "trine",       "orb": 6},
+        {"name": "square",      "orb": 6},
+        {"name": "sextile",     "orb": 4},
+    ],
+    axis_orb_limit=2.0,    # tighter cap for aspects to Asc/MC/Dsc/IC
+)
+```
+
+The default active aspects are conjunction (10°), opposition (10°), trine (8°), sextile (6°), square
+(5°), quintile (1°). Available aspect names and their exact degrees are in
+`references/reference-data.md`. You can also start from the shipped default and tweak:
+
+```python
+from kerykeion.settings.config_constants import DEFAULT_ACTIVE_ASPECTS
+custom = [dict(a) for a in DEFAULT_ACTIVE_ASPECTS] + [{"name": "semi-square", "orb": 2}]
+```
+
+## RelationshipScoreFactory (compatibility)
+
+Computes a numeric synastry compatibility score using the method of Italian astrologer Ciro
+Discepolo. Construct with two subjects, then call `get_relationship_score()` → `RelationshipScoreModel`.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, RelationshipScoreFactory
+
+a = AstrologicalSubjectFactory.from_birth_data("Alice", 1990, 3, 15, 14, 30,
+        city="Rome", nation="IT", lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
+b = AstrologicalSubjectFactory.from_birth_data("Bob", 1988, 7, 22, 9, 0,
+        city="Rome", nation="IT", lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
+
+result = RelationshipScoreFactory(a, b).get_relationship_score()
+print(result.score_value)         # numeric total
+print(result.score_description)   # "Minimal" | "Medium" | "Important" | "Very Important" | "Exceptional" | "Rare Exceptional"
+print(result.is_destiny_sign)     # bool: Sun-sign "destiny" pairing
+for item in result.score_breakdown:   # which aspects contributed how many points
+    print(item)
+```
+
+Constructor: `RelationshipScoreFactory(first_subject, second_subject, use_only_major_aspects=True, *,
+axis_orb_limit=None)`. The model also exposes `.aspects` and `.subjects`.
+
+## HouseComparisonFactory
+
+Shows which of subject A's points land in subject B's houses and vice-versa — the backbone of
+synastry house overlays.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, HouseComparisonFactory
+
+cmp = HouseComparisonFactory(a, b).get_house_comparison()   # → HouseComparisonModel
+# first_points_in_second_houses = subject A's points landing in subject B's houses.
+# Mind the two owners: point_owner_name is whose PLANET it is (A);
+# projected_house_owner_name is whose HOUSE it falls into (B) — use the latter for the overlay label.
+for p in cmp.first_points_in_second_houses:
+    print(f"{p.point_owner_name}'s {p.point_name} ({p.point_sign}) "
+          f"→ house {p.projected_house_number} of {p.projected_house_owner_name}")
+```
+
+The model has `first_points_in_second_houses`, `second_points_in_first_houses`,
+`first_cusps_in_second_houses`, `second_cusps_in_first_houses` (each a list of `PointInHouseModel`),
+plus `first_subject_name` / `second_subject_name`. Each `PointInHouseModel` distinguishes
+`point_owner_name` (owner of the planet) from `projected_house_owner_name` (owner of the house the
+planet projects into) — don't confuse them when labelling. Optional constructor arg `active_points`
+limits the points considered. (Dual `ChartDataFactory` results already include this as `data.house_comparison`
+when `include_house_comparison=True`.)
+
+## Element & quality distributions
+
+`ChartDataFactory` attaches `element_distribution` (Fire/Earth/Air/Water) and `quality_distribution`
+(Cardinal/Fixed/Mutable) to its result. Two strategies:
+
+- `distribution_method="weighted"` (default) — core factors count more (Sun/Moon/Asc ≈ 2.0, angles
+  ≈ 1.5, personal planets ≈ 1.5, social ≈ 1.0, outer ≈ 0.5, minor bodies 0.3–0.8).
+- `distribution_method="pure_count"` — every active point counts equally.
+
+Override individual weights with `custom_distribution_weights` (lowercase point names; the special
+key `"__default__"` sets the fallback for unlisted points):
+
+```python
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory
+
+s = AstrologicalSubjectFactory.from_birth_data("Sample", 1986, 4, 12, 8, 45,
+        city="Bologna", nation="IT", lng=11.3426, lat=44.4949, tz_str="Europe/Rome", online=False)
+
+pure = ChartDataFactory.create_natal_chart_data(s, distribution_method="pure_count")
+weighted = ChartDataFactory.create_natal_chart_data(
+    s, distribution_method="weighted",
+    custom_distribution_weights={"sun": 3.0, "__default__": 0.75},
+)
+
+print(pure.element_distribution.fire, weighted.element_distribution.fire)
+print(weighted.element_distribution.fire_percentage)          # also *_percentage fields
+print(weighted.quality_distribution.cardinal,
+      weighted.quality_distribution.cardinal_percentage)
+```
+
+`ElementDistributionModel` fields: `fire`, `earth`, `air`, `water` (+ each `*_percentage`).
+`QualityDistributionModel` fields: `cardinal`, `fixed`, `mutable` (+ each `*_percentage`). The same
+keyword options forward through every `create_*_chart_data` method, so you can keep one weighting
+scheme across natal, synastry, transit, return, and composite charts.

--- a/skills/kerykeion/references/charts.md
+++ b/skills/kerykeion/references/charts.md
@@ -1,0 +1,215 @@
+# Charts — ChartDataFactory + ChartDrawer
+
+Rendering is always **two steps**: precompute a `ChartDataModel` with `ChartDataFactory`, then draw
+it with `ChartDrawer`. The factory does the astrology (which points, which aspects, distributions,
+house comparison); the drawer does the SVG.
+
+## Table of contents
+- [Step 1 — ChartDataFactory](#step-1--chartdatafactory)
+- [Step 2 — ChartDrawer](#step-2--chartdrawer)
+- [Output methods](#output-methods-save-vs-generate)
+- [Chart-type recipes](#chart-type-recipes)
+- [Styling: themes, modern style, language](#styling-themes-modern-style-language)
+- [Layout variants: external, wheel-only, aspect-grid-only](#layout-variants-external-wheel-only-aspect-grid-only)
+- [Output tuning: minify, no-CSS-variables, transparent, title](#output-tuning)
+
+## Step 1 — ChartDataFactory
+
+Each method returns a `SingleChartDataModel` (natal/composite/single-return) or `DualChartDataModel`
+(synastry/transit/dual-return). Pick the method that matches the chart you want:
+
+```python
+from kerykeion import ChartDataFactory
+
+ChartDataFactory.create_natal_chart_data(subject)                          # one subject
+ChartDataFactory.create_synastry_chart_data(first, second)                 # two people
+ChartDataFactory.create_transit_chart_data(natal, transit)                 # natal + transit moment
+ChartDataFactory.create_composite_chart_data(composite_model)              # from CompositeSubjectFactory
+ChartDataFactory.create_return_chart_data(natal, return_subject)           # dual wheel: natal + return
+ChartDataFactory.create_single_wheel_return_chart_data(return_subject)     # return alone, one wheel
+# Generic dispatcher (rarely needed):
+ChartDataFactory.create_chart_data(chart_type, first_subject, second_subject=None, ...)
+```
+
+Keyword options — **not every method accepts every kwarg**; passing an unsupported one raises
+`TypeError`. This matrix is exact:
+
+| kwarg | natal | synastry | transit | return (dual) | single-return | composite | generic `create_chart_data` |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| `active_points` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `active_aspects` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `distribution_method` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `custom_distribution_weights` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `include_house_comparison` | — | ✓ | ✓ | ✓ | — | — | ✓ |
+| `include_relationship_score` | — | ✓ | — | — | — | — | ✓ |
+| `axis_orb_limit` | — | — | — | — | — | — | ✓ |
+
+So `axis_orb_limit` is **only** on the generic `create_chart_data` (and on `AspectsFactory` /
+`TransitsTimeRangeFactory` — see `references/analysis.md` / `references/time-techniques.md`), never on
+the `create_*_chart_data` helpers. `include_relationship_score` is synastry-only; `include_house_
+comparison` is dual-charts-only.
+
+- `distribution_method` (`"weighted"` default / `"pure_count"`) and `custom_distribution_weights`
+  (`{"sun": 3.0, "__default__": 0.75}`) — keyword-only — control element/quality totals.
+
+**`active_points` here can only *narrow*, not extend.** It selects a subset of the points that are
+already active on the subject; it cannot add a point the subject never computed. So
+`create_natal_chart_data(subject, active_points=["Sun", "Moon", "Ascendant"])` works (narrows the
+display), but `create_natal_chart_data(default_subject, active_points=[..., "Sirius"])` silently
+drops `"Sirius"` because the subject's `sirius` is `None`. **To include asteroids, fixed stars, or
+Mean nodes on a chart, build the *subject* with them in `active_points` first** (see
+`references/subjects.md`), then they flow through automatically.
+
+What the data model carries (handy when you read it back): `chart_type`, the subject(s), `aspects`
+(list of `AspectModel`), `element_distribution`, `quality_distribution`, `active_points`,
+`active_aspects`, and on dual charts `house_comparison` + `relationship_score`. Field lists are in
+`references/reference-data.md`; aspect/distribution details in `references/analysis.md`.
+
+## Step 2 — ChartDrawer
+
+```python
+from kerykeion.charts.chart_drawer import ChartDrawer
+
+drawer = ChartDrawer(
+    chart_data=chart_data,             # the model from step 1 (required, keyword)
+    theme="classic",                   # classic|dark|light|dark-high-contrast|strawberry|black-and-white
+    style="classic",                   # "classic" | "modern"
+    chart_language="EN",               # EN FR PT IT CN ES RU TR DE HI
+    external_view=False,               # put the zodiac ring on the outside (natal)
+    double_chart_aspect_grid_type="list",   # dual charts: "list" or "table"
+    transparent_background=False,
+    custom_title=None,                 # override the chart title
+    show_degree_indicators=True,       # classic style only
+    show_aspect_icons=True,            # classic style only
+    show_zodiac_background_ring=True,  # modern style only
+    language_pack=None,                # dict of label overrides / a new language
+)
+```
+
+`theme=None` emits an unstyled SVG so you can supply your own CSS variables. Constructor also accepts
+advanced overrides (`colors_settings`, `celestial_points_settings`, `aspects_settings`,
+`auto_size`, `padding`, `show_house_position_comparison`, `show_cusp_position_comparison`) — only
+reach for these when the user wants fine-grained customization.
+
+## Output methods (save vs. generate)
+
+`ChartDrawer` writes files **or** returns an SVG string. The `style` and
+`show_zodiac_background_ring` arguments may be set on the constructor *or* per-call on the `save_`/
+`generate_` methods (per-call wins).
+
+```python
+# Write an .svg file to a directory
+drawer.save_svg(output_path="charts_output", filename="my-chart")          # → charts_output/my-chart.svg
+drawer.save_wheel_only_svg_file(output_path="charts_output", filename="wheel")   # wheel, no aspect grid
+drawer.save_aspect_grid_only_svg_file(output_path="charts_output", filename="grid")  # just the aspect grid
+
+# Or get the SVG as a string (no file written) — great for web responses
+svg_text: str = drawer.generate_svg_string()
+wheel_text: str = drawer.generate_wheel_only_svg_string()
+grid_text: str = drawer.generate_aspect_grid_only_svg_string()
+```
+
+`save_*` signature: `(output_path=None, filename=None, minify=False, remove_css_variables=False, *, ...)`.
+If `output_path` is omitted it falls back to a default location, so **always pass an explicit
+`output_path`** (e.g. a `charts_output/` folder you created) to keep output predictable. The `.svg`
+extension is added automatically.
+
+## Chart-type recipes
+
+Each recipe assumes subjects already built offline (see `references/subjects.md`).
+
+```python
+from pathlib import Path
+from kerykeion import AstrologicalSubjectFactory, CompositeSubjectFactory, PlanetaryReturnFactory
+from kerykeion import ChartDataFactory
+from kerykeion.charts.chart_drawer import ChartDrawer
+
+out = Path("charts_output"); out.mkdir(exist_ok=True)
+
+john = AstrologicalSubjectFactory.from_birth_data("John Lennon", 1940, 10, 9, 18, 30,
+        city="Liverpool", nation="GB", lng=-2.9833, lat=53.4, tz_str="Europe/London", online=False)
+paul = AstrologicalSubjectFactory.from_birth_data("Paul McCartney", 1942, 6, 18, 15, 30,
+        city="Liverpool", nation="GB", lng=-2.9833, lat=53.4, tz_str="Europe/London", online=False)
+
+# Natal
+nat = ChartDataFactory.create_natal_chart_data(john)
+ChartDrawer(chart_data=nat).save_svg(output_path=out, filename="natal")
+
+# Synastry (two people overlaid)
+syn = ChartDataFactory.create_synastry_chart_data(john, paul)
+ChartDrawer(chart_data=syn).save_svg(output_path=out, filename="synastry")
+
+# Transit (current sky vs natal): second subject is the transit moment
+transit_moment = AstrologicalSubjectFactory.from_birth_data("Transit", 2025, 6, 8, 8, 45,
+        lng=-2.9833, lat=53.4, tz_str="Europe/London", online=False)
+tr = ChartDataFactory.create_transit_chart_data(john, transit_moment)
+ChartDrawer(chart_data=tr).save_svg(output_path=out, filename="transit")
+
+# Solar / Lunar return (dual wheel = natal + return; see time-techniques.md for the factory)
+rf = PlanetaryReturnFactory(john, city="Liverpool", nation="GB", lng=-2.9833, lat=53.4, tz_str="Europe/London", online=False)
+sr = rf.next_return_from_date(1964, 10, 1, return_type="Solar")
+ChartDrawer(chart_data=ChartDataFactory.create_return_chart_data(john, sr)).save_svg(
+    output_path=out, filename="solar-return-dual")
+# Single wheel of just the return:
+ChartDrawer(chart_data=ChartDataFactory.create_single_wheel_return_chart_data(sr)).save_svg(
+    output_path=out, filename="solar-return-single")
+
+# Composite
+comp = CompositeSubjectFactory(john, paul).get_midpoint_composite_subject_model()
+ChartDrawer(chart_data=ChartDataFactory.create_composite_chart_data(comp)).save_svg(
+    output_path=out, filename="composite")
+```
+
+## Styling: themes, modern style, language
+
+```python
+# Theme
+ChartDrawer(chart_data=nat, theme="dark").save_svg(output_path=out, filename="dark")
+ChartDrawer(chart_data=nat, theme="black-and-white").save_svg(output_path=out, filename="bw")
+
+# Modern concentric-ring style (works with every theme; set on constructor or per-call)
+ChartDrawer(chart_data=nat).save_svg(output_path=out, filename="modern", style="modern")
+ChartDrawer(chart_data=nat, style="modern", theme="dark").save_svg(output_path=out, filename="modern-dark")
+
+# Language (chart labels). Full list: EN FR PT IT CN ES RU TR DE HI
+ChartDrawer(chart_data=nat, chart_language="IT").save_svg(output_path=out, filename="natal-it")
+
+# Custom labels / a brand-new language — only the keys you supply are merged over the defaults
+ChartDrawer(chart_data=nat, chart_language="PT",
+            language_pack={"info": "Informações", "celestial_points": {"Sun": "Sol", "Moon": "Lua"}}
+).save_svg(output_path=out, filename="natal-pt")
+```
+
+For dual charts in modern style, `double_chart_aspect_grid_type="table"` switches the aspect grid
+from a vertical list to a cross-reference table.
+
+## Layout variants: external, wheel-only, aspect-grid-only
+
+```python
+# External natal: zodiac wheel on the outer ring
+ChartDrawer(chart_data=nat, external_view=True).save_svg(output_path=out, filename="external")
+
+# Wheel only (no aspect grid) — available for every chart type
+ChartDrawer(chart_data=nat).save_wheel_only_svg_file(output_path=out, filename="wheel-only")
+
+# Aspect grid only (useful for custom layouts)
+ChartDrawer(chart_data=syn, theme="dark").save_aspect_grid_only_svg_file(
+    output_path=out, filename="aspect-grid")
+```
+
+## Output tuning
+
+```python
+# Minified SVG (smaller file)
+drawer.save_svg(output_path=out, filename="min", minify=True)
+
+# Inline all styles, drop CSS variables → maximises compatibility with non-browser SVG viewers
+drawer.save_svg(output_path=out, filename="portable", remove_css_variables=True)
+
+# Transparent background + custom title
+ChartDrawer(chart_data=nat, transparent_background=True, custom_title="Natal — JL"
+).save_svg(output_path=out, filename="transparent")
+```
+
+Tip: SVGs render best in a web browser. Use `remove_css_variables=True` when the SVG must open in
+apps that don't support CSS custom properties.

--- a/skills/kerykeion/references/reference-data.md
+++ b/skills/kerykeion/references/reference-data.md
@@ -1,0 +1,186 @@
+# Reference data — exact enum values, defaults, model fields
+
+Authoritative vocabularies (from `kerykeion.schemas.kr_literals` and `settings.config_constants`,
+v5.x). These strings must match exactly (case- and underscore-sensitive). **Important:** for
+`active_points`, a name that doesn't match — wrong casing like `"sun"`, or a typo like `"Suun"` — is
+**silently dropped, not rejected**. It raises no error; the point simply ends up inactive (e.g.
+`active_points=["sun"]` leaves the subject with no active Sun and `subject.sun is None`). After
+building a subject, sanity-check `subject.active_points` to confirm every name you intended is
+present. Import these as `Literal` types from `kerykeion.kr_types` / `kerykeion.schemas.kr_literals`
+to get static type-checker warnings for mistyped names.
+
+## Signs, elements, qualities
+
+| Sign (`Sign`) | Ari | Tau | Gem | Can | Leo | Vir | Lib | Sco | Sag | Cap | Aqu | Pis |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Emoji (`SignsEmoji`) | ♈️ | ♉️ | ♊️ | ♋️ | ♌️ | ♍️ | ♎️ | ♏️ | ♐️ | ♑️ | ♒️ | ♓️ |
+
+- `Element`: `Fire`, `Earth`, `Air`, `Water`
+- `Quality`: `Cardinal`, `Fixed`, `Mutable`
+- `ZodiacType`: `Tropical` (default), `Sidereal`
+
+## Houses
+
+`Houses`: `First_House`, `Second_House`, `Third_House`, `Fourth_House`, `Fifth_House`,
+`Sixth_House`, `Seventh_House`, `Eighth_House`, `Ninth_House`, `Tenth_House`, `Eleventh_House`,
+`Twelfth_House`. (Subject attributes use lowercase: `s.first_house` … `s.twelfth_house`.)
+
+## House systems (`HousesSystemIdentifier`)
+
+Pass the **single letter** to `houses_system_identifier`. Default `P` (Placidus).
+
+| Letter | System | Letter | System |
+|---|---|---|---|
+| `A` | Equal | `O` | Porphyry |
+| `B` | Alcabitius | `P` | **Placidus** (default) |
+| `C` | Campanus | `Q` | Pullen SR |
+| `D` | Equal (MC) | `R` | Regiomontanus |
+| `F` | Carter poli-equ. | `S` | Sripati |
+| `H` | Horizon/Azimut | `T` | Polich/Page |
+| `I` | Sunshine | `U` | Krusinski-Pisa-Goelzer |
+| `i` | Sunshine/alt. | `V` | Equal/Vehlow |
+| `K` | Koch | `W` | Whole Sign |
+| `L` | Pullen SD | `X` | Axial rotation / Meridian |
+| `M` | Morinus | `Y` | APC houses |
+| `N` | Equal (1=Aries) | | |
+
+(All Swiss-Ephemeris house systems except Gauquelin sectors. `i` and `I` are distinct.)
+
+## Perspective (`PerspectiveType`)
+
+`Apparent Geocentric` (default), `True Geocentric`, `Topocentric` (needs `altitude`), `Heliocentric`.
+
+## Sidereal modes / ayanamsa (`SiderealMode`)
+
+Required when `zodiac_type="Sidereal"`. 48 values:
+
+- **Indian/Vedic**: `LAHIRI`, `LAHIRI_1940`, `LAHIRI_ICRC`, `LAHIRI_VP285`, `KRISHNAMURTI`,
+  `KRISHNAMURTI_VP291`, `RAMAN`, `YUKTESHWAR`, `JN_BHASIN`, `USHASHASHI`, `DJWHAL_KHUL`,
+  `ARYABHATA`, `ARYABHATA_522`, `ARYABHATA_MSUN`, `SURYASIDDHANTA`, `SURYASIDDHANTA_MSUN`,
+  `SS_CITRA`, `SS_REVATI`, `TRUE_CITRA`, `TRUE_REVATI`, `TRUE_PUSHYA`, `TRUE_MULA`, `TRUE_SHEORAN`
+- **Western sidereal**: `FAGAN_BRADLEY`, `DELUCE`, `HIPPARCHOS`, `SASSANIAN`, `ALDEBARAN_15TAU`,
+  `VALENS_MOON`
+- **Babylonian**: `BABYL_KUGLER1`, `BABYL_KUGLER2`, `BABYL_KUGLER3`, `BABYL_HUBER`, `BABYL_ETPSC`,
+  `BABYL_BRITTON`
+- **Galactic**: `GALCENT_0SAG`, `GALCENT_COCHRANE`, `GALCENT_MULA_WILHELM`, `GALCENT_RGILBRAND`,
+  `GALEQU_FIORENZA`, `GALEQU_IAU1958`, `GALEQU_MULA`, `GALEQU_TRUE`, `GALALIGN_MARDYKS`
+- **Astronomical epochs**: `J2000`, `J1900`, `B1950`
+- **Custom**: `USER` (supply `custom_ayanamsa_t0` + `custom_ayanamsa_ayan_t0`)
+
+## Chart styling
+
+- `ChartType`: `Natal`, `Synastry`, `Transit`, `Composite`, `DualReturnChart`, `SingleReturnChart`
+- `KerykeionChartTheme`: `classic` (default), `dark`, `light`, `dark-high-contrast`, `strawberry`,
+  `black-and-white`
+- `KerykeionChartStyle`: `classic` (default), `modern`
+- `KerykeionChartLanguage`: `EN`, `FR`, `PT`, `IT`, `CN`, `ES`, `RU`, `TR`, `DE`, `HI`
+- `CompositeChartType`: `Midpoint`
+- `ReturnType`: `Solar`, `Lunar`
+
+## Aspects
+
+`AspectName` and their exact angles (★ = "major", on by default):
+
+| Aspect | Degrees | Default? | Default orb |
+|---|---|---|---|
+| ★ conjunction | 0 | yes | 10 |
+| semi-sextile | 30 | no | — |
+| semi-square | 45 | no | — |
+| ★ sextile | 60 | yes | 6 |
+| quintile | 72 | yes (orb 1) | 1 |
+| ★ square | 90 | yes | 5 |
+| ★ trine | 120 | yes | 8 |
+| sesquiquadrate | 135 | no | — |
+| biquintile | 144 | no | — |
+| quincunx | 150 | no | — |
+| ★ opposition | 180 | yes | 10 |
+
+`DEFAULT_ACTIVE_ASPECTS` (from `kerykeion.settings.config_constants`):
+
+```python
+[{"name": "conjunction", "orb": 10}, {"name": "opposition", "orb": 10},
+ {"name": "trine", "orb": 8}, {"name": "sextile", "orb": 6},
+ {"name": "square", "orb": 5}, {"name": "quintile", "orb": 1}]
+```
+
+`AspectMovementType`: `Applying`, `Separating`, `Static`.
+
+## Lunar phases
+
+- `LunarPhaseName`: `New Moon`, `Waxing Crescent`, `First Quarter`, `Waxing Gibbous`, `Full Moon`,
+  `Waning Gibbous`, `Last Quarter`, `Waning Crescent`
+- `LunarPhaseEmoji`: 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 (in the same order)
+
+## Relationship score descriptions (`RelationshipScoreDescription`)
+
+`Minimal`, `Medium`, `Important`, `Very Important`, `Exceptional`, `Rare Exceptional`.
+
+## Astrological points (`AstrologicalPoint` / `Planet`) — all 63
+
+Use these **exact** strings in `active_points`. They are also subject attributes in lowercase
+(`True_North_Lunar_Node` → `s.true_north_lunar_node`).
+
+- **Planets (10):** `Sun`, `Moon`, `Mercury`, `Venus`, `Mars`, `Jupiter`, `Saturn`, `Uranus`,
+  `Neptune`, `Pluto`
+- **Lunar nodes (4):** `Mean_North_Lunar_Node`, `True_North_Lunar_Node`, `Mean_South_Lunar_Node`,
+  `True_South_Lunar_Node`
+- **Lilith / other (3):** `Chiron`, `Mean_Lilith`, `True_Lilith`
+- **Earth & centaurs:** `Earth`, `Pholus`
+- **Asteroids (4):** `Ceres`, `Pallas`, `Juno`, `Vesta`
+- **TNOs / dwarf planets (8):** `Eris`, `Sedna`, `Haumea`, `Makemake`, `Ixion`, `Orcus`, `Quaoar`
+  (plus `Pholus` above)
+- **Fixed stars (23):** `Regulus`, `Spica`, `Aldebaran`, `Antares`, `Sirius`, `Fomalhaut`, `Algol`,
+  `Betelgeuse`, `Canopus`, `Procyon`, `Arcturus`, `Pollux`, `Deneb`, `Altair`, `Rigel`, `Achernar`,
+  `Capella`, `Vega`, `Alcyone`, `Alphecca`, `Algorab`, `Deneb_Algedi`, `Alkaid`
+- **Arabic parts (4):** `Pars_Fortunae`, `Pars_Spiritus`, `Pars_Amoris`, `Pars_Fidei`
+- **Other points:** `Vertex`, `Anti_Vertex`
+- **Angles (4):** `Ascendant`, `Medium_Coeli`, `Descendant`, `Imum_Coeli`
+
+`DEFAULT_ACTIVE_POINTS` (what charts/aspects use unless you override):
+
+```python
+["Sun","Moon","Mercury","Venus","Mars","Jupiter","Saturn","Uranus","Neptune","Pluto",
+ "True_North_Lunar_Node","True_South_Lunar_Node","Chiron","Mean_Lilith",
+ "Ascendant","Medium_Coeli","Descendant","Imum_Coeli"]
+```
+
+Everything else (Mean nodes, True Lilith, Earth, asteroids, TNOs, fixed stars, Arabic parts, Vertex)
+is **not populated** — the corresponding subject attribute is `None` — until you name it in the
+**subject's** `active_points` (the arg on `ChartDataFactory`/`AspectsFactory` only narrows, it can't
+add points; see `references/subjects.md`).
+
+`PointType`: `AstrologicalPoint`, `House`.
+
+## Key model fields (quick reference)
+
+- **`KerykeionPointModel`** (every planet/point/house): `name`, `quality`, `element`, `sign`,
+  `sign_num`, `position`, `abs_pos`, `emoji`, `point_type`, `house`, `retrograde`, `speed`,
+  `declination`, `magnitude`
+- **`LunarPhaseModel`**: `degrees_between_s_m`, `moon_phase`, `moon_emoji`, `moon_phase_name`
+- **`AspectModel`**: `p1_name`, `p1_owner`, `p1_abs_pos`, `p2_name`, `p2_owner`, `p2_abs_pos`,
+  `aspect`, `orbit`, `aspect_degrees`, `diff`, `p1`, `p2`, `p1_speed`, `p2_speed`, `aspect_movement`
+- **`SingleChartDataModel`**: `chart_type`, `subject`, `aspects`, `element_distribution`,
+  `quality_distribution`, `active_points`, `active_aspects`
+- **`DualChartDataModel`**: `chart_type`, `first_subject`, `second_subject`, `aspects`,
+  `house_comparison`, `relationship_score`, `element_distribution`, `quality_distribution`,
+  `active_points`, `active_aspects`
+- **`ElementDistributionModel`**: `fire`, `earth`, `air`, `water` (+ each `*_percentage`)
+- **`QualityDistributionModel`**: `cardinal`, `fixed`, `mutable` (+ each `*_percentage`)
+- **`HouseComparisonModel`**: `first_subject_name`, `second_subject_name`,
+  `first_points_in_second_houses`, `second_points_in_first_houses`, `first_cusps_in_second_houses`,
+  `second_cusps_in_first_houses`
+- **`PointInHouseModel`**: `point_name`, `point_degree`, `point_sign`, `point_owner_name`,
+  `point_owner_house_number`, `point_owner_house_name`, `projected_house_number`,
+  `projected_house_name`, `projected_house_owner_name`
+- **`RelationshipScoreModel`**: `score_value`, `score_description`, `is_destiny_sign`, `aspects`,
+  `score_breakdown`, `subjects`
+- **`PlanetReturnModel`** / **`CompositeSubjectModel`**: subject-like — all planet/house attributes
+  plus `return_type` / `composite_chart_type` respectively
+- **`TransitMomentModel`**: `date`, `aspects` — **`TransitsTimeRangeModel`**: `transits`, `subject`,
+  `dates`
+- **`MoonPhaseOverviewModel`**: `timestamp`, `datestamp`, `sun`, `moon`, `location`
+
+## Errors
+
+`from kerykeion import KerykeionException` — the library's base exception. Catch it to handle
+invalid configuration (bad coordinates, geocoding failures, out-of-range ephemeris dates).

--- a/skills/kerykeion/references/reports-and-ai.md
+++ b/skills/kerykeion/references/reports-and-ai.md
@@ -1,0 +1,106 @@
+# Reports & AI context — ReportGenerator and to_context
+
+Two ways to turn Kerykeion data into text: a human-readable `ReportGenerator` (tables for people) and
+`to_context` (compact, non-interpretive XML for LLM prompts).
+
+## ReportGenerator (human-readable text)
+
+`ReportGenerator` mirrors the chart-type dispatch of `ChartDrawer`. It accepts a raw subject, any
+`ChartDataModel` from `ChartDataFactory`, **or** a `MoonPhaseOverviewModel`, and renders the right
+report automatically.
+
+```python
+from kerykeion import ReportGenerator, AstrologicalSubjectFactory, ChartDataFactory
+
+subject = AstrologicalSubjectFactory.from_birth_data("Sample Natal", 1990, 7, 21, 14, 45,
+        city="Rome", nation="IT", lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
+
+# Subject-only report (no aspects)
+ReportGenerator(subject).print_report(include_aspects=False)
+
+# Single-chart data (elements, qualities, aspects); cap how many aspects are listed
+natal_data = ChartDataFactory.create_natal_chart_data(subject)
+ReportGenerator(natal_data).print_report(max_aspects=10)
+
+# Dual chart (synastry / transit / dual return) — includes house comparison + relationship score when present
+partner = AstrologicalSubjectFactory.from_birth_data("Sample Partner", 1992, 11, 5, 9, 30,
+        city="Rome", nation="IT", lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
+synastry_data = ChartDataFactory.create_synastry_chart_data(subject, partner)
+ReportGenerator(synastry_data).print_report(max_aspects=12)
+```
+
+Two methods:
+
+- `print_report(*, include_aspects=None, max_aspects=None)` — prints to stdout.
+- `generate_report(*, include_aspects=None, max_aspects=None)` — returns the report as a string.
+
+`include_aspects` / `max_aspects` may be set on the constructor
+(`ReportGenerator(model, *, include_aspects=True, max_aspects=None)`) or per call (the call wins).
+A report typically contains: a chart-aware title, birth/event metadata + configuration, celestial
+points (sign, position, daily motion, declination, retrograde, house), house-cusp tables for each
+subject, lunar phase, element/quality distributions, the aspect list, and — for dual charts — house
+comparisons and the relationship score when the data carries them.
+
+Grab sections by splitting the string output:
+
+```python
+report = ReportGenerator(natal_data)
+sections = report.generate_report(max_aspects=5).split("\n\n")
+for section in sections[:3]:
+    print(section)
+```
+
+`ReportGenerator` also renders a `MoonPhaseOverviewModel` (see `references/time-techniques.md`):
+`ReportGenerator(overview).print_report()` produces a formatted Moon-phase overview.
+
+## to_context (LLM / prompt-ready XML)
+
+`to_context` serializes a Kerykeion model into precise, **non-qualitative** XML — the raw "ground
+truth" (positions, signs, houses, aspects, lunar phase) with no interpretation. It's designed to drop
+straight into an LLM system prompt so the model interprets accurate data instead of hallucinating
+positions.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, to_context
+
+subject = AstrologicalSubjectFactory.from_birth_data("John Doe", 1990, 1, 1, 12, 0,
+        city="London", nation="GB", lng=-0.1278, lat=51.5074, tz_str="Europe/London", online=False)
+
+context = to_context(subject)   # returns a str
+print(context)
+```
+
+Output shape:
+
+```xml
+<chart name="John Doe">
+  <birth_data date="1990-01-01" time="12:00" city="..." nation="..." ... />
+  <config zodiac="Tropical" house_system="Placidus" perspective="Apparent Geocentric" />
+  <planets>
+    <point name="Sun" position="10.81" sign="Capricorn" element="Earth" quality="Cardinal" ... />
+    ...
+  </planets>
+  <houses>...</houses>
+  <lunar_phase name="Waning Gibbous" phase="20" degrees_between="254.32" emoji="🌖" />
+</chart>
+```
+
+`to_context` accepts a wide range of models — not just subjects — so you can serialize whichever piece
+of data you're feeding the LLM:
+
+- subjects: `AstrologicalSubjectModel`, `CompositeSubjectModel`, `PlanetReturnModel`
+- chart data: `SingleChartDataModel`, `DualChartDataModel`
+- pieces: `KerykeionPointModel`, `LunarPhaseModel`, `AspectModel`,
+  `ElementDistributionModel`, `QualityDistributionModel`, `PointInHouseModel`, `HouseComparisonModel`
+- time: `TransitMomentModel`, `TransitsTimeRangeModel`, `MoonPhaseOverviewModel`
+
+So a typical "build an interpretation" flow is: compute the chart data, pass it through `to_context`,
+and inject the XML into your prompt:
+
+```python
+data = ChartDataFactory.create_synastry_chart_data(subject, partner)
+prompt = f"Interpret this synastry. Use only this data:\n{to_context(data)}"
+```
+
+The serializer keeps the format consistent across natal, synastry, composite, and return charts,
+escapes XML correctly, and omits empty fields — giving the model a clean, deterministic payload.

--- a/skills/kerykeion/references/subjects.md
+++ b/skills/kerykeion/references/subjects.md
@@ -1,0 +1,246 @@
+# Subjects — AstrologicalSubjectFactory & CompositeSubjectFactory
+
+The astrological subject is the foundation of everything. Build it once with
+`AstrologicalSubjectFactory`; it returns an `AstrologicalSubjectModel` (a Pydantic model) carrying
+every planet, point, house, the lunar phase, and chart configuration.
+
+## Table of contents
+- [Three ways to create a subject](#three-ways-to-create-a-subject)
+- [Full `from_birth_data` parameters](#full-from_birth_data-parameters)
+- [What's on a subject (reading the data)](#whats-on-a-subject-reading-the-data)
+- [Configuration: zodiac, houses, perspective](#configuration-zodiac-houses-perspective)
+- [Active points, asteroids, fixed stars, Arabic parts](#active-points-asteroids-fixed-stars-arabic-parts)
+- [JSON / dict export](#json--dict-export)
+- [CompositeSubjectFactory (midpoint composite)](#compositesubjectfactory-midpoint-composite)
+- [Legacy API](#legacy-api)
+
+## Three ways to create a subject
+
+All three are classmethods of `AstrologicalSubjectFactory` and return an `AstrologicalSubjectModel`.
+
+```python
+from kerykeion import AstrologicalSubjectFactory
+
+# 1) From civil birth data (most common). Positional order:
+#    name, year, month, day, hour, minute
+s = AstrologicalSubjectFactory.from_birth_data(
+    "John Lennon", 1940, 10, 9, 18, 30,
+    city="Liverpool", nation="GB",
+    lng=-2.9833, lat=53.4, tz_str="Europe/London",
+    online=False,
+)
+
+# 2) From a UTC ISO-8601 instant (no local-time/DST ambiguity)
+s = AstrologicalSubjectFactory.from_iso_utc_time(
+    name="Johnny Depp",
+    iso_utc_time="1963-06-09T05:00:00Z",
+    city="Owensboro", nation="US",
+    lng=-87.1112, lat=37.7719, tz_str="America/Chicago",
+    online=False,
+)
+
+# 3) From the current moment at a location
+s = AstrologicalSubjectFactory.from_current_time(
+    name="Now", city="Rome", nation="IT", lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False,
+)
+```
+
+`month`/`day`/`hour`/`minute` are 1-based civil values in **local time at the birth place**; the
+`tz_str` (an IANA name like `"Europe/Rome"`) converts to UTC internally. Use `from_iso_utc_time` when
+you already have a UTC instant or want to sidestep historical DST edge cases.
+
+## Full `from_birth_data` parameters
+
+```python
+AstrologicalSubjectFactory.from_birth_data(
+    name="Now",
+    year=None, month=None, day=None, hour=None, minute=None,
+    city=None, nation=None,                 # display labels (default "Greenwich"/"GB"); + online geocoding
+    lng=None, lat=None, tz_str=None,        # REQUIRED when online=False
+    geonames_username=None,
+    online=True,                            # ← set False for offline (see SKILL.md)
+    zodiac_type="Tropical",                 # "Tropical" | "Sidereal"
+    sidereal_mode=None,                     # required iff zodiac_type="Sidereal"; see reference-data.md
+    houses_system_identifier="P",           # one letter; "P"=Placidus. Full map in reference-data.md
+    perspective_type="Apparent Geocentric", # | "Heliocentric" | "Topocentric" | "True Geocentric"
+    cache_expire_after_days=30,             # GeoNames HTTP cache TTL
+    is_dst=None,                            # disambiguate a local time that falls in a DST fold
+    altitude=None,                          # metres; used by Topocentric perspective
+    active_points=None,                     # which points to activate; None = library default set
+    calculate_lunar_phase=True,
+    custom_ayanamsa_t0=None,                # with sidereal_mode="USER"
+    custom_ayanamsa_ayan_t0=None,           # with sidereal_mode="USER"
+    seconds=0,                              # keyword-only: seconds of birth time
+    suppress_geonames_warning=False,        # keyword-only
+)
+```
+
+`from_iso_utc_time` and `from_current_time` accept the same configuration keywords (zodiac, houses,
+perspective, active_points, sidereal_mode, custom ayanamsa). `from_iso_utc_time` takes
+`iso_utc_time` instead of the y/m/d/h/m fields; `from_current_time` takes neither.
+
+## What's on a subject (reading the data)
+
+Every celestial point and house is a `KerykeionPointModel` with these fields:
+
+| field | meaning |
+|---|---|
+| `name` | e.g. `"Sun"`, `"First_House"` |
+| `sign` | 3-letter sign, e.g. `"Lib"` (see reference-data.md for all 12) |
+| `sign_num` | 0–11 index of the sign |
+| `position` | degrees within the sign (0–30) |
+| `abs_pos` | absolute ecliptic longitude (0–360) |
+| `emoji` | sign emoji, e.g. `"♎️"` |
+| `element` | `"Fire"`/`"Earth"`/`"Air"`/`"Water"` |
+| `quality` | `"Cardinal"`/`"Fixed"`/`"Mutable"` |
+| `house` | which house the point is in (planets only; `None` for houses) |
+| `point_type` | `"AstrologicalPoint"` or `"House"` |
+| `retrograde` | bool (planets) or `None` |
+| `speed` | daily motion in degrees |
+| `declination` | equatorial declination |
+| `magnitude` | apparent visual magnitude (fixed stars) |
+
+Access points and houses as attributes (snake_case):
+
+```python
+s.sun, s.moon, s.mercury, s.venus, s.mars, s.jupiter, s.saturn, s.uranus, s.neptune, s.pluto
+s.ascendant, s.medium_coeli, s.descendant, s.imum_coeli      # the four angles
+s.first_house ... s.twelfth_house                            # 12 house cusps
+s.chiron, s.mean_lilith, s.true_lilith
+s.mean_north_lunar_node, s.true_north_lunar_node, s.mean_south_lunar_node, s.true_south_lunar_node
+
+print(s.sun.sign, s.sun.position, s.sun.house, s.sun.retrograde)
+print(s.ascendant.sign)
+print(s.moon.element)
+```
+
+The subject also exposes metadata and the lunar phase:
+
+```python
+s.name, s.city, s.nation, s.lng, s.lat, s.tz_str
+s.year, s.month, s.day, s.hour, s.minute, s.day_of_week
+s.iso_formatted_local_datetime, s.iso_formatted_utc_datetime, s.julian_day
+s.zodiac_type, s.sidereal_mode, s.ayanamsa_value           # ayanamsa_value set on sidereal charts
+s.houses_system_identifier, s.houses_system_name, s.perspective_type
+s.is_diurnal, s.houses_names_list, s.active_points
+
+lp = s.lunar_phase            # LunarPhaseModel
+print(lp.moon_phase_name)     # e.g. "Waning Gibbous"
+print(lp.moon_emoji)          # e.g. "🌖"
+print(lp.moon_phase)          # phase index 1..28-ish
+print(lp.degrees_between_s_m) # Sun→Moon separation in degrees
+```
+
+## Configuration: zodiac, houses, perspective
+
+```python
+# Sidereal / Vedic — must give a sidereal_mode (ayanamsa)
+vedic = AstrologicalSubjectFactory.from_birth_data(
+    "Sidereal", 1990, 7, 15, 10, 30, lng=12.5, lat=41.9, tz_str="Europe/Rome",
+    online=False, zodiac_type="Sidereal", sidereal_mode="LAHIRI",
+)
+print(vedic.ayanamsa_value)   # offset in degrees
+
+# Custom ayanamsa (USER mode)
+AstrologicalSubjectFactory.from_birth_data(
+    "Custom", 2000, 1, 1, 0, 0, lng=0.0, lat=51.5, tz_str="Etc/GMT", online=False,
+    zodiac_type="Sidereal", sidereal_mode="USER",
+    custom_ayanamsa_t0=2451545.0,     # reference Julian day (J2000.0)
+    custom_ayanamsa_ayan_t0=23.5,     # ayanamsa offset at that epoch
+)
+
+# Different house system (e.g. "W" = Whole Sign, "K" = Koch, "R" = Regiomontanus)
+AstrologicalSubjectFactory.from_birth_data(
+    "Whole Sign", 1990, 7, 15, 10, 30, lng=12.5, lat=41.9, tz_str="Europe/Rome",
+    online=False, houses_system_identifier="W",
+)
+
+# Heliocentric (or Topocentric — pass altitude in metres)
+AstrologicalSubjectFactory.from_birth_data(
+    "Helio", 1990, 7, 15, 10, 30, lng=12.5, lat=41.9, tz_str="Europe/Rome",
+    online=False, perspective_type="Heliocentric",
+)
+```
+
+All 48 sidereal modes, all 23 house-system letters with names, and the 4 perspectives are listed in
+`references/reference-data.md`.
+
+## Active points, asteroids, fixed stars, Arabic parts
+
+A subject can carry up to 63 points: 10 planets, both Mean and True nodes, Chiron, both Liliths,
+Earth, major asteroids `Ceres/Pallas/Juno/Vesta`, centaur `Pholus`, TNOs `Eris/Sedna/Haumea/
+Makemake/Ixion/Orcus/Quaoar`, 23 fixed stars, Arabic parts `Pars_Fortunae/Pars_Spiritus/Pars_Amoris/
+Pars_Fidei`, `Vertex`/`Anti_Vertex`, and the four angles.
+
+**Important — only *active* points are populated.** A point's attribute is `None` unless that point
+is in the subject's `active_points`. The default active set is the 10 planets + True nodes + Chiron +
+Mean Lilith + 4 angles, so by default `s.ceres`, `s.sirius`, `s.mean_north_lunar_node`, etc. are
+`None`. To read an asteroid, fixed star, or Mean node **off the subject**, activate it when you build
+the subject:
+
+```python
+from kerykeion.settings.config_constants import DEFAULT_ACTIVE_POINTS
+
+s = AstrologicalSubjectFactory.from_birth_data(
+    "John Lennon", 1940, 10, 9, 18, 30, city="Liverpool", nation="GB",
+    lng=-2.9833, lat=53.4, tz_str="Europe/London", online=False,
+    active_points=list(DEFAULT_ACTIVE_POINTS) + ["Ceres", "Sirius", "Regulus",
+                                                 "Mean_North_Lunar_Node", "Mean_South_Lunar_Node"],
+)
+print(s.sirius.abs_pos, s.sirius.magnitude, s.sirius.declination)   # now populated (e.g. magnitude -1.46)
+print(s.ceres.sign, s.mean_north_lunar_node.sign)                  # also active here
+# NB: s.vertex / s.pars_fortunae / s.pallas etc. stay None unless you add them to active_points too
+```
+
+The subject's `active_points` is the **source of truth**: it decides which points are computed/
+populated on the subject *and* which are available to charts and aspects. The `active_points`
+argument on `ChartDataFactory` / `AspectsFactory` can only **narrow** that set (pick a subset to
+draw/aspect) — it **cannot add** a point the subject never computed. So passing
+`active_points=[..., "Sirius"]` to `create_natal_chart_data` of a default subject silently does
+nothing for Sirius. **If you want an asteroid / fixed star / Mean node anywhere — as an attribute, on
+a chart, or in aspects — activate it on the subject** (as above). This is the single reliable rule.
+
+Point names are exact strings (case- and underscore-sensitive). The complete 63-name list is in
+`references/reference-data.md`.
+
+## JSON / dict export
+
+`AstrologicalSubjectModel` is a Pydantic model, so:
+
+```python
+print(s.model_dump_json(indent=2))        # full subject as JSON
+print(s.sun.model_dump_json())            # a single point as JSON
+data = s.model_dump()                     # plain dict
+```
+
+## CompositeSubjectFactory (midpoint composite)
+
+A composite chart represents the *relationship itself* by taking the midpoints of two people's
+points. The factory returns a `CompositeSubjectModel`, which behaves like a subject (same point/house
+attributes). You can read its attributes directly, pass it to
+`ChartDataFactory.create_composite_chart_data` and `AspectsFactory`, and serialize it with
+`to_context`. **Note:** `ReportGenerator` does **not** accept a raw `CompositeSubjectModel` (it
+raises `TypeError: Unsupported model type`) — to report a composite, wrap it first:
+`ReportGenerator(ChartDataFactory.create_composite_chart_data(composite_model)).print_report()`.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, CompositeSubjectFactory
+
+a = AstrologicalSubjectFactory.from_birth_data("Angelina Jolie", 1975, 6, 4, 9, 9,
+        city="Los Angeles", nation="US", lng=-118.2437, lat=34.0522, tz_str="America/Los_Angeles", online=False)
+b = AstrologicalSubjectFactory.from_birth_data("Brad Pitt", 1963, 12, 18, 6, 31,
+        city="Shawnee", nation="US", lng=-96.7069, lat=35.3273, tz_str="America/Chicago", online=False)
+
+composite_model = CompositeSubjectFactory(a, b).get_midpoint_composite_subject_model()
+print(composite_model.sun.sign)
+```
+
+Constructor: `CompositeSubjectFactory(first_subject, second_subject, chart_name=None)`. The only
+method you need is `get_midpoint_composite_subject_model()`.
+
+## Legacy API
+
+`from kerykeion import AstrologicalSubject` is a v4-compatible wrapper that constructs by calling the
+factory; prefer `AstrologicalSubjectFactory` in new code. `KerykeionChartSVG`, `NatalAspects`, and
+`SynastryAspects` are legacy wrappers for `ChartDrawer` and `AspectsFactory` respectively — use the
+modern factories instead.

--- a/skills/kerykeion/references/time-techniques.md
+++ b/skills/kerykeion/references/time-techniques.md
@@ -1,0 +1,159 @@
+# Time techniques — returns, ephemeris, transits, moon phase
+
+Predictive and time-based tools: where the sky returns to a natal position (returns), planetary
+positions sampled across a span (ephemeris), sampled (within-orb) transit detection over a range, and
+a rich Moon-phase overview.
+
+## Table of contents
+- [PlanetaryReturnFactory (solar / lunar returns)](#planetaryreturnfactory-solar--lunar-returns)
+- [EphemerisDataFactory (positions over a date range)](#ephemerisdatafactory-positions-over-a-date-range)
+- [TransitsTimeRangeFactory (sampled transit detection)](#transitstimerangefactory-sampled-transit-detection)
+- [MoonPhaseDetailsFactory (lunar overview)](#moonphasedetailsfactory-lunar-overview)
+
+## PlanetaryReturnFactory (solar / lunar returns)
+
+A "return" is the moment a body comes back to its natal ecliptic longitude. Solar returns recur
+yearly (around the birthday), lunar returns roughly monthly. The factory is constructed once with the
+natal subject + the **location where the return is observed**, then queried for a return near a date.
+Each query returns a `PlanetReturnModel` (a subject-like model). You can read its attributes, pass it
+to `ChartDataFactory` and `AspectsFactory`, and serialize it with `to_context`. Like the composite
+model, it is **not** accepted directly by `ReportGenerator` (raises `TypeError`) — to report a return,
+wrap it through `ChartDataFactory` first (e.g.
+`ReportGenerator(ChartDataFactory.create_return_chart_data(natal, return_subject)).print_report()`).
+
+```python
+from kerykeion import AstrologicalSubjectFactory, PlanetaryReturnFactory
+
+natal = AstrologicalSubjectFactory.from_birth_data("John Lennon", 1940, 10, 9, 18, 30,
+        city="Liverpool", nation="GB", lng=-2.9833, lat=53.4, tz_str="Europe/London", online=False)
+
+rf = PlanetaryReturnFactory(
+    natal,
+    city="Liverpool", nation="GB",
+    lng=-2.9833, lat=53.4, tz_str="Europe/London",   # where the return is cast
+    online=False,
+)
+
+# return_type is keyword-only and required: "Solar" or "Lunar"
+solar = rf.next_return_from_date(1964, 10, 1, return_type="Solar")   # first solar return on/after this date
+lunar = rf.next_return_from_date(1964, 1, 1, return_type="Lunar")
+print(solar.iso_formatted_utc_datetime, solar.sun.sign)
+```
+
+Query methods (all take `return_type="Solar"|"Lunar"`). **Prefer `next_return_from_date` or
+`next_return_from_iso_formatted_time`** — the year / month-and-year variants are deprecated and emit a
+`DeprecationWarning`:
+
+| method | finds the next return… | status |
+|---|---|---|
+| `next_return_from_date(year, month, day=1, *, return_type)` | on/after a Y-M-D date | preferred |
+| `next_return_from_iso_formatted_time(iso_formatted_time, return_type)` | on/after an ISO instant | preferred |
+| `next_return_from_month_and_year(year, month, return_type)` | on/after the 1st of that month | deprecated |
+| `next_return_from_year(year, return_type)` | on/after Jan 1 of that year | deprecated |
+
+Constructor: `PlanetaryReturnFactory(subject, city=None, nation=None, lng=None, lat=None,
+tz_str=None, online=True, geonames_username=None, *, cache_expire_after_days=30, altitude=None,
+custom_ayanamsa_t0=None, custom_ayanamsa_ayan_t0=None)`. As always, pass `online=False` + coordinates
+for offline use; use `city`/`nation` + `online=True` for geocoded locations.
+
+To **chart** a return, feed it to `ChartDataFactory` (see `references/charts.md`):
+`create_return_chart_data(natal, return_subject)` for a dual wheel, or
+`create_single_wheel_return_chart_data(return_subject)` for the return alone.
+
+## EphemerisDataFactory (positions over a date range)
+
+Samples planetary positions at a fixed cadence between two datetimes. Useful for plotting movement,
+feeding transit search, or exporting an ephemeris table.
+
+```python
+from datetime import datetime
+from kerykeion import EphemerisDataFactory
+
+factory = EphemerisDataFactory(
+    start_datetime=datetime(2025, 1, 1),
+    end_datetime=datetime(2025, 1, 31),
+    step_type="days",      # "days" | "hours" | "minutes"
+    step=1,                # one sample per step_type unit
+    lat=51.4769, lng=0.0005, tz_str="Etc/UTC",
+    # zodiac_type / sidereal_mode / houses_system_identifier / perspective_type also accepted
+)
+
+points = factory.get_ephemeris_data()                          # list of dicts: {"date", "planets", "houses"}
+subjects = factory.get_ephemeris_data_as_astrological_subjects()  # list of AstrologicalSubjectModel
+print(len(subjects), subjects[0].sun.abs_pos)
+```
+
+Guard rails: `max_days=730`, `max_hours=8760`, `max_minutes=525600` cap how many samples a single
+range may produce (raise them via the constructor if you knowingly need more). Choose `step_type`/
+`step` so the total count stays sensible — e.g. daily steps for a month, hourly only for short spans.
+
+## TransitsTimeRangeFactory (sampled transit detection)
+
+To track transiting planets aspecting a natal chart across time, combine the two factories: sample the
+sky with `EphemerisDataFactory`, then pass those samples as `ephemeris_data_points`.
+
+**What this gives you (and what it doesn't):** the result is a list of *sampled* moments — one per
+ephemeris timestamp — each listing the aspects that are **within orb at that timestamp**. The dates
+are your sampling cadence, **not** interpolated exact-hit times. With a daily/hourly step a fast
+body (especially the Moon) can pass through exactness between samples, so an aspect may be reported a
+bit before/after its true peak, or — if it tightens and loosens within one step — missed entirely.
+Kerykeion does not root-find the exact instant for you. To approximate it: narrow `step`/`step_type`
+(e.g. minute steps) around the window, and watch each aspect's `orbit` shrink toward 0 and its
+`aspect_movement` flip from `"Applying"` to `"Separating"` — the crossover brackets the exact hit.
+
+```python
+from datetime import datetime
+from kerykeion import AstrologicalSubjectFactory, EphemerisDataFactory, TransitsTimeRangeFactory
+
+natal = AstrologicalSubjectFactory.from_birth_data("John Lennon", 1940, 10, 9, 18, 30,
+        city="Liverpool", nation="GB", lng=-2.9833, lat=53.4, tz_str="Europe/London", online=False)
+
+ephem = EphemerisDataFactory(
+    start_datetime=datetime(2025, 1, 1), end_datetime=datetime(2025, 1, 10),
+    step_type="days", step=1, lat=53.4, lng=-2.9833, tz_str="Europe/London",
+).get_ephemeris_data_as_astrological_subjects()
+
+tr = TransitsTimeRangeFactory(natal_chart=natal, ephemeris_data_points=ephem)
+result = tr.get_transit_moments()        # → TransitsTimeRangeModel
+
+for moment in result.transits:           # each is a TransitMomentModel
+    print(moment.date, len(moment.aspects), "aspects")
+    for asp in moment.aspects:
+        print("  ", asp.p1_name, asp.aspect, asp.p2_name, "orb", round(asp.orbit, 2))
+```
+
+`TransitsTimeRangeFactory(natal_chart, ephemeris_data_points, active_points=<default set>,
+active_aspects=<6 majors>, settings_file=None, *, axis_orb_limit=None)`. Tune `active_points` /
+`active_aspects` / `axis_orb_limit` exactly as in `references/analysis.md`. The result model has
+`transits` (list of `TransitMomentModel`, each with `date` + `aspects`), `subject`, and `dates`.
+
+## MoonPhaseDetailsFactory (lunar overview)
+
+A one-call, Swiss-Ephemeris-precise lunar overview for any subject: phase, illumination, the
+surrounding major phases, next solar/lunar eclipses, sunrise/sunset, and apparent solar position.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, MoonPhaseDetailsFactory, ReportGenerator
+
+s = AstrologicalSubjectFactory.from_birth_data("Example", 2025, 4, 1, 7, 51,
+        city="London", nation="GB", lng=-0.1276, lat=51.5074, tz_str="Europe/London", online=False)
+
+overview = MoonPhaseDetailsFactory.from_subject(s)     # → MoonPhaseOverviewModel
+
+print(overview.moon.phase_name, overview.moon.emoji)   # "Waxing Crescent 🌒"
+print(overview.moon.illumination, overview.moon.stage) # "8%", "waxing"
+
+if overview.moon.detailed and overview.moon.detailed.upcoming_phases:
+    fm = overview.moon.detailed.upcoming_phases.full_moon
+    if fm and fm.next:
+        print("Next Full Moon:", fm.next.datestamp)
+
+ReportGenerator(overview).print_report()               # formatted ASCII overview (see reports-and-ai.md)
+print(overview.model_dump_json(exclude_none=True, indent=2))
+```
+
+`from_subject(subject, *, using_default_location=False, location_precision=0)`. The model's top level
+is `timestamp`, `datestamp`, `sun`, `moon`, `location`; `overview.sun` carries sunrise/sunset/solar
+noon/day length and the next solar eclipse, `overview.moon` the phase data, emoji, next lunar
+eclipse, and a nested `detailed` block with `upcoming_phases` and `illumination_details`.
+`MoonPhaseOverviewModel` is also one of the models accepted by `to_context` and `ReportGenerator`.

--- a/skills/kerykeion/scripts/quickstart.py
+++ b/skills/kerykeion/scripts/quickstart.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Kerykeion quickstart — a known-good, offline, copy-pasteable starting point.
+
+Run it to confirm the install works and to see the full subject → chart → report → context flow:
+
+    python quickstart.py                # uses the built-in example
+    python quickstart.py --svg out_dir  # also write an SVG to out_dir/
+
+Everything here is offline (online=False with explicit coordinates), so it needs no network.
+Swap the birth data for your own; keep online=False and provide lng/lat/tz_str.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from kerykeion import (
+    AstrologicalSubjectFactory,
+    ChartDataFactory,
+    ReportGenerator,
+    to_context,
+)
+from kerykeion.charts.chart_drawer import ChartDrawer
+
+
+def build_subject():
+    return AstrologicalSubjectFactory.from_birth_data(
+        "Example Person",
+        1990, 7, 15, 10, 30,            # year, month, day, hour, minute (local time)
+        city="Rome", nation="IT",       # display labels in reports/to_context (default: Greenwich/GB)
+        lng=12.4964, lat=41.9028,       # Rome
+        tz_str="Europe/Rome",
+        online=False,                   # offline: no GeoNames call
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Kerykeion quickstart")
+    ap.add_argument("--svg", metavar="DIR", help="also render an SVG into DIR/")
+    args = ap.parse_args()
+
+    subject = build_subject()
+
+    # 1) Read data straight off the subject
+    print(f"Sun:  {subject.sun.sign} {subject.sun.position:.2f}°  (house {subject.sun.house})")
+    print(f"Moon: {subject.moon.sign} {subject.moon.position:.2f}°  element {subject.moon.element}")
+    print(f"Asc:  {subject.ascendant.sign} {subject.ascendant.position:.2f}°")
+    print(f"Lunar phase: {subject.lunar_phase.moon_phase_name} {subject.lunar_phase.moon_emoji}")
+
+    # 2) Precompute chart data (needed for charts, reports, distributions, aspects)
+    chart_data = ChartDataFactory.create_natal_chart_data(subject)
+    print(f"\nElement balance: fire={chart_data.element_distribution.fire:.1f} "
+          f"earth={chart_data.element_distribution.earth:.1f} "
+          f"air={chart_data.element_distribution.air:.1f} "
+          f"water={chart_data.element_distribution.water:.1f}")
+    print(f"Aspects found: {len(chart_data.aspects)}")
+
+    # 3) Human-readable report
+    print("\n--- REPORT ---")
+    ReportGenerator(chart_data).print_report(max_aspects=8)
+
+    # 4) LLM-ready context (inject into a prompt)
+    print("\n--- LLM CONTEXT (truncated) ---")
+    ctx = to_context(subject)
+    print(ctx[:600] + ("…" if len(ctx) > 600 else ""))
+
+    # 5) Optional SVG
+    if args.svg:
+        out = Path(args.svg)
+        out.mkdir(parents=True, exist_ok=True)
+        ChartDrawer(chart_data=chart_data).save_svg(output_path=out, filename="quickstart-natal")
+        print(f"\nSVG written to {(out / 'quickstart-natal.svg').resolve()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a cross-platform **Agent Skill** for Kerykeion under `skills/kerykeion/`, so AI coding agents generate correct Kerykeion code instead of guessing method names.

## Contents
- **`SKILL.md`** — mental model, offline/online guidance, the 2-step chart flow, capability routing, licensing, pitfalls
- **`references/`** — `subjects`, `charts`, `analysis`, `time-techniques`, `reports-and-ai`, `reference-data` (every enum value, default, and model field)
- **`scripts/quickstart.py`** — runnable offline example (subject → SVG + report + LLM context)
- **`README.md`** + **`LICENSE`** (AGPL-3.0)

## Notes
- Documents only the real, **shipped (git-tracked) public API** — verified end-to-end against the installed package (5.12.9). **No library code changed.**
- **Platform-agnostic**: works with Claude Code, Cursor, Codex, Copilot, Gemini, Windsurf, Cline, …; installable via `npx skills add g-battaglia/kerykeion`.
- Surfaces **AGPL-3.0** obligations and points to the commercial license / hosted [Astrologer API](https://rapidapi.com/gbattaglia/api/astrologer) for closed-source use.
- Offline examples pass `city`/`nation` so reports and `to_context` emit truthful birth-place metadata (default is Greenwich/GB).
- The local-only `.claude/skills/kerykeion` convenience symlink is gitignored, so the published tree stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTqN3iFB6Q1zjwo6b2VmxU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline quickstart script that walks through creating a sample chart, generating a report/context, and optionally saving an SVG.
* **Documentation**
  * Added comprehensive guides for charts, subjects, analysis, time-based techniques, reports, and reference data.
  * Added licensing and setup notes, plus clearer usage guidance and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->