### PR TITLE
feat(chart-data): forward axis_orb_limit through convenience methods

### DIFF
--- a/kerykeion/chart_data_factory.py
+++ b/kerykeion/chart_data_factory.py
@@ -403,6 +403,7 @@ class ChartDataFactory:
         active_points: Optional[list[AstrologicalPoint]] = None,
         active_aspects: Optional[list[ActiveAspect]] = None,
         *,
+        axis_orb_limit: Optional[float] = None,
         point_orb_adjustments: Optional[Mapping[str, float]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
@@ -415,6 +416,8 @@ class ChartDataFactory:
             subject: Astrological subject
             active_points: Points to include in calculations
             active_aspects: Aspect types and orbs to use
+            axis_orb_limit: Optional orb threshold for chart axes (Ascendant,
+                Medium_Coeli, Descendant, Imum_Coeli). ``None`` (default) disables it.
             point_orb_adjustments: Per-point orb adjustment table. ``None`` uses
                 the natal default (Sun/Moon +1.5°, the luminary-widening rule);
                 pass ``{}`` to disable.
@@ -430,6 +433,7 @@ class ChartDataFactory:
             chart_type="Natal",
             active_points=active_points,
             active_aspects=active_aspects,
+            axis_orb_limit=axis_orb_limit,
             point_orb_adjustments=point_orb_adjustments,
             point_orb_adjustment_strategy=point_orb_adjustment_strategy,
             distribution_method=distribution_method,
@@ -445,6 +449,7 @@ class ChartDataFactory:
         include_house_comparison: bool = True,
         include_relationship_score: bool = True,
         *,
+        axis_orb_limit: Optional[float] = None,
         point_orb_adjustments: Optional[Mapping[str, float]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
@@ -460,6 +465,9 @@ class ChartDataFactory:
             active_aspects: Aspect types and orbs to use
             include_house_comparison: Whether to include house comparison
             include_relationship_score: Whether to include relationship scoring
+            axis_orb_limit: Optional orb threshold for chart axes (Ascendant,
+                Medium_Coeli, Descendant, Imum_Coeli). Applied to dual-chart
+                aspects and the relationship score. ``None`` (default) disables it.
             point_orb_adjustments: Per-point orb adjustment table. ``None`` uses
                 the natal default (Sun/Moon +1.5°); pass ``{}`` to disable.
             point_orb_adjustment_strategy: How to combine the two points' adjustments
@@ -477,6 +485,7 @@ class ChartDataFactory:
             active_aspects=active_aspects,
             include_house_comparison=include_house_comparison,
             include_relationship_score=include_relationship_score,
+            axis_orb_limit=axis_orb_limit,
             point_orb_adjustments=point_orb_adjustments,
             point_orb_adjustment_strategy=point_orb_adjustment_strategy,
             distribution_method=distribution_method,
@@ -491,6 +500,7 @@ class ChartDataFactory:
         active_aspects: Optional[list[ActiveAspect]] = None,
         include_house_comparison: bool = True,
         *,
+        axis_orb_limit: Optional[float] = None,
         point_orb_adjustments: Optional[Mapping[str, float]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
@@ -505,6 +515,8 @@ class ChartDataFactory:
             active_points: Points to include in calculations
             active_aspects: Aspect types and orbs to use
             include_house_comparison: Whether to include house comparison
+            axis_orb_limit: Optional orb threshold for chart axes (Ascendant,
+                Medium_Coeli, Descendant, Imum_Coeli). ``None`` (default) disables it.
             point_orb_adjustments: Per-point orb adjustment table. ``None`` means
                 no adjustment — transits use a flat tight orb by convention.
             point_orb_adjustment_strategy: How to combine the two points' adjustments
@@ -521,6 +533,7 @@ class ChartDataFactory:
             active_points=active_points,
             active_aspects=active_aspects,
             include_house_comparison=include_house_comparison,
+            axis_orb_limit=axis_orb_limit,
             point_orb_adjustments=point_orb_adjustments,
             point_orb_adjustment_strategy=point_orb_adjustment_strategy,
             distribution_method=distribution_method,
@@ -533,6 +546,7 @@ class ChartDataFactory:
         active_points: Optional[list[AstrologicalPoint]] = None,
         active_aspects: Optional[list[ActiveAspect]] = None,
         *,
+        axis_orb_limit: Optional[float] = None,
         point_orb_adjustments: Optional[Mapping[str, float]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
@@ -545,6 +559,8 @@ class ChartDataFactory:
             composite_subject: Composite astrological subject
             active_points: Points to include in calculations
             active_aspects: Aspect types and orbs to use
+            axis_orb_limit: Optional orb threshold for chart axes (Ascendant,
+                Medium_Coeli, Descendant, Imum_Coeli). ``None`` (default) disables it.
             point_orb_adjustments: Per-point orb adjustment table. ``None`` uses
                 the natal default (Sun/Moon +1.5°); pass ``{}`` to disable.
             point_orb_adjustment_strategy: How to combine the two points' adjustments
@@ -559,6 +575,7 @@ class ChartDataFactory:
             chart_type="Composite",
             active_points=active_points,
             active_aspects=active_aspects,
+            axis_orb_limit=axis_orb_limit,
             point_orb_adjustments=point_orb_adjustments,
             point_orb_adjustment_strategy=point_orb_adjustment_strategy,
             distribution_method=distribution_method,
@@ -573,6 +590,7 @@ class ChartDataFactory:
         active_aspects: Optional[list[ActiveAspect]] = None,
         include_house_comparison: bool = True,
         *,
+        axis_orb_limit: Optional[float] = None,
         point_orb_adjustments: Optional[Mapping[str, float]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
@@ -588,6 +606,8 @@ class ChartDataFactory:
             active_aspects: Aspect types and orbs to use. Defaults to the
                 predictive set (3° orb) — the conventional return-chart default.
             include_house_comparison: Whether to include house comparison
+            axis_orb_limit: Optional orb threshold for chart axes (Ascendant,
+                Medium_Coeli, Descendant, Imum_Coeli). ``None`` (default) disables it.
             point_orb_adjustments: Per-point orb adjustment table. ``None`` means
                 no adjustment — returns use a flat tight orb by convention.
             point_orb_adjustment_strategy: How to combine the two points' adjustments
@@ -604,6 +624,7 @@ class ChartDataFactory:
             active_points=active_points,
             active_aspects=active_aspects,
             include_house_comparison=include_house_comparison,
+            axis_orb_limit=axis_orb_limit,
             point_orb_adjustments=point_orb_adjustments,
             point_orb_adjustment_strategy=point_orb_adjustment_strategy,
             distribution_method=distribution_method,
@@ -616,6 +637,7 @@ class ChartDataFactory:
         active_points: Optional[list[AstrologicalPoint]] = None,
         active_aspects: Optional[list[ActiveAspect]] = None,
         *,
+        axis_orb_limit: Optional[float] = None,
         point_orb_adjustments: Optional[Mapping[str, float]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
@@ -629,6 +651,8 @@ class ChartDataFactory:
             active_points: Points to include in calculations
             active_aspects: Aspect types and orbs to use. Defaults to the
                 predictive set (3° orb) — the conventional return-chart default.
+            axis_orb_limit: Optional orb threshold for chart axes (Ascendant,
+                Medium_Coeli, Descendant, Imum_Coeli). ``None`` (default) disables it.
             point_orb_adjustments: Per-point orb adjustment table. ``None`` means
                 no adjustment — returns use a flat tight orb by convention.
             point_orb_adjustment_strategy: How to combine the two points' adjustments
@@ -643,6 +667,7 @@ class ChartDataFactory:
             chart_type="SingleReturnChart",
             active_points=active_points,
             active_aspects=active_aspects,
+            axis_orb_limit=axis_orb_limit,
             point_orb_adjustments=point_orb_adjustments,
             point_orb_adjustment_strategy=point_orb_adjustment_strategy,
             distribution_method=distribution_method,

--- a/tests/core/test_chart_data_factory.py
+++ b/tests/core/test_chart_data_factory.py
@@ -733,6 +733,32 @@ class TestFactoryParameterValidation:
         assert len(limited.aspects) <= len(full.aspects)
         assert len(limited.active_points) <= len(full.active_points)
 
+    def test_axis_orb_limit_forwarded_natal(self, johnny_depp):
+        """The natal convenience method must forward ``axis_orb_limit`` so that
+        axis-involving aspects beyond the threshold are dropped. Regression
+        guard against the parameter being a silent no-op."""
+        axes = {"Ascendant", "Medium_Coeli", "Descendant", "Imum_Coeli"}
+        full = ChartDataFactory.create_natal_chart_data(johnny_depp)
+        tight = ChartDataFactory.create_natal_chart_data(johnny_depp, axis_orb_limit=0.5)
+
+        assert len(tight.aspects) <= len(full.aspects)
+        # Every surviving aspect that touches an axis must respect the tight limit.
+        for asp in tight.aspects:
+            if asp.p1_name in axes or asp.p2_name in axes:
+                assert abs(asp.orbit) <= 0.5 + 1e-9
+
+    def test_axis_orb_limit_forwarded_synastry(self, johnny_depp, john_lennon):
+        """The synastry convenience method must forward ``axis_orb_limit`` (it
+        affects both the dual-chart aspects and the relationship score)."""
+        axes = {"Ascendant", "Medium_Coeli", "Descendant", "Imum_Coeli"}
+        full = ChartDataFactory.create_synastry_chart_data(johnny_depp, john_lennon)
+        tight = ChartDataFactory.create_synastry_chart_data(johnny_depp, john_lennon, axis_orb_limit=0.5)
+
+        assert len(tight.aspects) <= len(full.aspects)
+        for asp in tight.aspects:
+            if asp.p1_name in axes or asp.p2_name in axes:
+                assert abs(asp.orbit) <= 0.5 + 1e-9
+
     def test_selective_synastry_features(self, johnny_depp, john_lennon):
         """Toggling house_comparison and relationship_score flags works."""
         full = ChartDataFactory.create_synastry_chart_data(


### PR DESCRIPTION
## Summary

`ChartDataFactory.create_natal / create_synastry / create_transit / create_composite / create_return / create_single_wheel_return` chart-data convenience methods delegate to `create_chart_data` but **dropped `axis_orb_limit`** — so any caller using the wrappers (instead of `create_chart_data` directly) could never tighten the orb for axis-involving aspects (ASC/MC/DSC/IC). It was a silent no-op for them.

This adds the keyword-only `axis_orb_limit` parameter to each wrapper and forwards it to `create_chart_data`, matching `create_progression_chart_data`, which already exposed it.

## Why

Surfaced during a mapping audit of the astrologer-api against kerykeion v6: the API worked around this by routing through `create_chart_data` directly, but the convenience methods are part of kerykeion's public surface and should honor the same knob. This closes that parity gap at the source.

## Changes
- `kerykeion/chart_data_factory.py`: add `axis_orb_limit` (keyword-only) to the 6 convenience methods, forwarded to `create_chart_data`.
- `tests/core/test_chart_data_factory.py`: effect-asserting tests (natal + synastry) proving axis-involving aspects beyond the threshold are dropped when `axis_orb_limit` is set.

## Compatibility
Purely additive — new keyword-only parameter defaulting to `None` (current behavior). No existing signature or default changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)