### PR TITLE
fix(sun-times): solar noon is the meridian transit, and now it is anchored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,11 @@
   Descendant 15, Imum Coeli 15) across 28 fixtures, plus **122 non-angle speed
   cells** — the Uranian points and, not previously named anywhere,
   True Lilith 12, True Priapus 12 and Interpolated Perigee 11 — and
-  **17 declination cells**. `ascmc_speed` comes from `houses_ex2`; the parity
+  **19 declination cells** (Mean Lilith 8, Mean Priapus 8, Hades 1, White
+  Moon 1, Admetos 1 — a first count said 17, having taken the dual-return
+  fixture's Lilith and Priapus rows once when that file carries them in both
+  its tables: the very duplicate-cell trap this paragraph warns about).
+  `ascmc_speed` comes from `houses_ex2`; the parity
   front excludes cusp and angle speed by design, so the campaign could not have
   seen any of it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,17 +52,36 @@
 
 ### Changed
 
-- `libephemeris` pinned to **3.0.0** (from `3.0.0rc15`). Validated rather than
-  assumed: a full cross-engine parity campaign against a file-backed reference
-  returned identical verdicts and identical counts over 5213 compared quantities,
-  and a direct value-by-value diff of 16337 quantities found 16267 bit-identical.
-  House cusps and angles did not move at all. The 70 that did are sidereal
-  ayanamsas at 0.0014″ and the apsis family at 0.064″, and the eight Uranian
-  points, which go from a disordered ±20″ scatter against the reference to a
-  uniform +2..3″ bias — 8 of 9 improve, Kronos by 20″. The report fixtures were
-  regenerated for that reason and no other: exactly eleven points changed
-  position, all of them analytically-modelled bodies, none of them a planet, an
-  angle or a cusp.
+- `libephemeris` floor raised to **>=3.0.0,<4** (from the exact `==3.0.0rc15`).
+  Validated rather than assumed, and the evidence is worth stating precisely
+  because a first draft of this entry overstated it.
+
+  The cross-engine parity campaign, run against a file-backed reference before
+  and after, returned **identical per-domain counts over 5213 compared
+  quantities** and no divergence appearing or disappearing. Note the verdict it
+  returns is RED in both runs — the pre-existing sidereal-ayanamsa and
+  deep-time offenders — so "identical" means unchanged, not clean. The campaign
+  was also run under kerykeion `6.0.0a75`, the version its lockfile pins.
+
+  Two further measurements come from ad-hoc scripts rather than from that
+  campaign, and are reproducible but not archived in any repository: a
+  value-by-value diff of 16337 quantities found 16267 bit-identical, and the
+  eight Uranian points move from a ±20″ scatter against the reference to a
+  uniform +2..3″ bias (8 of 9 improve, Kronos by 20″). The parity grid does not
+  cover the Uranian family at all, which is exactly why those bodies could move
+  36″ and pass 5213 comparisons unseen.
+
+  What the fixtures show directly: **exactly eleven points changed position** —
+  the eight Uranian points, White Moon, mean Lilith and mean Priapus, every one
+  analytically modelled. No planet, angle or cusp changed POSITION. Angle
+  *speeds* did, in 80 cells (`ascmc_speed` comes from `houses_ex2`, and the
+  parity front excludes cusp and angle speed by design, so the campaign could
+  not have seen it): Ascendant and Medium Coeli move by about 0.002 °/day, five
+  parts per million. Two knock-on effects are worth naming rather than leaving
+  to be discovered: one report gains an aspect row (`Pallas sesquiquadrate
+  Poseidon`, an orb-boundary crossing) and three Zeus aspects flip their
+  Movement column to `Static` as its speed crosses the 0.001 °/day display
+  floor.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,80 @@
 
 ## [Unreleased]
 
+## 6.0.0a79 - 2026-08-05
+
+### Fixed
+
+- **`solar_noon` is now the meridian transit, which is what it always claimed to
+  be.** It was the midpoint between sunrise and sunset. The two coincide only
+  while the Sun's declination is stationary, so the old value was right at the
+  solstices and on the equator — where anyone spot-checking it would look — and
+  wrong everywhere else: measured against two national observatories, +21.5 s at
+  Rome on the equinox, +33.5 s at Ushuaia, +62.4 s at Reykjavík. Worse, when the
+  rise/set pair straddles local midnight the midpoint lands on the wrong civil
+  day entirely, which is what Singapore did. Nothing in the library consumed the
+  field — it is printed in the report, serialised into the AI context and
+  returned to callers — so the correction is visible rather than structural.
+  - `solar_noon` is now also reported on **polar days and polar nights**, where
+    it previously had to be `None`. A transit is a meridian crossing, not a
+    horizon crossing: the Sun culminates on a day it never rises. `day_length`
+    stays `None` there, since there is no pair to measure.
+  - `MoonPhaseSunInfoModel.solar_noon` moved with it, and stays in the subject's
+    local timezone as before.
+
+### Added
+
+- **Sunrise, sunset and solar noon are now anchored to published data we did not
+  produce.** `tests/core/test_sun_times_anchors.py` carries values transcribed by
+  hand from the US Naval Observatory and from IMCCE (Observatoire de Paris) for
+  the same UTC civil day, with the capture date recorded. No script regenerates
+  them: a golden snapshot proves constancy, an anchor proves truth, and only the
+  second kind survives a bad engine bump followed by a blind regeneration.
+  - The tolerances are shaped by what the sources actually do rather than by what
+    would be convenient. The two agree on sunrise and transit, so those are held
+    to 45 s of USNO; they disagree by about two minutes on sunset (a horizon
+    convention), so every event is additionally required to lie inside the span
+    the two of them bracket. Above 60° latitude no time-domain claim is made at
+    all — the Sun grazes the horizon there and clock time stops being a
+    well-conditioned way to state an error, which the sources demonstrate
+    themselves by differing by 10 and 11 minutes at Tromsø. A test asserts that
+    divergence, so the cut-off is earned rather than assumed.
+- **An angle-based check that does not degrade with latitude.**
+  `tests/core/test_sun_times_altitude_invariant.py` never compares times: it takes
+  the instant we return and asks Skyfield — a separate position pipeline — where
+  the Sun was. Across ten sites and four seasons the true upper limb sits at
+  −33.59′ with a spread of 2.5″, solar noon has an hour angle under 0.1 s, and
+  `is_diurnal` flips within a second of the geometric centre crossing zero.
+  - The documented gap between sunrise and diurnality (3.3 min at the equator,
+    4.4 at Rome, 8.2 at Reykjavík) is pinned there too, so the prose cannot drift
+    away from the code.
+
+### Changed
+
+- `libephemeris` pinned to **3.0.0** (from `3.0.0rc15`). Validated rather than
+  assumed: a full cross-engine parity campaign against a file-backed reference
+  returned identical verdicts and identical counts over 5213 compared quantities,
+  and a direct value-by-value diff of 16337 quantities found 16267 bit-identical.
+  House cusps and angles did not move at all. The 70 that did are sidereal
+  ayanamsas at 0.0014″ and the apsis family at 0.064″, and the eight Uranian
+  points, which go from a disordered ±20″ scatter against the reference to a
+  uniform +2..3″ bias — 8 of 9 improve, Kronos by 20″. The report fixtures were
+  regenerated for that reason and no other: exactly eleven points changed
+  position, all of them analytically-modelled bodies, none of them a planet, an
+  angle or a cusp.
+
+### Documentation
+
+- The rise/set horizon convention is now stated where callers will meet it: the
+  apparent upper limb, a semidiameter taken from the real distance rather than a
+  fixed 16′, standard-atmosphere refraction, and a level sea horizon at any
+  elevation. Both the README and the model docstrings say plainly that sunrise
+  and `is_diurnal` answer different questions and must never be derived from one
+  another.
+- `_APPARENT_UPPER_LIMB_HORIZON_DEGREES` now explains why the polar
+  discriminator's textbook −0.833° differs from the −0.827° the search itself
+  implies, and why closing that 0.006° gap would buy nothing.
+
 ## 6.0.0a78 - 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@
     stays `None` there, since there is no pair to measure.
   - `MoonPhaseSunInfoModel.solar_noon` moved with it, and stays in the subject's
     local timezone as before.
+  - **New contract, stated because it is a real regression for one case class.**
+    The transit is now searched independently from local midnight instead of
+    being derived from the pair, so `sunrise < solar_noon < sunset` is no longer
+    guaranteed. It holds for every location whose timezone matches its longitude
+    (0 violations in 300 matched city/zone samples), and fails when they do not:
+    65 of 300 random lat/lon/zone triples, 75 of 300 with `tz_str="UTC"` at
+    arbitrary longitudes. Measured worst case: 62.71 N / 121.43 E under UTC
+    reports a solar noon 15 hours BEFORE its sunrise, because the two belong to
+    different solar days. The old midpoint was inside the window by construction
+    and was, for this class alone, better. Both the library API and
+    `/api/v6/sun-times` accept latitude, longitude and timezone as an
+    unvalidated triple, so it is reachable — pass a timezone that belongs to the
+    longitude and it cannot occur.
 
 ### Added
 
@@ -73,15 +86,28 @@
 
   What the fixtures show directly: **exactly eleven points changed position** —
   the eight Uranian points, White Moon, mean Lilith and mean Priapus, every one
-  analytically modelled. No planet, angle or cusp changed POSITION. Angle
-  *speeds* did, in 80 cells (`ascmc_speed` comes from `houses_ex2`, and the
-  parity front excludes cusp and angle speed by design, so the campaign could
-  not have seen it): Ascendant and Medium Coeli move by about 0.002 °/day, five
-  parts per million. Two knock-on effects are worth naming rather than leaving
-  to be discovered: one report gains an aspect row (`Pallas sesquiquadrate
-  Poseidon`, an orb-boundary crossing) and three Zeus aspects flip their
-  Movement column to `Static` as its speed crosses the 0.001 °/day display
-  floor.
+  analytically modelled. No planet, angle or cusp changed POSITION.
+
+  SPEEDS did, and this is where a first correction of this entry was itself
+  wrong — it said 80 cells, which is the number of (fixture, angle) pairs, not
+  of table cells; dual charts carry the same angle two or three times per file.
+  Counted properly: **104 angle-speed cells** (Ascendant 37, Medium Coeli 37,
+  Descendant 15, Imum Coeli 15) across 28 fixtures, plus **122 non-angle speed
+  cells** — the Uranian points and, not previously named anywhere,
+  True Lilith 12, True Priapus 12 and Interpolated Perigee 11 — and
+  **17 declination cells**. `ascmc_speed` comes from `houses_ex2`; the parity
+  front excludes cusp and angle speed by design, so the campaign could not have
+  seen any of it.
+
+  Magnitudes: the scale-free figure is **five parts per million** (5.15–5.74 over
+  all 104 cells). In absolute terms the MC and IC move about 0.002 °/day; the
+  Ascendant's median is 0.0016 with a worst case of 0.0046, so "about 0.002" is
+  right for two of the four angles and loose for the other two.
+
+  Two knock-on effects worth naming rather than leaving to be discovered: one
+  report gains an aspect row (`Pallas sesquiquadrate Poseidon`, an orb-boundary
+  crossing) and three Zeus aspects flip their Movement column to `Static` as its
+  speed crosses the 0.001 °/day display floor.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -1804,7 +1804,11 @@ Six lightweight factories that work directly from dates/locations (no full `Astr
 
 ### Sun Times
 
-`SunTimesFactory` returns sunrise / sunset / solar-noon / day-length for a civil date at a location (apparent upper-limb refraction), with polar day/night detection.
+`SunTimesFactory` returns sunrise / sunset / solar-noon / day-length for a civil date at a location, with polar day/night detection.
+
+**What the numbers mean.** Sunrise and sunset are the moment the Sun's apparent **upper limb** meets the horizon: the semidiameter is taken from the real Earth–Sun distance rather than a fixed 16′, and refraction from a standard atmosphere (1013.25 hPa, 15 °C), which puts the Sun's geometric centre near −0.83° at the event. The horizon is the level sea horizon at any elevation, which is the convention published rise/set tables use. Solar noon is the **meridian transit** — the instant the Sun is highest — not the midpoint of sunrise and sunset; the two agree only while the declination is stationary, and away from the solstices the midpoint drifts by up to a minute, more the higher the latitude. Because a transit is a meridian crossing rather than a horizon crossing, solar noon is reported on polar days too, when there is no rise/set pair at all.
+
+**Sunrise is not `is_diurnal`.** `AstrologicalSubjectModel.is_diurnal` tests the Sun's **geometric centre** against the true horizon — no disc, no atmosphere — because that is the question a chart is cast from. Sunrise counts the Sun as risen as soon as its upper edge shows through the air, which happens earlier. The gap is real and grows towards the poles: about **3.3 min at the equator, 4.4 min at Rome, 8.2 min at Reykjavík and 10 min at Tromsø**. Both answers are right to their own question, and neither should ever be derived from the other.
 
 ```python
 from kerykeion import SunTimesFactory

--- a/kerykeion/moon_phase_details/factory.py
+++ b/kerykeion/moon_phase_details/factory.py
@@ -226,12 +226,18 @@ def _build_upcoming_phases(
 
 def _compute_sun_times(
     subject: AstrologicalSubjectModel,
-) -> Optional[tuple[datetime, datetime, Optional[datetime]]]:
+) -> Optional[tuple[Optional[datetime], Optional[datetime], Optional[datetime]]]:
     """
     Compute sunrise, sunset and solar noon as local datetimes.
 
     Uses the backend's `rise_trans` (via `compute_sun_rise_set_ephe` and
     `compute_sun_transit_ephe`) for the subject's local civil day.
+
+    Returns ``None`` only when the location or timezone cannot be resolved at
+    all. Otherwise a 3-tuple, in which the first two elements are ``None`` on a
+    polar day or night — there is no rise/set pair — while the third can still
+    carry the meridian transit. Callers must test the elements, not the tuple:
+    ``(None, None, None)`` is reachable and truthy.
 
     Solar noon is returned from here rather than derived by the caller because
     it needs `jd_midnight`, which only exists inside this function: deriving it

--- a/kerykeion/moon_phase_details/factory.py
+++ b/kerykeion/moon_phase_details/factory.py
@@ -57,6 +57,7 @@ from kerykeion.moon_phase_details.utils import (
     compute_next_solar_eclipse_jd,
     compute_next_lunar_eclipse_jd,
     compute_sun_rise_set_ephe,
+    compute_sun_transit_ephe,
     compute_lunar_phase_jd,
     compute_sun_position,
 )
@@ -225,12 +226,18 @@ def _build_upcoming_phases(
 
 def _compute_sun_times(
     subject: AstrologicalSubjectModel,
-) -> Optional[tuple[datetime, datetime]]:
+) -> Optional[tuple[datetime, datetime, Optional[datetime]]]:
     """
-    Compute precise sunrise and sunset local datetimes using Swiss Ephemeris.
+    Compute sunrise, sunset and solar noon as local datetimes.
 
-    Uses Swiss Ephemeris `ephe.rise_trans` (via `compute_sun_rise_set_ephe`)
-    to obtain sunrise and sunset for the subject's local civil day.
+    Uses the backend's `rise_trans` (via `compute_sun_rise_set_ephe` and
+    `compute_sun_transit_ephe`) for the subject's local civil day.
+
+    Solar noon is returned from here rather than derived by the caller because
+    it needs `jd_midnight`, which only exists inside this function: deriving it
+    outside meant either re-deriving local midnight — the DST reasoning below is
+    subtle enough that a second copy would drift — or settling for the midpoint
+    of the pair, which is a different quantity (see `compute_sun_transit_ephe`).
     """
     lat = subject.lat
     lng = subject.lng
@@ -278,8 +285,8 @@ def _compute_sun_times(
     midnight_utc = midnight_local.astimezone(timezone.utc)
     jd_midnight = datetime_to_julian(midnight_utc)
 
-    # Compute both sunrise and sunset using Swiss Ephemeris, inside a
-    # serialized session (the helper mutates the global ephemeris path).
+    # Compute sunrise, sunset and the meridian transit inside a serialized
+    # session (the helpers mutate the global ephemeris path).
     with ephemeris_session():
         sunrise_jd, sunset_jd = compute_sun_rise_set_ephe(jd_midnight, lat, lng)
 
@@ -287,10 +294,11 @@ def _compute_sun_times(
             # Midnight-sun transition days: the only set after local midnight
             # precedes the sunrise (the Sun was still up at 00:00). Pair the
             # sunrise with its actual following sunset — same handling as
-            # sun_times.utils — or day_length goes negative and solar_noon
-            # lands at solar midnight.
+            # sun_times.utils — or day_length goes negative.
             _, paired_sunset_jd = compute_sun_rise_set_ephe(sunrise_jd + 1e-6, lat, lng)
             sunset_jd = paired_sunset_jd if paired_sunset_jd is not None and paired_sunset_jd > sunrise_jd else None
+
+        transit_jd = compute_sun_transit_ephe(jd_midnight, lat, lng)
 
     if sunrise_jd is None or sunset_jd is None:
         return None
@@ -301,8 +309,13 @@ def _compute_sun_times(
 
     sunrise_local = sunrise_utc.astimezone(tzinfo)
     sunset_local = sunset_utc.astimezone(tzinfo)
+    solar_noon_local = (
+        julian_to_datetime(transit_jd).replace(tzinfo=timezone.utc).astimezone(tzinfo)
+        if transit_jd is not None
+        else None
+    )
 
-    return sunrise_local, sunset_local
+    return sunrise_local, sunset_local, solar_noon_local
 
 
 def _compute_sun_position(
@@ -633,25 +646,16 @@ class MoonPhaseDetailsFactory:
         try:
             sun_times = _compute_sun_times(subject)
             if sun_times is not None:
-                sunrise_local, sunset_local = sun_times
-                # Solar noon as the midpoint between sunrise and sunset, computed in
-                # INSTANT space. Adding a timedelta to an aware datetime is wall-clock
-                # arithmetic: the fields advance and the offset is then re-resolved at
-                # the NEW clock time, so on a DST-transition day the midpoint lands on a
-                # different moment (measured: one hour off across a spring-forward).
-                # Converting to UTC first makes the addition offset-independent; the
-                # result is rendered back in the subject's zone, which restores the
-                # correct local wall clock on either side of the transition.
-                # Both endpoints are converted BEFORE the subtraction, not just
-                # before the addition: when two aware datetimes share the same
-                # tzinfo object — and ZoneInfo caches, so they always do here —
-                # Python subtracts their wall-clock fields and never consults
-                # the offsets. Across a transition that silently reports the
-                # clock elapsed rather than the time elapsed.
+                sunrise_local, sunset_local, solar_noon_local = sun_times
+                # Both endpoints are converted to UTC BEFORE the subtraction: when
+                # two aware datetimes share the same tzinfo object — and ZoneInfo
+                # caches, so they always do here — Python subtracts their
+                # wall-clock fields and never consults the offsets. Across a DST
+                # transition that silently reports the clock elapsed rather than
+                # the time elapsed.
                 sunrise_utc = sunrise_local.astimezone(timezone.utc)
                 sunset_utc = sunset_local.astimezone(timezone.utc)
                 day_length = sunset_utc - sunrise_utc
-                solar_noon_local = (sunrise_utc + day_length / 2).astimezone(sunrise_local.tzinfo)
         except _BACKEND_ERRORS as exc:
             # Expected error: polar regions, ephemeris unavailable, etc.
             logger.debug("Sunrise/sunset calculation failed (expected): %s", exc)

--- a/kerykeion/moon_phase_details/factory.py
+++ b/kerykeion/moon_phase_details/factory.py
@@ -300,8 +300,18 @@ def _compute_sun_times(
 
         transit_jd = compute_sun_transit_ephe(jd_midnight, lat, lng)
 
+    solar_noon_local = (
+        julian_to_datetime(transit_jd).replace(tzinfo=timezone.utc).astimezone(tzinfo)
+        if transit_jd is not None
+        else None
+    )
+
     if sunrise_jd is None or sunset_jd is None:
-        return None
+        # Polar day or night: no pair, so no rise, set or day length — but the Sun
+        # still culminates, and the transit above already found when. Returning it
+        # rather than dropping the whole result is what makes the model docstring
+        # true; the earlier version computed the transit here and threw it away.
+        return None, None, solar_noon_local
 
     # Convert JD back to datetime in local timezone
     sunrise_utc = julian_to_datetime(sunrise_jd).replace(tzinfo=timezone.utc)
@@ -309,12 +319,6 @@ def _compute_sun_times(
 
     sunrise_local = sunrise_utc.astimezone(tzinfo)
     sunset_local = sunset_utc.astimezone(tzinfo)
-    solar_noon_local = (
-        julian_to_datetime(transit_jd).replace(tzinfo=timezone.utc).astimezone(tzinfo)
-        if transit_jd is not None
-        else None
-    )
-
     return sunrise_local, sunset_local, solar_noon_local
 
 
@@ -647,15 +651,16 @@ class MoonPhaseDetailsFactory:
             sun_times = _compute_sun_times(subject)
             if sun_times is not None:
                 sunrise_local, sunset_local, solar_noon_local = sun_times
-                # Both endpoints are converted to UTC BEFORE the subtraction: when
-                # two aware datetimes share the same tzinfo object — and ZoneInfo
-                # caches, so they always do here — Python subtracts their
-                # wall-clock fields and never consults the offsets. Across a DST
-                # transition that silently reports the clock elapsed rather than
-                # the time elapsed.
-                sunrise_utc = sunrise_local.astimezone(timezone.utc)
-                sunset_utc = sunset_local.astimezone(timezone.utc)
-                day_length = sunset_utc - sunrise_utc
+                if sunrise_local is not None and sunset_local is not None:
+                    # Both endpoints are converted to UTC BEFORE the subtraction:
+                    # when two aware datetimes share the same tzinfo object — and
+                    # ZoneInfo caches, so they always do here — Python subtracts
+                    # their wall-clock fields and never consults the offsets.
+                    # Across a DST transition that silently reports the clock
+                    # elapsed rather than the time elapsed.
+                    sunrise_utc = sunrise_local.astimezone(timezone.utc)
+                    sunset_utc = sunset_local.astimezone(timezone.utc)
+                    day_length = sunset_utc - sunrise_utc
         except _BACKEND_ERRORS as exc:
             # Expected error: polar regions, ephemeris unavailable, etc.
             logger.debug("Sunrise/sunset calculation failed (expected): %s", exc)

--- a/kerykeion/moon_phase_details/utils.py
+++ b/kerykeion/moon_phase_details/utils.py
@@ -660,6 +660,7 @@ __all__ = [
     "compute_next_solar_eclipse_jd",
     "compute_next_lunar_eclipse_jd",
     "compute_sun_rise_set_ephe",
+    "compute_sun_transit_ephe",
     "compute_lunar_phase_jd",
     "greenwich_mean_sidereal_time",
     "equatorial_to_horizontal",

--- a/kerykeion/moon_phase_details/utils.py
+++ b/kerykeion/moon_phase_details/utils.py
@@ -253,21 +253,121 @@ def compute_next_lunar_eclipse_jd(jd_start: float) -> Optional[tuple[int, float]
     return _extract_eclipse_result(result)
 
 
+def _extract_event_time(result: object) -> Optional[float]:
+    """
+    Extract the primary event time (JD) from an `ephe.rise_trans` result.
+
+    The backend returns:
+
+        (res, tret)
+
+    where:
+        - res: integer status (0 = event found, -2 = circumpolar, etc.)
+        - tret: tuple of 10 floats, with tret[0] = JD of the event.
+
+    Module-level rather than nested so the rise/set and transit helpers share
+    one reading of that contract: they must agree on what "no event" means, and
+    two copies would be free to drift apart.
+    """
+    if not isinstance(result, tuple) or not result:
+        return None
+
+    if len(result) < 2:
+        return None
+
+    res, tret = result[0], result[1]
+
+    # We only accept res == 0 (event found).
+    if not isinstance(res, int) or res != 0:
+        return None
+
+    if not isinstance(tret, (list, tuple)) or not tret:
+        return None
+
+    if not isinstance(tret[0], (float, int)):
+        return None
+
+    return float(tret[0])
+
+
+def compute_sun_transit_ephe(
+    jd_start: float,
+    latitude: float,
+    longitude: float,
+) -> Optional[float]:
+    """
+    Compute the Sun's next upper meridian transit — true local noon.
+
+    This is the instant the Sun crosses the observer's meridian, i.e. the moment
+    it is highest in the sky. It is NOT the midpoint between sunrise and sunset:
+    the two coincide only when the declination is stationary. Away from the
+    solstices the midpoint drifts, and it drifts further the higher the latitude
+    (measured against this function: +21 s at Rome on the equinox, +34 s at
+    Ushuaia, +62 s at Reykjavik) — while at a longitude far from its timezone
+    the midpoint can land on the wrong civil day altogether.
+
+    A transit is a pure hour-angle search, so unlike rise/set it has no horizon,
+    no disc and no refraction: `atpress`/`attemp` are accepted by the backend and
+    ignored on this path, and the geocentric place is the correct one (diurnal
+    parallax displaces a body in altitude only, leaving the hour angle intact).
+    It also exists on days when rise and set do not — the Sun still culminates
+    during polar night — which is why the caller must not gate it on them.
+
+    Args:
+        jd_start: Julian Day (UT) to search forward from, normally local midnight.
+        latitude: Observer latitude in degrees.
+        longitude: Observer longitude in degrees.
+
+    Returns:
+        The transit instant as a Julian Day, or ``None`` if the backend could not
+        produce one.
+    """
+    try:
+        iflag = configure_ephemeris_path()
+        geopos = (float(longitude), float(latitude), 0.0)
+        CALC_MTRANSIT = getattr(ephe, "CALC_MTRANSIT", getattr(ephe, "SE_CALC_MTRANSIT", 4))
+
+        result = ephe.rise_trans(
+            jd_start,
+            ephe.SUN,
+            CALC_MTRANSIT,
+            geopos,
+            atpress=0.0,
+            attemp=0.0,
+            flags=iflag,
+        )
+        return _extract_event_time(result)
+
+    except _BACKEND_ERRORS as exc:
+        logger.debug("Sun transit calculation failed: %s", exc)
+        return None
+    except (AttributeError, TypeError, IndexError, ValueError) as exc:  # pragma: no cover
+        logger.error("Unexpected error in Sun transit calculation: %s", exc, exc_info=True)
+        return None
+
+
 def compute_sun_rise_set_ephe(
     jd_midnight: float,
     latitude: float,
     longitude: float,
 ) -> tuple[Optional[float], Optional[float]]:
     """
-    Compute precise sunrise and sunset times using Swiss Ephemeris `ephe.rise_trans`.
+    Compute precise sunrise and sunset times via the backend's `rise_trans`.
 
-    This helper delegates the heavy lifting to Swiss Ephemeris' dedicated
+    This helper delegates the heavy lifting to the backend's dedicated
     rise/transit routines, avoiding any custom numerical search logic.
+
+    The event is the apparent UPPER LIMB on the horizon under a standard
+    atmosphere (1013.25 hPa, 15 degrees C), which leaves the Sun's geometric
+    centre near -0.83 degrees. That is deliberately a different question from
+    ``AstrologicalSubjectModel.is_diurnal``, which tests the geometric centre
+    against the true horizon: within a few minutes of the event the two
+    legitimately disagree, by 3.3 min at the equator and 10 min at 70 degrees.
 
     Args:
         jd_midnight: Julian Day at the start of the *local* civil day,
             expressed in UT (i.e. the Julian day of local midnight converted
-            to UTC). Swiss Ephemeris will search for events around this time.
+            to UTC). The backend will search for events around this time.
         latitude: Observer latitude in degrees.
         longitude: Observer longitude in degrees.
 
@@ -276,7 +376,7 @@ def compute_sun_rise_set_ephe(
             Returns None for each event that doesn't occur on this day (polar day/night).
     """
     try:
-        # Ensure Swiss Ephemeris is configured (idempotent).
+        # Ensure the ephemeris backend is configured (idempotent).
         iflag = configure_ephemeris_path()
 
         # Observer position: longitude, latitude, altitude (meters)
@@ -289,38 +389,6 @@ def compute_sun_rise_set_ephe(
         # Compatibility shims for rise/set calculation flags
         CALC_RISE = getattr(ephe, "CALC_RISE", getattr(ephe, "SE_CALC_RISE", 1))
         CALC_SET = getattr(ephe, "CALC_SET", getattr(ephe, "SE_CALC_SET", 2))
-
-        def _extract_event_time(result: object) -> Optional[float]:
-            """
-            Extract the primary event time (JD) from `ephe.rise_trans` result.
-
-            According to the Python wrapper documentation, the result is:
-
-                (res, tret)
-
-            where:
-                - res: integer status (0 = event found, -2 = circumpolar, etc.)
-                - tret: tuple of 10 floats, with tret[0] = JD of the event.
-            """
-            if not isinstance(result, tuple) or not result:
-                return None
-
-            if len(result) < 2:
-                return None
-
-            res, tret = result[0], result[1]
-
-            # We only accept res == 0 (event found).
-            if not isinstance(res, int) or res != 0:
-                return None
-
-            if not isinstance(tret, (list, tuple)) or not tret:
-                return None
-
-            if not isinstance(tret[0], (float, int)):
-                return None
-
-            return float(tret[0])
 
         # Sunrise (next rise after jd_midnight)
         sunrise_result = ephe.rise_trans(

--- a/kerykeion/schemas/kr_models.py
+++ b/kerykeion/schemas/kr_models.py
@@ -139,13 +139,15 @@ class MoonPhaseSunInfoModel(SubscriptableBaseModel):
     presented for the subject's civil day); ``day_length`` is a ``timedelta``.
     This differs from :class:`SunTimesModel`, whose instants are in UTC. All
     fields are optional and are populated as available — e.g. during polar
-    day/night a full sunrise→sunset pair may be missing, leaving ``solar_noon``
-    and ``day_length`` as ``None``.
+    day/night a full sunrise→sunset pair may be missing, leaving ``day_length``
+    as ``None``.
 
     Attributes:
         sunrise: Moment of sunrise (subject-local), or ``None``.
         sunset: Moment of sunset (subject-local), or ``None``.
-        solar_noon: Midpoint between sunrise and sunset (subject-local), or ``None``.
+        solar_noon: Meridian transit — the moment the Sun is highest
+            (subject-local), or ``None``. Not the midpoint of the pair: the two
+            agree only while the declination is stationary.
         day_length: Duration from sunrise to sunset, or ``None``.
         position: Apparent solar position (altitude/azimuth/distance).
         next_solar_eclipse: Next global solar eclipse, if computed.
@@ -395,11 +397,12 @@ class SunTimesModel(SubscriptableBaseModel):
 
     All instants are timezone-aware ``datetime`` objects in UTC. During polar day
     or polar night the Sun may not provide a complete sunrise -> sunset pair, so
-    ``solar_noon`` and ``day_length`` are ``None`` and the matching
-    ``is_polar_day`` / ``is_polar_night`` flag is set. On transition dates,
-    ``sunrise`` or ``sunset`` can be present independently, and a paired
-    ``sunset`` may fall on the following civil date (so ``day_length`` can
-    exceed 24 hours) when daylight spans local midnight at high latitudes.
+    ``day_length`` is ``None`` and the matching ``is_polar_day`` /
+    ``is_polar_night`` flag is set — but ``solar_noon`` is still reported, since
+    the Sun culminates on a day it never rises. On transition dates, ``sunrise``
+    or ``sunset`` can be present independently, and a paired ``sunset`` may fall
+    on the following civil date (so ``day_length`` can exceed 24 hours) when
+    daylight spans local midnight at high latitudes.
 
     Attributes:
         date: Civil date (``YYYY-MM-DD``) in the requested timezone.
@@ -408,7 +411,12 @@ class SunTimesModel(SubscriptableBaseModel):
         longitude: Observer longitude in degrees (east positive).
         sunrise: Moment of sunrise (upper limb, atmospheric refraction applied), or ``None``.
         sunset: Moment of sunset (upper limb, atmospheric refraction applied), or ``None``.
-        solar_noon: Midpoint between a paired sunrise and later sunset, or ``None``.
+        solar_noon: Meridian transit — the moment the Sun crosses the observer's
+            meridian and is highest in the sky. This is true local noon, not the
+            midpoint of the rise/set pair: the two agree only while the
+            declination is stationary, and away from the solstices the midpoint
+            drifts by up to a minute (further the higher the latitude). Present
+            on polar days too, when there is no pair to take a midpoint of.
         day_length: Duration from sunrise to a later paired sunset, or ``None``.
         is_polar_day: ``True`` when the Sun stays above the horizon all day.
         is_polar_night: ``True`` when the Sun stays below the horizon all day.

--- a/kerykeion/sun_times/factory.py
+++ b/kerykeion/sun_times/factory.py
@@ -18,8 +18,9 @@ class SunTimesFactory:
     ephemeris backend's rise/set routine directly (with atmospheric refraction)
     rather than building a full astrological subject, so it is fast and has no
     geolocation dependency. Times are returned as timezone-aware UTC datetimes;
-    on polar day/night or transition dates the derived ``solar_noon`` and
-    ``day_length`` are ``None`` unless a sunrise can be paired with a later sunset.
+    on polar day/night or transition dates ``day_length`` is ``None``,
+    while ``solar_noon`` is still reported — a meridian crossing happens on a day
+    with no horizon crossing unless a sunrise can be paired with a later sunset.
 
     Example:
         >>> from kerykeion import SunTimesFactory

--- a/kerykeion/sun_times/factory.py
+++ b/kerykeion/sun_times/factory.py
@@ -18,9 +18,10 @@ class SunTimesFactory:
     ephemeris backend's rise/set routine directly (with atmospheric refraction)
     rather than building a full astrological subject, so it is fast and has no
     geolocation dependency. Times are returned as timezone-aware UTC datetimes;
-    on polar day/night or transition dates ``day_length`` is ``None``,
-    while ``solar_noon`` is still reported — a meridian crossing happens on a day
-    with no horizon crossing unless a sunrise can be paired with a later sunset.
+    on polar day/night or transition dates ``day_length`` is
+    ``None``, because no sunrise could be paired with a later sunset. Solar noon
+    is still reported: a meridian crossing is not a horizon crossing, so the Sun
+    culminates on a day it never rises.
 
     Example:
         >>> from kerykeion import SunTimesFactory

--- a/kerykeion/sun_times/factory.py
+++ b/kerykeion/sun_times/factory.py
@@ -18,8 +18,10 @@ class SunTimesFactory:
     ephemeris backend's rise/set routine directly (with atmospheric refraction)
     rather than building a full astrological subject, so it is fast and has no
     geolocation dependency. Times are returned as timezone-aware UTC datetimes;
-    on polar day/night or transition dates ``day_length`` is
-    ``None``, because no sunrise could be paired with a later sunset. Solar noon
+    on polar day/night dates ``day_length`` is ``None``; on transition dates it
+    is ``None`` only when no sunrise could be paired with a later sunset — a
+    successful pairing can reach past local midnight and push ``day_length``
+    beyond 24 hours (see ``SunTimesModel``). Solar noon
     is still reported: a meridian crossing is not a horizon crossing, so the Sun
     culminates on a day it never rises.
 

--- a/kerykeion/sun_times/utils.py
+++ b/kerykeion/sun_times/utils.py
@@ -292,10 +292,11 @@ def _civil_day_bounds(year: int, month: int, day: int, tz: ZoneInfo) -> tuple[fl
 def _polar_state(jd_noon: float, latitude: float) -> tuple[bool, bool]:
     """Classify a no-rise/no-set day as polar day or polar night.
 
-    Uses the TEXTBOOK apparent upper-limb horizon convention, which is deliberately
-    not quite the one used by Swiss Ephemeris
-    rise/set searches. Refraction and the Sun's semidiameter put the apparent
-    sunrise/sunset threshold near -0.833 degrees for the Sun's center.
+    Uses the TEXTBOOK apparent upper-limb horizon convention — deliberately not
+    quite the one the rise/set search itself uses; the note on
+    ``_APPARENT_UPPER_LIMB_HORIZON_DEGREES`` above owns that gap. Refraction and
+    the Sun's semidiameter put the apparent sunrise/sunset threshold near
+    -0.833 degrees for the Sun's center.
 
     Args:
         jd_noon: Julian Day (UT) near local solar noon — used to read the Sun's

--- a/kerykeion/sun_times/utils.py
+++ b/kerykeion/sun_times/utils.py
@@ -25,6 +25,7 @@ from zoneinfo import ZoneInfo
 from kerykeion.ephemeris_backend import ephemeris_session, ephe
 from kerykeion.moon_phase_details.utils import (
     compute_sun_rise_set_ephe,
+    compute_sun_transit_ephe,
     configure_ephemeris_path,
 )
 from kerykeion.schemas.kerykeion_exception import KerykeionException
@@ -39,6 +40,22 @@ from kerykeion.utilities import (
 
 logger = logging.getLogger(__name__)
 
+#: Centre-of-disc altitude that stands for "the apparent upper limb is on the
+#: horizon", used ONLY by the polar-day/night discriminator below.
+#:
+#: It is the textbook 34' of refraction plus 16' of semidiameter. The rise/set
+#: search itself does not use this number: it computes both terms for the day in
+#: question — Bennett refraction at the pressure and temperature it is given, and
+#: a semidiameter from the real Earth-Sun distance — which lands the centre at
+#: about -0.827 deg, measured -0.822 to -0.831 over a year.
+#:
+#: The 0.006 deg gap is deliberate rather than an oversight, and small: the
+#: discriminator only has to answer whether the Sun crosses the horizon AT ALL on
+#: a given day, so its threshold matters only within a few hours of the first and
+#: last day of a midnight-sun season. Matching it to the search would mean
+#: recomputing refraction and distance just to classify a day, and would move the
+#: boundary date by a fraction of a day at the very edge of the Arctic circle,
+#: with no external reference to say which side is right.
 _APPARENT_UPPER_LIMB_HORIZON_DEGREES = -0.833
 
 
@@ -385,14 +402,30 @@ def compute_sun_events(
                     f"at ({latitude}, {longitude}) and the geometry is not polar; the date or location may be "
                     f"outside the backend's supported rise/set range."
                 )
+            # The Sun still culminates on a day it never rises: a transit is an
+            # hour-angle crossing, not a horizon crossing. Reporting solar noon
+            # here is what lets a polar-night caller say when the sky is least
+            # dark, which the old midpoint could never do because it had no pair
+            # to take a midpoint of.
+            transit_jd = compute_sun_transit_ephe(jd_midnight, latitude, longitude)
             sunrise = julian_day_to_utc(sunrise_jd) if sunrise_jd is not None else None
             sunset = julian_day_to_utc(sunset_jd) if sunset_jd is not None else None
-            return SunEvents(sunrise, sunset, None, None, is_polar_day, is_polar_night)
+            solar_noon = julian_day_to_utc(transit_jd) if transit_jd is not None else None
+            return SunEvents(sunrise, sunset, solar_noon, None, is_polar_day, is_polar_night)
+
+        # Solar noon is the meridian transit, NOT the midpoint of the pair above.
+        # The two agree only while the declination is stationary; elsewhere the
+        # midpoint lags or leads by up to a minute (measured: +21 s at Rome on
+        # the equinox, +62 s at Reykjavik in April), and when the pair spans two
+        # civil days it lands on the wrong date entirely. Searched from local
+        # midnight so it belongs to the requested civil day rather than to the
+        # sunrise that may have preceded it.
+        transit_jd = compute_sun_transit_ephe(jd_midnight, latitude, longitude)
 
     sunrise = julian_day_to_utc(sunrise_jd)
     sunset = julian_day_to_utc(sunset_jd)
     day_length = sunset - sunrise
-    solar_noon = sunrise + day_length / 2
+    solar_noon = julian_day_to_utc(transit_jd) if transit_jd is not None else None
     return SunEvents(sunrise, sunset, solar_noon, day_length, False, False)
 
 

--- a/kerykeion/sun_times/utils.py
+++ b/kerykeion/sun_times/utils.py
@@ -8,8 +8,10 @@ refraction — is delegated to the well-tested
 the active ephemeris backend's ``rise_trans`` routine. This module adds the thin
 layer on top: timezone/Julian-Day bookkeeping, solar noon, day length, the polar
 day / polar night discriminator, and civil/nautical/astronomical twilight. No
-full astrological subject is built, so the computation stays cheap: two
-``rise_trans`` calls for sunrise/sunset (plus one position lookup) and up to six
+full astrological subject is built, so the computation stays cheap: three
+``rise_trans`` calls for sunrise, sunset and the meridian transit (plus one
+position lookup, and a fourth rise/set call on the transition days that need a
+paired sunset re-searched) and up to six
 more for the twilight crossings.
 """
 
@@ -290,7 +292,8 @@ def _civil_day_bounds(year: int, month: int, day: int, tz: ZoneInfo) -> tuple[fl
 def _polar_state(jd_noon: float, latitude: float) -> tuple[bool, bool]:
     """Classify a no-rise/no-set day as polar day or polar night.
 
-    Uses the same apparent upper-limb horizon convention as Swiss Ephemeris
+    Uses the TEXTBOOK apparent upper-limb horizon convention, which is deliberately
+    not quite the one used by Swiss Ephemeris
     rise/set searches. Refraction and the Sun's semidiameter put the apparent
     sunrise/sunset threshold near -0.833 degrees for the Sun's center.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     # TODO before tagging 6.0.0: bump the floor to the stable 3.0.0 once released.
-    "libephemeris==3.0.0rc15",
+    "libephemeris==3.0.0",
     "pydantic>=2.5",
     "svg-polish>=1.0.0",
     "requests-cache>=1.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,10 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "libephemeris==3.0.0",
+    # A FLOOR, not a pin. The 3.0.0rc1 exact pin was deliberately relaxed once
+    # before (see CHANGELOG 5.x) "so the stable release does not conflict with
+    # other constraints"; the stable release is what this is.
+    "libephemeris>=3.0.0,<4",
     "pydantic>=2.5",
     "svg-polish>=1.0.0",
     "requests-cache>=1.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kerykeion"
-version = "6.0.0a78"
+version = "6.0.0a79"
 authors = [
     { name = "Giacomo Battaglia", email = "kerykeion.astrology@gmail.com" }
 ]
@@ -45,7 +45,6 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    # TODO before tagging 6.0.0: bump the floor to the stable 3.0.0 once released.
     "libephemeris==3.0.0",
     "pydantic>=2.5",
     "svg-polish>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,21 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    # A FLOOR, not a pin. The 3.0.0rc1 exact pin was deliberately relaxed once
-    # before (see CHANGELOG 5.x) "so the stable release does not conflict with
-    # other constraints"; the stable release is what this is.
+    # A FLOOR, not a pin — and the precedent is mixed, so here is the whole of it.
+    # The rc1 pin was relaxed once, in 6.0.0a62, "so the stable release does not
+    # conflict with other constraints"; every release after that re-pinned
+    # exactly (a67, a68, a72, a73, a78), and a78's own note reasons FROM the pin
+    # being exact. So this is a change of policy, not a return to one.
+    # The argument for it: an exact pin on a library that is itself pre-release
+    # makes kerykeion unco-installable with anything else that depends on
+    # libephemeris, which is what a62 was about, and 3.0.0 is the first stable
+    # release where that stops being hypothetical.
+    # The argument against, which is real: this project's verification model is
+    # version-locked — the golden fixtures were regenerated for rc15 -> 3.0.0,
+    # and `test_sun_times_altitude_invariant.py` hardcodes an invariant that a
+    # 3.1 with a different refraction or rise/set convention would silently
+    # invalidate. Nothing asserts the installed version. The lockfile protects
+    # this repository; it does not protect `pip install kerykeion`.
     "libephemeris>=3.0.0,<4",
     "pydantic>=2.5",
     "svg-polish>=1.0.0",

--- a/tests/core/test_moon_phase_details_factory_mocked.py
+++ b/tests/core/test_moon_phase_details_factory_mocked.py
@@ -70,6 +70,7 @@ _SOLAR_ECLIPSE_JD = 2449305.40616  # Nov 13, 1993
 
 # Sunrise/sunset Julian Days for London on Oct 10, 1993
 _SUNRISE_JD = 2449270.80208
+_SOLAR_NOON_JD = (2449270.80208 + 2449271.26250) / 2  # midway between the two above
 _SUNSET_JD = 2449271.26250
 
 
@@ -280,6 +281,12 @@ class TestFactoryFromSubjectMocked:
             patch(f"{_FACTORY}.compute_next_solar_eclipse_jd", return_value=(16, _SOLAR_ECLIPSE_JD)),
             patch(f"{_FACTORY}.compute_next_lunar_eclipse_jd", return_value=(4, _LUNAR_ECLIPSE_JD)),
             patch(f"{_FACTORY}.compute_sun_rise_set_ephe", return_value=(_SUNRISE_JD, _SUNSET_JD)),
+            # The transit is a SIXTH backend call, added when solar noon stopped
+            # being the midpoint. Unpatched it ran for real inside the suite whose
+            # whole premise is that it does not, and `test_sun_info_populated`
+            # then compared a real transit against two fabricated JD constants —
+            # passing only because the fabricated window happened to bracket it.
+            patch(f"{_FACTORY}.compute_sun_transit_ephe", return_value=_SOLAR_NOON_JD),
             patch(f"{_FACTORY}.compute_sun_position", return_value=(31.25, 169.67, 149_200_000.0)),
         ):
             yield
@@ -443,6 +450,12 @@ class TestFactoryEdgeCasesNullReturns:
             patch(f"{_FACTORY}.compute_next_solar_eclipse_jd", return_value=None),
             patch(f"{_FACTORY}.compute_next_lunar_eclipse_jd", return_value=None),
             patch(f"{_FACTORY}.compute_sun_rise_set_ephe", return_value=(_SUNRISE_JD, _SUNSET_JD)),
+            # The transit is a SIXTH backend call, added when solar noon stopped
+            # being the midpoint. Unpatched it ran for real inside the suite whose
+            # whole premise is that it does not, and `test_sun_info_populated`
+            # then compared a real transit against two fabricated JD constants —
+            # passing only because the fabricated window happened to bracket it.
+            patch(f"{_FACTORY}.compute_sun_transit_ephe", return_value=_SOLAR_NOON_JD),
             patch(f"{_FACTORY}.compute_sun_position", return_value=(31.25, 169.67, 149_200_000.0)),
         ):
             overview = MoonPhaseDetailsFactory.from_subject(subject)
@@ -465,7 +478,10 @@ class TestFactoryEdgeCasesNullReturns:
 
         assert overview.sun.sunrise is None
         assert overview.sun.sunset is None
-        assert overview.sun.solar_noon is None
+        # solar_noon survives a rise/set failure now, and that is the point: a
+        # transit is a meridian crossing, so it exists on a day with no horizon
+        # crossing and does not depend on the pair. Only day_length does.
+        assert overview.sun.solar_noon is not None
         assert overview.sun.day_length is None
         assert overview.sun.position is None
 

--- a/tests/core/test_moon_phase_details_factory_mocked.py
+++ b/tests/core/test_moon_phase_details_factory_mocked.py
@@ -6,12 +6,21 @@ verified without ephemeris data files or real ephe calls. This isolates the
 factory's orchestration, model assembly, and edge-case handling.
 
 Mocking strategy:
-    All five Swiss Ephemeris utility functions imported by factory.py are
-    patched via ``kerykeion.moon_phase_details.factory.<function>``:
+    All SIX ephemeris helpers imported by factory.py are patched via
+    ``kerykeion.moon_phase_details.factory.<function>``. The transit is patched by
+    a MODULE-level autouse fixture rather than per class: it was added later, and
+    patching it only in the two blocks that obviously needed it left thirteen
+    tests in this file making real backend calls — including the one asserting
+    that solar noon survives a rise/set failure, whose green then depended on a
+    real ephemeris succeeding. A per-class fixture cannot prevent that recurring;
+    a module-level one can.
+
+    The patched helpers:
         - compute_lunar_phase_jd
         - compute_next_solar_eclipse_jd
         - compute_next_lunar_eclipse_jd
         - compute_sun_rise_set_ephe
+        - compute_sun_transit_ephe
         - compute_sun_position
 """
 
@@ -70,7 +79,12 @@ _SOLAR_ECLIPSE_JD = 2449305.40616  # Nov 13, 1993
 
 # Sunrise/sunset Julian Days for London on Oct 10, 1993
 _SUNRISE_JD = 2449270.80208
-_SOLAR_NOON_JD = (2449270.80208 + 2449271.26250) / 2  # midway between the two above
+# The REAL meridian transit for this subject (London, 1993-10-10 11:47:30 UTC),
+# not the midpoint of the pair above. Using the midpoint would encode the very
+# definition this release removes, and would make `sunrise < solar_noon <
+# sunset` tautological — it is 59 minutes from the true transit, and that
+# assertion is one of the few things here that still says something.
+_SOLAR_NOON_JD = 2449270.9913192377
 _SUNSET_JD = 2449271.26250
 
 
@@ -159,6 +173,20 @@ def _side_effect_lunar_phase_jd(jd_start: float, target_angle: float, forward: b
 # 1. Pure utility function tests (no mocking needed)
 # ---------------------------------------------------------------------------
 
+
+
+@pytest.fixture(autouse=True)
+def _no_real_transit_calls():
+    """Patch the transit for EVERY test in this module.
+
+    Module-scoped autouse, deliberately. `compute_sun_transit_ephe` arrived after
+    this file was written, and patching it inside the two fixtures that obviously
+    needed it left thirteen tests calling the real backend — the exact thing the
+    module docstring promises does not happen. Tests that want their own value
+    still override it with a nested `patch`; this only guarantees the floor.
+    """
+    with patch(f"{_FACTORY}.compute_sun_transit_ephe", return_value=_SOLAR_NOON_JD):
+        yield
 
 class TestSafeParseIsoDatetime:
     """safe_parse_iso_datetime: tolerant on format, strict on invalid input."""

--- a/tests/core/test_moon_phase_details_factory_mocked.py
+++ b/tests/core/test_moon_phase_details_factory_mocked.py
@@ -1,7 +1,7 @@
 """
 Mocked unit tests for MoonPhaseDetailsFactory.
 
-These tests mock the Swiss Ephemeris utility layer so the factory logic can be
+These tests mock the ephemeris utility layer so the factory logic can be
 verified without ephemeris data files or real ephe calls. This isolates the
 factory's orchestration, model assembly, and edge-case handling.
 
@@ -13,7 +13,11 @@ Mocking strategy:
     tests in this file making real backend calls — including the one asserting
     that solar noon survives a rise/set failure, whose green then depended on a
     real ephemeris succeeding. A per-class fixture cannot prevent that recurring;
-    a module-level one can.
+    a module-level one can. The two NON-mocked classes at the bottom
+    (`TestMoonPhaseDetailsIntegration`, `TestFactoryFromSubjectRangeEdge`)
+    override it back to the real call: an earlier revision blindfolded them too,
+    silently zeroing the file's only real-ephemeris transit coverage while the
+    commit message claimed the opposite.
 
     The patched helpers:
         - compute_lunar_phase_jd
@@ -184,6 +188,8 @@ def _no_real_transit_calls():
     needed it left thirteen tests calling the real backend — the exact thing the
     module docstring promises does not happen. Tests that want their own value
     still override it with a nested `patch`; this only guarantees the floor.
+    The two real-ephemeris classes shadow this fixture with a no-op, or their
+    transit-path coverage would be silently zero.
     """
     with patch(f"{_FACTORY}.compute_sun_transit_ephe", return_value=_SOLAR_NOON_JD):
         yield
@@ -690,7 +696,16 @@ class TestComputeLunarPhaseMetrics:
 
 
 class TestMoonPhaseDetailsIntegration:
-    """Integration test exercising real Swiss Ephemeris calls."""
+    """Integration test exercising real ephemeris backend calls."""
+
+    @pytest.fixture(autouse=True)
+    def _no_real_transit_calls(self):
+        """Shadow the module blindfold: this class IS the real-ephemeris path.
+
+        With the module fixture active its transit coverage was silently zero —
+        five real helpers plus one fake, while the commit message said six.
+        """
+        yield
 
     def test_from_subject_returns_valid_overview(self):
         from kerykeion.moon_phase_details import MoonPhaseDetailsFactory
@@ -750,6 +765,14 @@ class TestFactoryFromSubjectRangeEdge:
     lower-precision source (the rc12 behaviour): sealed LEB mode raises the
     typed ``EphemerisRangeError`` by deliberate contract ("LEB mode does not
     silently substitute a lower-precision source")."""
+
+    @pytest.fixture(autouse=True)
+    def _no_real_transit_calls(self):
+        """Shadow the module blindfold — same reason as the class above: the
+        whole point of this class is that the REAL backend degrades cleanly,
+        transit included (it computes fine at 2649-12-20; the edge the class
+        exercises is the forward phase scan, not the transit)."""
+        yield
 
     def test_range_end_subject_returns_model(self) -> None:
         # 2649-12-20 is inside the final synodic month of the medium (DE440)

--- a/tests/core/test_sun_times_altitude_invariant.py
+++ b/tests/core/test_sun_times_altitude_invariant.py
@@ -1,0 +1,345 @@
+"""Sun-vs-horizon measured as an ANGLE, by a second implementation.
+
+The anchors next door compare our instants to published instants. That works at
+mid latitudes and stops working near the poles, where the Sun grazes the horizon:
+`dh/dt` collapses, so a milliarcsecond of altitude becomes minutes of clock and
+the comparison starts measuring conditioning instead of correctness. Measured on
+this grid, one arcminute of error is worth 4 s of time at Quito and 200 s at
+Tromso in mid-May — a fifty-fold swing in what "the same error" looks like.
+
+So this module never compares times. It takes the instant we return and asks an
+independent implementation where the Sun actually was. The answer is an angle,
+which does not deform with latitude, and it must be the same angle everywhere:
+
+    at every sunrise and sunset, the Sun's true upper limb is on the refracted
+    horizon;
+    at every solar noon, the Sun's hour angle is zero;
+    at the instant `is_diurnal` flips, the Sun's geometric centre is at 0.
+
+The independent side is Skyfield reading its own JPL kernel — a separate position
+pipeline from the one under test, with its own frame handling. It is not a claim
+of absolute truth (the anchors are what carry that); it is a claim that two
+implementations that share no code agree on where the Sun was, which is what
+isolates OUR geometry from the convention question.
+
+Needs `skyfield` and `skyfield-data`, both already present as transitive
+dependencies of the ephemeris backend.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+
+import pytest
+
+from kerykeion import AstrologicalSubjectFactory, SunTimesFactory
+
+skyfield_api = pytest.importorskip("skyfield.api")
+skyfield_data = pytest.importorskip("skyfield_data")
+
+_SOLAR_RADIUS_AU = 696000.0 / 149597870.700
+
+#: True altitude of the Sun's upper limb at a rise/set we return. It is minus the
+#: atmospheric refraction at the apparent horizon under the standard atmosphere
+#: the backend is driven with (1013.25 hPa, 15 C). Measured over the grid below
+#: the spread is 2.5", so this is an invariant and not an average.
+_LIMB_ON_HORIZON_ARCMIN = -33.59
+
+#: ~2.7x the observed spread. Tight enough to fail on a dropped solar parallax
+#: (8.8" = 0.147') or a switch to a fixed semidiameter; loose enough that no
+#: amount of ordinary ephemeris noise can reach it.
+_LIMB_TOL_ARCMIN = 0.06
+
+#: Hour angle at solar noon, in seconds of time. Measured worst case is 0.083 s;
+#: 2 s leaves an enormous margin and still fails the moment solar noon reverts to
+#: the sunrise/sunset midpoint, which is 20-60 s away from the meridian at these
+#: latitudes.
+_TRANSIT_HOUR_ANGLE_TOL_S = 2.0
+
+_GRID = [
+    ("quito", -0.1807, -78.4678, 2026, 3, 20),
+    ("rome_equinox", 41.9028, 12.4964, 2026, 3, 20),
+    ("rome_solstice", 41.9028, 12.4964, 2026, 6, 21),
+    ("london", 51.5074, -0.1278, 2026, 8, 5),
+    ("sydney", -33.8688, 151.2093, 2026, 12, 21),
+    ("reykjavik", 64.1466, -21.9426, 2026, 4, 15),
+    ("tromso", 69.6492, 18.9553, 2026, 4, 5),
+    ("ushuaia", -54.8019, -68.3030, 2026, 9, 22),
+    ("nairobi", -1.2921, 36.8219, 2026, 1, 15),
+    ("singapore", 1.3521, 103.8198, 2026, 8, 5),
+]
+
+
+@pytest.fixture(scope="module")
+def oracle():
+    """Skyfield, loaded once: the second implementation everything is checked against."""
+    loader = skyfield_api.Loader(skyfield_data.get_skyfield_data_path(), verbose=False)
+    ephemeris = loader("de421.bsp")
+    return {
+        "ts": loader.timescale(),
+        "earth": ephemeris["earth"],
+        "sun": ephemeris["sun"],
+        "wgs84": skyfield_api.wgs84,
+    }
+
+
+def _observer(oracle, latitude: float, longitude: float):
+    return oracle["earth"] + oracle["wgs84"].latlon(latitude, longitude, elevation_m=0)
+
+
+def _true_altitude_and_semidiameter(oracle, moment: dt.datetime, latitude: float, longitude: float):
+    """Independent (altitude, semidiameter) in arcminutes at `moment`."""
+    apparent = _observer(oracle, latitude, longitude).at(oracle["ts"].from_datetime(moment)).observe(oracle["sun"]).apparent()
+    altitude, _azimuth, distance = apparent.altaz()
+    semidiameter = math.degrees(math.asin(_SOLAR_RADIUS_AU / distance.au))
+    return altitude.degrees * 60.0, semidiameter * 60.0
+
+
+def _hour_angle_seconds(oracle, moment: dt.datetime, latitude: float, longitude: float) -> float:
+    """Independent hour angle at `moment`, in seconds of time (0 = on the meridian)."""
+    time = oracle["ts"].from_datetime(moment)
+    right_ascension, _declination, _distance = (
+        _observer(oracle, latitude, longitude).at(time).observe(oracle["sun"]).apparent().radec(epoch="date")
+    )
+    hours = (time.gast + longitude / 15.0 - right_ascension.hours) % 24.0
+    if hours > 12.0:
+        hours -= 24.0
+    return hours * 3600.0
+
+
+def _sun_times(latitude: float, longitude: float, year: int, month: int, day: int):
+    return SunTimesFactory.from_date(year, month, day, latitude=latitude, longitude=longitude, tz_str="UTC")
+
+
+@pytest.mark.parametrize("name,lat,lon,y,m,d", _GRID, ids=lambda v: v if isinstance(v, str) else "")
+def test_the_upper_limb_is_on_the_horizon_at_every_rise_and_set(oracle, name, lat, lon, y, m, d):
+    """One number, the whole globe, every season."""
+    model = _sun_times(lat, lon, y, m, d)
+
+    failures: list[str] = []
+    for label, moment in (("sunrise", model.sunrise), ("sunset", model.sunset)):
+        if moment is None:
+            continue
+        altitude, semidiameter = _true_altitude_and_semidiameter(oracle, moment, lat, lon)
+        limb = altitude + semidiameter
+        if abs(limb - _LIMB_ON_HORIZON_ARCMIN) > _LIMB_TOL_ARCMIN:
+            failures.append(
+                f"{label} at {moment:%Y-%m-%d %H:%M:%S}Z: upper limb {limb:.4f}', "
+                f"expected {_LIMB_ON_HORIZON_ARCMIN}' +/- {_LIMB_TOL_ARCMIN}'"
+            )
+
+    assert not failures, (
+        f"{name}: the horizon convention moved.\n  " + "\n  ".join(failures) + "\n"
+        "Check the refraction parameters, the disc-limb term and the topocentric "
+        "parallax before touching anything else."
+    )
+
+
+@pytest.mark.parametrize("name,lat,lon,y,m,d", _GRID, ids=lambda v: v if isinstance(v, str) else "")
+def test_solar_noon_is_on_the_meridian(oracle, name, lat, lon, y, m, d):
+    """Solar noon is a meridian crossing, so its hour angle is zero.
+
+    The direct statement of what the field means, and the tight one: the anchors
+    can only bound it to the reference's whole-minute publication, while an hour
+    angle can be measured to a fraction of a second. This is the test that fails
+    the moment solar noon goes back to being the midpoint of the rise/set pair.
+    """
+    model = _sun_times(lat, lon, y, m, d)
+    assert model.solar_noon is not None, "the Sun culminates every day"
+
+    hour_angle = _hour_angle_seconds(oracle, model.solar_noon, lat, lon)
+    assert abs(hour_angle) < _TRANSIT_HOUR_ANGLE_TOL_S, (
+        f"{name}: at the reported solar noon {model.solar_noon:%Y-%m-%d %H:%M:%S}Z the Sun's "
+        f"hour angle is {hour_angle:+.2f} s of time, not 0. Solar noon is the meridian "
+        f"transit; a value tens of seconds out is the midpoint of sunrise and sunset, "
+        f"which is a different quantity."
+    )
+
+
+#: The midpoint comparison needs the observer's OWN timezone, not UTC. Asked for
+#: a UTC civil day at 151 E, the rise/set pair and the meridian crossing belong to
+#: two different local days and the comparison is meaningless — the first draft of
+#: these tests failed on exactly that and it was the harness, not the code.
+_LOCAL_GRID = [
+    ("quito", -0.1807, -78.4678, "America/Guayaquil", 2026, 3, 20),
+    ("rome_equinox", 41.9028, 12.4964, "Europe/Rome", 2026, 3, 20),
+    ("rome_solstice", 41.9028, 12.4964, "Europe/Rome", 2026, 6, 21),
+    ("london", 51.5074, -0.1278, "Europe/London", 2026, 8, 5),
+    ("sydney", -33.8688, 151.2093, "Australia/Sydney", 2026, 12, 21),
+    ("reykjavik", 64.1466, -21.9426, "Atlantic/Reykjavik", 2026, 4, 15),
+    ("singapore", 1.3521, 103.8198, "Asia/Singapore", 2026, 8, 5),
+    ("ushuaia", -54.8019, -68.3030, "America/Argentina/Ushuaia", 2026, 9, 22),
+    ("nairobi", -1.2921, 36.8219, "Africa/Nairobi", 2026, 1, 15),
+]
+
+
+def _local_sun_times(lat: float, lon: float, tz: str, y: int, m: int, d: int):
+    return SunTimesFactory.from_date(y, m, d, latitude=lat, longitude=lon, tz_str=tz)
+
+
+@pytest.mark.parametrize(
+    "name,lat,lon,tz,y,m,d", _LOCAL_GRID,
+    ids=lambda v: v if isinstance(v, str) and "/" not in v else "",
+)
+def test_the_midpoint_of_the_pair_is_not_the_meridian(oracle, name, lat, lon, tz, y, m, d):
+    """The two really are different quantities, and by how much depends on where.
+
+    Kept as a positive statement rather than a comment, because the whole reason
+    solar noon was wrong for so long is that the two look interchangeable. This
+    checks the difference is real geometry rather than bookkeeping: whatever the
+    midpoint's distance from the reported noon, its hour angle must equal it.
+    """
+    model = _local_sun_times(lat, lon, tz, y, m, d)
+    if model.sunrise is None or model.sunset is None:
+        pytest.skip("no rise/set pair to take a midpoint of")
+
+    midpoint = model.sunrise + (model.sunset - model.sunrise) / 2
+    hour_angle = _hour_angle_seconds(oracle, midpoint, lat, lon)
+    drift = (midpoint - model.solar_noon).total_seconds()
+
+    assert abs(hour_angle - drift) < 1.5, (
+        f"{name}: the midpoint sits {drift:+.1f} s from the reported noon while its hour "
+        f"angle is {hour_angle:+.1f} s — the two disagree, so one of them is not what it "
+        f"claims to be"
+    )
+
+
+def test_the_midpoint_drift_grows_with_latitude_away_from_the_solstice():
+    """It is not noise: it has a direction and a cause.
+
+    At the solstice, and on the equator, the declination barely moves between
+    sunrise and sunset and the midpoint IS the meridian. Away from both it is not,
+    and the gap widens with latitude. Pinning the pattern rather than a single
+    number is what makes this a statement about geometry instead of an accident of
+    one date — and it is the reason the old implementation looked right for years
+    to anyone who checked it in June.
+    """
+    def drift_seconds(lat: float, lon: float, tz: str, y: int, m: int, d: int) -> float:
+        model = _local_sun_times(lat, lon, tz, y, m, d)
+        midpoint = model.sunrise + (model.sunset - model.sunrise) / 2
+        return abs((midpoint - model.solar_noon).total_seconds())
+
+    equator = drift_seconds(-0.1807, -78.4678, "America/Guayaquil", 2026, 3, 20)
+    rome_solstice = drift_seconds(41.9028, 12.4964, "Europe/Rome", 2026, 6, 21)
+    rome_equinox = drift_seconds(41.9028, 12.4964, "Europe/Rome", 2026, 3, 20)
+    reykjavik_april = drift_seconds(64.1466, -21.9426, "Atlantic/Reykjavik", 2026, 4, 15)
+
+    assert equator < 3.0, (
+        f"on the equator the day is symmetric about the meridian; drift {equator:.1f} s"
+    )
+    assert rome_solstice < 3.0, (
+        f"at the solstice the declination is stationary, so the midpoint should BE the "
+        f"meridian; it is {rome_solstice:.1f} s away"
+    )
+    assert rome_equinox > 10.0, (
+        f"at the equinox the midpoint should visibly miss the meridian; it is only "
+        f"{rome_equinox:.1f} s away"
+    )
+    assert reykjavik_april > 2 * rome_equinox, (
+        f"the drift should grow steeply with latitude: Reykjavik {reykjavik_april:.1f} s "
+        f"against Rome {rome_equinox:.1f} s"
+    )
+
+
+@pytest.mark.parametrize(
+    "name,lat,lon,tz,y,m,d",
+    [
+        ("quito", -0.1807, -78.4678, "America/Guayaquil", 2026, 3, 20),
+        ("rome", 41.9028, 12.4964, "Europe/Rome", 2026, 3, 20),
+        ("london", 51.5074, -0.1278, "Europe/London", 2026, 8, 5),
+        ("reykjavik", 64.1466, -21.9426, "Atlantic/Reykjavik", 2026, 4, 15),
+    ],
+    ids=lambda v: v if isinstance(v, str) and "/" not in v else "",
+)
+def test_is_diurnal_flips_when_the_geometric_centre_crosses_zero(oracle, name, lat, lon, tz, y, m, d):
+    """`is_diurnal` answers a different question from sunrise, and answers it right.
+
+    Sunrise is the apparent upper limb; `is_diurnal` is the geometric centre. The
+    two are minutes apart by construction, and every attempt to derive one from
+    the other has been a bug. This bisects the flip and checks the independent
+    altitude there is zero — the direct statement of what the field means.
+    """
+    model = _sun_times(lat, lon, y, m, d)
+    sunrise = model.sunrise
+    assert sunrise is not None
+
+    def is_diurnal_at(moment: dt.datetime) -> bool:
+        local = moment.astimezone(dt.timezone.utc)
+        subject = AstrologicalSubjectFactory.from_birth_data(
+            "probe", local.year, local.month, local.day, local.hour, local.minute,
+            lng=lon, lat=lat, tz_str="UTC", city="probe", nation="XX", seconds=local.second,
+        )
+        return subject.is_diurnal
+
+    low, high = sunrise - dt.timedelta(minutes=30), sunrise + dt.timedelta(minutes=30)
+    assert is_diurnal_at(low) is False and is_diurnal_at(high) is True, (
+        "the bracket must straddle the flip for the bisection below to mean anything"
+    )
+    for _ in range(20):
+        middle = low + (high - low) / 2
+        if is_diurnal_at(middle):
+            high = middle
+        else:
+            low = middle
+
+    # Stated in SECONDS, not arcminutes. The probe takes whole seconds, so the
+    # bisection can only ever land within a second of the true crossing, and one
+    # second buys 15" of altitude at the equator but only 6" at 64 N. A fixed
+    # angular tolerance would therefore be far stricter near the equator than at
+    # the pole for no reason; dividing by the local rate makes the claim the same
+    # everywhere: "the flip is where the centre crosses zero, to within the
+    # resolution we can even ask the question at".
+    altitude, _semidiameter = _true_altitude_and_semidiameter(oracle, high, lat, lon)
+    before, _ = _true_altitude_and_semidiameter(oracle, high - dt.timedelta(seconds=30), lat, lon)
+    after, _ = _true_altitude_and_semidiameter(oracle, high + dt.timedelta(seconds=30), lat, lon)
+    rate_arcmin_per_second = (after - before) / 60.0
+    offset_seconds = abs(altitude / rate_arcmin_per_second)
+    assert offset_seconds < 1.5, (
+        f"{name}: is_diurnal flips at {high:%H:%M:%S}Z where the Sun's centre is "
+        f"{altitude:.4f}' — {offset_seconds:.2f} s from the geometric horizon, more than "
+        f"the one-second resolution of the probe can explain. The flag is not testing "
+        f"the geometric horizon."
+    )
+
+    # And the flip is AFTER sunrise, never before: the limb clears the horizon
+    # first. A build that got this backwards would still bisect to something.
+    assert high > sunrise, "is_diurnal cannot turn true before the Sun has risen"
+
+
+def test_the_gap_between_sunrise_and_diurnality_grows_towards_the_pole():
+    """The documented figures, pinned so the documentation cannot rot silently.
+
+    The Sun has to climb the same ~0.83 degrees at every latitude, but it climbs
+    at a shallower angle the further from the equator, so the same geometry costs
+    more time. The README and the model docstrings quote these; this is what
+    stops them drifting away from the code.
+    """
+    def gap_minutes(lat: float, lon: float, tz: str, y: int, m: int, d: int) -> float:
+        model = _sun_times(lat, lon, y, m, d)
+        sunrise = model.sunrise
+
+        def is_diurnal_at(moment: dt.datetime) -> bool:
+            subject = AstrologicalSubjectFactory.from_birth_data(
+                "probe", moment.year, moment.month, moment.day, moment.hour, moment.minute,
+                lng=lon, lat=lat, tz_str="UTC", city="probe", nation="XX", seconds=moment.second,
+            )
+            return subject.is_diurnal
+
+        low, high = sunrise - dt.timedelta(minutes=40), sunrise + dt.timedelta(minutes=40)
+        for _ in range(20):
+            middle = low + (high - low) / 2
+            if is_diurnal_at(middle):
+                high = middle
+            else:
+                low = middle
+        return (high - sunrise).total_seconds() / 60.0
+
+    quito = gap_minutes(-0.1807, -78.4678, "UTC", 2026, 3, 20)
+    rome = gap_minutes(41.9028, 12.4964, "UTC", 2026, 3, 20)
+    reykjavik = gap_minutes(64.1466, -21.9426, "UTC", 2026, 4, 15)
+
+    assert 3.0 < quito < 4.0, f"equator gap {quito:.2f} min, documented as about 3.3"
+    assert 4.0 < rome < 5.5, f"Rome gap {rome:.2f} min, documented as about 4.4"
+    assert 7.5 < reykjavik < 9.5, f"Reykjavik gap {reykjavik:.2f} min, documented as about 8.2"
+    assert quito < rome < reykjavik, "the gap must widen towards the pole"

--- a/tests/core/test_sun_times_altitude_invariant.py
+++ b/tests/core/test_sun_times_altitude_invariant.py
@@ -16,11 +16,16 @@ which does not deform with latitude, and it must be the same angle everywhere:
     at every solar noon, the Sun's hour angle is zero;
     at the instant `is_diurnal` flips, the Sun's geometric centre is at 0.
 
-The independent side is Skyfield reading its own JPL kernel — a separate position
-pipeline from the one under test, with its own frame handling. It is not a claim
-of absolute truth (the anchors are what carry that); it is a claim that two
-implementations that share no code agree on where the Sun was, which is what
-isolates OUR geometry from the convention question.
+The second opinion is Skyfield reading its own de421 kernel — and honesty about
+HOW second it is: the ephemeris backend is itself built on Skyfield's machinery
+(timescale, frames, aberration), so a common-mode error inside Skyfield would
+move both sides together and pass here unseen. Absolute truth is the anchors'
+job, at the latitudes where published instants are well conditioned. What this
+module does isolate is everything KERYKEION adds on top of the backend: the
+Julian-Day and timezone bookkeeping, the event search and its pairing, the
+transit-vs-midpoint choice, and the horizon convention itself. A midpoint
+regression, a wrong search seed or a dropped refraction term fails here (proven
+by mutation); a Skyfield frame bug would not, and no test here claims otherwise.
 
 Needs `skyfield` and `skyfield-data`, both already present as transitive
 dependencies of the ephemeris backend.

--- a/tests/core/test_sun_times_anchors.py
+++ b/tests/core/test_sun_times_anchors.py
@@ -296,6 +296,12 @@ def test_every_event_lies_inside_the_span_of_the_two_observatories(name):
 def test_the_cut_off_latitude_is_earned():
     """The reason there is no time-domain anchor above 60 degrees, measured.
 
+    Note what this does and does not exercise: it reads only the two published
+    columns and compares them to each other, so it executes no line of this
+    library. That is deliberate — the claim is about the SOURCES, not about us,
+    and it is the premise the cut-off rests on. It belongs in this file because
+    it is the thing that would silently stop being true after a re-capture.
+
     A cut-off chosen for convenience is a way of hiding failures. This one is a
     statement about conditioning, so it has to be demonstrable: the same two
     services that agree to a minute at mid-latitudes must be seen to fall apart
@@ -313,7 +319,12 @@ def test_the_cut_off_latitude_is_earned():
         spreads[name] = worst
 
     below = [spreads[name] for name in _ANCHORED]
-    assert max(below) <= 3 * 60.0, (
+    # 4 minutes, not 3: the widest below the cut-off is Stockholm at exactly
+    # 180.0 s, which against a `<= 3 * 60` bound is zero margin — the next
+    # re-capture would have reddened it for no reason. The claim being made is
+    # "they stay within a few minutes down here and fall apart up there", and
+    # 240 vs 660 states that with room on both sides.
+    assert max(below) <= 4 * 60.0, (
         "below the cut-off the two sources are expected to stay within a few minutes "
         f"of each other; worst was {max(below) / 60.0:.0f} min"
     )

--- a/tests/core/test_sun_times_anchors.py
+++ b/tests/core/test_sun_times_anchors.py
@@ -1,0 +1,339 @@
+"""Sunrise, sunset and solar noon against two national observatories.
+
+*** NO REGENERATION SCRIPT WRITES THIS FILE. ***
+
+Every expected value below was transcribed by hand from a published service on
+the capture date recorded in `_CAPTURED`. Nothing in this repository can rewrite
+them, and that is the point: the golden report snapshots next door encode what
+this library produced, which is *constancy*; these encode what two independent
+observatories say the sky did, which is *truth*. A blind regeneration can bless a
+wrong number in the first class and cannot touch the second. If an anchor turns
+red, the fix is a new capture with a new date — never an edit to make the number
+match the code.
+
+Sources, both public, both national institutions, both queried for the same UTC
+civil day so no timezone handling of ours sits between us and them:
+
+  * United States Naval Observatory, Astronomical Applications Department
+    https://aa.usno.navy.mil/api/rstt/oneday   (API version 4.0.1)
+  * Institut de mecanique celeste et de calcul des ephemerides (IMCCE),
+    Observatoire de Paris
+    https://ssp.imcce.fr/webservices/miriade/api/rts.php
+
+Why two, and why the tolerances are shaped the way they are
+-----------------------------------------------------------
+Because they disagree with each other, and the size of that disagreement is the
+real floor on how tightly anyone can be anchored. Over this grid the two agree on
+sunrise and on transit, but IMCCE's sunset runs about two minutes earlier than
+USNO's throughout — a horizon-convention difference, not an error by either.
+Wellington reverses it: there IMCCE and this library agree while USNO sits 82 s
+away. Publishing to the whole minute adds another +/-30 s on top.
+
+So the file makes two claims of different strengths rather than one dishonest one:
+
+  * a TIGHT claim on the two quantities the sources agree on — sunrise and
+    solar noon must land within `_USNO_TOL_S` of USNO;
+  * an ENVELOPE claim on all three — our value must lie inside the span the two
+    observatories bracket, padded by `_ENVELOPE_PAD_S` for their rounding.
+
+Above `_ANCHOR_MAX_ABS_LAT` no time-domain claim is made at all. That is not
+squeamishness, it is conditioning: near the poles the Sun grazes the horizon, so
+`dh/dt` collapses and a milliarcsecond of altitude becomes minutes of clock. The
+two sources demonstrate it themselves — at Tromso (69.6 N) they differ by 10 and
+11 minutes on the same two events they agree on everywhere else, and
+`test_the_cut_off_latitude_is_earned` asserts exactly that rather than taking it
+on trust. Those latitudes are covered instead by
+`test_sun_times_altitude_invariant.py`, which measures an angle and stays well
+conditioned everywhere.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from kerykeion import SunTimesFactory
+
+#: Capture date of every reference value in this module. Bump it only together
+#: with a fresh capture from both services.
+_CAPTURED = "2026-08-05"
+
+#: Sunrise and solar noon must land this close to USNO. The residuals measured
+#: at capture time span -28.7 s to +31.3 s, which is USNO's own published
+#: accuracy (about a minute) plus its rounding to the whole minute; 45 s leaves
+#: roughly 1.4x headroom over the worst observed case without ever admitting a
+#: real defect, the smallest of which in this area is tens of seconds.
+_USNO_TOL_S = 45.0
+
+#: Padding on the two-source envelope, for the fact that both publish whole
+#: minutes (so each printed value is up to 30 s from its own true instant) plus
+#: a little slack. Sunset needs the envelope rather than a single-source
+#: tolerance because the two sources genuinely disagree there.
+_ENVELOPE_PAD_S = 60.0
+
+#: Above this latitude a time-domain anchor measures conditioning, not accuracy.
+_ANCHOR_MAX_ABS_LAT = 60.0
+
+#: (rise, transit, set) as published, UTC, HH:MM.
+_REFERENCE = {
+    "quito_equinox": dict(
+        lat=-0.1807, lon=-78.4678, date=(2026, 3, 20),
+        usno=("11:18", "17:21", "23:24"), imcce=("11:18", "17:21", "23:23"),
+        why="equator, equinox: fastest declination change",
+    ),
+    "nairobi_january": dict(
+        lat=-1.2921, lon=36.8219, date=(2026, 1, 15),
+        usno=("03:36", "09:42", "15:48"), imcce=("03:37", "09:42", "15:46"),
+        why="just south of the equator, northern winter",
+    ),
+    "singapore_august": dict(
+        lat=1.3521, lon=103.8198, date=(2026, 8, 5),
+        usno=("23:06", "05:11", "11:16"), imcce=("23:06", "05:10", "11:14"),
+        why="near-equatorial, and the rise straddles the UTC day boundary",
+    ),
+    "rome_equinox": dict(
+        lat=41.9028, lon=12.4964, date=(2026, 3, 20),
+        usno=("05:14", "11:17", "17:22"), imcce=("05:14", "11:17", "17:20"),
+        why="mid-north at the equinox: where a midpoint solar noon drifts most",
+    ),
+    "rome_solstice": dict(
+        lat=41.9028, lon=12.4964, date=(2026, 6, 21),
+        usno=("03:35", "11:12", "18:49"), imcce=("03:36", "11:11", "18:47"),
+        why="the same place at the solstice, where the declination is stationary",
+    ),
+    "london_august": dict(
+        lat=51.5074, lon=-0.1278, date=(2026, 8, 5),
+        usno=("04:30", "12:07", "19:42"), imcce=("04:31", "12:06", "19:40"),
+        why="the case this investigation started from",
+    ),
+    "newyork_december": dict(
+        lat=40.7128, lon=-74.006, date=(2026, 12, 21),
+        usno=("12:17", "16:54", "21:32"), imcce=("12:17", "16:54", "21:30"),
+        why="mid-north, winter solstice, western hemisphere",
+    ),
+    "tokyo_june": dict(
+        lat=35.6762, lon=139.6503, date=(2026, 6, 15),
+        usno=("19:25", "02:42", "09:59"), imcce=("19:26", "02:41", "09:57"),
+        why="far-east longitude: transit lands early in the UTC day",
+    ),
+    "sydney_solstice": dict(
+        lat=-33.8688, lon=151.2093, date=(2026, 12, 21),
+        usno=("18:41", "01:53", "09:05"), imcce=("18:42", "01:53", "09:04"),
+        why="mid-south, austral summer solstice",
+    ),
+    "capetown_may": dict(
+        lat=-33.9249, lon=18.4241, date=(2026, 5, 10),
+        usno=("05:28", "10:43", "15:57"), imcce=("05:28", "10:42", "15:56"),
+        why="mid-south, austral autumn",
+    ),
+    "santiago_september": dict(
+        lat=-33.4489, lon=-70.6693, date=(2026, 9, 22),
+        usno=("10:32", "16:35", "22:39"), imcce=("10:33", "16:35", "22:38"),
+        why="mid-south at the equinox",
+    ),
+    "buenosaires_march": dict(
+        lat=-34.6037, lon=-58.3816, date=(2026, 3, 20),
+        usno=("09:57", "16:01", "22:05"), imcce=("09:57", "16:00", "22:03"),
+        why="mid-south equinox, western hemisphere",
+    ),
+    "madrid_november": dict(
+        lat=40.4168, lon=-3.7038, date=(2026, 11, 1),
+        usno=("06:44", "11:58", "17:12"), imcce=("06:45", "11:58", "17:10"),
+        why="well west of the meridian its civil time follows",
+    ),
+    "urumqi_february": dict(
+        lat=43.8256, lon=87.6168, date=(2026, 2, 10),
+        usno=("01:16", "06:24", "11:32"), imcce=("01:17", "06:23", "11:30"),
+        why="the extreme case of a single national timezone: solar noon near 14:00 local",
+    ),
+    "stockholm_october": dict(
+        lat=59.3293, lon=18.0686, date=(2026, 10, 15),
+        usno=("05:25", "10:34", "15:41"), imcce=("05:27", "10:33", "15:38"),
+        why="just under the cut-off, where the sources start to spread",
+    ),
+    "ushuaia_july": dict(
+        lat=-54.8019, lon=-68.303, date=(2026, 7, 1),
+        usno=("12:58", "16:37", "20:16"), imcce=("13:00", "16:37", "20:14"),
+        why="the far south in austral winter, a short day at high latitude",
+    ),
+    "wellington_april": dict(
+        lat=-41.2866, lon=174.7756, date=(2026, 4, 20),
+        usno=("18:57", "00:20", "05:43"), imcce=("18:58", "00:19", "05:41"),
+        why="date-line side; and the one case where USNO, not IMCCE, is the outlier",
+    ),
+    # Above the cut-off. Kept in the table on purpose: they are what
+    # `test_the_cut_off_latitude_is_earned` measures.
+    "reykjavik_april": dict(
+        lat=64.1466, lon=-21.9426, date=(2026, 4, 15),
+        usno=("05:56", "13:28", "21:01"), imcce=("05:58", "13:27", "20:59"),
+        why="above the cut-off: the altitude invariant covers it instead",
+    ),
+    "tromso_may": dict(
+        lat=69.6492, lon=18.9553, date=(2026, 5, 15),
+        usno=("23:32", "10:41", "21:48"), imcce=("23:42", "10:40", "21:37"),
+        why="above the cut-off, and the proof that the cut-off is needed",
+    ),
+}
+
+_EVENTS = ("rise", "transit", "set")
+
+
+def _published_instant(reference_hhmm: str, ours: dt.datetime) -> dt.datetime:
+    """The published HH:MM placed on the same UTC day as our own instant.
+
+    Anchored to `ours` rather than to the requested date because an event can
+    legitimately fall on either side of midnight UTC (Singapore, Tokyo,
+    Wellington all do). The caller unwraps the result onto the nearest day.
+    """
+    hour, minute = (int(part) for part in reference_hhmm.split(":"))
+    return ours.replace(hour=hour, minute=minute, second=0, microsecond=0)
+
+
+def _signed_delta_seconds(ours: dt.datetime, reference_hhmm: str) -> float:
+    """``ours - published`` in seconds, unwrapped to the nearest day.
+
+    Without the unwrap a 23:5x event compared against a 00:0x publication would
+    read as a 24-hour error instead of a few seconds.
+    """
+    delta = (ours - _published_instant(reference_hhmm, ours)).total_seconds()
+    if delta > 43200.0:
+        delta -= 86400.0
+    if delta < -43200.0:
+        delta += 86400.0
+    return delta
+
+
+def _our_events(case: dict) -> dict[str, dt.datetime | None]:
+    year, month, day = case["date"]
+    model = SunTimesFactory.from_date(
+        year, month, day, latitude=case["lat"], longitude=case["lon"], tz_str="UTC"
+    )
+    return {"rise": model.sunrise, "transit": model.solar_noon, "set": model.sunset}
+
+
+_ANCHORED = [name for name, case in _REFERENCE.items() if abs(case["lat"]) <= _ANCHOR_MAX_ABS_LAT]
+_ABOVE_CUT_OFF = [name for name in _REFERENCE if name not in _ANCHORED]
+
+
+def test_the_grid_actually_has_cases_on_both_sides_of_the_cut_off():
+    """Guards every case below: an empty list would make them all vacuous.
+
+    The whole file is parametrised off `_REFERENCE`, so a bad edit that emptied
+    or mis-filtered it would turn a suite of anchors into a suite of no-ops that
+    still reports green — the exact failure mode anchors exist to prevent.
+    """
+    assert len(_ANCHORED) >= 15, f"only {len(_ANCHORED)} anchored cases"
+    assert len(_ABOVE_CUT_OFF) >= 2, f"only {len(_ABOVE_CUT_OFF)} cases above the cut-off"
+    assert {case["lat"] for case in _REFERENCE.values()}, "no latitudes at all"
+    # Both hemispheres and a real spread, or "global coverage" is a story.
+    latitudes = [case["lat"] for case in _REFERENCE.values()]
+    assert min(latitudes) < -30.0 and max(latitudes) > 60.0
+
+
+@pytest.mark.parametrize("name", _ANCHORED)
+def test_sunrise_and_solar_noon_match_the_naval_observatory(name):
+    """The tight claim, on the two quantities the two sources agree about."""
+    case = _REFERENCE[name]
+    ours = _our_events(case)
+
+    failures: list[str] = []
+    for event in ("rise", "transit"):
+        moment = ours[event]
+        if moment is None:
+            failures.append(f"{event}: we produced nothing")
+            continue
+        published = case["usno"][_EVENTS.index(event)]
+        delta = _signed_delta_seconds(moment, published)
+        if abs(delta) > _USNO_TOL_S:
+            failures.append(
+                f"{event}: ours {moment:%H:%M:%S} vs published {published} "
+                f"-> {delta:+.1f} s (limit {_USNO_TOL_S:.0f} s)"
+            )
+
+    assert not failures, (
+        f"{name} ({case['why']}) diverged from the reference captured {_CAPTURED}:\n  "
+        + "\n  ".join(failures)
+        + "\n\nDo NOT edit the constants to match. Re-capture from the source and "
+          "record the new date, or find what moved."
+    )
+
+
+@pytest.mark.parametrize("name", _ANCHORED)
+def test_every_event_lies_inside_the_span_of_the_two_observatories(name):
+    """The envelope claim, including sunset, where the sources disagree.
+
+    Stated as "inside the band the two of them bracket" rather than "close to
+    one of them", because with a two-minute convention gap between the sources
+    picking a favourite would be asserting a preference, not a measurement.
+    """
+    case = _REFERENCE[name]
+    ours = _our_events(case)
+
+    failures: list[str] = []
+    for index, event in enumerate(_EVENTS):
+        moment = ours[event]
+        if moment is None:
+            failures.append(f"{event}: we produced nothing")
+            continue
+        deltas = [_signed_delta_seconds(moment, case[src][index]) for src in ("usno", "imcce")]
+        low, high = min(deltas), max(deltas)
+        # Inside the bracket means our value is not beyond BOTH sources on the
+        # same side by more than the padding.
+        if low > _ENVELOPE_PAD_S or high < -_ENVELOPE_PAD_S:
+            failures.append(
+                f"{event}: ours {moment:%H:%M:%S}, published {case['usno'][index]} and "
+                f"{case['imcce'][index]} -> {deltas[0]:+.1f} s / {deltas[1]:+.1f} s, "
+                f"outside the bracket by more than {_ENVELOPE_PAD_S:.0f} s"
+            )
+
+    assert not failures, (
+        f"{name} ({case['why']}) fell outside the two-source span captured {_CAPTURED}:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+def test_the_cut_off_latitude_is_earned():
+    """The reason there is no time-domain anchor above 60 degrees, measured.
+
+    A cut-off chosen for convenience is a way of hiding failures. This one is a
+    statement about conditioning, so it has to be demonstrable: the same two
+    services that agree to a minute at mid-latitudes must be seen to fall apart
+    above the cut-off, on their own, with this library taking no part in it.
+    """
+    spreads: dict[str, float] = {}
+    for name, case in _REFERENCE.items():
+        worst = 0.0
+        for index in range(len(_EVENTS)):
+            usno_hour, usno_minute = (int(p) for p in case["usno"][index].split(":"))
+            imcce_hour, imcce_minute = (int(p) for p in case["imcce"][index].split(":"))
+            gap = (imcce_hour * 60 + imcce_minute) - (usno_hour * 60 + usno_minute)
+            gap = (gap + 720) % 1440 - 720
+            worst = max(worst, abs(gap) * 60.0)
+        spreads[name] = worst
+
+    below = [spreads[name] for name in _ANCHORED]
+    assert max(below) <= 3 * 60.0, (
+        "below the cut-off the two sources are expected to stay within a few minutes "
+        f"of each other; worst was {max(below) / 60.0:.0f} min"
+    )
+
+    tromso = spreads["tromso_may"]
+    assert tromso >= 10 * 60.0, (
+        "the cut-off is justified by the sources diverging above it; at Tromso they "
+        f"differ by only {tromso / 60.0:.0f} min, so the cut-off may no longer be needed"
+    )
+
+
+@pytest.mark.parametrize("name", _ABOVE_CUT_OFF)
+def test_above_the_cut_off_we_still_produce_something_sane(name):
+    """No time-domain claim up here, but silence would hide a real breakage.
+
+    Ordering and presence only: the numbers themselves are adjudicated by the
+    altitude invariant, which does not degrade with latitude.
+    """
+    case = _REFERENCE[name]
+    ours = _our_events(case)
+    assert ours["transit"] is not None, "the Sun culminates every day, even a polar one"
+    if ours["rise"] is not None and ours["set"] is not None:
+        assert ours["set"] > ours["rise"], "a paired sunset must follow its sunrise"

--- a/tests/core/test_sun_times_anchors.py
+++ b/tests/core/test_sun_times_anchors.py
@@ -231,6 +231,30 @@ def test_the_grid_actually_has_cases_on_both_sides_of_the_cut_off():
     assert min(latitudes) < -30.0 and max(latitudes) > 60.0
 
 
+@pytest.mark.parametrize("name", list(_REFERENCE))
+def test_solar_noon_belongs_to_the_requested_civil_day(name):
+    """The one claim only a calendar can make, pinned because nothing else can.
+
+    Every time comparison in this file unwraps to the nearest day, and the
+    altitude suite's hour angle wraps mod 24 h — so a transit reported for the
+    WRONG CIVIL DAY reads as its sub-day residual everywhere else and sails
+    through. Proven by mutation in review: reverting solar noon to the
+    sunrise/sunset midpoint made Singapore report its 2026-08-05 noon at 05:10
+    on 2026-08-06 and every test in this module still passed. The requests here
+    use tz_str="UTC", and the transit is searched from local midnight, so the
+    returned instant must carry the requested UTC date — at every latitude,
+    polar cases included, since a culmination exists on days a sunrise does not.
+    """
+    case = _REFERENCE[name]
+    events = _our_events(case)
+    assert events["transit"] is not None, f"{name}: no solar noon at all"
+    year, month, day = case["date"]
+    assert events["transit"].astimezone(dt.timezone.utc).date() == dt.date(year, month, day), (
+        f"{name}: solar noon {events['transit'].isoformat()} does not belong to the "
+        f"requested UTC civil day {year:04d}-{month:02d}-{day:02d}"
+    )
+
+
 @pytest.mark.parametrize("name", _ANCHORED)
 def test_sunrise_and_solar_noon_match_the_naval_observatory(name):
     """The tight claim, on the two quantities the two sources agree about."""

--- a/tests/core/test_sun_times_factory.py
+++ b/tests/core/test_sun_times_factory.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import date
+from zoneinfo import ZoneInfo
+
 import pytest
 
 import kerykeion.sun_times.utils as sun_times_utils
@@ -222,7 +225,14 @@ def test_polar_edge_does_not_return_next_day_events():
     assert s.is_polar_day is True
     assert s.is_polar_night is False
     assert s.sunrise is None and s.sunset is None
-    assert s.solar_noon is None and s.day_length is None
+    # No pair, so no day length. Solar noon is a different kind of event — a
+    # meridian crossing, not a horizon crossing — so it survives here, and it has
+    # to fall inside the requested civil day rather than leaking to the next one,
+    # which is the very failure this test guards for rise/set.
+    assert s.day_length is None
+    assert s.solar_noon is not None
+    local_noon = s.solar_noon.astimezone(ZoneInfo(TROMSO["tz_str"]))
+    assert local_noon.date() == date(2026, 7, 25)
 
 
 def test_no_events_but_not_polar_raises(monkeypatch):

--- a/tests/fixtures/composite_all_points_all_aspects_report.txt
+++ b/tests/fixtures/composite_all_points_all_aspects_report.txt
@@ -101,7 +101,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Interpolated Lilith   | Leo ♌ | 28.93°   | N/A   | N/A   | -    | Tenth House    |
 | Interpolated Perigee  | Vir ♍ | 15.85°   | N/A   | N/A   | -    | Eleventh House |
 | Cupido                | Lib ♎ | 9.65°    | N/A   | N/A   | -    | Twelfth House  |
-| Hades                 | Tau ♉ | 10.07°   | N/A   | N/A   | -    | Seventh House  |
+| Hades                 | Tau ♉ | 10.06°   | N/A   | N/A   | -    | Seventh House  |
 | Zeus                  | Vir ♍ | 3.25°    | N/A   | N/A   | -    | Eleventh House |
 | Kronos                | Gem ♊ | 1.11°    | N/A   | N/A   | -    | Eighth House   |
 | Apollon               | Vir ♍ | 26.36°   | N/A   | N/A   | -    | Eleventh House |
@@ -120,7 +120,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Pars Amoris           | Lib ♎ | 0.90°    | N/A   | N/A   | -    | Twelfth House  |
 | Pars Fidei            | Tau ♉ | 13.79°   | N/A   | N/A   | -    | Seventh House  |
 | Vertex                | Tau ♉ | 19.11°   | N/A   | N/A   | -    | Seventh House  |
-| White Moon            | Gem ♊ | 19.86°   | N/A   | N/A   | -    | Eighth House   |
+| White Moon            | Gem ♊ | 19.85°   | N/A   | N/A   | -    | Eighth House   |
 | Anti Vertex           | Sco ♏ | 19.11°   | N/A   | N/A   | -    | First House    |
 | Mean South Lunar Node | Leo ♌ | 23.06°   | N/A   | N/A   | -    | Tenth House    |
 | True South Lunar Node | Leo ♌ | 22.53°   | N/A   | N/A   | -    | Tenth House    |
@@ -264,7 +264,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Sun                   | trine △          | True Priapus          | 0.46° | Static = |
 | Sun                   | trine △          | Interpolated Perigee  | 1.89° | Static = |
 | Sun                   | biquintile bQ    | Cupido                | 1.69° | Static = |
-| Sun                   | conjunction ☌    | Hades                 | 3.89° | Static = |
+| Sun                   | conjunction ☌    | Hades                 | 3.90° | Static = |
 | Sun                   | sesquiquadrate ⚼ | Apollon               | 2.60° | Static = |
 | Sun                   | semi-square ∠    | Vulkanus              | 0.32° | Static = |
 | Sun                   | quincunx ⚻       | Poseidon              | 1.35° | Static = |
@@ -288,7 +288,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Moon                  | semi-square ∠    | Anti Vertex           | 2.94° | Static = |
 | Moon                  | semi-sextile ⚺   | Interpolated Lilith   | 2.24° | Static = |
 | Moon                  | quincunx ⚻       | Mean Priapus          | 0.42° | Static = |
-| Moon                  | biquintile bQ    | Hades                 | 2.90° | Static = |
+| Moon                  | biquintile bQ    | Hades                 | 2.89° | Static = |
 | Moon                  | semi-sextile ⚺   | Zeus                  | 2.08° | Static = |
 | Moon                  | trine △          | Kronos                | 0.06° | Static = |
 | Moon                  | conjunction ☌    | Apollon               | 4.81° | Static = |
@@ -339,7 +339,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Venus                 | biquintile bQ    | Pars Fortunae         | 1.17° | Static = |
 | Venus                 | biquintile bQ    | Pars Spiritus         | 0.09° | Static = |
 | Venus                 | biquintile bQ    | Interpolated Perigee  | 0.90° | Static = |
-| Venus                 | sextile ⚹        | White Moon            | 2.89° | Static = |
+| Venus                 | sextile ⚹        | White Moon            | 2.90° | Static = |
 | Venus                 | conjunction ☌    | Admetos               | 4.82° | Static = |
 | Mars                  | trine △          | Neptune               | 0.37° | Static = |
 | Mars                  | trine △          | True Lilith           | 3.87° | Static = |
@@ -349,7 +349,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Mars                  | quintile Q       | Sedna                 | 0.82° | Static = |
 | Mars                  | sextile ⚹        | Pars Fidei            | 3.25° | Static = |
 | Mars                  | sextile ⚹        | True Priapus          | 3.87° | Static = |
-| Mars                  | square □         | Cupido                | 0.90° | Static = |
+| Mars                  | square □         | Cupido                | 0.89° | Static = |
 | Mars                  | sextile ⚹        | Hades                 | 0.48° | Static = |
 | Mars                  | quintile Q       | Admetos               | 0.98° | Static = |
 | Mars                  | square □         | Poseidon              | 4.76° | Static = |
@@ -388,7 +388,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Saturn                | semi-sextile ⚺   | Mean Priapus          | 0.13° | Static = |
 | Saturn                | sesquiquadrate ⚼ | True Priapus          | 1.21° | Static = |
 | Saturn                | sesquiquadrate ⚼ | Interpolated Perigee  | 0.23° | Static = |
-| Saturn                | trine △          | Kronos                | 0.49° | Static = |
+| Saturn                | trine △          | Kronos                | 0.48° | Static = |
 | Saturn                | trine △          | Apollon               | 4.27° | Static = |
 | Saturn                | square □         | Admetos               | 3.06° | Static = |
 | Saturn                | quincunx ⚻       | Vulkanus              | 1.35° | Static = |
@@ -409,9 +409,9 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Uranus                | quintile Q       | Hades                 | 0.58° | Static = |
 | Uranus                | opposition ☍     | Zeus                  | 4.61° | Static = |
 | Uranus                | square □         | Kronos                | 2.47° | Static = |
-| Uranus                | sextile ⚹        | Admetos               | 1.07° | Static = |
+| Uranus                | sextile ⚹        | Admetos               | 1.08° | Static = |
 | Uranus                | trine △          | Vulkanus              | 0.64° | Static = |
-| Uranus                | sesquiquadrate ⚼ | Poseidon              | 1.66° | Static = |
+| Uranus                | sesquiquadrate ⚼ | Poseidon              | 1.67° | Static = |
 | Neptune               | quintile Q       | Mean Lilith           | 1.83° | Static = |
 | Neptune               | trine △          | True Lilith           | 3.50° | Static = |
 | Neptune               | conjunction ☌    | Juno                  | 2.95° | Static = |
@@ -422,7 +422,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Neptune               | sextile ⚹        | True Priapus          | 3.50° | Static = |
 | Neptune               | sextile ⚹        | Interpolated Perigee  | 4.93° | Static = |
 | Neptune               | semi-sextile ⚺   | Cupido                | 1.27° | Static = |
-| Neptune               | opposition ☍     | Hades                 | 0.85° | Static = |
+| Neptune               | opposition ☍     | Hades                 | 0.86° | Static = |
 | Neptune               | semi-square ∠    | Apollon               | 0.44° | Static = |
 | Pluto                 | square □         | Chiron                | 3.51° | Static = |
 | Pluto                 | opposition ☍     | True Lilith           | 3.88° | Static = |
@@ -455,7 +455,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Mean North Lunar Node | opposition ☍     | Interpolated Lilith   | 5.86° | Static = |
 | Mean North Lunar Node | trine △          | White Moon            | 3.21° | Static = |
 | Mean North Lunar Node | sesquiquadrate ⚼ | Cupido                | 1.59° | Static = |
-| Mean North Lunar Node | sextile ⚹        | Admetos               | 4.51° | Static = |
+| Mean North Lunar Node | sextile ⚹        | Admetos               | 4.50° | Static = |
 | True North Lunar Node | trine △          | Chiron                | 0.72° | Static = |
 | True North Lunar Node | trine △          | Ascendant             | 0.42° | Static = |
 | True North Lunar Node | sextile ⚹        | Descendant            | 0.42° | Static = |
@@ -484,8 +484,8 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Chiron                | trine △          | Quaoar                | 1.39° | Static = |
 | Chiron                | square □         | Pars Spiritus         | 5.15° | Static = |
 | Chiron                | square □         | Interpolated Perigee  | 5.96° | Static = |
-| Chiron                | conjunction ☌    | White Moon            | 1.95° | Static = |
-| Chiron                | quintile Q       | Zeus                  | 0.56° | Static = |
+| Chiron                | conjunction ☌    | White Moon            | 1.96° | Static = |
+| Chiron                | quintile Q       | Zeus                  | 0.55° | Static = |
 | Chiron                | square □         | Apollon               | 4.55° | Static = |
 | Ascendant             | sextile ⚹        | Mean South Lunar Node | 0.95° | Static = |
 | Ascendant             | sextile ⚹        | True South Lunar Node | 0.42° | Static = |
@@ -495,7 +495,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Ascendant             | quincunx ⚻       | Vesta                 | 0.57° | Static = |
 | Ascendant             | conjunction ☌    | Ixion                 | 3.84° | Static = |
 | Ascendant             | conjunction ☌    | Quaoar                | 1.70° | Static = |
-| Ascendant             | trine △          | White Moon            | 2.26° | Static = |
+| Ascendant             | trine △          | White Moon            | 2.27° | Static = |
 | Ascendant             | opposition ☍     | Admetos               | 5.45° | Static = |
 | Medium Coeli          | semi-sextile ⚺   | Mean Lilith           | 1.14° | Static = |
 | Medium Coeli          | sesquiquadrate ⚼ | True Lilith           | 0.19° | Static = |
@@ -528,7 +528,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Descendant            | biquintile bQ    | Pars Spiritus         | 0.54° | Static = |
 | Descendant            | biquintile bQ    | True Priapus          | 1.70° | Static = |
 | Descendant            | biquintile bQ    | Interpolated Perigee  | 0.27° | Static = |
-| Descendant            | sextile ⚹        | White Moon            | 2.26° | Static = |
+| Descendant            | sextile ⚹        | White Moon            | 2.27° | Static = |
 | Descendant            | conjunction ☌    | Admetos               | 5.45° | Static = |
 | Imum Coeli            | quincunx ⚻       | Mean Lilith           | 1.14° | Static = |
 | Imum Coeli            | semi-square ∠    | True Lilith           | 0.19° | Static = |
@@ -561,9 +561,9 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Mean Lilith           | quintile Q       | White Moon            | 1.10° | Static = |
 | Mean Lilith           | conjunction ☌    | Zeus                  | 2.50° | Static = |
 | Mean Lilith           | square □         | Kronos                | 0.36° | Static = |
-| Mean Lilith           | trine △          | Admetos               | 3.18° | Static = |
+| Mean Lilith           | trine △          | Admetos               | 3.19° | Static = |
 | Mean Lilith           | sextile ⚹        | Vulkanus              | 1.47° | Static = |
-| Mean Lilith           | semi-square ∠    | Poseidon              | 0.45° | Static = |
+| Mean Lilith           | semi-square ∠    | Poseidon              | 0.44° | Static = |
 | Mean South Lunar Node | sesquiquadrate ⚼ | Pholus                | 0.03° | Static = |
 | Mean South Lunar Node | square □         | Ceres                 | 0.96° | Static = |
 | Mean South Lunar Node | trine △          | Pallas                | 0.79° | Static = |
@@ -577,7 +577,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Mean South Lunar Node | conjunction ☌    | Interpolated Lilith   | 5.86° | Static = |
 | Mean South Lunar Node | sextile ⚹        | White Moon            | 3.21° | Static = |
 | Mean South Lunar Node | semi-square ∠    | Cupido                | 1.59° | Static = |
-| Mean South Lunar Node | trine △          | Admetos               | 4.51° | Static = |
+| Mean South Lunar Node | trine △          | Admetos               | 4.50° | Static = |
 | True South Lunar Node | sesquiquadrate ⚼ | Pholus                | 0.56° | Static = |
 | True South Lunar Node | square □         | Ceres                 | 0.43° | Static = |
 | True South Lunar Node | trine △          | Pallas                | 1.32° | Static = |
@@ -588,7 +588,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | True South Lunar Node | square □         | Vertex                | 3.42° | Static = |
 | True South Lunar Node | square □         | Anti Vertex           | 3.42° | Static = |
 | True South Lunar Node | sextile ⚹        | White Moon            | 2.68° | Static = |
-| True South Lunar Node | trine △          | Admetos               | 5.04° | Static = |
+| True South Lunar Node | trine △          | Admetos               | 5.03° | Static = |
 | True Lilith           | semi-square ∠    | Sedna                 | 0.06° | Static = |
 | True Lilith           | biquintile bQ    | Quaoar                | 0.00° | Static = |
 | True Lilith           | opposition ☍     | Pars Spiritus         | 2.24° | Static = |
@@ -597,8 +597,8 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | True Lilith           | trine △          | Anti Vertex           | 4.69° | Static = |
 | True Lilith           | opposition ☍     | Interpolated Perigee  | 1.43° | Static = |
 | True Lilith           | square □         | White Moon            | 5.43° | Static = |
-| True Lilith           | sextile ⚹        | Hades                 | 4.35° | Static = |
-| True Lilith           | semi-square ∠    | Admetos               | 1.85° | Static = |
+| True Lilith           | sextile ⚹        | Hades                 | 4.36° | Static = |
+| True Lilith           | semi-square ∠    | Admetos               | 1.86° | Static = |
 | True Lilith           | quincunx ⚻       | Poseidon              | 0.89° | Static = |
 | Pholus                | semi-square ∠    | Ceres                 | 0.99° | Static = |
 | Pholus                | quincunx ⚻       | Juno                  | 0.13° | Static = |
@@ -608,7 +608,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Pholus                | trine △          | Makemake              | 5.44° | Static = |
 | Pholus                | square □         | Orcus                 | 3.78° | Static = |
 | Pholus                | quintile Q       | White Moon            | 0.24° | Static = |
-| Pholus                | opposition ☍     | Cupido                | 1.55° | Static = |
+| Pholus                | opposition ☍     | Cupido                | 1.56° | Static = |
 | Pholus                | semi-sextile ⚺   | Hades                 | 1.97° | Static = |
 | Pholus                | biquintile bQ    | Zeus                  | 1.16° | Static = |
 | Ceres                 | semi-sextile ⚺   | Pallas                | 1.75° | Static = |
@@ -619,8 +619,8 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Ceres                 | trine △          | Pars Spiritus         | 5.44° | Static = |
 | Ceres                 | conjunction ☌    | Vertex                | 2.99° | Static = |
 | Ceres                 | opposition ☍     | Anti Vertex           | 2.99° | Static = |
-| Ceres                 | trine △          | Apollon               | 4.25° | Static = |
-| Ceres                 | biquintile bQ    | Poseidon              | 0.80° | Static = |
+| Ceres                 | trine △          | Apollon               | 4.26° | Static = |
+| Ceres                 | biquintile bQ    | Poseidon              | 0.79° | Static = |
 | Pallas                | semi-sextile ⚺   | Vesta                 | 1.16° | Static = |
 | Pallas                | conjunction ☌    | Sedna                 | 5.52° | Static = |
 | Pallas                | opposition ☍     | Ixion                 | 2.11° | Static = |
@@ -629,13 +629,13 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Pallas                | biquintile bQ    | Pars Spiritus         | 1.19° | Static = |
 | Pallas                | trine △          | Interpolated Lilith   | 5.08° | Static = |
 | Pallas                | biquintile bQ    | Interpolated Perigee  | 2.00° | Static = |
-| Pallas                | sextile ⚹        | White Moon            | 3.99° | Static = |
+| Pallas                | sextile ⚹        | White Moon            | 4.00° | Static = |
 | Pallas                | conjunction ☌    | Admetos               | 3.72° | Static = |
 | Juno                  | quincunx ⚻       | Eris                  | 1.86° | Static = |
 | Juno                  | square □         | Makemake              | 5.31° | Static = |
 | Juno                  | trine △          | Orcus                 | 3.65° | Static = |
 | Juno                  | opposition ☍     | Pars Fidei            | 5.83° | Static = |
-| Juno                  | semi-sextile ⚺   | Cupido                | 1.68° | Static = |
+| Juno                  | semi-sextile ⚺   | Cupido                | 1.69° | Static = |
 | Juno                  | opposition ☍     | Hades                 | 2.10° | Static = |
 | Juno                  | sextile ⚹        | Zeus                  | 4.71° | Static = |
 | Vesta                 | opposition ☍     | Pars Fortunae         | 4.89° | Static = |
@@ -646,10 +646,10 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Vesta                 | biquintile bQ    | Poseidon              | 1.38° | Static = |
 | Eris                  | square □         | Orcus                 | 5.51° | Static = |
 | Eris                  | quintile Q       | White Moon            | 1.97° | Static = |
-| Eris                  | opposition ☍     | Cupido                | 0.18° | Static = |
+| Eris                  | opposition ☍     | Cupido                | 0.17° | Static = |
 | Eris                  | semi-sextile ⚺   | Hades                 | 0.24° | Static = |
 | Eris                  | biquintile bQ    | Zeus                  | 0.57° | Static = |
-| Eris                  | opposition ☍     | Poseidon              | 5.48° | Static = |
+| Eris                  | opposition ☍     | Poseidon              | 5.49° | Static = |
 | Sedna                 | trine △          | Haumea                | 1.31° | Static = |
 | Sedna                 | square □         | Makemake              | 3.29° | Static = |
 | Sedna                 | opposition ☍     | Ixion                 | 3.40° | Static = |
@@ -661,9 +661,9 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Sedna                 | sesquiquadrate ⚼ | True Priapus          | 0.06° | Static = |
 | Sedna                 | sesquiquadrate ⚼ | Interpolated Perigee  | 1.49° | Static = |
 | Sedna                 | trine △          | Zeus                  | 3.89° | Static = |
-| Sedna                 | semi-sextile ⚺   | Kronos                | 1.75° | Static = |
+| Sedna                 | semi-sextile ⚺   | Kronos                | 1.74° | Static = |
 | Sedna                 | conjunction ☌    | Admetos               | 1.80° | Static = |
-| Sedna                 | sextile ⚹        | Vulkanus              | 0.08° | Static = |
+| Sedna                 | sextile ⚹        | Vulkanus              | 0.09° | Static = |
 | Haumea                | semi-sextile ⚺   | Makemake              | 1.98° | Static = |
 | Haumea                | sextile ⚹        | Ixion                 | 4.71° | Static = |
 | Haumea                | sextile ⚹        | Orcus                 | 3.64° | Static = |
@@ -674,7 +674,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Haumea                | quintile Q       | White Moon            | 1.18° | Static = |
 | Haumea                | conjunction ☌    | Zeus                  | 2.58° | Static = |
 | Haumea                | square □         | Kronos                | 0.44° | Static = |
-| Haumea                | trine △          | Admetos               | 3.10° | Static = |
+| Haumea                | trine △          | Admetos               | 3.11° | Static = |
 | Haumea                | sextile ⚹        | Vulkanus              | 1.39° | Static = |
 | Haumea                | semi-square ∠    | Poseidon              | 0.36° | Static = |
 | Makemake              | semi-sextile ⚺   | Orcus                 | 1.66° | Static = |
@@ -685,7 +685,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Makemake              | quincunx ⚻       | Mean Priapus          | 1.90° | Static = |
 | Makemake              | semi-square ∠    | Interpolated Perigee  | 1.80° | Static = |
 | Makemake              | semi-sextile ⚺   | Zeus                  | 0.60° | Static = |
-| Makemake              | sextile ⚹        | Kronos                | 1.54° | Static = |
+| Makemake              | sextile ⚹        | Kronos                | 1.55° | Static = |
 | Makemake              | square □         | Admetos               | 5.09° | Static = |
 | Makemake              | quintile Q       | Poseidon              | 0.65° | Static = |
 | Ixion                 | conjunction ☌    | Quaoar                | 5.54° | Static = |
@@ -694,7 +694,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Ixion                 | trine △          | Mean Priapus          | 4.79° | Static = |
 | Ixion                 | biquintile bQ    | Kronos                | 0.85° | Static = |
 | Ixion                 | semi-sextile ⚺   | Apollon               | 0.40° | Static = |
-| Ixion                 | opposition ☍     | Admetos               | 1.61° | Static = |
+| Ixion                 | opposition ☍     | Admetos               | 1.60° | Static = |
 | Ixion                 | trine △          | Vulkanus              | 3.32° | Static = |
 | Orcus                 | biquintile bQ    | Pars Fortunae         | 0.74° | Static = |
 | Orcus                 | quintile Q       | Pars Spiritus         | 0.35° | Static = |
@@ -710,7 +710,7 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Quaoar                | quincunx ⚻       | Vertex                | 1.31° | Static = |
 | Quaoar                | semi-sextile ⚺   | Anti Vertex           | 1.31° | Static = |
 | Quaoar                | trine △          | White Moon            | 0.57° | Static = |
-| Quaoar                | conjunction ☌    | Poseidon              | 5.12° | Static = |
+| Quaoar                | conjunction ☌    | Poseidon              | 5.11° | Static = |
 | Pars Fortunae         | quintile Q       | Pars Spiritus         | 1.08° | Static = |
 | Pars Fortunae         | sextile ⚹        | Pars Amoris           | 3.33° | Static = |
 | Pars Fortunae         | square □         | Interpolated Lilith   | 1.35° | Static = |
@@ -718,67 +718,67 @@ Sample Natal Subject & Yoko Ono — Composite Report
 | Pars Fortunae         | quintile Q       | True Priapus          | 1.15° | Static = |
 | Pars Fortunae         | quintile Q       | Interpolated Perigee  | 0.28° | Static = |
 | Pars Fortunae         | square □         | Zeus                  | 5.68° | Static = |
-| Pars Fortunae         | opposition ☍     | Kronos                | 3.54° | Static = |
+| Pars Fortunae         | opposition ☍     | Kronos                | 3.53° | Static = |
 | Pars Fortunae         | sextile ⚹        | Apollon               | 1.22° | Static = |
 | Pars Fortunae         | quincunx ⚻       | Admetos               | 0.01° | Static = |
-| Pars Fortunae         | quincunx ⚻       | Vulkanus              | 1.71° | Static = |
+| Pars Fortunae         | quincunx ⚻       | Vulkanus              | 1.70° | Static = |
 | Pars Spiritus         | trine △          | Pars Fidei            | 2.86° | Static = |
 | Pars Spiritus         | trine △          | Vertex                | 2.45° | Static = |
 | Pars Spiritus         | sextile ⚹        | Anti Vertex           | 2.45° | Static = |
 | Pars Spiritus         | conjunction ☌    | True Priapus          | 2.24° | Static = |
 | Pars Spiritus         | conjunction ☌    | Interpolated Perigee  | 0.81° | Static = |
-| Pars Spiritus         | square □         | White Moon            | 3.20° | Static = |
+| Pars Spiritus         | square □         | White Moon            | 3.19° | Static = |
 | Pars Spiritus         | semi-sextile ⚺   | Poseidon              | 1.35° | Static = |
 | Pars Amoris           | semi-sextile ⚺   | Interpolated Lilith   | 1.98° | Static = |
 | Pars Amoris           | quincunx ⚻       | Mean Priapus          | 0.15° | Static = |
 | Pars Amoris           | trine △          | Kronos                | 0.21° | Static = |
-| Pars Amoris           | conjunction ☌    | Apollon               | 4.55° | Static = |
+| Pars Amoris           | conjunction ☌    | Apollon               | 4.54° | Static = |
 | Pars Amoris           | square □         | Vulkanus              | 1.62° | Static = |
 | Pars Fidei            | conjunction ☌    | Vertex                | 5.31° | Static = |
 | Pars Fidei            | opposition ☍     | Anti Vertex           | 5.31° | Static = |
 | Pars Fidei            | quintile Q       | Mean Priapus          | 1.04° | Static = |
 | Pars Fidei            | trine △          | True Priapus          | 0.63° | Static = |
 | Pars Fidei            | trine △          | Interpolated Perigee  | 2.06° | Static = |
-| Pars Fidei            | biquintile bQ    | Cupido                | 1.85° | Static = |
+| Pars Fidei            | biquintile bQ    | Cupido                | 1.86° | Static = |
 | Pars Fidei            | conjunction ☌    | Hades                 | 3.73° | Static = |
-| Pars Fidei            | semi-square ∠    | Vulkanus              | 0.49° | Static = |
+| Pars Fidei            | semi-square ∠    | Vulkanus              | 0.48° | Static = |
 | Pars Fidei            | quincunx ⚻       | Poseidon              | 1.51° | Static = |
 | Vertex                | trine △          | True Priapus          | 4.69° | Static = |
 | Vertex                | trine △          | Interpolated Perigee  | 3.26° | Static = |
-| Vertex                | semi-sextile ⚺   | White Moon            | 0.75° | Static = |
+| Vertex                | semi-sextile ⚺   | White Moon            | 0.74° | Static = |
 | Anti Vertex           | sextile ⚹        | True Priapus          | 4.69° | Static = |
 | Anti Vertex           | sextile ⚹        | Interpolated Perigee  | 3.26° | Static = |
-| Anti Vertex           | quincunx ⚻       | White Moon            | 0.75° | Static = |
+| Anti Vertex           | quincunx ⚻       | White Moon            | 0.74° | Static = |
 | Interpolated Lilith   | opposition ☍     | Mean Priapus          | 1.83° | Static = |
-| Interpolated Lilith   | conjunction ☌    | Zeus                  | 4.32° | Static = |
+| Interpolated Lilith   | conjunction ☌    | Zeus                  | 4.33° | Static = |
 | Interpolated Lilith   | square □         | Kronos                | 2.18° | Static = |
 | Interpolated Lilith   | trine △          | Admetos               | 1.36° | Static = |
 | Interpolated Lilith   | sextile ⚹        | Vulkanus              | 0.35° | Static = |
 | Interpolated Lilith   | semi-square ∠    | Poseidon              | 1.38° | Static = |
 | Mean Priapus          | opposition ☍     | Zeus                  | 2.50° | Static = |
 | Mean Priapus          | square □         | Kronos                | 0.36° | Static = |
-| Mean Priapus          | sextile ⚹        | Admetos               | 3.18° | Static = |
+| Mean Priapus          | sextile ⚹        | Admetos               | 3.19° | Static = |
 | Mean Priapus          | trine △          | Vulkanus              | 1.47° | Static = |
-| Mean Priapus          | sesquiquadrate ⚼ | Poseidon              | 0.45° | Static = |
+| Mean Priapus          | sesquiquadrate ⚼ | Poseidon              | 0.44° | Static = |
 | True Priapus          | conjunction ☌    | Interpolated Perigee  | 1.43° | Static = |
 | True Priapus          | square □         | White Moon            | 5.43° | Static = |
-| True Priapus          | trine △          | Hades                 | 4.35° | Static = |
-| True Priapus          | sesquiquadrate ⚼ | Admetos               | 1.85° | Static = |
+| True Priapus          | trine △          | Hades                 | 4.36° | Static = |
+| True Priapus          | sesquiquadrate ⚼ | Admetos               | 1.86° | Static = |
 | True Priapus          | semi-sextile ⚺   | Poseidon              | 0.89° | Static = |
 | Interpolated Perigee  | square □         | White Moon            | 4.00° | Static = |
-| Interpolated Perigee  | trine △          | Hades                 | 5.78° | Static = |
+| Interpolated Perigee  | trine △          | Hades                 | 5.79° | Static = |
 | Interpolated Perigee  | semi-sextile ⚺   | Poseidon              | 0.54° | Static = |
 | White Moon            | quintile Q       | Zeus                  | 1.40° | Static = |
-| White Moon            | trine △          | Poseidon              | 4.55° | Static = |
-| Cupido                | quincunx ⚻       | Hades                 | 0.42° | Static = |
+| White Moon            | trine △          | Poseidon              | 4.54° | Static = |
+| Cupido                | quincunx ⚻       | Hades                 | 0.41° | Static = |
 | Cupido                | conjunction ☌    | Poseidon              | 5.66° | Static = |
-| Hades                 | sesquiquadrate ⚼ | Apollon               | 1.29° | Static = |
+| Hades                 | sesquiquadrate ⚼ | Apollon               | 1.30° | Static = |
 | Zeus                  | square □         | Kronos                | 2.14° | Static = |
-| Zeus                  | trine △          | Admetos               | 5.68° | Static = |
+| Zeus                  | trine △          | Admetos               | 5.69° | Static = |
 | Zeus                  | sextile ⚹        | Vulkanus              | 3.97° | Static = |
-| Kronos                | trine △          | Apollon               | 4.76° | Static = |
+| Kronos                | trine △          | Apollon               | 4.75° | Static = |
 | Kronos                | semi-sextile ⚺   | Vulkanus              | 1.83° | Static = |
-| Kronos                | sesquiquadrate ⚼ | Poseidon              | 0.81° | Static = |
+| Kronos                | sesquiquadrate ⚼ | Poseidon              | 0.80° | Static = |
 | Apollon               | quincunx ⚻       | Admetos               | 1.21° | Static = |
 | Apollon               | square □         | Vulkanus              | 2.92° | Static = |
 | Admetos               | sextile ⚹        | Vulkanus              | 1.71° | Static = |

--- a/tests/fixtures/dual_return_all_points_all_aspects_report.txt
+++ b/tests/fixtures/dual_return_all_points_all_aspects_report.txt
@@ -56,10 +56,10 @@ Sample Natal Subject — Solar Return Comparison 1990
 +Natal Subject Celestial Points--+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House    |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6390°/d | N/A     | -    | Tenth House    |
-| Descendant            | Tau ♉ | 5.82°    | +245.7237°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6390°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House    |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6410°/d | N/A     | -    | Tenth House    |
+| Descendant            | Tau ♉ | 5.82°    | +245.7250°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6410°/d | N/A     | -    | Fourth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House    |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House    |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House    |
@@ -72,8 +72,8 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Pluto                 | Sco ♏ | 14.97°   | -0.0025°/d   | -1.42°  | R    | First House    |
 | Mean North Lunar Node | Aqu ♒ | 7.79°    | -0.0529°/d   | -18.32° | R    | Third House    |
 | True North Lunar Node | Aqu ♒ | 7.26°    | -0.0080°/d   | -18.46° | R    | Third House    |
-| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.61° | -    | First House    |
-| True Lilith           | Sag ♐ | 18.01°   | -1.4331°/d   | -26.88° | R    | Second House   |
+| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.62° | -    | First House    |
+| True Lilith           | Sag ♐ | 18.01°   | -1.4330°/d   | -26.88° | R    | Second House   |
 | Chiron                | Can ♋ | 19.88°   | +0.1071°/d   | +15.79° | -    | Ninth House    |
 | Pholus                | Can ♋ | 7.99°    | +0.1329°/d   | +13.79° | -    | Eighth House   |
 | Ceres                 | Leo ♌ | 13.71°   | +0.4493°/d   | +23.05° | -    | Ninth House    |
@@ -81,15 +81,15 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Juno                  | Sco ♏ | 10.10°   | +0.0843°/d   | -2.06°  | -    | First House    |
 | Vesta                 | Tau ♉ | 18.15°   | +0.3292°/d   | +10.88° | -    | Seventh House  |
 | Interpolated Lilith   | Sco ♏ | 25.48°   | +0.1694°/d   | -23.89° | -    | First House    |
-| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1732°/d   | +26.84° | -    | Eighth House   |
-| Cupido                | Sco ♏ | 18.62°   | -0.0042°/d   | -16.34° | R    | First House    |
-| Hades                 | Gem ♊ | 9.93°    | +0.0152°/d   | +20.93° | -    | Eighth House   |
-| Zeus                  | Vir ♍ | 26.03°   | +0.0110°/d   | +1.58°  | -    | Eleventh House |
-| Kronos                | Gem ♊ | 21.90°   | +0.0137°/d   | +23.21° | -    | Eighth House   |
-| Apollon               | Lib ♎ | 13.83°   | +0.0053°/d   | -5.46°  | -    | Eleventh House |
-| Admetos               | Tau ♉ | 14.96°   | +0.0053°/d   | +16.33° | -    | Seventh House  |
-| Vulkanus              | Can ♋ | 15.35°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
-| Poseidon              | Lib ♎ | 28.68°   | +0.0014°/d   | -11.01° | -    | Twelfth House  |
+| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1733°/d   | +26.84° | -    | Eighth House   |
+| Cupido                | Sco ♏ | 18.62°   | -0.0043°/d   | -16.34° | R    | First House    |
+| Hades                 | Gem ♊ | 9.92°    | +0.0153°/d   | +20.93° | -    | Eighth House   |
+| Zeus                  | Vir ♍ | 26.03°   | +0.0109°/d   | +1.58°  | -    | Eleventh House |
+| Kronos                | Gem ♊ | 21.89°   | +0.0138°/d   | +23.21° | -    | Eighth House   |
+| Apollon               | Lib ♎ | 13.82°   | +0.0052°/d   | -5.46°  | -    | Eleventh House |
+| Admetos               | Tau ♉ | 14.96°   | +0.0054°/d   | +16.33° | -    | Seventh House  |
+| Vulkanus              | Can ♋ | 15.34°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
+| Poseidon              | Lib ♎ | 28.68°   | +0.0013°/d   | -11.01° | -    | Twelfth House  |
 | Eris                  | Ari ♈ | 17.60°   | -0.0013°/d   | -9.16°  | R    | Sixth House    |
 | Sedna                 | Tau ♉ | 11.55°   | +0.0038°/d   | +4.25°  | -    | Seventh House  |
 | Haumea                | Vir ♍ | 26.32°   | +0.0134°/d   | +23.02° | -    | Eleventh House |
@@ -102,21 +102,21 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Pars Amoris           | Lib ♎ | 8.99°    | N/A          | N/A     | -    | Eleventh House |
 | Pars Fidei            | Tau ♉ | 8.22°    | N/A          | N/A     | -    | Seventh House  |
 | Vertex                | Gem ♊ | 11.46°   | N/A          | N/A     | -    | Eighth House   |
-| White Moon            | Can ♋ | 26.44°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
+| White Moon            | Can ♋ | 26.43°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
 | Anti Vertex           | Sag ♐ | 11.46°   | N/A          | N/A     | -    | Second House   |
 | Mean South Lunar Node | Leo ♌ | 7.79°    | -0.0529°/d   | +18.32° | R    | Ninth House    |
 | True South Lunar Node | Leo ♌ | 7.26°    | -0.0080°/d   | +18.46° | R    | Ninth House    |
-| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.61° | -    | Seventh House  |
-| True Priapus          | Gem ♊ | 18.01°   | -1.4331°/d   | +26.88° | R    | Eighth House   |
+| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.62° | -    | Seventh House  |
+| True Priapus          | Gem ♊ | 18.01°   | -1.4330°/d   | +26.88° | R    | Eighth House   |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +Return Subject Celestial Points-+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House    |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6344°/d | N/A     | -    | Tenth House    |
-| Descendant            | Tau ♉ | 5.82°    | +245.7237°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6344°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House    |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6364°/d | N/A     | -    | Tenth House    |
+| Descendant            | Tau ♉ | 5.82°    | +245.7250°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6364°/d | N/A     | -    | Fourth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House    |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House    |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House    |
@@ -129,8 +129,8 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Pluto                 | Sco ♏ | 14.97°   | -0.0025°/d   | -1.42°  | R    | First House    |
 | Mean North Lunar Node | Aqu ♒ | 7.79°    | -0.0529°/d   | -18.32° | R    | Third House    |
 | True North Lunar Node | Aqu ♒ | 7.26°    | -0.0080°/d   | -18.46° | R    | Third House    |
-| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.61° | -    | First House    |
-| True Lilith           | Sag ♐ | 18.01°   | -1.4331°/d   | -26.88° | R    | Second House   |
+| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.62° | -    | First House    |
+| True Lilith           | Sag ♐ | 18.01°   | -1.4330°/d   | -26.88° | R    | Second House   |
 | Chiron                | Can ♋ | 19.88°   | +0.1071°/d   | +15.79° | -    | Ninth House    |
 | Pholus                | Can ♋ | 7.99°    | +0.1329°/d   | +13.79° | -    | Eighth House   |
 | Ceres                 | Leo ♌ | 13.71°   | +0.4493°/d   | +23.05° | -    | Ninth House    |
@@ -138,15 +138,15 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Juno                  | Sco ♏ | 10.10°   | +0.0843°/d   | -2.06°  | -    | First House    |
 | Vesta                 | Tau ♉ | 18.15°   | +0.3292°/d   | +10.88° | -    | Seventh House  |
 | Interpolated Lilith   | Sco ♏ | 25.48°   | +0.1694°/d   | -23.89° | -    | First House    |
-| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1732°/d   | +26.84° | -    | Eighth House   |
-| Cupido                | Sco ♏ | 18.62°   | -0.0042°/d   | -16.34° | R    | First House    |
-| Hades                 | Gem ♊ | 9.93°    | +0.0152°/d   | +20.93° | -    | Eighth House   |
-| Zeus                  | Vir ♍ | 26.03°   | +0.0110°/d   | +1.58°  | -    | Eleventh House |
-| Kronos                | Gem ♊ | 21.90°   | +0.0137°/d   | +23.21° | -    | Eighth House   |
-| Apollon               | Lib ♎ | 13.83°   | +0.0053°/d   | -5.46°  | -    | Eleventh House |
-| Admetos               | Tau ♉ | 14.96°   | +0.0053°/d   | +16.33° | -    | Seventh House  |
-| Vulkanus              | Can ♋ | 15.35°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
-| Poseidon              | Lib ♎ | 28.68°   | +0.0014°/d   | -11.01° | -    | Twelfth House  |
+| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1733°/d   | +26.84° | -    | Eighth House   |
+| Cupido                | Sco ♏ | 18.62°   | -0.0043°/d   | -16.34° | R    | First House    |
+| Hades                 | Gem ♊ | 9.92°    | +0.0153°/d   | +20.93° | -    | Eighth House   |
+| Zeus                  | Vir ♍ | 26.03°   | +0.0109°/d   | +1.58°  | -    | Eleventh House |
+| Kronos                | Gem ♊ | 21.89°   | +0.0138°/d   | +23.21° | -    | Eighth House   |
+| Apollon               | Lib ♎ | 13.82°   | +0.0052°/d   | -5.46°  | -    | Eleventh House |
+| Admetos               | Tau ♉ | 14.96°   | +0.0054°/d   | +16.33° | -    | Seventh House  |
+| Vulkanus              | Can ♋ | 15.34°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
+| Poseidon              | Lib ♎ | 28.68°   | +0.0013°/d   | -11.01° | -    | Twelfth House  |
 | Eris                  | Ari ♈ | 17.60°   | -0.0013°/d   | -9.16°  | R    | Sixth House    |
 | Sedna                 | Tau ♉ | 11.55°   | +0.0038°/d   | +4.25°  | -    | Seventh House  |
 | Haumea                | Vir ♍ | 26.32°   | +0.0134°/d   | +23.02° | -    | Eleventh House |
@@ -159,12 +159,12 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Pars Amoris           | Lib ♎ | 8.98°    | N/A          | N/A     | -    | Eleventh House |
 | Pars Fidei            | Tau ♉ | 8.21°    | N/A          | N/A     | -    | Seventh House  |
 | Vertex                | Gem ♊ | 11.46°   | N/A          | N/A     | -    | Eighth House   |
-| White Moon            | Can ♋ | 26.44°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
+| White Moon            | Can ♋ | 26.43°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
 | Anti Vertex           | Sag ♐ | 11.46°   | N/A          | N/A     | -    | Second House   |
 | Mean South Lunar Node | Leo ♌ | 7.79°    | -0.0529°/d   | +18.32° | R    | Ninth House    |
 | True South Lunar Node | Leo ♌ | 7.26°    | -0.0080°/d   | +18.46° | R    | Ninth House    |
-| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.61° | -    | Seventh House  |
-| True Priapus          | Gem ♊ | 18.01°   | -1.4331°/d   | +26.88° | R    | Eighth House   |
+| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.62° | -    | Seventh House  |
+| True Priapus          | Gem ♊ | 18.01°   | -1.4330°/d   | +26.88° | R    | Eighth House   |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +Natal Subject Houses (Placidus)-----+-------------------+
@@ -254,12 +254,12 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Sample Natal Subject – Interpolated Lilith   | 1 (First House)     | 1 (First House)     | Sco  | 25.48° |
 | Sample Natal Subject – Interpolated Perigee  | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 20.98° |
 | Sample Natal Subject – Cupido                | 1 (First House)     | 1 (First House)     | Sco  | 18.62° |
-| Sample Natal Subject – Hades                 | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 9.93°  |
+| Sample Natal Subject – Hades                 | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 9.92°  |
 | Sample Natal Subject – Zeus                  | 11 (Eleventh House) | 11 (Eleventh House) | Vir  | 26.03° |
-| Sample Natal Subject – Kronos                | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 21.90° |
-| Sample Natal Subject – Apollon               | 11 (Eleventh House) | 11 (Eleventh House) | Lib  | 13.83° |
+| Sample Natal Subject – Kronos                | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 21.89° |
+| Sample Natal Subject – Apollon               | 11 (Eleventh House) | 11 (Eleventh House) | Lib  | 13.82° |
 | Sample Natal Subject – Admetos               | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 14.96° |
-| Sample Natal Subject – Vulkanus              | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 15.35° |
+| Sample Natal Subject – Vulkanus              | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 15.34° |
 | Sample Natal Subject – Poseidon              | 12 (Twelfth House)  | 12 (Twelfth House)  | Lib  | 28.68° |
 | Sample Natal Subject – Eris                  | 6 (Sixth House)     | 6 (Sixth House)     | Ari  | 17.60° |
 | Sample Natal Subject – Sedna                 | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 11.55° |
@@ -273,7 +273,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Sample Natal Subject – Pars Amoris           | 11 (Eleventh House) | 11 (Eleventh House) | Lib  | 8.99°  |
 | Sample Natal Subject – Pars Fidei            | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 8.22°  |
 | Sample Natal Subject – Vertex                | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 11.46° |
-| Sample Natal Subject – White Moon            | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 26.44° |
+| Sample Natal Subject – White Moon            | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 26.43° |
 | Sample Natal Subject – Descendant            | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 5.82°  |
 | Sample Natal Subject – Imum Coeli            | 4 (Fourth House)    | 4 (Fourth House)    | Aqu  | 19.91° |
 | Sample Natal Subject – Anti Vertex           | 2 (Second House)    | 2 (Second House)    | Sag  | 11.46° |
@@ -311,12 +311,12 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Sample Natal Subject Solar Return – Interpolated Lilith   | 1 (First House)     | 1 (First House)     | Sco  | 25.48° |
 | Sample Natal Subject Solar Return – Interpolated Perigee  | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 20.98° |
 | Sample Natal Subject Solar Return – Cupido                | 1 (First House)     | 1 (First House)     | Sco  | 18.62° |
-| Sample Natal Subject Solar Return – Hades                 | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 9.93°  |
+| Sample Natal Subject Solar Return – Hades                 | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 9.92°  |
 | Sample Natal Subject Solar Return – Zeus                  | 11 (Eleventh House) | 11 (Eleventh House) | Vir  | 26.03° |
-| Sample Natal Subject Solar Return – Kronos                | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 21.90° |
-| Sample Natal Subject Solar Return – Apollon               | 11 (Eleventh House) | 11 (Eleventh House) | Lib  | 13.83° |
+| Sample Natal Subject Solar Return – Kronos                | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 21.89° |
+| Sample Natal Subject Solar Return – Apollon               | 11 (Eleventh House) | 11 (Eleventh House) | Lib  | 13.82° |
 | Sample Natal Subject Solar Return – Admetos               | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 14.96° |
-| Sample Natal Subject Solar Return – Vulkanus              | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 15.35° |
+| Sample Natal Subject Solar Return – Vulkanus              | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 15.34° |
 | Sample Natal Subject Solar Return – Poseidon              | 12 (Twelfth House)  | 12 (Twelfth House)  | Lib  | 28.68° |
 | Sample Natal Subject Solar Return – Eris                  | 6 (Sixth House)     | 6 (Sixth House)     | Ari  | 17.60° |
 | Sample Natal Subject Solar Return – Sedna                 | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 11.55° |
@@ -330,7 +330,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Sample Natal Subject Solar Return – Pars Amoris           | 11 (Eleventh House) | 11 (Eleventh House) | Lib  | 8.98°  |
 | Sample Natal Subject Solar Return – Pars Fidei            | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 8.21°  |
 | Sample Natal Subject Solar Return – Vertex                | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 11.46° |
-| Sample Natal Subject Solar Return – White Moon            | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 26.44° |
+| Sample Natal Subject Solar Return – White Moon            | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 26.43° |
 | Sample Natal Subject Solar Return – Descendant            | 7 (Seventh House)   | 6 (Sixth House)     | Tau  | 5.82°  |
 | Sample Natal Subject Solar Return – Imum Coeli            | 4 (Fourth House)    | 3 (Third House)     | Aqu  | 19.91° |
 | Sample Natal Subject Solar Return – Anti Vertex           | 2 (Second House)    | 2 (Second House)    | Sag  | 11.46° |
@@ -481,11 +481,11 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Moon                  | Sample Natal Subject | quintile Q       | Pars Fidei            | Sample Natal Subject Solar Return | 0.99° | Static =     |
 | Moon                  | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 4.27° | Separating ← |
 | Moon                  | Sample Natal Subject | semi-sextile ⚺   | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.23° | Applying →   |
-| Moon                  | Sample Natal Subject | conjunction ☌    | White Moon            | Sample Natal Subject Solar Return | 5.23° | Separating ← |
+| Moon                  | Sample Natal Subject | conjunction ☌    | White Moon            | Sample Natal Subject Solar Return | 5.22° | Separating ← |
 | Moon                  | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 2.59° | Separating ← |
 | Moon                  | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 4.82° | Separating ← |
 | Moon                  | Sample Natal Subject | semi-sextile ⚺   | Kronos                | Sample Natal Subject Solar Return | 0.69° | Separating ← |
-| Moon                  | Sample Natal Subject | conjunction ☌    | Vulkanus              | Sample Natal Subject Solar Return | 5.86° | Applying →   |
+| Moon                  | Sample Natal Subject | conjunction ☌    | Vulkanus              | Sample Natal Subject Solar Return | 5.87° | Applying →   |
 | Mercury               | Sample Natal Subject | conjunction ☌    | Mercury               | Sample Natal Subject Solar Return | 0.00° | Applying →   |
 | Mercury               | Sample Natal Subject | semi-square ∠    | Venus                 | Sample Natal Subject Solar Return | 0.90° | Applying →   |
 | Mercury               | Sample Natal Subject | biquintile bQ    | Neptune               | Sample Natal Subject Solar Return | 1.15° | Applying →   |
@@ -560,7 +560,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Jupiter               | Sample Natal Subject | square □         | Pars Fortunae         | Sample Natal Subject Solar Return | 4.57° | Static =     |
 | Jupiter               | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.56° | Separating ← |
 | Jupiter               | Sample Natal Subject | conjunction ☌    | White Moon            | Sample Natal Subject Solar Return | 2.52° | Separating ← |
-| Jupiter               | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 5.30° | Separating ← |
+| Jupiter               | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 5.29° | Separating ← |
 | Jupiter               | Sample Natal Subject | semi-square ∠    | Hades                 | Sample Natal Subject Solar Return | 1.01° | Separating ← |
 | Jupiter               | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 2.12° | Separating ← |
 | Jupiter               | Sample Natal Subject | square □         | Poseidon              | Sample Natal Subject Solar Return | 4.77° | Separating ← |
@@ -580,7 +580,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Saturn                | Sample Natal Subject | quincunx ⚻       | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.53° | Applying →   |
 | Saturn                | Sample Natal Subject | opposition ☍     | White Moon            | Sample Natal Subject Solar Return | 4.92° | Separating ← |
 | Saturn                | Sample Natal Subject | sextile ⚹        | Cupido                | Sample Natal Subject Solar Return | 2.90° | Separating ← |
-| Saturn                | Sample Natal Subject | trine △          | Zeus                  | Sample Natal Subject Solar Return | 4.52° | Separating ← |
+| Saturn                | Sample Natal Subject | trine △          | Zeus                  | Sample Natal Subject Solar Return | 4.51° | Separating ← |
 | Saturn                | Sample Natal Subject | quincunx ⚻       | Kronos                | Sample Natal Subject Solar Return | 0.38° | Separating ← |
 | Uranus                | Sample Natal Subject | opposition ☍     | Venus                 | Sample Natal Subject Solar Return | 5.03° | Applying →   |
 | Uranus                | Sample Natal Subject | trine △          | Mars                  | Sample Natal Subject Solar Return | 0.77° | Applying →   |
@@ -644,7 +644,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Pluto                 | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 3.64° | Applying →   |
 | Pluto                 | Sample Natal Subject | biquintile bQ    | Kronos                | Sample Natal Subject Solar Return | 0.92° | Separating ← |
 | Pluto                 | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Sample Natal Subject Solar Return | 1.15° | Applying →   |
-| Pluto                 | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 0.01° | Applying →   |
+| Pluto                 | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 0.02° | Applying →   |
 | Pluto                 | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 0.37° | Separating ← |
 | Mean North Lunar Node | Sample Natal Subject | biquintile bQ    | Venus                 | Sample Natal Subject Solar Return | 0.08° | Applying →   |
 | Mean North Lunar Node | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 1.82° | Applying →   |
@@ -669,7 +669,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Mean North Lunar Node | Sample Natal Subject | sextile ⚹        | Anti Vertex           | Sample Natal Subject Solar Return | 3.67° | Static =     |
 | Mean North Lunar Node | Sample Natal Subject | quintile Q       | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.31° | Applying →   |
 | Mean North Lunar Node | Sample Natal Subject | sesquiquadrate ⚼ | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.81° | Applying →   |
-| Mean North Lunar Node | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 2.14° | Separating ← |
+| Mean North Lunar Node | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 2.13° | Separating ← |
 | Mean North Lunar Node | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | Sample Natal Subject Solar Return | 0.89° | Applying →   |
 | True North Lunar Node | Sample Natal Subject | biquintile bQ    | Venus                 | Sample Natal Subject Solar Return | 0.44° | Separating ← |
 | True North Lunar Node | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 1.30° | Applying →   |
@@ -716,7 +716,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Chiron                | Sample Natal Subject | semi-sextile ⚺   | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.10° | Separating ← |
 | Chiron                | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 1.26° | Separating ← |
 | Chiron                | Sample Natal Subject | sextile ⚹        | Admetos               | Sample Natal Subject Solar Return | 4.92° | Applying →   |
-| Chiron                | Sample Natal Subject | conjunction ☌    | Vulkanus              | Sample Natal Subject Solar Return | 4.53° | Applying →   |
+| Chiron                | Sample Natal Subject | conjunction ☌    | Vulkanus              | Sample Natal Subject Solar Return | 4.54° | Applying →   |
 | Ascendant             | Sample Natal Subject | trine △          | Venus                 | Sample Natal Subject Solar Return | 4.11° | Applying →   |
 | Ascendant             | Sample Natal Subject | opposition ☍     | Mars                  | Sample Natal Subject Solar Return | 0.15° | Separating ← |
 | Ascendant             | Sample Natal Subject | sextile ⚹        | Uranus                | Sample Natal Subject Solar Return | 0.92° | Applying →   |
@@ -736,7 +736,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Ascendant             | Sample Natal Subject | biquintile bQ    | Vertex                | Sample Natal Subject Solar Return | 0.36° | Static =     |
 | Ascendant             | Sample Natal Subject | sesquiquadrate ⚼ | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.16° | Separating ← |
 | Ascendant             | Sample Natal Subject | biquintile bQ    | Hades                 | Sample Natal Subject Solar Return | 1.90° | Applying →   |
-| Ascendant             | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | Sample Natal Subject Solar Return | 1.08° | Separating ← |
+| Ascendant             | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | Sample Natal Subject Solar Return | 1.07° | Separating ← |
 | Medium Coeli          | Sample Natal Subject | semi-sextile ⚺   | Moon                  | Sample Natal Subject Solar Return | 1.29° | Separating ← |
 | Medium Coeli          | Sample Natal Subject | conjunction ☌    | Mercury               | Sample Natal Subject Solar Return | 2.31° | Applying →   |
 | Medium Coeli          | Sample Natal Subject | quincunx ⚻       | Saturn                | Sample Natal Subject Solar Return | 1.60° | Applying →   |
@@ -756,7 +756,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Medium Coeli          | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.07° | Separating ← |
 | Medium Coeli          | Sample Natal Subject | square □         | Cupido                | Sample Natal Subject Solar Return | 1.30° | Separating ← |
 | Medium Coeli          | Sample Natal Subject | sextile ⚹        | Kronos                | Sample Natal Subject Solar Return | 1.98° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 4.95° | Applying →   |
+| Medium Coeli          | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 4.96° | Applying →   |
 | Descendant            | Sample Natal Subject | sextile ⚹        | Venus                 | Sample Natal Subject Solar Return | 4.11° | Applying →   |
 | Descendant            | Sample Natal Subject | conjunction ☌    | Mars                  | Sample Natal Subject Solar Return | 0.15° | Separating ← |
 | Descendant            | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 0.92° | Applying →   |
@@ -775,7 +775,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Descendant            | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Sample Natal Subject Solar Return | 2.39° | Static =     |
 | Descendant            | Sample Natal Subject | biquintile bQ    | Anti Vertex           | Sample Natal Subject Solar Return | 0.36° | Static =     |
 | Descendant            | Sample Natal Subject | semi-square ∠    | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.16° | Separating ← |
-| Descendant            | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 1.08° | Separating ← |
+| Descendant            | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 1.07° | Separating ← |
 | Imum Coeli            | Sample Natal Subject | quincunx ⚻       | Moon                  | Sample Natal Subject Solar Return | 1.29° | Separating ← |
 | Imum Coeli            | Sample Natal Subject | opposition ☍     | Mercury               | Sample Natal Subject Solar Return | 2.31° | Applying →   |
 | Imum Coeli            | Sample Natal Subject | semi-sextile ⚺   | Saturn                | Sample Natal Subject Solar Return | 1.60° | Applying →   |
@@ -796,8 +796,8 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Imum Coeli            | Sample Natal Subject | square □         | Cupido                | Sample Natal Subject Solar Return | 1.30° | Separating ← |
 | Imum Coeli            | Sample Natal Subject | biquintile bQ    | Zeus                  | Sample Natal Subject Solar Return | 0.12° | Separating ← |
 | Imum Coeli            | Sample Natal Subject | trine △          | Kronos                | Sample Natal Subject Solar Return | 1.98° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 4.95° | Applying →   |
-| Imum Coeli            | Sample Natal Subject | biquintile bQ    | Vulkanus              | Sample Natal Subject Solar Return | 1.43° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 4.96° | Applying →   |
+| Imum Coeli            | Sample Natal Subject | biquintile bQ    | Vulkanus              | Sample Natal Subject Solar Return | 1.42° | Separating ← |
 | Mean Lilith           | Sample Natal Subject | trine △          | Sun                   | Sample Natal Subject Solar Return | 0.45° | Applying →   |
 | Mean Lilith           | Sample Natal Subject | trine △          | Jupiter               | Sample Natal Subject Solar Return | 5.08° | Applying →   |
 | Mean Lilith           | Sample Natal Subject | semi-square ∠    | Neptune               | Sample Natal Subject Solar Return | 1.23° | Separating ← |
@@ -808,10 +808,10 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Mean Lilith           | Sample Natal Subject | semi-sextile ⚺   | Pars Fortunae         | Sample Natal Subject Solar Return | 0.51° | Static =     |
 | Mean Lilith           | Sample Natal Subject | conjunction ☌    | Interpolated Lilith   | Sample Natal Subject Solar Return | 3.51° | Applying →   |
 | Mean Lilith           | Sample Natal Subject | opposition ☍     | Mean Priapus          | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 2.55° | Applying →   |
+| Mean Lilith           | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 2.56° | Applying →   |
 | Mean Lilith           | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 2.96° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | semi-square ∠    | Apollon               | Sample Natal Subject Solar Return | 0.16° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | sesquiquadrate ⚼ | Vulkanus              | Sample Natal Subject Solar Return | 1.36° | Separating ← |
+| Mean Lilith           | Sample Natal Subject | semi-square ∠    | Apollon               | Sample Natal Subject Solar Return | 0.17° | Applying →   |
+| Mean Lilith           | Sample Natal Subject | sesquiquadrate ⚼ | Vulkanus              | Sample Natal Subject Solar Return | 1.35° | Separating ← |
 | Mean Lilith           | Sample Natal Subject | semi-sextile ⚺   | Poseidon              | Sample Natal Subject Solar Return | 0.31° | Applying →   |
 | Mean South Lunar Node | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 1.82° | Applying →   |
 | Mean South Lunar Node | Sample Natal Subject | quincunx ⚻       | Uranus                | Sample Natal Subject Solar Return | 1.05° | Separating ← |
@@ -833,7 +833,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Mean South Lunar Node | Sample Natal Subject | sextile ⚹        | Vertex                | Sample Natal Subject Solar Return | 3.67° | Static =     |
 | Mean South Lunar Node | Sample Natal Subject | trine △          | Anti Vertex           | Sample Natal Subject Solar Return | 3.67° | Static =     |
 | Mean South Lunar Node | Sample Natal Subject | semi-square ∠    | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.81° | Applying →   |
-| Mean South Lunar Node | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 2.14° | Separating ← |
+| Mean South Lunar Node | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 2.13° | Separating ← |
 | Mean South Lunar Node | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 0.89° | Applying →   |
 | True South Lunar Node | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 1.30° | Applying →   |
 | True South Lunar Node | Sample Natal Subject | quincunx ⚻       | Uranus                | Sample Natal Subject Solar Return | 0.53° | Separating ← |
@@ -890,8 +890,8 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Pholus                | Sample Natal Subject | trine △          | Pars Spiritus         | Sample Natal Subject Solar Return | 5.16° | Static =     |
 | Pholus                | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 0.99° | Static =     |
 | Pholus                | Sample Natal Subject | sextile ⚹        | Pars Fidei            | Sample Natal Subject Solar Return | 0.22° | Static =     |
-| Pholus                | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Sample Natal Subject Solar Return | 1.94° | Separating ← |
-| Pholus                | Sample Natal Subject | square □         | Apollon               | Sample Natal Subject Solar Return | 5.84° | Separating ← |
+| Pholus                | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Sample Natal Subject Solar Return | 1.93° | Separating ← |
+| Pholus                | Sample Natal Subject | square □         | Apollon               | Sample Natal Subject Solar Return | 5.83° | Separating ← |
 | Ceres                 | Sample Natal Subject | conjunction ☌    | Mercury               | Sample Natal Subject Solar Return | 3.89° | Separating ← |
 | Ceres                 | Sample Natal Subject | biquintile bQ    | Uranus                | Sample Natal Subject Solar Return | 0.98° | Separating ← |
 | Ceres                 | Sample Natal Subject | quincunx ⚻       | Neptune               | Sample Natal Subject Solar Return | 0.95° | Separating ← |
@@ -914,7 +914,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Ceres                 | Sample Natal Subject | square □         | Cupido                | Sample Natal Subject Solar Return | 4.90° | Applying →   |
 | Ceres                 | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 3.79° | Applying →   |
 | Ceres                 | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 0.11° | Separating ← |
-| Ceres                 | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 1.25° | Separating ← |
+| Ceres                 | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 1.24° | Separating ← |
 | Ceres                 | Sample Natal Subject | semi-sextile ⚺   | Vulkanus              | Sample Natal Subject Solar Return | 1.63° | Separating ← |
 | Pallas                | Sample Natal Subject | conjunction ☌    | Venus                 | Sample Natal Subject Solar Return | 5.54° | Applying →   |
 | Pallas                | Sample Natal Subject | sextile ⚹        | Mars                  | Sample Natal Subject Solar Return | 1.28° | Applying →   |
@@ -961,9 +961,9 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Juno                  | Sample Natal Subject | semi-sextile ⚺   | Anti Vertex           | Sample Natal Subject Solar Return | 1.36° | Static =     |
 | Juno                  | Sample Natal Subject | biquintile bQ    | True Priapus          | Sample Natal Subject Solar Return | 1.92° | Applying →   |
 | Juno                  | Sample Natal Subject | quincunx ⚻       | Hades                 | Sample Natal Subject Solar Return | 0.17° | Applying →   |
-| Juno                  | Sample Natal Subject | semi-square ∠    | Zeus                  | Sample Natal Subject Solar Return | 0.94° | Separating ← |
+| Juno                  | Sample Natal Subject | semi-square ∠    | Zeus                  | Sample Natal Subject Solar Return | 0.93° | Separating ← |
 | Juno                  | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 4.86° | Separating ← |
-| Juno                  | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 5.25° | Separating ← |
+| Juno                  | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 5.24° | Separating ← |
 | Vesta                 | Sample Natal Subject | quintile Q       | Sun                   | Sample Natal Subject Solar Return | 1.60° | Applying →   |
 | Vesta                 | Sample Natal Subject | sextile ⚹        | Moon                  | Sample Natal Subject Solar Return | 3.06° | Separating ← |
 | Vesta                 | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 0.54° | Applying →   |
@@ -985,7 +985,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Vesta                 | Sample Natal Subject | opposition ☍     | Cupido                | Sample Natal Subject Solar Return | 0.47° | Applying →   |
 | Vesta                 | Sample Natal Subject | biquintile bQ    | Apollon               | Sample Natal Subject Solar Return | 1.68° | Separating ← |
 | Vesta                 | Sample Natal Subject | conjunction ☌    | Admetos               | Sample Natal Subject Solar Return | 3.19° | Applying →   |
-| Vesta                 | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 2.80° | Applying →   |
+| Vesta                 | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 2.81° | Applying →   |
 | Eris                  | Sample Natal Subject | square □         | Moon                  | Sample Natal Subject Solar Return | 3.61° | Separating ← |
 | Eris                  | Sample Natal Subject | trine △          | Mercury               | Sample Natal Subject Solar Return | 0.01° | Separating ← |
 | Eris                  | Sample Natal Subject | square □         | Saturn                | Sample Natal Subject Solar Return | 3.92° | Applying →   |
@@ -1007,7 +1007,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Eris                  | Sample Natal Subject | quincunx ⚻       | Cupido                | Sample Natal Subject Solar Return | 1.02° | Applying →   |
 | Eris                  | Sample Natal Subject | sextile ⚹        | Kronos                | Sample Natal Subject Solar Return | 4.30° | Separating ← |
 | Eris                  | Sample Natal Subject | opposition ☍     | Apollon               | Sample Natal Subject Solar Return | 3.77° | Applying →   |
-| Eris                  | Sample Natal Subject | square □         | Vulkanus              | Sample Natal Subject Solar Return | 2.25° | Applying →   |
+| Eris                  | Sample Natal Subject | square □         | Vulkanus              | Sample Natal Subject Solar Return | 2.26° | Applying →   |
 | Sedna                 | Sample Natal Subject | conjunction ☌    | Mars                  | Sample Natal Subject Solar Return | 5.58° | Applying →   |
 | Sedna                 | Sample Natal Subject | quintile Q       | Jupiter               | Sample Natal Subject Solar Return | 0.36° | Separating ← |
 | Sedna                 | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 4.81° | Separating ← |
@@ -1031,10 +1031,10 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Sedna                 | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Sample Natal Subject Solar Return | 3.33° | Static =     |
 | Sedna                 | Sample Natal Subject | semi-sextile ⚺   | Vertex                | Sample Natal Subject Solar Return | 0.09° | Static =     |
 | Sedna                 | Sample Natal Subject | quincunx ⚻       | Anti Vertex           | Sample Natal Subject Solar Return | 0.09° | Static =     |
-| Sedna                 | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Sample Natal Subject Solar Return | 1.62° | Applying →   |
+| Sedna                 | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Sample Natal Subject Solar Return | 1.63° | Applying →   |
 | Sedna                 | Sample Natal Subject | sesquiquadrate ⚼ | Zeus                  | Sample Natal Subject Solar Return | 0.52° | Applying →   |
 | Sedna                 | Sample Natal Subject | conjunction ☌    | Admetos               | Sample Natal Subject Solar Return | 3.41° | Separating ← |
-| Sedna                 | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 3.80° | Separating ← |
+| Sedna                 | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 3.79° | Separating ← |
 | Haumea                | Sample Natal Subject | sextile ⚹        | Sun                   | Sample Natal Subject Solar Return | 2.22° | Separating ← |
 | Haumea                | Sample Natal Subject | square □         | Venus                 | Sample Natal Subject Solar Return | 5.39° | Separating ← |
 | Haumea                | Sample Natal Subject | sextile ⚹        | Jupiter               | Sample Natal Subject Solar Return | 2.41° | Applying →   |
@@ -1053,7 +1053,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Haumea                | Sample Natal Subject | square □         | Interpolated Perigee  | Sample Natal Subject Solar Return | 5.34° | Applying →   |
 | Haumea                | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 0.11° | Separating ← |
 | Haumea                | Sample Natal Subject | conjunction ☌    | Zeus                  | Sample Natal Subject Solar Return | 0.29° | Applying →   |
-| Haumea                | Sample Natal Subject | square □         | Kronos                | Sample Natal Subject Solar Return | 4.42° | Applying →   |
+| Haumea                | Sample Natal Subject | square □         | Kronos                | Sample Natal Subject Solar Return | 4.43° | Applying →   |
 | Haumea                | Sample Natal Subject | quintile Q       | Vulkanus              | Sample Natal Subject Solar Return | 1.02° | Separating ← |
 | Makemake              | Sample Natal Subject | semi-square ∠    | Moon                  | Sample Natal Subject Solar Return | 1.71° | Separating ← |
 | Makemake              | Sample Natal Subject | sextile ⚹        | Venus                 | Sample Natal Subject Solar Return | 2.79° | Applying →   |
@@ -1071,7 +1071,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Makemake              | Sample Natal Subject | trine △          | Pars Fidei            | Sample Natal Subject Solar Return | 3.72° | Static =     |
 | Makemake              | Sample Natal Subject | square □         | Mean Priapus          | Sample Natal Subject Solar Return | 5.51° | Applying →   |
 | Makemake              | Sample Natal Subject | quintile Q       | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.51° | Applying →   |
-| Makemake              | Sample Natal Subject | square □         | Hades                 | Sample Natal Subject Solar Return | 5.43° | Separating ← |
+| Makemake              | Sample Natal Subject | square □         | Hades                 | Sample Natal Subject Solar Return | 5.42° | Separating ← |
 | Makemake              | Sample Natal Subject | quintile Q       | Kronos                | Sample Natal Subject Solar Return | 0.60° | Applying →   |
 | Ixion                 | Sample Natal Subject | trine △          | Sun                   | Sample Natal Subject Solar Return | 5.84° | Separating ← |
 | Ixion                 | Sample Natal Subject | trine △          | Moon                  | Sample Natal Subject Solar Return | 1.49° | Applying →   |
@@ -1095,7 +1095,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Ixion                 | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 3.73° | Separating ← |
 | Ixion                 | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 4.09° | Separating ← |
 | Ixion                 | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 3.33° | Separating ← |
-| Ixion                 | Sample Natal Subject | quincunx ⚻       | Kronos                | Sample Natal Subject Solar Return | 0.80° | Applying →   |
+| Ixion                 | Sample Natal Subject | quincunx ⚻       | Kronos                | Sample Natal Subject Solar Return | 0.81° | Applying →   |
 | Orcus                 | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 4.87° | Applying →   |
 | Orcus                 | Sample Natal Subject | biquintile bQ    | Uranus                | Sample Natal Subject Solar Return | 1.90° | Applying →   |
 | Orcus                 | Sample Natal Subject | quincunx ⚻       | Neptune               | Sample Natal Subject Solar Return | 1.92° | Applying →   |
@@ -1117,7 +1117,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Orcus                 | Sample Natal Subject | sextile ⚹        | Vertex                | Sample Natal Subject Solar Return | 0.62° | Static =     |
 | Orcus                 | Sample Natal Subject | trine △          | Anti Vertex           | Sample Natal Subject Solar Return | 0.62° | Static =     |
 | Orcus                 | Sample Natal Subject | quintile Q       | Mean Priapus          | Sample Natal Subject Solar Return | 0.15° | Separating ← |
-| Orcus                 | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 0.91° | Applying →   |
+| Orcus                 | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 0.92° | Applying →   |
 | Orcus                 | Sample Natal Subject | semi-square ∠    | Zeus                  | Sample Natal Subject Solar Return | 0.19° | Separating ← |
 | Orcus                 | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 2.99° | Separating ← |
 | Orcus                 | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 4.12° | Separating ← |
@@ -1144,7 +1144,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Quaoar                | Sample Natal Subject | opposition ☍     | Mean Priapus          | Sample Natal Subject Solar Return | 4.91° | Separating ← |
 | Quaoar                | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 2.36° | Separating ← |
 | Quaoar                | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 5.46° | Separating ← |
-| Quaoar                | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 1.96° | Separating ← |
+| Quaoar                | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 1.95° | Separating ← |
 | Pars Fortunae         | Sample Natal Subject | square □         | Sun                   | Sample Natal Subject Solar Return | 0.06° | Separating ← |
 | Pars Fortunae         | Sample Natal Subject | quintile Q       | Mercury               | Sample Natal Subject Solar Return | 1.12° | Separating ← |
 | Pars Fortunae         | Sample Natal Subject | trine △          | Venus                 | Sample Natal Subject Solar Return | 3.22° | Separating ← |
@@ -1152,7 +1152,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Pars Fortunae         | Sample Natal Subject | semi-sextile ⚺   | Mean Lilith           | Sample Natal Subject Solar Return | 0.50° | Separating ← |
 | Pars Fortunae         | Sample Natal Subject | conjunction ☌    | Pars Fortunae         | Sample Natal Subject Solar Return | 0.00° | Static =     |
 | Pars Fortunae         | Sample Natal Subject | quincunx ⚻       | Mean Priapus          | Sample Natal Subject Solar Return | 0.50° | Separating ← |
-| Pars Fortunae         | Sample Natal Subject | square □         | White Moon            | Sample Natal Subject Solar Return | 2.05° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | square □         | White Moon            | Sample Natal Subject Solar Return | 2.06° | Applying →   |
 | Pars Fortunae         | Sample Natal Subject | conjunction ☌    | Poseidon              | Sample Natal Subject Solar Return | 0.20° | Separating ← |
 | Pars Spiritus         | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 4.45° | Separating ← |
 | Pars Spiritus         | Sample Natal Subject | sextile ⚹        | Neptune               | Sample Natal Subject Solar Return | 0.39° | Separating ← |
@@ -1178,7 +1178,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Pars Spiritus         | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 5.46° | Applying →   |
 | Pars Spiritus         | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Sample Natal Subject Solar Return | 0.67° | Separating ← |
 | Pars Spiritus         | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 1.80° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 2.19° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 2.18° | Separating ← |
 | Pars Amoris           | Sample Natal Subject | quintile Q       | Sun                   | Sample Natal Subject Solar Return | 1.56° | Separating ← |
 | Pars Amoris           | Sample Natal Subject | square □         | Uranus                | Sample Natal Subject Solar Return | 2.25° | Separating ← |
 | Pars Amoris           | Sample Natal Subject | square □         | Neptune               | Sample Natal Subject Solar Return | 3.78° | Applying →   |
@@ -1198,8 +1198,8 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Pars Amoris           | Sample Natal Subject | trine △          | Vertex                | Sample Natal Subject Solar Return | 2.47° | Static =     |
 | Pars Amoris           | Sample Natal Subject | sextile ⚹        | Anti Vertex           | Sample Natal Subject Solar Return | 2.47° | Static =     |
 | Pars Amoris           | Sample Natal Subject | semi-square ∠    | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.49° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | quintile Q       | White Moon            | Sample Natal Subject Solar Return | 0.55° | Applying →   |
-| Pars Amoris           | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 0.94° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | quintile Q       | White Moon            | Sample Natal Subject Solar Return | 0.56° | Applying →   |
+| Pars Amoris           | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 0.93° | Separating ← |
 | Pars Amoris           | Sample Natal Subject | conjunction ☌    | Apollon               | Sample Natal Subject Solar Return | 4.84° | Separating ← |
 | Pars Amoris           | Sample Natal Subject | biquintile bQ    | Admetos               | Sample Natal Subject Solar Return | 0.03° | Applying →   |
 | Pars Fidei            | Sample Natal Subject | quintile Q       | Moon                  | Sample Natal Subject Solar Return | 0.99° | Separating ← |
@@ -1223,7 +1223,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Pars Fidei            | Sample Natal Subject | opposition ☍     | Pars Spiritus         | Sample Natal Subject Solar Return | 4.94° | Static =     |
 | Pars Fidei            | Sample Natal Subject | quincunx ⚻       | Pars Amoris           | Sample Natal Subject Solar Return | 0.77° | Static =     |
 | Pars Fidei            | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Pars Fidei            | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Sample Natal Subject Solar Return | 1.71° | Separating ← |
+| Pars Fidei            | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Sample Natal Subject Solar Return | 1.70° | Separating ← |
 | Pars Fidei            | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 1.32° | Applying →   |
 | Vertex                | Sample Natal Subject | quincunx ⚻       | Neptune               | Sample Natal Subject Solar Return | 1.30° | Applying →   |
 | Vertex                | Sample Natal Subject | trine △          | Mean North Lunar Node | Sample Natal Subject Solar Return | 3.68° | Separating ← |
@@ -1279,7 +1279,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Interpolated Lilith   | Sample Natal Subject | conjunction ☌    | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.00° | Applying →   |
 | Interpolated Lilith   | Sample Natal Subject | opposition ☍     | Mean Priapus          | Sample Natal Subject Solar Return | 3.51° | Separating ← |
 | Interpolated Lilith   | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 0.96° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 0.56° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 0.55° | Separating ← |
 | Mean Priapus          | Sample Natal Subject | sextile ⚹        | Sun                   | Sample Natal Subject Solar Return | 0.45° | Applying →   |
 | Mean Priapus          | Sample Natal Subject | biquintile bQ    | Uranus                | Sample Natal Subject Solar Return | 1.75° | Applying →   |
 | Mean Priapus          | Sample Natal Subject | sesquiquadrate ⚼ | Neptune               | Sample Natal Subject Solar Return | 1.23° | Separating ← |
@@ -1291,10 +1291,10 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Mean Priapus          | Sample Natal Subject | quincunx ⚻       | Pars Fortunae         | Sample Natal Subject Solar Return | 0.51° | Static =     |
 | Mean Priapus          | Sample Natal Subject | opposition ☍     | Interpolated Lilith   | Sample Natal Subject Solar Return | 3.51° | Applying →   |
 | Mean Priapus          | Sample Natal Subject | conjunction ☌    | Mean Priapus          | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 2.55° | Applying →   |
+| Mean Priapus          | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 2.56° | Applying →   |
 | Mean Priapus          | Sample Natal Subject | trine △          | Zeus                  | Sample Natal Subject Solar Return | 2.96° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | sesquiquadrate ⚼ | Apollon               | Sample Natal Subject Solar Return | 0.16° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | semi-square ∠    | Vulkanus              | Sample Natal Subject Solar Return | 1.36° | Separating ← |
+| Mean Priapus          | Sample Natal Subject | sesquiquadrate ⚼ | Apollon               | Sample Natal Subject Solar Return | 0.17° | Applying →   |
+| Mean Priapus          | Sample Natal Subject | semi-square ∠    | Vulkanus              | Sample Natal Subject Solar Return | 1.35° | Separating ← |
 | Mean Priapus          | Sample Natal Subject | quincunx ⚻       | Poseidon              | Sample Natal Subject Solar Return | 0.31° | Applying →   |
 | True Priapus          | Sample Natal Subject | sextile ⚹        | Mercury               | Sample Natal Subject Solar Return | 0.41° | Applying →   |
 | True Priapus          | Sample Natal Subject | semi-sextile ⚺   | Chiron                | Sample Natal Subject Solar Return | 1.87° | Separating ← |
@@ -1334,30 +1334,30 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Interpolated Perigee  | Sample Natal Subject | conjunction ☌    | True Priapus          | Sample Natal Subject Solar Return | 2.97° | Separating ← |
 | Interpolated Perigee  | Sample Natal Subject | conjunction ☌    | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.00° | Applying →   |
 | Interpolated Perigee  | Sample Natal Subject | square □         | Zeus                  | Sample Natal Subject Solar Return | 5.05° | Separating ← |
-| Interpolated Perigee  | Sample Natal Subject | conjunction ☌    | Kronos                | Sample Natal Subject Solar Return | 0.92° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | conjunction ☌    | Kronos                | Sample Natal Subject Solar Return | 0.91° | Separating ← |
 | White Moon            | Sample Natal Subject | conjunction ☌    | Sun                   | Sample Natal Subject Solar Return | 2.11° | Separating ← |
-| White Moon            | Sample Natal Subject | conjunction ☌    | Moon                  | Sample Natal Subject Solar Return | 5.23° | Applying →   |
+| White Moon            | Sample Natal Subject | conjunction ☌    | Moon                  | Sample Natal Subject Solar Return | 5.22° | Applying →   |
 | White Moon            | Sample Natal Subject | conjunction ☌    | Jupiter               | Sample Natal Subject Solar Return | 2.52° | Applying →   |
 | White Moon            | Sample Natal Subject | opposition ☍     | Saturn                | Sample Natal Subject Solar Return | 4.92° | Separating ← |
-| White Moon            | Sample Natal Subject | trine △          | Mean Lilith           | Sample Natal Subject Solar Return | 2.55° | Separating ← |
+| White Moon            | Sample Natal Subject | trine △          | Mean Lilith           | Sample Natal Subject Solar Return | 2.56° | Separating ← |
 | White Moon            | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 0.11° | Applying →   |
 | White Moon            | Sample Natal Subject | trine △          | Ixion                 | Sample Natal Subject Solar Return | 3.73° | Separating ← |
 | White Moon            | Sample Natal Subject | trine △          | Quaoar                | Sample Natal Subject Solar Return | 2.36° | Separating ← |
 | White Moon            | Sample Natal Subject | square □         | Pars Fortunae         | Sample Natal Subject Solar Return | 2.05° | Static =     |
 | White Moon            | Sample Natal Subject | quintile Q       | Pars Amoris           | Sample Natal Subject Solar Return | 0.55° | Static =     |
-| White Moon            | Sample Natal Subject | semi-square ∠    | Vertex                | Sample Natal Subject Solar Return | 0.02° | Static =     |
-| White Moon            | Sample Natal Subject | sesquiquadrate ⚼ | Anti Vertex           | Sample Natal Subject Solar Return | 0.02° | Static =     |
+| White Moon            | Sample Natal Subject | semi-square ∠    | Vertex                | Sample Natal Subject Solar Return | 0.03° | Static =     |
+| White Moon            | Sample Natal Subject | sesquiquadrate ⚼ | Anti Vertex           | Sample Natal Subject Solar Return | 0.03° | Static =     |
 | White Moon            | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.96° | Applying →   |
-| White Moon            | Sample Natal Subject | sextile ⚹        | Mean Priapus          | Sample Natal Subject Solar Return | 2.55° | Separating ← |
+| White Moon            | Sample Natal Subject | sextile ⚹        | Mean Priapus          | Sample Natal Subject Solar Return | 2.56° | Separating ← |
 | White Moon            | Sample Natal Subject | conjunction ☌    | White Moon            | Sample Natal Subject Solar Return | 0.00° | Applying →   |
 | White Moon            | Sample Natal Subject | semi-square ∠    | Hades                 | Sample Natal Subject Solar Return | 1.51° | Applying →   |
 | White Moon            | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 0.40° | Applying →   |
-| White Moon            | Sample Natal Subject | quintile Q       | Admetos               | Sample Natal Subject Solar Return | 0.52° | Separating ← |
+| White Moon            | Sample Natal Subject | quintile Q       | Admetos               | Sample Natal Subject Solar Return | 0.53° | Separating ← |
 | White Moon            | Sample Natal Subject | square □         | Poseidon              | Sample Natal Subject Solar Return | 2.25° | Separating ← |
 | Cupido                | Sample Natal Subject | trine △          | Moon                  | Sample Natal Subject Solar Return | 2.59° | Separating ← |
 | Cupido                | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 1.01° | Applying →   |
 | Cupido                | Sample Natal Subject | sesquiquadrate ⚼ | Venus                 | Sample Natal Subject Solar Return | 1.91° | Applying →   |
-| Cupido                | Sample Natal Subject | trine △          | Jupiter               | Sample Natal Subject Solar Return | 5.30° | Separating ← |
+| Cupido                | Sample Natal Subject | trine △          | Jupiter               | Sample Natal Subject Solar Return | 5.29° | Separating ← |
 | Cupido                | Sample Natal Subject | sextile ⚹        | Saturn                | Sample Natal Subject Solar Return | 2.90° | Applying →   |
 | Cupido                | Sample Natal Subject | conjunction ☌    | Pluto                 | Sample Natal Subject Solar Return | 3.64° | Separating ← |
 | Cupido                | Sample Natal Subject | trine △          | Chiron                | Sample Natal Subject Solar Return | 1.26° | Separating ← |
@@ -1373,23 +1373,23 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Cupido                | Sample Natal Subject | quincunx ⚻       | True Priapus          | Sample Natal Subject Solar Return | 0.60° | Separating ← |
 | Cupido                | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 0.00° | Separating ← |
 | Cupido                | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 3.66° | Applying →   |
-| Cupido                | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 3.27° | Applying →   |
+| Cupido                | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 3.28° | Applying →   |
 | Hades                 | Sample Natal Subject | semi-square ∠    | Jupiter               | Sample Natal Subject Solar Return | 1.01° | Applying →   |
-| Hades                 | Sample Natal Subject | trine △          | Mean North Lunar Node | Sample Natal Subject Solar Return | 2.14° | Separating ← |
+| Hades                 | Sample Natal Subject | trine △          | Mean North Lunar Node | Sample Natal Subject Solar Return | 2.13° | Separating ← |
 | Hades                 | Sample Natal Subject | trine △          | True North Lunar Node | Sample Natal Subject Solar Return | 2.66° | Separating ← |
-| Hades                 | Sample Natal Subject | biquintile bQ    | Ascendant             | Sample Natal Subject Solar Return | 1.89° | Separating ← |
-| Hades                 | Sample Natal Subject | sextile ⚹        | Mean South Lunar Node | Sample Natal Subject Solar Return | 2.14° | Separating ← |
+| Hades                 | Sample Natal Subject | biquintile bQ    | Ascendant             | Sample Natal Subject Solar Return | 1.90° | Separating ← |
+| Hades                 | Sample Natal Subject | sextile ⚹        | Mean South Lunar Node | Sample Natal Subject Solar Return | 2.13° | Separating ← |
 | Hades                 | Sample Natal Subject | sextile ⚹        | True South Lunar Node | Sample Natal Subject Solar Return | 2.66° | Separating ← |
-| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Pholus                | Sample Natal Subject Solar Return | 1.94° | Applying →   |
+| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Pholus                | Sample Natal Subject Solar Return | 1.93° | Applying →   |
 | Hades                 | Sample Natal Subject | sextile ⚹        | Ceres                 | Sample Natal Subject Solar Return | 3.79° | Separating ← |
 | Hades                 | Sample Natal Subject | quincunx ⚻       | Juno                  | Sample Natal Subject Solar Return | 0.17° | Separating ← |
-| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Sedna                 | Sample Natal Subject Solar Return | 1.62° | Separating ← |
-| Hades                 | Sample Natal Subject | square □         | Makemake              | Sample Natal Subject Solar Return | 5.43° | Applying →   |
-| Hades                 | Sample Natal Subject | sextile ⚹        | Orcus                 | Sample Natal Subject Solar Return | 0.91° | Separating ← |
+| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Sedna                 | Sample Natal Subject Solar Return | 1.63° | Separating ← |
+| Hades                 | Sample Natal Subject | square □         | Makemake              | Sample Natal Subject Solar Return | 5.42° | Applying →   |
+| Hades                 | Sample Natal Subject | sextile ⚹        | Orcus                 | Sample Natal Subject Solar Return | 0.92° | Separating ← |
 | Hades                 | Sample Natal Subject | trine △          | Pars Amoris           | Sample Natal Subject Solar Return | 0.94° | Static =     |
 | Hades                 | Sample Natal Subject | semi-sextile ⚺   | Pars Fidei            | Sample Natal Subject Solar Return | 1.71° | Static =     |
-| Hades                 | Sample Natal Subject | conjunction ☌    | Vertex                | Sample Natal Subject Solar Return | 1.53° | Static =     |
-| Hades                 | Sample Natal Subject | opposition ☍     | Anti Vertex           | Sample Natal Subject Solar Return | 1.53° | Static =     |
+| Hades                 | Sample Natal Subject | conjunction ☌    | Vertex                | Sample Natal Subject Solar Return | 1.54° | Static =     |
+| Hades                 | Sample Natal Subject | opposition ☍     | Anti Vertex           | Sample Natal Subject Solar Return | 1.54° | Static =     |
 | Hades                 | Sample Natal Subject | semi-square ∠    | White Moon            | Sample Natal Subject Solar Return | 1.51° | Separating ← |
 | Hades                 | Sample Natal Subject | conjunction ☌    | Hades                 | Sample Natal Subject Solar Return | 0.00° | Separating ← |
 | Hades                 | Sample Natal Subject | trine △          | Apollon               | Sample Natal Subject Solar Return | 3.90° | Separating ← |
@@ -1397,21 +1397,21 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Zeus                  | Sample Natal Subject | sextile ⚹        | Moon                  | Sample Natal Subject Solar Return | 4.82° | Applying →   |
 | Zeus                  | Sample Natal Subject | square □         | Venus                 | Sample Natal Subject Solar Return | 5.68° | Separating ← |
 | Zeus                  | Sample Natal Subject | sextile ⚹        | Jupiter               | Sample Natal Subject Solar Return | 2.12° | Applying →   |
-| Zeus                  | Sample Natal Subject | trine △          | Saturn                | Sample Natal Subject Solar Return | 4.52° | Separating ← |
+| Zeus                  | Sample Natal Subject | trine △          | Saturn                | Sample Natal Subject Solar Return | 4.51° | Separating ← |
 | Zeus                  | Sample Natal Subject | biquintile bQ    | Imum Coeli            | Sample Natal Subject Solar Return | 0.12° | Applying →   |
 | Zeus                  | Sample Natal Subject | sextile ⚹        | Mean Lilith           | Sample Natal Subject Solar Return | 2.96° | Separating ← |
-| Zeus                  | Sample Natal Subject | semi-square ∠    | Juno                  | Sample Natal Subject Solar Return | 0.94° | Applying →   |
+| Zeus                  | Sample Natal Subject | semi-square ∠    | Juno                  | Sample Natal Subject Solar Return | 0.93° | Applying →   |
 | Zeus                  | Sample Natal Subject | sesquiquadrate ⚼ | Sedna                 | Sample Natal Subject Solar Return | 0.52° | Separating ← |
 | Zeus                  | Sample Natal Subject | conjunction ☌    | Haumea                | Sample Natal Subject Solar Return | 0.29° | Separating ← |
 | Zeus                  | Sample Natal Subject | sextile ⚹        | Ixion                 | Sample Natal Subject Solar Return | 3.33° | Separating ← |
 | Zeus                  | Sample Natal Subject | semi-square ∠    | Orcus                 | Sample Natal Subject Solar Return | 0.19° | Applying →   |
-| Zeus                  | Sample Natal Subject | sextile ⚹        | Quaoar                | Sample Natal Subject Solar Return | 1.96° | Separating ← |
-| Zeus                  | Sample Natal Subject | sextile ⚹        | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.56° | Applying →   |
+| Zeus                  | Sample Natal Subject | sextile ⚹        | Quaoar                | Sample Natal Subject Solar Return | 1.95° | Separating ← |
+| Zeus                  | Sample Natal Subject | sextile ⚹        | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.55° | Applying →   |
 | Zeus                  | Sample Natal Subject | trine △          | Mean Priapus          | Sample Natal Subject Solar Return | 2.96° | Separating ← |
 | Zeus                  | Sample Natal Subject | square □         | Interpolated Perigee  | Sample Natal Subject Solar Return | 5.05° | Applying →   |
 | Zeus                  | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 0.40° | Separating ← |
 | Zeus                  | Sample Natal Subject | conjunction ☌    | Zeus                  | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Zeus                  | Sample Natal Subject | square □         | Kronos                | Sample Natal Subject Solar Return | 4.13° | Applying →   |
+| Zeus                  | Sample Natal Subject | square □         | Kronos                | Sample Natal Subject Solar Return | 4.14° | Applying →   |
 | Zeus                  | Sample Natal Subject | quintile Q       | Vulkanus              | Sample Natal Subject Solar Return | 1.31° | Separating ← |
 | Kronos                | Sample Natal Subject | semi-sextile ⚺   | Moon                  | Sample Natal Subject Solar Return | 0.69° | Applying →   |
 | Kronos                | Sample Natal Subject | sextile ⚹        | Mercury               | Sample Natal Subject Solar Return | 4.29° | Applying →   |
@@ -1421,36 +1421,36 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Kronos                | Sample Natal Subject | sesquiquadrate ⚼ | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.89° | Applying →   |
 | Kronos                | Sample Natal Subject | sesquiquadrate ⚼ | True North Lunar Node | Sample Natal Subject Solar Return | 0.37° | Applying →   |
 | Kronos                | Sample Natal Subject | sesquiquadrate ⚼ | Ascendant             | Sample Natal Subject Solar Return | 1.08° | Applying →   |
-| Kronos                | Sample Natal Subject | sextile ⚹        | Medium Coeli          | Sample Natal Subject Solar Return | 1.99° | Applying →   |
+| Kronos                | Sample Natal Subject | sextile ⚹        | Medium Coeli          | Sample Natal Subject Solar Return | 1.98° | Applying →   |
 | Kronos                | Sample Natal Subject | semi-square ∠    | Descendant            | Sample Natal Subject Solar Return | 1.08° | Applying →   |
-| Kronos                | Sample Natal Subject | trine △          | Imum Coeli            | Sample Natal Subject Solar Return | 1.99° | Applying →   |
+| Kronos                | Sample Natal Subject | trine △          | Imum Coeli            | Sample Natal Subject Solar Return | 1.98° | Applying →   |
 | Kronos                | Sample Natal Subject | semi-square ∠    | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.89° | Applying →   |
 | Kronos                | Sample Natal Subject | semi-square ∠    | True South Lunar Node | Sample Natal Subject Solar Return | 0.37° | Applying →   |
 | Kronos                | Sample Natal Subject | opposition ☍     | True Lilith           | Sample Natal Subject Solar Return | 3.88° | Separating ← |
 | Kronos                | Sample Natal Subject | sextile ⚹        | Eris                  | Sample Natal Subject Solar Return | 4.30° | Separating ← |
-| Kronos                | Sample Natal Subject | square □         | Haumea                | Sample Natal Subject Solar Return | 4.42° | Separating ← |
+| Kronos                | Sample Natal Subject | square □         | Haumea                | Sample Natal Subject Solar Return | 4.43° | Separating ← |
 | Kronos                | Sample Natal Subject | quintile Q       | Makemake              | Sample Natal Subject Solar Return | 0.60° | Separating ← |
-| Kronos                | Sample Natal Subject | quincunx ⚻       | Ixion                 | Sample Natal Subject Solar Return | 0.80° | Applying →   |
+| Kronos                | Sample Natal Subject | quincunx ⚻       | Ixion                 | Sample Natal Subject Solar Return | 0.81° | Applying →   |
 | Kronos                | Sample Natal Subject | semi-square ∠    | Pars Fidei            | Sample Natal Subject Solar Return | 1.32° | Static =     |
 | Kronos                | Sample Natal Subject | conjunction ☌    | True Priapus          | Sample Natal Subject Solar Return | 3.88° | Separating ← |
-| Kronos                | Sample Natal Subject | conjunction ☌    | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.92° | Applying →   |
-| Kronos                | Sample Natal Subject | square □         | Zeus                  | Sample Natal Subject Solar Return | 4.13° | Separating ← |
+| Kronos                | Sample Natal Subject | conjunction ☌    | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.91° | Applying →   |
+| Kronos                | Sample Natal Subject | square □         | Zeus                  | Sample Natal Subject Solar Return | 4.14° | Separating ← |
 | Kronos                | Sample Natal Subject | conjunction ☌    | Kronos                | Sample Natal Subject Solar Return | 0.00° | Separating ← |
 | Apollon               | Sample Natal Subject | sextile ⚹        | Mercury               | Sample Natal Subject Solar Return | 3.78° | Separating ← |
 | Apollon               | Sample Natal Subject | square □         | Neptune               | Sample Natal Subject Solar Return | 1.06° | Separating ← |
 | Apollon               | Sample Natal Subject | semi-sextile ⚺   | Pluto                 | Sample Natal Subject Solar Return | 1.15° | Applying →   |
-| Apollon               | Sample Natal Subject | semi-square ∠    | Mean Lilith           | Sample Natal Subject Solar Return | 0.16° | Separating ← |
+| Apollon               | Sample Natal Subject | semi-square ∠    | Mean Lilith           | Sample Natal Subject Solar Return | 0.17° | Separating ← |
 | Apollon               | Sample Natal Subject | sextile ⚹        | True Lilith           | Sample Natal Subject Solar Return | 4.19° | Applying →   |
-| Apollon               | Sample Natal Subject | square □         | Pholus                | Sample Natal Subject Solar Return | 5.84° | Applying →   |
+| Apollon               | Sample Natal Subject | square □         | Pholus                | Sample Natal Subject Solar Return | 5.83° | Applying →   |
 | Apollon               | Sample Natal Subject | sextile ⚹        | Ceres                 | Sample Natal Subject Solar Return | 0.11° | Applying →   |
 | Apollon               | Sample Natal Subject | biquintile bQ    | Vesta                 | Sample Natal Subject Solar Return | 1.68° | Applying →   |
 | Apollon               | Sample Natal Subject | opposition ☍     | Eris                  | Sample Natal Subject Solar Return | 3.77° | Applying →   |
 | Apollon               | Sample Natal Subject | sextile ⚹        | Orcus                 | Sample Natal Subject Solar Return | 2.99° | Applying →   |
 | Apollon               | Sample Natal Subject | semi-sextile ⚺   | Pars Spiritus         | Sample Natal Subject Solar Return | 0.67° | Static =     |
 | Apollon               | Sample Natal Subject | conjunction ☌    | Pars Amoris           | Sample Natal Subject Solar Return | 4.84° | Static =     |
-| Apollon               | Sample Natal Subject | trine △          | Vertex                | Sample Natal Subject Solar Return | 2.37° | Static =     |
-| Apollon               | Sample Natal Subject | sextile ⚹        | Anti Vertex           | Sample Natal Subject Solar Return | 2.37° | Static =     |
-| Apollon               | Sample Natal Subject | sesquiquadrate ⚼ | Mean Priapus          | Sample Natal Subject Solar Return | 0.16° | Separating ← |
+| Apollon               | Sample Natal Subject | trine △          | Vertex                | Sample Natal Subject Solar Return | 2.36° | Static =     |
+| Apollon               | Sample Natal Subject | sextile ⚹        | Anti Vertex           | Sample Natal Subject Solar Return | 2.36° | Static =     |
+| Apollon               | Sample Natal Subject | sesquiquadrate ⚼ | Mean Priapus          | Sample Natal Subject Solar Return | 0.17° | Separating ← |
 | Apollon               | Sample Natal Subject | trine △          | True Priapus          | Sample Natal Subject Solar Return | 4.19° | Applying →   |
 | Apollon               | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 3.90° | Applying →   |
 | Apollon               | Sample Natal Subject | conjunction ☌    | Apollon               | Sample Natal Subject Solar Return | 0.00° | Separating ← |
@@ -1460,40 +1460,40 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Admetos               | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 2.65° | Separating ← |
 | Admetos               | Sample Natal Subject | semi-square ∠    | Venus                 | Sample Natal Subject Solar Return | 1.75° | Separating ← |
 | Admetos               | Sample Natal Subject | trine △          | Neptune               | Sample Natal Subject Solar Return | 2.20° | Separating ← |
-| Admetos               | Sample Natal Subject | opposition ☍     | Pluto                 | Sample Natal Subject Solar Return | 0.01° | Applying →   |
+| Admetos               | Sample Natal Subject | opposition ☍     | Pluto                 | Sample Natal Subject Solar Return | 0.02° | Applying →   |
 | Admetos               | Sample Natal Subject | sextile ⚹        | Chiron                | Sample Natal Subject Solar Return | 4.92° | Separating ← |
 | Admetos               | Sample Natal Subject | square □         | Medium Coeli          | Sample Natal Subject Solar Return | 4.95° | Separating ← |
 | Admetos               | Sample Natal Subject | square □         | Imum Coeli            | Sample Natal Subject Solar Return | 4.95° | Separating ← |
-| Admetos               | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 1.25° | Applying →   |
+| Admetos               | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 1.24° | Applying →   |
 | Admetos               | Sample Natal Subject | opposition ☍     | Juno                  | Sample Natal Subject Solar Return | 4.86° | Applying →   |
 | Admetos               | Sample Natal Subject | conjunction ☌    | Vesta                 | Sample Natal Subject Solar Return | 3.19° | Separating ← |
 | Admetos               | Sample Natal Subject | conjunction ☌    | Sedna                 | Sample Natal Subject Solar Return | 3.41° | Applying →   |
 | Admetos               | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 4.12° | Applying →   |
 | Admetos               | Sample Natal Subject | opposition ☍     | Pars Spiritus         | Sample Natal Subject Solar Return | 1.81° | Static =     |
-| Admetos               | Sample Natal Subject | biquintile bQ    | Pars Amoris           | Sample Natal Subject Solar Return | 0.02° | Static =     |
-| Admetos               | Sample Natal Subject | quintile Q       | White Moon            | Sample Natal Subject Solar Return | 0.52° | Applying →   |
+| Admetos               | Sample Natal Subject | biquintile bQ    | Pars Amoris           | Sample Natal Subject Solar Return | 0.03° | Static =     |
+| Admetos               | Sample Natal Subject | quintile Q       | White Moon            | Sample Natal Subject Solar Return | 0.53° | Applying →   |
 | Admetos               | Sample Natal Subject | opposition ☍     | Cupido                | Sample Natal Subject Solar Return | 3.66° | Applying →   |
 | Admetos               | Sample Natal Subject | quincunx ⚻       | Apollon               | Sample Natal Subject Solar Return | 1.13° | Applying →   |
 | Admetos               | Sample Natal Subject | conjunction ☌    | Admetos               | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Admetos               | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 0.39° | Separating ← |
-| Vulkanus              | Sample Natal Subject | conjunction ☌    | Moon                  | Sample Natal Subject Solar Return | 5.86° | Separating ← |
+| Admetos               | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 0.38° | Separating ← |
+| Vulkanus              | Sample Natal Subject | conjunction ☌    | Moon                  | Sample Natal Subject Solar Return | 5.87° | Separating ← |
 | Vulkanus              | Sample Natal Subject | opposition ☍     | Neptune               | Sample Natal Subject Solar Return | 2.58° | Separating ← |
 | Vulkanus              | Sample Natal Subject | trine △          | Pluto                 | Sample Natal Subject Solar Return | 0.37° | Separating ← |
-| Vulkanus              | Sample Natal Subject | conjunction ☌    | Chiron                | Sample Natal Subject Solar Return | 4.53° | Separating ← |
+| Vulkanus              | Sample Natal Subject | conjunction ☌    | Chiron                | Sample Natal Subject Solar Return | 4.54° | Separating ← |
 | Vulkanus              | Sample Natal Subject | biquintile bQ    | Imum Coeli            | Sample Natal Subject Solar Return | 1.43° | Applying →   |
-| Vulkanus              | Sample Natal Subject | sesquiquadrate ⚼ | Mean Lilith           | Sample Natal Subject Solar Return | 1.36° | Applying →   |
+| Vulkanus              | Sample Natal Subject | sesquiquadrate ⚼ | Mean Lilith           | Sample Natal Subject Solar Return | 1.35° | Applying →   |
 | Vulkanus              | Sample Natal Subject | semi-sextile ⚺   | Ceres                 | Sample Natal Subject Solar Return | 1.63° | Applying →   |
-| Vulkanus              | Sample Natal Subject | trine △          | Juno                  | Sample Natal Subject Solar Return | 5.25° | Applying →   |
-| Vulkanus              | Sample Natal Subject | sextile ⚹        | Vesta                 | Sample Natal Subject Solar Return | 2.80° | Separating ← |
-| Vulkanus              | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 2.25° | Applying →   |
-| Vulkanus              | Sample Natal Subject | sextile ⚹        | Sedna                 | Sample Natal Subject Solar Return | 3.80° | Applying →   |
+| Vulkanus              | Sample Natal Subject | trine △          | Juno                  | Sample Natal Subject Solar Return | 5.24° | Applying →   |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | Vesta                 | Sample Natal Subject Solar Return | 2.81° | Separating ← |
+| Vulkanus              | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 2.26° | Applying →   |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | Sedna                 | Sample Natal Subject Solar Return | 3.79° | Applying →   |
 | Vulkanus              | Sample Natal Subject | quintile Q       | Haumea                | Sample Natal Subject Solar Return | 1.02° | Applying →   |
 | Vulkanus              | Sample Natal Subject | trine △          | Pars Spiritus         | Sample Natal Subject Solar Return | 2.19° | Static =     |
-| Vulkanus              | Sample Natal Subject | semi-square ∠    | Mean Priapus          | Sample Natal Subject Solar Return | 1.36° | Applying →   |
-| Vulkanus              | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 3.27° | Applying →   |
+| Vulkanus              | Sample Natal Subject | semi-square ∠    | Mean Priapus          | Sample Natal Subject Solar Return | 1.35° | Applying →   |
+| Vulkanus              | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 3.28° | Applying →   |
 | Vulkanus              | Sample Natal Subject | quintile Q       | Zeus                  | Sample Natal Subject Solar Return | 1.31° | Applying →   |
 | Vulkanus              | Sample Natal Subject | square □         | Apollon               | Sample Natal Subject Solar Return | 1.52° | Applying →   |
-| Vulkanus              | Sample Natal Subject | sextile ⚹        | Admetos               | Sample Natal Subject Solar Return | 0.39° | Applying →   |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | Admetos               | Sample Natal Subject Solar Return | 0.38° | Applying →   |
 | Vulkanus              | Sample Natal Subject | conjunction ☌    | Vulkanus              | Sample Natal Subject Solar Return | 0.00° | Separating ← |
 | Poseidon              | Sample Natal Subject | square □         | Sun                   | Sample Natal Subject Solar Return | 0.14° | Applying →   |
 | Poseidon              | Sample Natal Subject | quintile Q       | Mercury               | Sample Natal Subject Solar Return | 0.93° | Separating ← |

--- a/tests/fixtures/dual_return_report.txt
+++ b/tests/fixtures/dual_return_report.txt
@@ -56,8 +56,8 @@ Sample Natal Subject — Solar Return Comparison 1990
 +Natal Subject Celestial Points--+----------+--------------+---------+------+---------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House         |
 +-----------------------+--------+----------+--------------+---------+------+---------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House   |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6390°/d | N/A     | -    | Tenth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House   |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6410°/d | N/A     | -    | Tenth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House   |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House   |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House   |
@@ -75,8 +75,8 @@ Sample Natal Subject — Solar Return Comparison 1990
 +Return Subject Celestial Points-+----------+--------------+---------+------+---------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House         |
 +-----------------------+--------+----------+--------------+---------+------+---------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House   |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6344°/d | N/A     | -    | Tenth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House   |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6364°/d | N/A     | -    | Tenth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House   |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House   |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House   |

--- a/tests/fixtures/natal_all_aspects_report.txt
+++ b/tests/fixtures/natal_all_aspects_report.txt
@@ -31,8 +31,8 @@ Sample Natal Subject — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+---------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House         |
 +-----------------------+--------+----------+--------------+---------+------+---------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House   |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6390°/d | N/A     | -    | Tenth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House   |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6410°/d | N/A     | -    | Tenth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House   |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House   |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House   |

--- a/tests/fixtures/natal_all_points_all_aspects_report.txt
+++ b/tests/fixtures/natal_all_points_all_aspects_report.txt
@@ -31,10 +31,10 @@ Sample Natal Subject — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House    |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6390°/d | N/A     | -    | Tenth House    |
-| Descendant            | Tau ♉ | 5.82°    | +245.7237°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6390°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House    |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6410°/d | N/A     | -    | Tenth House    |
+| Descendant            | Tau ♉ | 5.82°    | +245.7250°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6410°/d | N/A     | -    | Fourth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House    |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House    |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House    |
@@ -47,8 +47,8 @@ Sample Natal Subject — Natal Chart Report
 | Pluto                 | Sco ♏ | 14.97°   | -0.0025°/d   | -1.42°  | R    | First House    |
 | Mean North Lunar Node | Aqu ♒ | 7.79°    | -0.0529°/d   | -18.32° | R    | Third House    |
 | True North Lunar Node | Aqu ♒ | 7.26°    | -0.0080°/d   | -18.46° | R    | Third House    |
-| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.61° | -    | First House    |
-| True Lilith           | Sag ♐ | 18.01°   | -1.4331°/d   | -26.88° | R    | Second House   |
+| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.62° | -    | First House    |
+| True Lilith           | Sag ♐ | 18.01°   | -1.4330°/d   | -26.88° | R    | Second House   |
 | Chiron                | Can ♋ | 19.88°   | +0.1071°/d   | +15.79° | -    | Ninth House    |
 | Pholus                | Can ♋ | 7.99°    | +0.1329°/d   | +13.79° | -    | Eighth House   |
 | Ceres                 | Leo ♌ | 13.71°   | +0.4493°/d   | +23.05° | -    | Ninth House    |
@@ -56,15 +56,15 @@ Sample Natal Subject — Natal Chart Report
 | Juno                  | Sco ♏ | 10.10°   | +0.0843°/d   | -2.06°  | -    | First House    |
 | Vesta                 | Tau ♉ | 18.15°   | +0.3292°/d   | +10.88° | -    | Seventh House  |
 | Interpolated Lilith   | Sco ♏ | 25.48°   | +0.1694°/d   | -23.89° | -    | First House    |
-| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1732°/d   | +26.84° | -    | Eighth House   |
-| Cupido                | Sco ♏ | 18.62°   | -0.0042°/d   | -16.34° | R    | First House    |
-| Hades                 | Gem ♊ | 9.93°    | +0.0152°/d   | +20.93° | -    | Eighth House   |
-| Zeus                  | Vir ♍ | 26.03°   | +0.0110°/d   | +1.58°  | -    | Eleventh House |
-| Kronos                | Gem ♊ | 21.90°   | +0.0137°/d   | +23.21° | -    | Eighth House   |
-| Apollon               | Lib ♎ | 13.83°   | +0.0053°/d   | -5.46°  | -    | Eleventh House |
-| Admetos               | Tau ♉ | 14.96°   | +0.0053°/d   | +16.33° | -    | Seventh House  |
-| Vulkanus              | Can ♋ | 15.35°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
-| Poseidon              | Lib ♎ | 28.68°   | +0.0014°/d   | -11.01° | -    | Twelfth House  |
+| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1733°/d   | +26.84° | -    | Eighth House   |
+| Cupido                | Sco ♏ | 18.62°   | -0.0043°/d   | -16.34° | R    | First House    |
+| Hades                 | Gem ♊ | 9.92°    | +0.0153°/d   | +20.93° | -    | Eighth House   |
+| Zeus                  | Vir ♍ | 26.03°   | +0.0109°/d   | +1.58°  | -    | Eleventh House |
+| Kronos                | Gem ♊ | 21.89°   | +0.0138°/d   | +23.21° | -    | Eighth House   |
+| Apollon               | Lib ♎ | 13.82°   | +0.0052°/d   | -5.46°  | -    | Eleventh House |
+| Admetos               | Tau ♉ | 14.96°   | +0.0054°/d   | +16.33° | -    | Seventh House  |
+| Vulkanus              | Can ♋ | 15.34°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
+| Poseidon              | Lib ♎ | 28.68°   | +0.0013°/d   | -11.01° | -    | Twelfth House  |
 | Eris                  | Ari ♈ | 17.60°   | -0.0013°/d   | -9.16°  | R    | Sixth House    |
 | Sedna                 | Tau ♉ | 11.55°   | +0.0038°/d   | +4.25°  | -    | Seventh House  |
 | Haumea                | Vir ♍ | 26.32°   | +0.0134°/d   | +23.02° | -    | Eleventh House |
@@ -77,12 +77,12 @@ Sample Natal Subject — Natal Chart Report
 | Pars Amoris           | Lib ♎ | 8.99°    | N/A          | N/A     | -    | Eleventh House |
 | Pars Fidei            | Tau ♉ | 8.22°    | N/A          | N/A     | -    | Seventh House  |
 | Vertex                | Gem ♊ | 11.46°   | N/A          | N/A     | -    | Eighth House   |
-| White Moon            | Can ♋ | 26.44°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
+| White Moon            | Can ♋ | 26.43°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
 | Anti Vertex           | Sag ♐ | 11.46°   | N/A          | N/A     | -    | Second House   |
 | Mean South Lunar Node | Leo ♌ | 7.79°    | -0.0529°/d   | +18.32° | R    | Ninth House    |
 | True South Lunar Node | Leo ♌ | 7.26°    | -0.0080°/d   | +18.46° | R    | Ninth House    |
-| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.61° | -    | Seventh House  |
-| True Priapus          | Gem ♊ | 18.01°   | -1.4331°/d   | +26.88° | R    | Eighth House   |
+| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.62° | -    | Seventh House  |
+| True Priapus          | Gem ♊ | 18.01°   | -1.4330°/d   | +26.88° | R    | Eighth House   |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +Natal Houses (Placidus)--+----------+-------------------+
@@ -249,13 +249,13 @@ Sample Natal Subject — Natal Chart Report
 | Moon                  | trine △          | Interpolated Lilith   | 4.27° | Applying →   |
 | Moon                  | semi-sextile ⚺   | True Priapus          | 3.19° | Separating ← |
 | Moon                  | semi-sextile ⚺   | Interpolated Perigee  | 0.23° | Separating ← |
-| Moon                  | conjunction ☌    | White Moon            | 5.23° | Applying →   |
+| Moon                  | conjunction ☌    | White Moon            | 5.22° | Applying →   |
 | Moon                  | trine △          | Cupido                | 2.59° | Separating ← |
 | Moon                  | sextile ⚹        | Zeus                  | 4.82° | Applying →   |
 | Moon                  | semi-sextile ⚺   | Kronos                | 0.69° | Applying →   |
 | Moon                  | square □         | Apollon               | 7.38° | Separating ← |
 | Moon                  | sextile ⚹        | Admetos               | 6.25° | Separating ← |
-| Moon                  | conjunction ☌    | Vulkanus              | 5.86° | Separating ← |
+| Moon                  | conjunction ☌    | Vulkanus              | 5.87° | Separating ← |
 | Moon                  | square □         | Poseidon              | 7.47° | Applying →   |
 | Mercury               | semi-square ∠    | Venus                 | 0.90° | Separating ← |
 | Mercury               | biquintile bQ    | Neptune               | 1.15° | Applying →   |
@@ -323,7 +323,7 @@ Sample Natal Subject — Natal Chart Report
 | Jupiter               | square □         | Pars Fortunae         | 4.58° | Applying →   |
 | Jupiter               | trine △          | Interpolated Lilith   | 1.56° | Applying →   |
 | Jupiter               | conjunction ☌    | White Moon            | 2.52° | Applying →   |
-| Jupiter               | trine △          | Cupido                | 5.30° | Separating ← |
+| Jupiter               | trine △          | Cupido                | 5.29° | Separating ← |
 | Jupiter               | semi-square ∠    | Hades                 | 1.01° | Applying →   |
 | Jupiter               | sextile ⚹        | Zeus                  | 2.12° | Applying →   |
 | Jupiter               | square □         | Poseidon              | 4.77° | Applying →   |
@@ -340,7 +340,7 @@ Sample Natal Subject — Natal Chart Report
 | Saturn                | quincunx ⚻       | Interpolated Perigee  | 0.53° | Applying →   |
 | Saturn                | opposition ☍     | White Moon            | 4.92° | Separating ← |
 | Saturn                | sextile ⚹        | Cupido                | 2.90° | Applying →   |
-| Saturn                | trine △          | Zeus                  | 4.52° | Separating ← |
+| Saturn                | trine △          | Zeus                  | 4.51° | Separating ← |
 | Saturn                | quincunx ⚻       | Kronos                | 0.38° | Separating ← |
 | Uranus                | semi-sextile ⚺   | Mean North Lunar Node | 1.05° | Applying →   |
 | Uranus                | semi-sextile ⚺   | True North Lunar Node | 0.53° | Separating ← |
@@ -395,7 +395,7 @@ Sample Natal Subject — Natal Chart Report
 | Pluto                 | conjunction ☌    | Cupido                | 3.64° | Applying →   |
 | Pluto                 | biquintile bQ    | Kronos                | 0.92° | Separating ← |
 | Pluto                 | semi-sextile ⚺   | Apollon               | 1.15° | Applying →   |
-| Pluto                 | opposition ☍     | Admetos               | 0.01° | Applying →   |
+| Pluto                 | opposition ☍     | Admetos               | 0.02° | Applying →   |
 | Pluto                 | trine △          | Vulkanus              | 0.37° | Separating ← |
 | Mean North Lunar Node | square □         | Ascendant             | 1.97° | Applying →   |
 | Mean North Lunar Node | square □         | Descendant            | 1.97° | Applying →   |
@@ -413,7 +413,7 @@ Sample Natal Subject — Natal Chart Report
 | Mean North Lunar Node | sextile ⚹        | Anti Vertex           | 3.68° | Separating ← |
 | Mean North Lunar Node | quintile Q       | Interpolated Lilith   | 0.31° | Applying →   |
 | Mean North Lunar Node | sesquiquadrate ⚼ | Interpolated Perigee  | 1.81° | Applying →   |
-| Mean North Lunar Node | trine △          | Hades                 | 2.14° | Separating ← |
+| Mean North Lunar Node | trine △          | Hades                 | 2.13° | Separating ← |
 | Mean North Lunar Node | sesquiquadrate ⚼ | Kronos                | 0.89° | Applying →   |
 | True North Lunar Node | square □         | Ascendant             | 1.44° | Applying →   |
 | True North Lunar Node | square □         | Descendant            | 1.44° | Applying →   |
@@ -447,7 +447,7 @@ Sample Natal Subject — Natal Chart Report
 | Chiron                | semi-sextile ⚺   | Interpolated Perigee  | 1.10° | Separating ← |
 | Chiron                | trine △          | Cupido                | 1.26° | Separating ← |
 | Chiron                | sextile ⚹        | Admetos               | 4.92° | Separating ← |
-| Chiron                | conjunction ☌    | Vulkanus              | 4.53° | Separating ← |
+| Chiron                | conjunction ☌    | Vulkanus              | 4.54° | Separating ← |
 | Ascendant             | square □         | Mean South Lunar Node | 1.97° | Applying →   |
 | Ascendant             | square □         | True South Lunar Node | 1.44° | Applying →   |
 | Ascendant             | trine △          | Pholus                | 2.17° | Applying →   |
@@ -460,7 +460,7 @@ Sample Natal Subject — Natal Chart Report
 | Ascendant             | biquintile bQ    | Vertex                | 0.36° | Separating ← |
 | Ascendant             | sesquiquadrate ⚼ | Interpolated Perigee  | 0.16° | Applying →   |
 | Ascendant             | biquintile bQ    | Hades                 | 1.90° | Separating ← |
-| Ascendant             | sesquiquadrate ⚼ | Kronos                | 1.08° | Applying →   |
+| Ascendant             | sesquiquadrate ⚼ | Kronos                | 1.07° | Applying →   |
 | Medium Coeli          | trine △          | True Lilith           | 1.90° | Separating ← |
 | Medium Coeli          | square □         | Vesta                 | 1.77° | Separating ← |
 | Medium Coeli          | trine △          | Eris                  | 2.32° | Separating ← |
@@ -471,7 +471,7 @@ Sample Natal Subject — Natal Chart Report
 | Medium Coeli          | sextile ⚹        | Interpolated Perigee  | 1.07° | Applying →   |
 | Medium Coeli          | square □         | Cupido                | 1.30° | Separating ← |
 | Medium Coeli          | sextile ⚹        | Kronos                | 1.98° | Applying →   |
-| Medium Coeli          | square □         | Admetos               | 4.95° | Separating ← |
+| Medium Coeli          | square □         | Admetos               | 4.96° | Separating ← |
 | Descendant            | square □         | Mean South Lunar Node | 1.97° | Applying →   |
 | Descendant            | square □         | True South Lunar Node | 1.44° | Applying →   |
 | Descendant            | sextile ⚹        | Pholus                | 2.17° | Applying →   |
@@ -483,7 +483,7 @@ Sample Natal Subject — Natal Chart Report
 | Descendant            | conjunction ☌    | Pars Fidei            | 2.40° | Applying →   |
 | Descendant            | biquintile bQ    | Anti Vertex           | 0.36° | Separating ← |
 | Descendant            | semi-square ∠    | Interpolated Perigee  | 0.16° | Applying →   |
-| Descendant            | semi-square ∠    | Kronos                | 1.08° | Applying →   |
+| Descendant            | semi-square ∠    | Kronos                | 1.07° | Applying →   |
 | Imum Coeli            | sextile ⚹        | True Lilith           | 1.90° | Separating ← |
 | Imum Coeli            | square □         | Vesta                 | 1.77° | Separating ← |
 | Imum Coeli            | sextile ⚹        | Eris                  | 2.32° | Separating ← |
@@ -496,17 +496,17 @@ Sample Natal Subject — Natal Chart Report
 | Imum Coeli            | square □         | Cupido                | 1.30° | Separating ← |
 | Imum Coeli            | biquintile bQ    | Zeus                  | 0.12° | Applying →   |
 | Imum Coeli            | trine △          | Kronos                | 1.98° | Applying →   |
-| Imum Coeli            | square □         | Admetos               | 4.95° | Separating ← |
-| Imum Coeli            | biquintile bQ    | Vulkanus              | 1.43° | Applying →   |
+| Imum Coeli            | square □         | Admetos               | 4.96° | Separating ← |
+| Imum Coeli            | biquintile bQ    | Vulkanus              | 1.42° | Applying →   |
 | Mean Lilith           | sextile ⚹        | Haumea                | 2.67° | Separating ← |
 | Mean Lilith           | square □         | Makemake              | 5.51° | Applying →   |
 | Mean Lilith           | conjunction ☌    | Quaoar                | 4.91° | Separating ← |
 | Mean Lilith           | semi-sextile ⚺   | Pars Fortunae         | 0.50° | Separating ← |
 | Mean Lilith           | conjunction ☌    | Interpolated Lilith   | 3.51° | Applying →   |
-| Mean Lilith           | trine △          | White Moon            | 2.55° | Applying →   |
+| Mean Lilith           | trine △          | White Moon            | 2.56° | Applying →   |
 | Mean Lilith           | sextile ⚹        | Zeus                  | 2.96° | Separating ← |
-| Mean Lilith           | semi-square ∠    | Apollon               | 0.16° | Separating ← |
-| Mean Lilith           | sesquiquadrate ⚼ | Vulkanus              | 1.36° | Applying →   |
+| Mean Lilith           | semi-square ∠    | Apollon               | 0.17° | Separating ← |
+| Mean Lilith           | sesquiquadrate ⚼ | Vulkanus              | 1.35° | Applying →   |
 | Mean Lilith           | semi-sextile ⚺   | Poseidon              | 0.31° | Separating ← |
 | Mean South Lunar Node | semi-sextile ⚺   | Pholus                | 0.20° | Separating ← |
 | Mean South Lunar Node | conjunction ☌    | Ceres                 | 5.93° | Separating ← |
@@ -520,7 +520,7 @@ Sample Natal Subject — Natal Chart Report
 | Mean South Lunar Node | sextile ⚹        | Vertex                | 3.68° | Separating ← |
 | Mean South Lunar Node | trine △          | Anti Vertex           | 3.68° | Separating ← |
 | Mean South Lunar Node | semi-square ∠    | Interpolated Perigee  | 1.81° | Applying →   |
-| Mean South Lunar Node | sextile ⚹        | Hades                 | 2.14° | Separating ← |
+| Mean South Lunar Node | sextile ⚹        | Hades                 | 2.13° | Separating ← |
 | Mean South Lunar Node | semi-square ∠    | Kronos                | 0.89° | Applying →   |
 | True South Lunar Node | semi-sextile ⚺   | Pholus                | 0.73° | Separating ← |
 | True South Lunar Node | semi-sextile ⚺   | Pallas                | 0.02° | Applying →   |
@@ -552,8 +552,8 @@ Sample Natal Subject — Natal Chart Report
 | Pholus                | trine △          | Pars Spiritus         | 5.17° | Applying →   |
 | Pholus                | square □         | Pars Amoris           | 1.00° | Applying →   |
 | Pholus                | sextile ⚹        | Pars Fidei            | 0.23° | Applying →   |
-| Pholus                | semi-sextile ⚺   | Hades                 | 1.94° | Applying →   |
-| Pholus                | square □         | Apollon               | 5.84° | Applying →   |
+| Pholus                | semi-sextile ⚺   | Hades                 | 1.93° | Applying →   |
+| Pholus                | square □         | Apollon               | 5.83° | Applying →   |
 | Ceres                 | square □         | Juno                  | 3.62° | Separating ← |
 | Ceres                 | square □         | Vesta                 | 4.43° | Applying →   |
 | Ceres                 | trine △          | Eris                  | 3.88° | Applying →   |
@@ -568,7 +568,7 @@ Sample Natal Subject — Natal Chart Report
 | Ceres                 | square □         | Cupido                | 4.90° | Applying →   |
 | Ceres                 | sextile ⚹        | Hades                 | 3.79° | Separating ← |
 | Ceres                 | sextile ⚹        | Apollon               | 0.11° | Applying →   |
-| Ceres                 | square □         | Admetos               | 1.25° | Applying →   |
+| Ceres                 | square □         | Admetos               | 1.24° | Applying →   |
 | Ceres                 | semi-sextile ⚺   | Vulkanus              | 1.63° | Applying →   |
 | Pallas                | trine △          | Juno                  | 2.85° | Applying →   |
 | Pallas                | sextile ⚹        | Sedna                 | 4.30° | Applying →   |
@@ -588,9 +588,9 @@ Sample Natal Subject — Natal Chart Report
 | Juno                  | semi-sextile ⚺   | Anti Vertex           | 1.37° | Applying →   |
 | Juno                  | biquintile bQ    | True Priapus          | 1.92° | Applying →   |
 | Juno                  | quincunx ⚻       | Hades                 | 0.17° | Separating ← |
-| Juno                  | semi-square ∠    | Zeus                  | 0.94° | Applying →   |
+| Juno                  | semi-square ∠    | Zeus                  | 0.93° | Applying →   |
 | Juno                  | opposition ☍     | Admetos               | 4.86° | Applying →   |
-| Juno                  | trine △          | Vulkanus              | 5.25° | Applying →   |
+| Juno                  | trine △          | Vulkanus              | 5.24° | Applying →   |
 | Vesta                 | semi-sextile ⚺   | Eris                  | 0.55° | Separating ← |
 | Vesta                 | opposition ☍     | Ixion                 | 4.56° | Applying →   |
 | Vesta                 | opposition ☍     | Quaoar                | 5.93° | Applying →   |
@@ -599,7 +599,7 @@ Sample Natal Subject — Natal Chart Report
 | Vesta                 | opposition ☍     | Cupido                | 0.47° | Applying →   |
 | Vesta                 | biquintile bQ    | Apollon               | 1.68° | Applying →   |
 | Vesta                 | conjunction ☌    | Admetos               | 3.19° | Separating ← |
-| Vesta                 | sextile ⚹        | Vulkanus              | 2.80° | Separating ← |
+| Vesta                 | sextile ⚹        | Vulkanus              | 2.81° | Separating ← |
 | Eris                  | sesquiquadrate ⚼ | Makemake              | 1.90° | Separating ← |
 | Eris                  | biquintile bQ    | Ixion                 | 0.89° | Separating ← |
 | Eris                  | biquintile bQ    | Quaoar                | 0.48° | Applying →   |
@@ -609,17 +609,17 @@ Sample Natal Subject — Natal Chart Report
 | Eris                  | quincunx ⚻       | Cupido                | 1.02° | Applying →   |
 | Eris                  | sextile ⚹        | Kronos                | 4.30° | Separating ← |
 | Eris                  | opposition ☍     | Apollon               | 3.77° | Applying →   |
-| Eris                  | square □         | Vulkanus              | 2.25° | Applying →   |
+| Eris                  | square □         | Vulkanus              | 2.26° | Applying →   |
 | Sedna                 | sesquiquadrate ⚼ | Haumea                | 0.23° | Applying →   |
 | Sedna                 | square □         | Orcus                 | 0.71° | Applying →   |
 | Sedna                 | opposition ☍     | Pars Spiritus         | 1.61° | Applying →   |
 | Sedna                 | conjunction ☌    | Pars Fidei            | 3.33° | Separating ← |
 | Sedna                 | semi-sextile ⚺   | Vertex                | 0.08° | Separating ← |
 | Sedna                 | quincunx ⚻       | Anti Vertex           | 0.08° | Separating ← |
-| Sedna                 | semi-sextile ⚺   | Hades                 | 1.62° | Applying →   |
+| Sedna                 | semi-sextile ⚺   | Hades                 | 1.63° | Applying →   |
 | Sedna                 | sesquiquadrate ⚼ | Zeus                  | 0.52° | Applying →   |
 | Sedna                 | conjunction ☌    | Admetos               | 3.41° | Separating ← |
-| Sedna                 | sextile ⚹        | Vulkanus              | 3.80° | Separating ← |
+| Sedna                 | sextile ⚹        | Vulkanus              | 3.79° | Separating ← |
 | Haumea                | sextile ⚹        | Ixion                 | 3.62° | Separating ← |
 | Haumea                | semi-square ∠    | Orcus                 | 0.48° | Applying →   |
 | Haumea                | sextile ⚹        | Quaoar                | 2.25° | Separating ← |
@@ -629,12 +629,12 @@ Sample Natal Subject — Natal Chart Report
 | Haumea                | square □         | Interpolated Perigee  | 5.34° | Applying →   |
 | Haumea                | sextile ⚹        | White Moon            | 0.11° | Separating ← |
 | Haumea                | conjunction ☌    | Zeus                  | 0.29° | Separating ← |
-| Haumea                | square □         | Kronos                | 4.42° | Static =     |
+| Haumea                | square □         | Kronos                | 4.43° | Static =     |
 | Haumea                | quintile Q       | Vulkanus              | 1.02° | Static =     |
 | Makemake              | trine △          | Pars Fidei            | 3.72° | Applying →   |
 | Makemake              | square □         | Mean Priapus          | 5.51° | Applying →   |
 | Makemake              | quintile Q       | Interpolated Perigee  | 1.51° | Applying →   |
-| Makemake              | square □         | Hades                 | 5.43° | Applying →   |
+| Makemake              | square □         | Hades                 | 5.42° | Applying →   |
 | Makemake              | quintile Q       | Kronos                | 0.60° | Separating ← |
 | Ixion                 | conjunction ☌    | Quaoar                | 1.37° | Static =     |
 | Ixion                 | semi-square ∠    | Pars Amoris           | 1.28° | Separating ← |
@@ -643,14 +643,14 @@ Sample Natal Subject — Natal Chart Report
 | Ixion                 | trine △          | White Moon            | 3.73° | Separating ← |
 | Ixion                 | conjunction ☌    | Cupido                | 4.09° | Applying →   |
 | Ixion                 | sextile ⚹        | Zeus                  | 3.33° | Separating ← |
-| Ixion                 | quincunx ⚻       | Kronos                | 0.80° | Applying →   |
+| Ixion                 | quincunx ⚻       | Kronos                | 0.81° | Applying →   |
 | Orcus                 | square □         | Pars Spiritus         | 2.32° | Applying →   |
 | Orcus                 | sextile ⚹        | Pars Amoris           | 1.85° | Separating ← |
 | Orcus                 | square □         | Pars Fidei            | 2.62° | Separating ← |
 | Orcus                 | sextile ⚹        | Vertex                | 0.63° | Applying →   |
 | Orcus                 | trine △          | Anti Vertex           | 0.63° | Applying →   |
 | Orcus                 | quintile Q       | Mean Priapus          | 0.15° | Separating ← |
-| Orcus                 | sextile ⚹        | Hades                 | 0.91° | Separating ← |
+| Orcus                 | sextile ⚹        | Hades                 | 0.92° | Separating ← |
 | Orcus                 | semi-square ∠    | Zeus                  | 0.19° | Applying →   |
 | Orcus                 | sextile ⚹        | Apollon               | 2.99° | Applying →   |
 | Orcus                 | square □         | Admetos               | 4.12° | Applying →   |
@@ -659,9 +659,9 @@ Sample Natal Subject — Natal Chart Report
 | Quaoar                | opposition ☍     | Mean Priapus          | 4.91° | Separating ← |
 | Quaoar                | trine △          | White Moon            | 2.36° | Separating ← |
 | Quaoar                | conjunction ☌    | Cupido                | 5.46° | Applying →   |
-| Quaoar                | sextile ⚹        | Zeus                  | 1.96° | Separating ← |
+| Quaoar                | sextile ⚹        | Zeus                  | 1.95° | Separating ← |
 | Pars Fortunae         | quincunx ⚻       | Mean Priapus          | 0.50° | Separating ← |
-| Pars Fortunae         | square □         | White Moon            | 2.05° | Applying →   |
+| Pars Fortunae         | square □         | White Moon            | 2.06° | Applying →   |
 | Pars Fortunae         | conjunction ☌    | Poseidon              | 0.20° | Separating ← |
 | Pars Spiritus         | opposition ☍     | Pars Fidei            | 4.94° | Static =     |
 | Pars Spiritus         | quincunx ⚻       | Vertex                | 1.69° | Static =     |
@@ -671,16 +671,16 @@ Sample Natal Subject — Natal Chart Report
 | Pars Spiritus         | conjunction ☌    | Cupido                | 5.46° | Applying →   |
 | Pars Spiritus         | semi-sextile ⚺   | Apollon               | 0.67° | Separating ← |
 | Pars Spiritus         | opposition ☍     | Admetos               | 1.80° | Separating ← |
-| Pars Spiritus         | trine △          | Vulkanus              | 2.19° | Separating ← |
+| Pars Spiritus         | trine △          | Vulkanus              | 2.18° | Separating ← |
 | Pars Amoris           | quincunx ⚻       | Pars Fidei            | 0.77° | Static =     |
 | Pars Amoris           | trine △          | Vertex                | 2.48° | Static =     |
 | Pars Amoris           | sextile ⚹        | Anti Vertex           | 2.48° | Static =     |
 | Pars Amoris           | semi-square ∠    | Interpolated Lilith   | 1.49° | Separating ← |
-| Pars Amoris           | quintile Q       | White Moon            | 0.55° | Applying →   |
-| Pars Amoris           | trine △          | Hades                 | 0.94° | Separating ← |
+| Pars Amoris           | quintile Q       | White Moon            | 0.56° | Applying →   |
+| Pars Amoris           | trine △          | Hades                 | 0.93° | Separating ← |
 | Pars Amoris           | conjunction ☌    | Apollon               | 4.84° | Separating ← |
 | Pars Amoris           | biquintile bQ    | Admetos               | 0.03° | Applying →   |
-| Pars Fidei            | semi-sextile ⚺   | Hades                 | 1.71° | Separating ← |
+| Pars Fidei            | semi-sextile ⚺   | Hades                 | 1.70° | Separating ← |
 | Pars Fidei            | semi-square ∠    | Kronos                | 1.32° | Applying →   |
 | Vertex                | semi-square ∠    | White Moon            | 0.03° | Applying →   |
 | Vertex                | conjunction ☌    | Hades                 | 1.54° | Applying →   |
@@ -690,28 +690,28 @@ Sample Natal Subject — Natal Chart Report
 | Anti Vertex           | sextile ⚹        | Apollon               | 2.36° | Separating ← |
 | Interpolated Lilith   | opposition ☍     | Mean Priapus          | 3.51° | Applying →   |
 | Interpolated Lilith   | trine △          | White Moon            | 0.96° | Applying →   |
-| Interpolated Lilith   | sextile ⚹        | Zeus                  | 0.56° | Applying →   |
-| Mean Priapus          | sextile ⚹        | White Moon            | 2.55° | Applying →   |
+| Interpolated Lilith   | sextile ⚹        | Zeus                  | 0.55° | Applying →   |
+| Mean Priapus          | sextile ⚹        | White Moon            | 2.56° | Applying →   |
 | Mean Priapus          | trine △          | Zeus                  | 2.96° | Separating ← |
-| Mean Priapus          | sesquiquadrate ⚼ | Apollon               | 0.16° | Separating ← |
-| Mean Priapus          | semi-square ∠    | Vulkanus              | 1.36° | Applying →   |
+| Mean Priapus          | sesquiquadrate ⚼ | Apollon               | 0.17° | Separating ← |
+| Mean Priapus          | semi-square ∠    | Vulkanus              | 1.35° | Applying →   |
 | Mean Priapus          | quincunx ⚻       | Poseidon              | 0.31° | Separating ← |
 | True Priapus          | conjunction ☌    | Interpolated Perigee  | 2.97° | Separating ← |
 | True Priapus          | quincunx ⚻       | Cupido                | 0.60° | Separating ← |
 | True Priapus          | conjunction ☌    | Kronos                | 3.88° | Separating ← |
 | True Priapus          | trine △          | Apollon               | 4.19° | Applying →   |
 | Interpolated Perigee  | square □         | Zeus                  | 5.05° | Applying →   |
-| Interpolated Perigee  | conjunction ☌    | Kronos                | 0.92° | Applying →   |
+| Interpolated Perigee  | conjunction ☌    | Kronos                | 0.91° | Applying →   |
 | White Moon            | semi-square ∠    | Hades                 | 1.51° | Separating ← |
 | White Moon            | sextile ⚹        | Zeus                  | 0.40° | Separating ← |
-| White Moon            | quintile Q       | Admetos               | 0.52° | Applying →   |
+| White Moon            | quintile Q       | Admetos               | 0.53° | Applying →   |
 | White Moon            | square □         | Poseidon              | 2.25° | Applying →   |
 | Cupido                | opposition ☍     | Admetos               | 3.66° | Applying →   |
-| Cupido                | trine △          | Vulkanus              | 3.27° | Applying →   |
+| Cupido                | trine △          | Vulkanus              | 3.28° | Applying →   |
 | Hades                 | trine △          | Apollon               | 3.90° | Applying →   |
-| Zeus                  | square □         | Kronos                | 4.13° | Applying →   |
+| Zeus                  | square □         | Kronos                | 4.14° | Applying →   |
 | Zeus                  | quintile Q       | Vulkanus              | 1.31° | Separating ← |
 | Apollon               | quincunx ⚻       | Admetos               | 1.13° | Static =     |
 | Apollon               | square □         | Vulkanus              | 1.52° | Separating ← |
-| Admetos               | sextile ⚹        | Vulkanus              | 0.39° | Separating ← |
+| Admetos               | sextile ⚹        | Vulkanus              | 0.38° | Separating ← |
 +-----------------------+------------------+-----------------------+-------+--------------+

--- a/tests/fixtures/natal_all_points_report.txt
+++ b/tests/fixtures/natal_all_points_report.txt
@@ -31,10 +31,10 @@ Sample Natal Subject — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House    |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6390°/d | N/A     | -    | Tenth House    |
-| Descendant            | Tau ♉ | 5.82°    | +245.7237°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6390°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House    |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6410°/d | N/A     | -    | Tenth House    |
+| Descendant            | Tau ♉ | 5.82°    | +245.7250°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6410°/d | N/A     | -    | Fourth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House    |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House    |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House    |
@@ -47,8 +47,8 @@ Sample Natal Subject — Natal Chart Report
 | Pluto                 | Sco ♏ | 14.97°   | -0.0025°/d   | -1.42°  | R    | First House    |
 | Mean North Lunar Node | Aqu ♒ | 7.79°    | -0.0529°/d   | -18.32° | R    | Third House    |
 | True North Lunar Node | Aqu ♒ | 7.26°    | -0.0080°/d   | -18.46° | R    | Third House    |
-| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.61° | -    | First House    |
-| True Lilith           | Sag ♐ | 18.01°   | -1.4331°/d   | -26.88° | R    | Second House   |
+| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.62° | -    | First House    |
+| True Lilith           | Sag ♐ | 18.01°   | -1.4330°/d   | -26.88° | R    | Second House   |
 | Chiron                | Can ♋ | 19.88°   | +0.1071°/d   | +15.79° | -    | Ninth House    |
 | Pholus                | Can ♋ | 7.99°    | +0.1329°/d   | +13.79° | -    | Eighth House   |
 | Ceres                 | Leo ♌ | 13.71°   | +0.4493°/d   | +23.05° | -    | Ninth House    |
@@ -56,15 +56,15 @@ Sample Natal Subject — Natal Chart Report
 | Juno                  | Sco ♏ | 10.10°   | +0.0843°/d   | -2.06°  | -    | First House    |
 | Vesta                 | Tau ♉ | 18.15°   | +0.3292°/d   | +10.88° | -    | Seventh House  |
 | Interpolated Lilith   | Sco ♏ | 25.48°   | +0.1694°/d   | -23.89° | -    | First House    |
-| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1732°/d   | +26.84° | -    | Eighth House   |
-| Cupido                | Sco ♏ | 18.62°   | -0.0042°/d   | -16.34° | R    | First House    |
-| Hades                 | Gem ♊ | 9.93°    | +0.0152°/d   | +20.93° | -    | Eighth House   |
-| Zeus                  | Vir ♍ | 26.03°   | +0.0110°/d   | +1.58°  | -    | Eleventh House |
-| Kronos                | Gem ♊ | 21.90°   | +0.0137°/d   | +23.21° | -    | Eighth House   |
-| Apollon               | Lib ♎ | 13.83°   | +0.0053°/d   | -5.46°  | -    | Eleventh House |
-| Admetos               | Tau ♉ | 14.96°   | +0.0053°/d   | +16.33° | -    | Seventh House  |
-| Vulkanus              | Can ♋ | 15.35°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
-| Poseidon              | Lib ♎ | 28.68°   | +0.0014°/d   | -11.01° | -    | Twelfth House  |
+| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1733°/d   | +26.84° | -    | Eighth House   |
+| Cupido                | Sco ♏ | 18.62°   | -0.0043°/d   | -16.34° | R    | First House    |
+| Hades                 | Gem ♊ | 9.92°    | +0.0153°/d   | +20.93° | -    | Eighth House   |
+| Zeus                  | Vir ♍ | 26.03°   | +0.0109°/d   | +1.58°  | -    | Eleventh House |
+| Kronos                | Gem ♊ | 21.89°   | +0.0138°/d   | +23.21° | -    | Eighth House   |
+| Apollon               | Lib ♎ | 13.82°   | +0.0052°/d   | -5.46°  | -    | Eleventh House |
+| Admetos               | Tau ♉ | 14.96°   | +0.0054°/d   | +16.33° | -    | Seventh House  |
+| Vulkanus              | Can ♋ | 15.34°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
+| Poseidon              | Lib ♎ | 28.68°   | +0.0013°/d   | -11.01° | -    | Twelfth House  |
 | Eris                  | Ari ♈ | 17.60°   | -0.0013°/d   | -9.16°  | R    | Sixth House    |
 | Sedna                 | Tau ♉ | 11.55°   | +0.0038°/d   | +4.25°  | -    | Seventh House  |
 | Haumea                | Vir ♍ | 26.32°   | +0.0134°/d   | +23.02° | -    | Eleventh House |
@@ -77,12 +77,12 @@ Sample Natal Subject — Natal Chart Report
 | Pars Amoris           | Lib ♎ | 8.99°    | N/A          | N/A     | -    | Eleventh House |
 | Pars Fidei            | Tau ♉ | 8.22°    | N/A          | N/A     | -    | Seventh House  |
 | Vertex                | Gem ♊ | 11.46°   | N/A          | N/A     | -    | Eighth House   |
-| White Moon            | Can ♋ | 26.44°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
+| White Moon            | Can ♋ | 26.43°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
 | Anti Vertex           | Sag ♐ | 11.46°   | N/A          | N/A     | -    | Second House   |
 | Mean South Lunar Node | Leo ♌ | 7.79°    | -0.0529°/d   | +18.32° | R    | Ninth House    |
 | True South Lunar Node | Leo ♌ | 7.26°    | -0.0080°/d   | +18.46° | R    | Ninth House    |
-| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.61° | -    | Seventh House  |
-| True Priapus          | Gem ♊ | 18.01°   | -1.4331°/d   | +26.88° | R    | Eighth House   |
+| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.62° | -    | Seventh House  |
+| True Priapus          | Gem ♊ | 18.01°   | -1.4330°/d   | +26.88° | R    | Eighth House   |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +Natal Houses (Placidus)--+----------+-------------------+
@@ -226,12 +226,12 @@ Sample Natal Subject — Natal Chart Report
 | Moon                  | trine △       | Quaoar                | 2.87° | Applying →   |
 | Moon                  | square □      | Pars Fortunae         | 7.28° | Applying →   |
 | Moon                  | trine △       | Interpolated Lilith   | 4.27° | Applying →   |
-| Moon                  | conjunction ☌ | White Moon            | 5.23° | Applying →   |
+| Moon                  | conjunction ☌ | White Moon            | 5.22° | Applying →   |
 | Moon                  | trine △       | Cupido                | 2.59° | Separating ← |
 | Moon                  | sextile ⚹     | Zeus                  | 4.82° | Applying →   |
 | Moon                  | square □      | Apollon               | 7.38° | Separating ← |
 | Moon                  | sextile ⚹     | Admetos               | 6.25° | Separating ← |
-| Moon                  | conjunction ☌ | Vulkanus              | 5.86° | Separating ← |
+| Moon                  | conjunction ☌ | Vulkanus              | 5.87° | Separating ← |
 | Moon                  | square □      | Poseidon              | 7.47° | Applying →   |
 | Mercury               | square □      | Pluto                 | 2.63° | Separating ← |
 | Mercury               | conjunction ☌ | Medium Coeli          | 2.31° | Separating ← |
@@ -281,7 +281,7 @@ Sample Natal Subject — Natal Chart Report
 | Jupiter               | square □      | Pars Fortunae         | 4.58° | Applying →   |
 | Jupiter               | trine △       | Interpolated Lilith   | 1.56° | Applying →   |
 | Jupiter               | conjunction ☌ | White Moon            | 2.52° | Applying →   |
-| Jupiter               | trine △       | Cupido                | 5.30° | Separating ← |
+| Jupiter               | trine △       | Cupido                | 5.29° | Separating ← |
 | Jupiter               | sextile ⚹     | Zeus                  | 2.12° | Applying →   |
 | Jupiter               | square □      | Poseidon              | 4.77° | Applying →   |
 | Saturn                | opposition ☍  | Chiron                | 1.64° | Applying →   |
@@ -293,7 +293,7 @@ Sample Natal Subject — Natal Chart Report
 | Saturn                | sextile ⚹     | Interpolated Lilith   | 3.96° | Separating ← |
 | Saturn                | opposition ☍  | White Moon            | 4.92° | Separating ← |
 | Saturn                | sextile ⚹     | Cupido                | 2.90° | Applying →   |
-| Saturn                | trine △       | Zeus                  | 4.52° | Separating ← |
+| Saturn                | trine △       | Zeus                  | 4.51° | Separating ← |
 | Uranus                | sextile ⚹     | Ascendant             | 0.92° | Applying →   |
 | Uranus                | trine △       | Descendant            | 0.92° | Applying →   |
 | Uranus                | opposition ☍  | Pholus                | 1.25° | Separating ← |
@@ -326,7 +326,7 @@ Sample Natal Subject — Natal Chart Report
 | Pluto                 | square □      | Orcus                 | 4.13° | Applying →   |
 | Pluto                 | conjunction ☌ | Pars Spiritus         | 1.82° | Applying →   |
 | Pluto                 | conjunction ☌ | Cupido                | 3.64° | Applying →   |
-| Pluto                 | opposition ☍  | Admetos               | 0.01° | Applying →   |
+| Pluto                 | opposition ☍  | Admetos               | 0.02° | Applying →   |
 | Pluto                 | trine △       | Vulkanus              | 0.37° | Separating ← |
 | Mean North Lunar Node | square □      | Ascendant             | 1.97° | Applying →   |
 | Mean North Lunar Node | square □      | Descendant            | 1.97° | Applying →   |
@@ -339,7 +339,7 @@ Sample Natal Subject — Natal Chart Report
 | Mean North Lunar Node | square □      | Pars Fidei            | 0.43° | Separating ← |
 | Mean North Lunar Node | trine △       | Vertex                | 3.68° | Separating ← |
 | Mean North Lunar Node | sextile ⚹     | Anti Vertex           | 3.68° | Separating ← |
-| Mean North Lunar Node | trine △       | Hades                 | 2.14° | Separating ← |
+| Mean North Lunar Node | trine △       | Hades                 | 2.13° | Separating ← |
 | True North Lunar Node | square □      | Ascendant             | 1.44° | Applying →   |
 | True North Lunar Node | square □      | Descendant            | 1.44° | Applying →   |
 | True North Lunar Node | square □      | Juno                  | 2.83° | Separating ← |
@@ -358,7 +358,7 @@ Sample Natal Subject — Natal Chart Report
 | Chiron                | trine △       | Interpolated Lilith   | 5.60° | Separating ← |
 | Chiron                | trine △       | Cupido                | 1.26° | Separating ← |
 | Chiron                | sextile ⚹     | Admetos               | 4.92° | Separating ← |
-| Chiron                | conjunction ☌ | Vulkanus              | 4.53° | Separating ← |
+| Chiron                | conjunction ☌ | Vulkanus              | 4.54° | Separating ← |
 | Ascendant             | square □      | Mean South Lunar Node | 1.97° | Applying →   |
 | Ascendant             | square □      | True South Lunar Node | 1.44° | Applying →   |
 | Ascendant             | trine △       | Pholus                | 2.17° | Applying →   |
@@ -378,7 +378,7 @@ Sample Natal Subject — Natal Chart Report
 | Medium Coeli          | sextile ⚹     | Interpolated Perigee  | 1.07° | Applying →   |
 | Medium Coeli          | square □      | Cupido                | 1.30° | Separating ← |
 | Medium Coeli          | sextile ⚹     | Kronos                | 1.98° | Applying →   |
-| Medium Coeli          | square □      | Admetos               | 4.95° | Separating ← |
+| Medium Coeli          | square □      | Admetos               | 4.96° | Separating ← |
 | Descendant            | square □      | Mean South Lunar Node | 1.97° | Applying →   |
 | Descendant            | square □      | True South Lunar Node | 1.44° | Applying →   |
 | Descendant            | sextile ⚹     | Pholus                | 2.17° | Applying →   |
@@ -398,12 +398,12 @@ Sample Natal Subject — Natal Chart Report
 | Imum Coeli            | trine △       | Interpolated Perigee  | 1.07° | Applying →   |
 | Imum Coeli            | square □      | Cupido                | 1.30° | Separating ← |
 | Imum Coeli            | trine △       | Kronos                | 1.98° | Applying →   |
-| Imum Coeli            | square □      | Admetos               | 4.95° | Separating ← |
+| Imum Coeli            | square □      | Admetos               | 4.96° | Separating ← |
 | Mean Lilith           | sextile ⚹     | Haumea                | 2.67° | Separating ← |
 | Mean Lilith           | square □      | Makemake              | 5.51° | Applying →   |
 | Mean Lilith           | conjunction ☌ | Quaoar                | 4.91° | Separating ← |
 | Mean Lilith           | conjunction ☌ | Interpolated Lilith   | 3.51° | Applying →   |
-| Mean Lilith           | trine △       | White Moon            | 2.55° | Applying →   |
+| Mean Lilith           | trine △       | White Moon            | 2.56° | Applying →   |
 | Mean Lilith           | sextile ⚹     | Zeus                  | 2.96° | Separating ← |
 | Mean South Lunar Node | conjunction ☌ | Ceres                 | 5.93° | Separating ← |
 | Mean South Lunar Node | square □      | Juno                  | 2.31° | Separating ← |
@@ -414,7 +414,7 @@ Sample Natal Subject — Natal Chart Report
 | Mean South Lunar Node | square □      | Pars Fidei            | 0.43° | Separating ← |
 | Mean South Lunar Node | sextile ⚹     | Vertex                | 3.68° | Separating ← |
 | Mean South Lunar Node | trine △       | Anti Vertex           | 3.68° | Separating ← |
-| Mean South Lunar Node | sextile ⚹     | Hades                 | 2.14° | Separating ← |
+| Mean South Lunar Node | sextile ⚹     | Hades                 | 2.13° | Separating ← |
 | True South Lunar Node | square □      | Juno                  | 2.83° | Separating ← |
 | True South Lunar Node | square □      | Sedna                 | 4.28° | Separating ← |
 | True South Lunar Node | conjunction ☌ | Orcus                 | 3.57° | Separating ← |
@@ -436,7 +436,7 @@ Sample Natal Subject — Natal Chart Report
 | Pholus                | trine △       | Pars Spiritus         | 5.17° | Applying →   |
 | Pholus                | square □      | Pars Amoris           | 1.00° | Applying →   |
 | Pholus                | sextile ⚹     | Pars Fidei            | 0.23° | Applying →   |
-| Pholus                | square □      | Apollon               | 5.84° | Applying →   |
+| Pholus                | square □      | Apollon               | 5.83° | Applying →   |
 | Ceres                 | square □      | Juno                  | 3.62° | Separating ← |
 | Ceres                 | square □      | Vesta                 | 4.43° | Applying →   |
 | Ceres                 | trine △       | Eris                  | 3.88° | Applying →   |
@@ -451,7 +451,7 @@ Sample Natal Subject — Natal Chart Report
 | Ceres                 | square □      | Cupido                | 4.90° | Applying →   |
 | Ceres                 | sextile ⚹     | Hades                 | 3.79° | Separating ← |
 | Ceres                 | sextile ⚹     | Apollon               | 0.11° | Applying →   |
-| Ceres                 | square □      | Admetos               | 1.25° | Applying →   |
+| Ceres                 | square □      | Admetos               | 1.24° | Applying →   |
 | Pallas                | trine △       | Juno                  | 2.85° | Applying →   |
 | Pallas                | sextile ⚹     | Sedna                 | 4.30° | Applying →   |
 | Pallas                | sextile ⚹     | Makemake              | 2.75° | Separating ← |
@@ -463,23 +463,23 @@ Sample Natal Subject — Natal Chart Report
 | Juno                  | conjunction ☌ | Pars Spiritus         | 3.06° | Applying →   |
 | Juno                  | opposition ☍  | Pars Fidei            | 1.88° | Separating ← |
 | Juno                  | opposition ☍  | Admetos               | 4.86° | Applying →   |
-| Juno                  | trine △       | Vulkanus              | 5.25° | Applying →   |
+| Juno                  | trine △       | Vulkanus              | 5.24° | Applying →   |
 | Vesta                 | opposition ☍  | Ixion                 | 4.56° | Applying →   |
 | Vesta                 | opposition ☍  | Quaoar                | 5.93° | Applying →   |
 | Vesta                 | opposition ☍  | Pars Spiritus         | 4.99° | Separating ← |
 | Vesta                 | opposition ☍  | Cupido                | 0.47° | Applying →   |
 | Vesta                 | conjunction ☌ | Admetos               | 3.19° | Separating ← |
-| Vesta                 | sextile ⚹     | Vulkanus              | 2.80° | Separating ← |
+| Vesta                 | sextile ⚹     | Vulkanus              | 2.81° | Separating ← |
 | Eris                  | sextile ⚹     | True Priapus          | 0.42° | Applying →   |
 | Eris                  | sextile ⚹     | Interpolated Perigee  | 3.39° | Separating ← |
 | Eris                  | sextile ⚹     | Kronos                | 4.30° | Separating ← |
 | Eris                  | opposition ☍  | Apollon               | 3.77° | Applying →   |
-| Eris                  | square □      | Vulkanus              | 2.25° | Applying →   |
+| Eris                  | square □      | Vulkanus              | 2.26° | Applying →   |
 | Sedna                 | square □      | Orcus                 | 0.71° | Applying →   |
 | Sedna                 | opposition ☍  | Pars Spiritus         | 1.61° | Applying →   |
 | Sedna                 | conjunction ☌ | Pars Fidei            | 3.33° | Separating ← |
 | Sedna                 | conjunction ☌ | Admetos               | 3.41° | Separating ← |
-| Sedna                 | sextile ⚹     | Vulkanus              | 3.80° | Separating ← |
+| Sedna                 | sextile ⚹     | Vulkanus              | 3.79° | Separating ← |
 | Haumea                | sextile ⚹     | Ixion                 | 3.62° | Separating ← |
 | Haumea                | sextile ⚹     | Quaoar                | 2.25° | Separating ← |
 | Haumea                | sextile ⚹     | Interpolated Lilith   | 0.85° | Applying →   |
@@ -487,10 +487,10 @@ Sample Natal Subject — Natal Chart Report
 | Haumea                | square □      | Interpolated Perigee  | 5.34° | Applying →   |
 | Haumea                | sextile ⚹     | White Moon            | 0.11° | Separating ← |
 | Haumea                | conjunction ☌ | Zeus                  | 0.29° | Separating ← |
-| Haumea                | square □      | Kronos                | 4.42° | Static =     |
+| Haumea                | square □      | Kronos                | 4.43° | Static =     |
 | Makemake              | trine △       | Pars Fidei            | 3.72° | Applying →   |
 | Makemake              | square □      | Mean Priapus          | 5.51° | Applying →   |
-| Makemake              | square □      | Hades                 | 5.43° | Applying →   |
+| Makemake              | square □      | Hades                 | 5.42° | Applying →   |
 | Ixion                 | conjunction ☌ | Quaoar                | 1.37° | Static =     |
 | Ixion                 | conjunction ☌ | Interpolated Lilith   | 2.77° | Separating ← |
 | Ixion                 | trine △       | White Moon            | 3.73° | Separating ← |
@@ -501,23 +501,23 @@ Sample Natal Subject — Natal Chart Report
 | Orcus                 | square □      | Pars Fidei            | 2.62° | Separating ← |
 | Orcus                 | sextile ⚹     | Vertex                | 0.63° | Applying →   |
 | Orcus                 | trine △       | Anti Vertex           | 0.63° | Applying →   |
-| Orcus                 | sextile ⚹     | Hades                 | 0.91° | Separating ← |
+| Orcus                 | sextile ⚹     | Hades                 | 0.92° | Separating ← |
 | Orcus                 | sextile ⚹     | Apollon               | 2.99° | Applying →   |
 | Orcus                 | square □      | Admetos               | 4.12° | Applying →   |
 | Quaoar                | conjunction ☌ | Interpolated Lilith   | 1.40° | Separating ← |
 | Quaoar                | opposition ☍  | Mean Priapus          | 4.91° | Separating ← |
 | Quaoar                | trine △       | White Moon            | 2.36° | Separating ← |
 | Quaoar                | conjunction ☌ | Cupido                | 5.46° | Applying →   |
-| Quaoar                | sextile ⚹     | Zeus                  | 1.96° | Separating ← |
-| Pars Fortunae         | square □      | White Moon            | 2.05° | Applying →   |
+| Quaoar                | sextile ⚹     | Zeus                  | 1.95° | Separating ← |
+| Pars Fortunae         | square □      | White Moon            | 2.06° | Applying →   |
 | Pars Fortunae         | conjunction ☌ | Poseidon              | 0.20° | Separating ← |
 | Pars Spiritus         | opposition ☍  | Pars Fidei            | 4.94° | Static =     |
 | Pars Spiritus         | conjunction ☌ | Cupido                | 5.46° | Applying →   |
 | Pars Spiritus         | opposition ☍  | Admetos               | 1.80° | Separating ← |
-| Pars Spiritus         | trine △       | Vulkanus              | 2.19° | Separating ← |
+| Pars Spiritus         | trine △       | Vulkanus              | 2.18° | Separating ← |
 | Pars Amoris           | trine △       | Vertex                | 2.48° | Static =     |
 | Pars Amoris           | sextile ⚹     | Anti Vertex           | 2.48° | Static =     |
-| Pars Amoris           | trine △       | Hades                 | 0.94° | Separating ← |
+| Pars Amoris           | trine △       | Hades                 | 0.93° | Separating ← |
 | Pars Amoris           | conjunction ☌ | Apollon               | 4.84° | Separating ← |
 | Vertex                | conjunction ☌ | Hades                 | 1.54° | Applying →   |
 | Vertex                | trine △       | Apollon               | 2.36° | Separating ← |
@@ -525,20 +525,20 @@ Sample Natal Subject — Natal Chart Report
 | Anti Vertex           | sextile ⚹     | Apollon               | 2.36° | Separating ← |
 | Interpolated Lilith   | opposition ☍  | Mean Priapus          | 3.51° | Applying →   |
 | Interpolated Lilith   | trine △       | White Moon            | 0.96° | Applying →   |
-| Interpolated Lilith   | sextile ⚹     | Zeus                  | 0.56° | Applying →   |
-| Mean Priapus          | sextile ⚹     | White Moon            | 2.55° | Applying →   |
+| Interpolated Lilith   | sextile ⚹     | Zeus                  | 0.55° | Applying →   |
+| Mean Priapus          | sextile ⚹     | White Moon            | 2.56° | Applying →   |
 | Mean Priapus          | trine △       | Zeus                  | 2.96° | Separating ← |
 | True Priapus          | conjunction ☌ | Interpolated Perigee  | 2.97° | Separating ← |
 | True Priapus          | conjunction ☌ | Kronos                | 3.88° | Separating ← |
 | True Priapus          | trine △       | Apollon               | 4.19° | Applying →   |
 | Interpolated Perigee  | square □      | Zeus                  | 5.05° | Applying →   |
-| Interpolated Perigee  | conjunction ☌ | Kronos                | 0.92° | Applying →   |
+| Interpolated Perigee  | conjunction ☌ | Kronos                | 0.91° | Applying →   |
 | White Moon            | sextile ⚹     | Zeus                  | 0.40° | Separating ← |
 | White Moon            | square □      | Poseidon              | 2.25° | Applying →   |
 | Cupido                | opposition ☍  | Admetos               | 3.66° | Applying →   |
-| Cupido                | trine △       | Vulkanus              | 3.27° | Applying →   |
+| Cupido                | trine △       | Vulkanus              | 3.28° | Applying →   |
 | Hades                 | trine △       | Apollon               | 3.90° | Applying →   |
-| Zeus                  | square □      | Kronos                | 4.13° | Applying →   |
+| Zeus                  | square □      | Kronos                | 4.14° | Applying →   |
 | Apollon               | square □      | Vulkanus              | 1.52° | Separating ← |
-| Admetos               | sextile ⚹     | Vulkanus              | 0.39° | Separating ← |
+| Admetos               | sextile ⚹     | Vulkanus              | 0.38° | Separating ← |
 +-----------------------+---------------+-----------------------+-------+--------------+

--- a/tests/fixtures/natal_ancient_rome_all_report.txt
+++ b/tests/fixtures/natal_ancient_rome_all_report.txt
@@ -31,10 +31,10 @@ Ancient Rome Subject — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Ari ♈ | 19.16°   | +622.4003°/d | N/A     | -    | First House    |
-| Medium Coeli          | Cap ♑ | 9.91°    | +332.4725°/d | N/A     | -    | Tenth House    |
-| Descendant            | Lib ♎ | 19.16°   | +622.4003°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Can ♋ | 9.91°    | +332.4725°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Ari ♈ | 19.16°   | +622.4037°/d | N/A     | -    | First House    |
+| Medium Coeli          | Cap ♑ | 9.91°    | +332.4743°/d | N/A     | -    | Tenth House    |
+| Descendant            | Lib ♎ | 19.16°   | +622.4037°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Can ♋ | 9.91°    | +332.4743°/d | N/A     | -    | Fourth House   |
 | Sun                   | Cap ♑ | 11.83°   | +1.0160°/d   | -23.15° | -    | Tenth House    |
 | Moon                  | Aqu ♒ | 28.41°   | +11.9746°/d  | -11.85° | -    | Eleventh House |
 | Mercury               | Cap ♑ | 22.77°   | +1.7455°/d   | -23.46° | -    | Tenth House    |
@@ -47,7 +47,7 @@ Ancient Rome Subject — Natal Chart Report
 | Pluto                 | Pis ♓ | 15.42°   | +0.0124°/d   | -21.30° | -    | Twelfth House  |
 | Mean North Lunar Node | Vir ♍ | 3.57°    | -0.0530°/d   | +10.30° | R    | Sixth House    |
 | True North Lunar Node | Vir ♍ | 1.90°    | -0.0082°/d   | +10.91° | R    | Fifth House    |
-| Mean Lilith           | Pis ♓ | 20.08°   | +0.1109°/d   | -5.31°  | -    | Twelfth House  |
+| Mean Lilith           | Pis ♓ | 20.07°   | +0.1109°/d   | -5.31°  | -    | Twelfth House  |
 | True Lilith           | Pis ♓ | 25.71°   | -1.4951°/d   | -3.63°  | R    | Twelfth House  |
 | Chiron                | Cap ♑ | 14.23°   | +0.0734°/d   | -16.49° | -    | Tenth House    |
 | Pholus                | Sag ♐ | 27.72°   | +0.0332°/d   | -19.68° | -    | Ninth House    |
@@ -56,15 +56,15 @@ Ancient Rome Subject — Natal Chart Report
 | Juno                  | Sco ♏ | 11.65°   | +0.3137°/d   | -13.78° | -    | Seventh House  |
 | Vesta                 | Aqu ♒ | 29.32°   | +0.4013°/d   | -15.71° | -    | Eleventh House |
 | Interpolated Lilith   | Pis ♓ | 22.96°   | +0.2206°/d   | -4.39°  | -    | Twelfth House  |
-| Interpolated Perigee  | Leo ♌ | 26.02°   | +0.0356°/d   | +12.34° | -    | Fifth House    |
+| Interpolated Perigee  | Leo ♌ | 26.02°   | +0.0358°/d   | +12.34° | -    | Fifth House    |
 | Cupido                | Leo ♌ | 12.00°   | -0.0175°/d   | +17.75° | R    | Fifth House    |
 | Hades                 | Aqu ♒ | 15.01°   | +0.0189°/d   | -16.42° | -    | Eleventh House |
-| Zeus                  | Can ♋ | 6.99°    | -0.0149°/d   | +23.29° | R    | Third House    |
-| Kronos                | Lib ♎ | 12.06°   | +0.0021°/d   | -4.68°  | -    | Sixth House    |
-| Apollon               | Can ♋ | 3.57°    | -0.0126°/d   | +23.42° | R    | Third House    |
-| Admetos               | Ari ♈ | 19.90°   | -0.0004°/d   | +7.69°  | R    | First House    |
-| Vulkanus              | Vir ♍ | 7.22°    | -0.0058°/d   | +8.96°  | R    | Sixth House    |
-| Poseidon              | Ari ♈ | 13.15°   | +0.0009°/d   | +5.10°  | -    | Twelfth House  |
+| Zeus                  | Can ♋ | 7.00°    | -0.0149°/d   | +23.29° | R    | Third House    |
+| Kronos                | Lib ♎ | 12.06°   | +0.0022°/d   | -4.68°  | -    | Sixth House    |
+| Apollon               | Can ♋ | 3.58°    | -0.0126°/d   | +23.42° | R    | Third House    |
+| Admetos               | Ari ♈ | 19.90°   | -0.0005°/d   | +7.69°  | R    | First House    |
+| Vulkanus              | Vir ♍ | 7.22°    | -0.0057°/d   | +8.96°  | R    | Sixth House    |
+| Poseidon              | Ari ♈ | 13.15°   | +0.0008°/d   | +5.10°  | -    | Twelfth House  |
 | Eris                  | Sag ♐ | 13.46°   | +0.0221°/d   | -62.08° | -    | Eighth House   |
 | Sedna                 | Cap ♑ | 2.92°    | +0.0016°/d   | -18.32° | -    | Ninth House    |
 | Haumea                | Sag ♐ | 9.62°    | +0.0242°/d   | -8.69°  | -    | Eighth House   |
@@ -77,11 +77,11 @@ Ancient Rome Subject — Natal Chart Report
 | Pars Amoris           | Tau ♉ | 28.29°   | N/A          | N/A     | -    | Second House   |
 | Pars Fidei            | Can ♋ | 15.82°   | N/A          | N/A     | -    | Fourth House   |
 | Vertex                | Lib ♎ | 7.92°    | N/A          | N/A     | -    | Sixth House    |
-| White Moon            | Gem ♊ | 23.23°   | +0.1408°/d   | +23.51° | -    | Third House    |
+| White Moon            | Gem ♊ | 23.24°   | +0.1408°/d   | +23.51° | -    | Third House    |
 | Anti Vertex           | Ari ♈ | 7.92°    | N/A          | N/A     | -    | Twelfth House  |
 | Mean South Lunar Node | Pis ♓ | 3.57°    | -0.0530°/d   | -10.30° | R    | Twelfth House  |
 | True South Lunar Node | Pis ♓ | 1.90°    | -0.0082°/d   | -10.91° | R    | Eleventh House |
-| Mean Priapus          | Vir ♍ | 20.08°   | +0.1109°/d   | +5.31°  | -    | Sixth House    |
+| Mean Priapus          | Vir ♍ | 20.07°   | +0.1109°/d   | +5.31°  | -    | Sixth House    |
 | True Priapus          | Vir ♍ | 25.71°   | -1.4951°/d   | +3.63°  | R    | Sixth House    |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
@@ -231,9 +231,9 @@ Ancient Rome Subject — Natal Chart Report
 | Sun                   | square □         | Anti Vertex           | 3.91° | Separating ← |
 | Sun                   | quintile Q       | Interpolated Lilith   | 0.87° | Separating ← |
 | Sun                   | sesquiquadrate ⚼ | Interpolated Perigee  | 0.81° | Separating ← |
-| Sun                   | quincunx ⚻       | Cupido                | 0.17° | Applying →   |
+| Sun                   | quincunx ⚻       | Cupido                | 0.18° | Applying →   |
 | Sun                   | semi-sextile ⚺   | Hades                 | 3.18° | Applying →   |
-| Sun                   | opposition ☍     | Zeus                  | 4.84° | Separating ← |
+| Sun                   | opposition ☍     | Zeus                  | 4.83° | Separating ← |
 | Sun                   | square □         | Kronos                | 0.23° | Applying →   |
 | Sun                   | trine △          | Vulkanus              | 4.61° | Separating ← |
 | Sun                   | square □         | Poseidon              | 1.32° | Applying →   |
@@ -296,9 +296,9 @@ Ancient Rome Subject — Natal Chart Report
 | Venus                 | quincunx ⚻       | Mean Priapus          | 0.88° | Separating ← |
 | Venus                 | biquintile bQ    | True Priapus          | 1.25° | Separating ← |
 | Venus                 | opposition ☍     | Interpolated Perigee  | 5.06° | Applying →   |
-| Venus                 | trine △          | White Moon            | 2.27° | Applying →   |
+| Venus                 | trine △          | White Moon            | 2.28° | Applying →   |
 | Venus                 | conjunction ☌    | Hades                 | 5.95° | Separating ← |
-| Venus                 | sesquiquadrate ⚼ | Zeus                  | 1.03° | Applying →   |
+| Venus                 | sesquiquadrate ⚼ | Zeus                  | 1.04° | Applying →   |
 | Venus                 | sextile ⚹        | Admetos               | 1.06° | Separating ← |
 | Mars                  | sextile ⚹        | Saturn                | 0.39° | Applying →   |
 | Mars                  | quincunx ⚻       | Uranus                | 1.82° | Separating ← |
@@ -319,7 +319,7 @@ Ancient Rome Subject — Natal Chart Report
 | Mars                  | square □         | Anti Vertex           | 5.77° | Applying →   |
 | Mars                  | opposition ☍     | Zeus                  | 4.84° | Applying →   |
 | Mars                  | opposition ☍     | Apollon               | 1.42° | Applying →   |
-| Mars                  | trine △          | Vulkanus              | 5.06° | Applying →   |
+| Mars                  | trine △          | Vulkanus              | 5.07° | Applying →   |
 | Jupiter               | square □         | Saturn                | 3.35° | Applying →   |
 | Jupiter               | trine △          | Uranus                | 1.14° | Applying →   |
 | Jupiter               | semi-square ∠    | Pluto                 | 1.22° | Applying →   |
@@ -367,7 +367,7 @@ Ancient Rome Subject — Natal Chart Report
 | Uranus                | semi-square ∠    | Pars Fidei            | 0.48° | Separating ← |
 | Uranus                | trine △          | True Priapus          | 4.63° | Separating ← |
 | Uranus                | square □         | Interpolated Perigee  | 4.32° | Applying →   |
-| Uranus                | quintile Q       | Cupido                | 0.34° | Applying →   |
+| Uranus                | quintile Q       | Cupido                | 0.33° | Applying →   |
 | Neptune               | trine △          | True South Lunar Node | 5.07° | Separating ← |
 | Neptune               | square □         | True Lilith           | 1.12° | Separating ← |
 | Neptune               | opposition ☍     | Pholus                | 0.89° | Separating ← |
@@ -380,8 +380,8 @@ Ancient Rome Subject — Natal Chart Report
 | Neptune               | square □         | Interpolated Lilith   | 3.87° | Applying →   |
 | Neptune               | square □         | True Priapus          | 1.12° | Separating ← |
 | Neptune               | sextile ⚹        | Interpolated Perigee  | 0.81° | Applying →   |
-| Neptune               | conjunction ☌    | White Moon            | 3.60° | Applying →   |
-| Neptune               | semi-square ∠    | Cupido                | 0.17° | Separating ← |
+| Neptune               | conjunction ☌    | White Moon            | 3.59° | Applying →   |
+| Neptune               | semi-square ∠    | Cupido                | 0.18° | Separating ← |
 | Neptune               | quintile Q       | Vulkanus              | 1.61° | Applying →   |
 | Neptune               | quintile Q       | Poseidon              | 1.68° | Applying →   |
 | Pluto                 | sextile ⚹        | Chiron                | 1.18° | Applying →   |
@@ -398,7 +398,7 @@ Ancient Rome Subject — Natal Chart Report
 | Pluto                 | quintile Q       | Pars Amoris           | 0.88° | Applying →   |
 | Pluto                 | trine △          | Pars Fidei            | 0.40° | Applying →   |
 | Pluto                 | opposition ☍     | Mean Priapus          | 4.66° | Separating ← |
-| Pluto                 | semi-sextile ⚺   | Hades                 | 0.40° | Applying →   |
+| Pluto                 | semi-sextile ⚺   | Hades                 | 0.41° | Applying →   |
 | Mean North Lunar Node | sesquiquadrate ⚼ | Ascendant             | 0.60° | Separating ← |
 | Mean North Lunar Node | semi-square ∠    | Descendant            | 0.60° | Separating ← |
 | Mean North Lunar Node | trine △          | Pholus                | 5.84° | Applying →   |
@@ -410,7 +410,7 @@ Ancient Rome Subject — Natal Chart Report
 | Mean North Lunar Node | square □         | Pars Amoris           | 5.27° | Applying →   |
 | Mean North Lunar Node | biquintile bQ    | Anti Vertex           | 1.65° | Applying →   |
 | Mean North Lunar Node | quintile Q       | White Moon            | 1.67° | Separating ← |
-| Mean North Lunar Node | sextile ⚹        | Zeus                  | 3.42° | Separating ← |
+| Mean North Lunar Node | sextile ⚹        | Zeus                  | 3.43° | Separating ← |
 | Mean North Lunar Node | sextile ⚹        | Apollon               | 0.01° | Separating ← |
 | Mean North Lunar Node | sesquiquadrate ⚼ | Admetos               | 1.33° | Separating ← |
 | Mean North Lunar Node | conjunction ☌    | Vulkanus              | 3.65° | Separating ← |
@@ -443,9 +443,9 @@ Ancient Rome Subject — Natal Chart Report
 | Chiron                | sesquiquadrate ⚼ | Pars Amoris           | 0.94° | Separating ← |
 | Chiron                | opposition ☍     | Pars Fidei            | 1.58° | Applying →   |
 | Chiron                | trine △          | Mean Priapus          | 5.84° | Separating ← |
-| Chiron                | semi-sextile ⚺   | Hades                 | 0.78° | Applying →   |
+| Chiron                | semi-sextile ⚺   | Hades                 | 0.77° | Applying →   |
 | Chiron                | square □         | Kronos                | 2.18° | Separating ← |
-| Chiron                | square □         | Admetos               | 5.66° | Applying →   |
+| Chiron                | square □         | Admetos               | 5.67° | Applying →   |
 | Chiron                | square □         | Poseidon              | 1.09° | Separating ← |
 | Ascendant             | semi-sextile ⚺   | Mean Lilith           | 0.91° | Applying →   |
 | Ascendant             | semi-square ∠    | Mean South Lunar Node | 0.60° | Separating ← |
@@ -457,7 +457,7 @@ Ancient Rome Subject — Natal Chart Report
 | Ascendant             | square □         | Pars Fidei            | 3.35° | Separating ← |
 | Ascendant             | quincunx ⚻       | Mean Priapus          | 0.91° | Applying →   |
 | Ascendant             | sextile ⚹        | White Moon            | 4.07° | Applying →   |
-| Ascendant             | sextile ⚹        | Hades                 | 4.15° | Separating ← |
+| Ascendant             | sextile ⚹        | Hades                 | 4.16° | Separating ← |
 | Ascendant             | conjunction ☌    | Admetos               | 0.74° | Applying →   |
 | Medium Coeli          | quintile Q       | Mean Lilith           | 1.83° | Separating ← |
 | Medium Coeli          | semi-square ∠    | Pallas                | 0.99° | Separating ← |
@@ -470,7 +470,7 @@ Ancient Rome Subject — Natal Chart Report
 | Medium Coeli          | square □         | Anti Vertex           | 1.99° | Separating ← |
 | Medium Coeli          | quintile Q       | Interpolated Lilith   | 1.05° | Applying →   |
 | Medium Coeli          | sesquiquadrate ⚼ | Interpolated Perigee  | 1.11° | Applying →   |
-| Medium Coeli          | opposition ☍     | Zeus                  | 2.92° | Separating ← |
+| Medium Coeli          | opposition ☍     | Zeus                  | 2.91° | Separating ← |
 | Medium Coeli          | square □         | Kronos                | 2.15° | Applying →   |
 | Medium Coeli          | trine △          | Vulkanus              | 2.69° | Separating ← |
 | Medium Coeli          | square □         | Poseidon              | 3.24° | Applying →   |
@@ -484,7 +484,7 @@ Ancient Rome Subject — Natal Chart Report
 | Descendant            | square □         | Pars Fidei            | 3.35° | Separating ← |
 | Descendant            | semi-sextile ⚺   | Mean Priapus          | 0.91° | Applying →   |
 | Descendant            | trine △          | White Moon            | 4.07° | Applying →   |
-| Descendant            | trine △          | Hades                 | 4.15° | Separating ← |
+| Descendant            | trine △          | Hades                 | 4.16° | Separating ← |
 | Descendant            | opposition ☍     | Admetos               | 0.74° | Applying →   |
 | Imum Coeli            | sesquiquadrate ⚼ | Pallas                | 0.99° | Separating ← |
 | Imum Coeli            | trine △          | Juno                  | 1.74° | Applying →   |
@@ -496,7 +496,7 @@ Ancient Rome Subject — Natal Chart Report
 | Imum Coeli            | quintile Q       | Mean Priapus          | 1.83° | Separating ← |
 | Imum Coeli            | semi-square ∠    | Interpolated Perigee  | 1.11° | Applying →   |
 | Imum Coeli            | biquintile bQ    | Hades                 | 0.90° | Separating ← |
-| Imum Coeli            | conjunction ☌    | Zeus                  | 2.92° | Separating ← |
+| Imum Coeli            | conjunction ☌    | Zeus                  | 2.91° | Separating ← |
 | Imum Coeli            | square □         | Kronos                | 2.15° | Applying →   |
 | Imum Coeli            | sextile ⚹        | Vulkanus              | 2.69° | Separating ← |
 | Imum Coeli            | square □         | Poseidon              | 3.24° | Applying →   |
@@ -516,7 +516,7 @@ Ancient Rome Subject — Natal Chart Report
 | Mean South Lunar Node | conjunction ☌    | Pars Spiritus         | 0.98° | Applying →   |
 | Mean South Lunar Node | square □         | Pars Amoris           | 5.27° | Applying →   |
 | Mean South Lunar Node | biquintile bQ    | Vertex                | 1.65° | Applying →   |
-| Mean South Lunar Node | trine △          | Zeus                  | 3.42° | Separating ← |
+| Mean South Lunar Node | trine △          | Zeus                  | 3.43° | Separating ← |
 | Mean South Lunar Node | trine △          | Apollon               | 0.01° | Separating ← |
 | Mean South Lunar Node | semi-square ∠    | Admetos               | 1.33° | Separating ← |
 | Mean South Lunar Node | opposition ☍     | Vulkanus              | 3.65° | Separating ← |
@@ -532,7 +532,7 @@ Ancient Rome Subject — Natal Chart Report
 | True South Lunar Node | sesquiquadrate ⚼ | Pars Fidei            | 1.08° | Applying →   |
 | True South Lunar Node | biquintile bQ    | Vertex                | 0.02° | Separating ← |
 | True South Lunar Node | opposition ☍     | Interpolated Perigee  | 5.87° | Applying →   |
-| True South Lunar Node | trine △          | Zeus                  | 5.09° | Applying →   |
+| True South Lunar Node | trine △          | Zeus                  | 5.10° | Applying →   |
 | True South Lunar Node | trine △          | Apollon               | 1.68° | Applying →   |
 | True South Lunar Node | opposition ☍     | Vulkanus              | 5.32° | Separating ← |
 | True Lilith           | square □         | Pholus                | 2.01° | Separating ← |
@@ -545,7 +545,7 @@ Ancient Rome Subject — Natal Chart Report
 | True Lilith           | opposition ☍     | Mean Priapus          | 5.63° | Applying →   |
 | True Lilith           | quincunx ⚻       | Interpolated Perigee  | 0.31° | Separating ← |
 | True Lilith           | square □         | White Moon            | 2.47° | Applying →   |
-| True Lilith           | sesquiquadrate ⚼ | Cupido                | 1.29° | Separating ← |
+| True Lilith           | sesquiquadrate ⚼ | Cupido                | 1.30° | Separating ← |
 | Pholus                | sextile ⚹        | Ceres                 | 2.83° | Separating ← |
 | Pholus                | semi-square ∠    | Juno                  | 1.07° | Applying →   |
 | Pholus                | sextile ⚹        | Vesta                 | 1.60° | Separating ← |
@@ -555,9 +555,9 @@ Ancient Rome Subject — Natal Chart Report
 | Pholus                | square □         | Interpolated Lilith   | 4.76° | Applying →   |
 | Pholus                | square □         | True Priapus          | 2.01° | Separating ← |
 | Pholus                | trine △          | Interpolated Perigee  | 1.70° | Applying →   |
-| Pholus                | opposition ☍     | White Moon            | 4.49° | Applying →   |
+| Pholus                | opposition ☍     | White Moon            | 4.48° | Applying →   |
 | Pholus                | sesquiquadrate ⚼ | Cupido                | 0.72° | Separating ← |
-| Pholus                | opposition ☍     | Apollon               | 5.85° | Applying →   |
+| Pholus                | opposition ☍     | Apollon               | 5.86° | Applying →   |
 | Ceres                 | trine △          | Vesta                 | 1.23° | Applying →   |
 | Ceres                 | sextile ⚹        | Sedna                 | 2.37° | Applying →   |
 | Ceres                 | sesquiquadrate ⚼ | Quaoar                | 0.54° | Applying →   |
@@ -565,7 +565,7 @@ Ancient Rome Subject — Natal Chart Report
 | Ceres                 | trine △          | Pars Spiritus         | 2.03° | Applying →   |
 | Ceres                 | biquintile bQ    | Interpolated Lilith   | 1.59° | Separating ← |
 | Ceres                 | sextile ⚹        | Interpolated Perigee  | 4.53° | Separating ← |
-| Ceres                 | trine △          | Apollon               | 3.02° | Applying →   |
+| Ceres                 | trine △          | Apollon               | 3.03° | Applying →   |
 | Pallas                | square □         | Vesta                 | 5.40° | Separating ← |
 | Pallas                | biquintile bQ    | Ixion                 | 1.66° | Separating ← |
 | Pallas                | semi-square ∠    | Orcus                 | 0.45° | Applying →   |
@@ -576,7 +576,7 @@ Ancient Rome Subject — Natal Chart Report
 | Pallas                | sextile ⚹        | Mean Priapus          | 3.85° | Separating ← |
 | Pallas                | sextile ⚹        | True Priapus          | 1.79° | Applying →   |
 | Pallas                | square □         | Interpolated Perigee  | 2.10° | Applying →   |
-| Pallas                | quincunx ⚻       | White Moon            | 0.69° | Separating ← |
+| Pallas                | quincunx ⚻       | White Moon            | 0.68° | Separating ← |
 | Pallas                | sesquiquadrate ⚼ | Zeus                  | 1.93° | Separating ← |
 | Pallas                | biquintile bQ    | Admetos               | 1.98° | Applying →   |
 | Juno                  | semi-sextile ⚺   | Eris                  | 1.82° | Applying →   |
@@ -584,9 +584,9 @@ Ancient Rome Subject — Natal Chart Report
 | Juno                  | trine △          | Quaoar                | 4.44° | Applying →   |
 | Juno                  | trine △          | Pars Fidei            | 4.17° | Applying →   |
 | Juno                  | semi-square ∠    | True Priapus          | 0.94° | Separating ← |
-| Juno                  | square □         | Cupido                | 0.35° | Applying →   |
+| Juno                  | square □         | Cupido                | 0.36° | Applying →   |
 | Juno                  | square □         | Hades                 | 3.36° | Applying →   |
-| Juno                  | trine △          | Zeus                  | 4.66° | Separating ← |
+| Juno                  | trine △          | Zeus                  | 4.65° | Separating ← |
 | Juno                  | semi-sextile ⚺   | Kronos                | 0.41° | Applying →   |
 | Juno                  | sextile ⚹        | Vulkanus              | 4.43° | Separating ← |
 | Juno                  | quincunx ⚻       | Poseidon              | 1.50° | Applying →   |
@@ -596,7 +596,7 @@ Ancient Rome Subject — Natal Chart Report
 | Vesta                 | square □         | Pars Amoris           | 1.02° | Separating ← |
 | Vesta                 | sesquiquadrate ⚼ | Pars Fidei            | 1.50° | Applying →   |
 | Vesta                 | opposition ☍     | Interpolated Perigee  | 3.30° | Separating ← |
-| Vesta                 | trine △          | Apollon               | 4.25° | Applying →   |
+| Vesta                 | trine △          | Apollon               | 4.26° | Applying →   |
 | Vesta                 | semi-square ∠    | Poseidon              | 1.17° | Separating ← |
 | Eris                  | conjunction ☌    | Haumea                | 3.85° | Applying →   |
 | Eris                  | opposition ☍     | Makemake              | 0.08° | Separating ← |
@@ -604,8 +604,8 @@ Ancient Rome Subject — Natal Chart Report
 | Eris                  | sextile ⚹        | Orcus                 | 4.10° | Separating ← |
 | Eris                  | square □         | Quaoar                | 2.63° | Applying →   |
 | Eris                  | trine △          | Anti Vertex           | 5.55° | Separating ← |
-| Eris                  | trine △          | Cupido                | 1.47° | Separating ← |
-| Eris                  | sextile ⚹        | Hades                 | 1.55° | Applying →   |
+| Eris                  | trine △          | Cupido                | 1.46° | Separating ← |
+| Eris                  | sextile ⚹        | Hades                 | 1.54° | Applying →   |
 | Eris                  | sextile ⚹        | Kronos                | 1.41° | Separating ← |
 | Eris                  | trine △          | Poseidon              | 0.32° | Separating ← |
 | Sedna                 | quintile Q       | Quaoar                | 1.17° | Separating ← |
@@ -615,7 +615,7 @@ Ancient Rome Subject — Natal Chart Report
 | Sedna                 | square □         | Anti Vertex           | 5.00° | Applying →   |
 | Sedna                 | opposition ☍     | Zeus                  | 4.07° | Applying →   |
 | Sedna                 | opposition ☍     | Apollon               | 0.65° | Applying →   |
-| Sedna                 | trine △          | Vulkanus              | 4.29° | Applying →   |
+| Sedna                 | trine △          | Vulkanus              | 4.30° | Applying →   |
 | Haumea                | opposition ☍     | Makemake              | 3.77° | Applying →   |
 | Haumea                | sextile ⚹        | Orcus                 | 0.25° | Separating ← |
 | Haumea                | opposition ☍     | Pars Fortunae         | 3.88° | Separating ← |
@@ -623,7 +623,7 @@ Ancient Rome Subject — Natal Chart Report
 | Haumea                | sextile ⚹        | Vertex                | 1.70° | Separating ← |
 | Haumea                | trine △          | Anti Vertex           | 1.70° | Separating ← |
 | Haumea                | quintile Q       | True Priapus          | 1.91° | Separating ← |
-| Haumea                | trine △          | Cupido                | 2.38° | Applying →   |
+| Haumea                | trine △          | Cupido                | 2.39° | Applying →   |
 | Haumea                | sextile ⚹        | Kronos                | 2.44° | Applying →   |
 | Haumea                | square □         | Vulkanus              | 2.40° | Separating ← |
 | Haumea                | trine △          | Poseidon              | 3.53° | Applying →   |
@@ -632,15 +632,15 @@ Ancient Rome Subject — Natal Chart Report
 | Makemake              | square □         | Quaoar                | 2.71° | Separating ← |
 | Makemake              | trine △          | Vertex                | 5.47° | Applying →   |
 | Makemake              | quintile Q       | Interpolated Perigee  | 0.64° | Separating ← |
-| Makemake              | sextile ⚹        | Cupido                | 1.39° | Static =     |
-| Makemake              | trine △          | Hades                 | 1.63° | Separating ← |
+| Makemake              | sextile ⚹        | Cupido                | 1.38° | Static =     |
+| Makemake              | trine △          | Hades                 | 1.62° | Separating ← |
 | Makemake              | trine △          | Kronos                | 1.33° | Applying →   |
 | Makemake              | sextile ⚹        | Poseidon              | 0.24° | Applying →   |
 | Ixion                 | semi-sextile ⚺   | Quaoar                | 0.16° | Applying →   |
 | Ixion                 | semi-square ∠    | Pars Spiritus         | 1.33° | Applying →   |
 | Ixion                 | square □         | Pars Fidei            | 0.44° | Separating ← |
-| Ixion                 | trine △          | Cupido                | 4.26° | Separating ← |
-| Ixion                 | sextile ⚹        | Hades                 | 1.24° | Applying →   |
+| Ixion                 | trine △          | Cupido                | 4.25° | Separating ← |
+| Ixion                 | sextile ⚹        | Hades                 | 1.25° | Applying →   |
 | Ixion                 | opposition ☍     | Kronos                | 4.20° | Separating ← |
 | Ixion                 | conjunction ☌    | Admetos               | 3.64° | Applying →   |
 | Ixion                 | conjunction ☌    | Poseidon              | 3.11° | Separating ← |
@@ -651,26 +651,26 @@ Ancient Rome Subject — Natal Chart Report
 | Orcus                 | semi-square ∠    | Interpolated Perigee  | 1.65° | Separating ← |
 | Orcus                 | sextile ⚹        | Cupido                | 2.63° | Applying →   |
 | Orcus                 | trine △          | Hades                 | 5.64° | Separating ← |
-| Orcus                 | square □         | Zeus                  | 2.38° | Separating ← |
+| Orcus                 | square □         | Zeus                  | 2.37° | Separating ← |
 | Orcus                 | conjunction ☌    | Kronos                | 2.69° | Static =     |
-| Orcus                 | square □         | Apollon               | 5.80° | Separating ← |
+| Orcus                 | square □         | Apollon               | 5.79° | Separating ← |
 | Orcus                 | opposition ☍     | Poseidon              | 3.78° | Applying →   |
 | Quaoar                | quintile Q       | Pars Amoris           | 0.20° | Applying →   |
 | Quaoar                | trine △          | Pars Fidei            | 0.28° | Separating ← |
 | Quaoar                | opposition ☍     | Mean Priapus          | 3.98° | Separating ← |
 | Quaoar                | biquintile bQ    | Cupido                | 1.91° | Applying →   |
-| Quaoar                | semi-sextile ⚺   | Hades                 | 1.08° | Applying →   |
+| Quaoar                | semi-sextile ⚺   | Hades                 | 1.09° | Applying →   |
 | Pars Fortunae         | square □         | Pars Spiritus         | 3.16° | Static =     |
 | Pars Fortunae         | trine △          | Vertex                | 2.18° | Static =     |
 | Pars Fortunae         | sextile ⚹        | Anti Vertex           | 2.18° | Static =     |
 | Pars Fortunae         | quintile Q       | Interpolated Lilith   | 0.78° | Applying →   |
 | Pars Fortunae         | semi-sextile ⚺   | Zeus                  | 1.25° | Applying →   |
 | Pars Fortunae         | semi-square ∠    | Admetos               | 0.84° | Static =     |
-| Pars Fortunae         | square □         | Vulkanus              | 1.47° | Applying →   |
+| Pars Fortunae         | square □         | Vulkanus              | 1.48° | Applying →   |
 | Pars Spiritus         | square □         | Pars Amoris           | 4.29° | Static =     |
 | Pars Spiritus         | sesquiquadrate ⚼ | Pars Fidei            | 1.77° | Static =     |
 | Pars Spiritus         | biquintile bQ    | Vertex                | 0.67° | Static =     |
-| Pars Spiritus         | trine △          | Zeus                  | 4.40° | Applying →   |
+| Pars Spiritus         | trine △          | Zeus                  | 4.41° | Applying →   |
 | Pars Spiritus         | trine △          | Apollon               | 0.99° | Applying →   |
 | Pars Spiritus         | opposition ☍     | Vulkanus              | 4.63° | Applying →   |
 | Pars Amoris           | trine △          | True Priapus          | 2.59° | Separating ← |
@@ -679,49 +679,49 @@ Ancient Rome Subject — Natal Chart Report
 | Pars Amoris           | sesquiquadrate ⚼ | Kronos                | 1.23° | Applying →   |
 | Pars Amoris           | semi-square ∠    | Poseidon              | 0.15° | Static =     |
 | Pars Fidei            | sextile ⚹        | Mean Priapus          | 4.26° | Separating ← |
-| Pars Fidei            | quincunx ⚻       | Hades                 | 0.80° | Applying →   |
+| Pars Fidei            | quincunx ⚻       | Hades                 | 0.81° | Applying →   |
 | Pars Fidei            | square □         | Kronos                | 3.76° | Applying →   |
 | Pars Fidei            | square □         | Admetos               | 4.08° | Static =     |
 | Pars Fidei            | square □         | Poseidon              | 2.67° | Static =     |
-| Vertex                | sextile ⚹        | Cupido                | 4.08° | Applying →   |
-| Vertex                | square □         | Zeus                  | 0.93° | Separating ← |
+| Vertex                | sextile ⚹        | Cupido                | 4.09° | Applying →   |
+| Vertex                | square □         | Zeus                  | 0.92° | Separating ← |
 | Vertex                | conjunction ☌    | Kronos                | 4.14° | Separating ← |
-| Vertex                | square □         | Apollon               | 4.35° | Separating ← |
+| Vertex                | square □         | Apollon               | 4.34° | Separating ← |
 | Vertex                | semi-sextile ⚺   | Vulkanus              | 0.70° | Separating ← |
 | Vertex                | opposition ☍     | Poseidon              | 5.23° | Static =     |
-| Anti Vertex           | trine △          | Cupido                | 4.08° | Applying →   |
-| Anti Vertex           | square □         | Zeus                  | 0.93° | Separating ← |
+| Anti Vertex           | trine △          | Cupido                | 4.09° | Applying →   |
+| Anti Vertex           | square □         | Zeus                  | 0.92° | Separating ← |
 | Anti Vertex           | opposition ☍     | Kronos                | 4.14° | Separating ← |
-| Anti Vertex           | square □         | Apollon               | 4.35° | Separating ← |
+| Anti Vertex           | square □         | Apollon               | 4.34° | Separating ← |
 | Anti Vertex           | quincunx ⚻       | Vulkanus              | 0.70° | Separating ← |
 | Anti Vertex           | conjunction ☌    | Poseidon              | 5.23° | Static =     |
 | Interpolated Lilith   | opposition ☍     | Mean Priapus          | 2.89° | Separating ← |
 | Interpolated Lilith   | opposition ☍     | True Priapus          | 2.75° | Applying →   |
-| Interpolated Lilith   | square □         | White Moon            | 0.27° | Applying →   |
+| Interpolated Lilith   | square □         | White Moon            | 0.28° | Applying →   |
 | Mean Priapus          | conjunction ☌    | True Priapus          | 5.63° | Applying →   |
 | Mean Priapus          | square □         | White Moon            | 3.16° | Separating ← |
-| Mean Priapus          | biquintile bQ    | Hades                 | 0.94° | Applying →   |
-| Mean Priapus          | quintile Q       | Zeus                  | 1.09° | Separating ← |
+| Mean Priapus          | biquintile bQ    | Hades                 | 0.93° | Applying →   |
+| Mean Priapus          | quintile Q       | Zeus                  | 1.08° | Separating ← |
 | Mean Priapus          | quincunx ⚻       | Admetos               | 0.18° | Separating ← |
 | True Priapus          | semi-sextile ⚺   | Interpolated Perigee  | 0.31° | Separating ← |
 | True Priapus          | square □         | White Moon            | 2.47° | Applying →   |
-| True Priapus          | semi-square ∠    | Cupido                | 1.29° | Separating ← |
-| Interpolated Perigee  | sextile ⚹        | White Moon            | 2.79° | Applying →   |
+| True Priapus          | semi-square ∠    | Cupido                | 1.30° | Separating ← |
+| Interpolated Perigee  | sextile ⚹        | White Moon            | 2.78° | Applying →   |
 | Interpolated Perigee  | semi-square ∠    | Kronos                | 1.04° | Applying →   |
-| White Moon            | sextile ⚹        | Admetos               | 3.33° | Separating ← |
+| White Moon            | sextile ⚹        | Admetos               | 3.34° | Separating ← |
 | White Moon            | quintile Q       | Vulkanus              | 1.98° | Applying →   |
 | White Moon            | quintile Q       | Poseidon              | 1.91° | Applying →   |
-| Cupido                | opposition ☍     | Hades                 | 3.01° | Separating ← |
-| Cupido                | sextile ⚹        | Kronos                | 0.06° | Separating ← |
-| Cupido                | trine △          | Poseidon              | 1.15° | Separating ← |
+| Cupido                | opposition ☍     | Hades                 | 3.00° | Separating ← |
+| Cupido                | sextile ⚹        | Kronos                | 0.05° | Separating ← |
+| Cupido                | trine △          | Poseidon              | 1.14° | Separating ← |
 | Hades                 | trine △          | Kronos                | 2.95° | Separating ← |
 | Hades                 | sextile ⚹        | Admetos               | 4.89° | Applying →   |
-| Hades                 | sextile ⚹        | Poseidon              | 1.87° | Separating ← |
-| Zeus                  | square □         | Kronos                | 5.07° | Separating ← |
+| Hades                 | sextile ⚹        | Poseidon              | 1.86° | Separating ← |
+| Zeus                  | square □         | Kronos                | 5.06° | Separating ← |
 | Zeus                  | conjunction ☌    | Apollon               | 3.42° | Applying →   |
-| Zeus                  | sextile ⚹        | Vulkanus              | 0.23° | Separating ← |
+| Zeus                  | sextile ⚹        | Vulkanus              | 0.22° | Separating ← |
 | Kronos                | opposition ☍     | Poseidon              | 1.09° | Applying →   |
-| Apollon               | quintile Q       | Admetos               | 1.67° | Applying →   |
+| Apollon               | quintile Q       | Admetos               | 1.68° | Applying →   |
 | Apollon               | sextile ⚹        | Vulkanus              | 3.64° | Separating ← |
 | Vulkanus              | biquintile bQ    | Poseidon              | 0.07° | Applying →   |
 +-----------------------+------------------+-----------------------+-------+--------------+

--- a/tests/fixtures/natal_buenos_aires_all_report.txt
+++ b/tests/fixtures/natal_buenos_aires_all_report.txt
@@ -31,10 +31,10 @@ Buenos Aires Subject — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Vir ♍ | 0.16°    | +515.9977°/d | N/A     | -    | First House    |
-| Medium Coeli          | Gem ♊ | 11.77°   | +337.2825°/d | N/A     | -    | Tenth House    |
-| Descendant            | Pis ♓ | 0.16°    | +515.9977°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Sag ♐ | 11.77°   | +337.2825°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Vir ♍ | 0.16°    | +516.0005°/d | N/A     | -    | First House    |
+| Medium Coeli          | Gem ♊ | 11.77°   | +337.2843°/d | N/A     | -    | Tenth House    |
+| Descendant            | Pis ♓ | 0.16°    | +516.0005°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Sag ♐ | 11.77°   | +337.2843°/d | N/A     | -    | Fourth House   |
 | Sun                   | Gem ♊ | 24.25°   | +0.9551°/d   | +23.32° | -    | Tenth House    |
 | Moon                  | Pis ♓ | 17.03°   | +13.4067°/d  | -2.13°  | -    | Seventh House  |
 | Mercury               | Gem ♊ | 5.91°    | +1.7217°/d   | +19.68° | -    | Ninth House    |
@@ -57,12 +57,12 @@ Buenos Aires Subject — Natal Chart Report
 | Vesta                 | Tau ♉ | 4.86°    | +0.4035°/d   | +7.62°  | -    | Eighth House   |
 | Interpolated Lilith   | Sco ♏ | 20.65°   | +0.0782°/d   | -22.78° | -    | Third House    |
 | Interpolated Perigee  | Gem ♊ | 8.49°    | +0.4458°/d   | +26.13° | -    | Ninth House    |
-| Cupido                | Sco ♏ | 18.99°   | -0.0160°/d   | -16.43° | R    | Third House    |
+| Cupido                | Sco ♏ | 19.00°   | -0.0160°/d   | -16.43° | R    | Third House    |
 | Hades                 | Gem ♊ | 9.26°    | +0.0209°/d   | +20.84° | -    | Ninth House    |
-| Zeus                  | Vir ♍ | 25.80°   | +0.0016°/d   | +1.67°  | -    | First House    |
-| Kronos                | Gem ♊ | 21.34°   | +0.0166°/d   | +23.17° | -    | Tenth House    |
-| Apollon               | Lib ♎ | 13.78°   | -0.0030°/d   | -5.44°  | R    | First House    |
-| Admetos               | Tau ♉ | 14.65°   | +0.0117°/d   | +16.24° | -    | Eighth House   |
+| Zeus                  | Vir ♍ | 25.80°   | +0.0015°/d   | +1.67°  | -    | First House    |
+| Kronos                | Gem ♊ | 21.33°   | +0.0166°/d   | +23.17° | -    | Tenth House    |
+| Apollon               | Lib ♎ | 13.79°   | -0.0031°/d   | -5.44°  | R    | First House    |
+| Admetos               | Tau ♉ | 14.64°   | +0.0117°/d   | +16.24° | -    | Eighth House   |
 | Vulkanus              | Can ♋ | 14.85°   | +0.0130°/d   | +22.63° | -    | Eleventh House |
 | Poseidon              | Lib ♎ | 28.76°   | -0.0054°/d   | -11.04° | R    | Second House   |
 | Eris                  | Ari ♈ | 17.53°   | +0.0049°/d   | -9.10°  | -    | Eighth House   |
@@ -233,9 +233,9 @@ Buenos Aires Subject — Natal Chart Report
 | Sun                   | semi-sextile ⚺   | Mean Priapus          | 0.72° | Applying →   |
 | Sun                   | conjunction ☌    | True Priapus          | 5.10° | Separating ← |
 | Sun                   | semi-sextile ⚺   | White Moon            | 2.88° | Separating ← |
-| Sun                   | biquintile bQ    | Cupido                | 0.74° | Applying →   |
+| Sun                   | biquintile bQ    | Cupido                | 0.75° | Applying →   |
 | Sun                   | square □         | Zeus                  | 1.55° | Applying →   |
-| Sun                   | conjunction ☌    | Kronos                | 2.91° | Separating ← |
+| Sun                   | conjunction ☌    | Kronos                | 2.92° | Separating ← |
 | Sun                   | trine △          | Poseidon              | 4.51° | Applying →   |
 | Moon                  | sextile ⚹        | Venus                 | 1.89° | Applying →   |
 | Moon                  | trine △          | Jupiter               | 1.11° | Separating ← |
@@ -262,10 +262,10 @@ Buenos Aires Subject — Natal Chart Report
 | Moon                  | trine △          | Interpolated Lilith   | 3.62° | Applying →   |
 | Moon                  | square □         | True Priapus          | 2.12° | Applying →   |
 | Moon                  | trine △          | White Moon            | 4.34° | Applying →   |
-| Moon                  | trine △          | Cupido                | 1.96° | Applying →   |
-| Moon                  | square □         | Kronos                | 4.31° | Applying →   |
-| Moon                  | quincunx ⚻       | Apollon               | 3.25° | Separating ← |
-| Moon                  | sextile ⚹        | Admetos               | 2.38° | Separating ← |
+| Moon                  | trine △          | Cupido                | 1.97° | Applying →   |
+| Moon                  | square □         | Kronos                | 4.30° | Applying →   |
+| Moon                  | quincunx ⚻       | Apollon               | 3.24° | Separating ← |
+| Moon                  | sextile ⚹        | Admetos               | 2.39° | Separating ← |
 | Moon                  | trine △          | Vulkanus              | 2.18° | Separating ← |
 | Moon                  | sesquiquadrate ⚼ | Poseidon              | 3.27° | Separating ← |
 | Mercury               | biquintile bQ    | Neptune               | 1.81° | Applying →   |
@@ -282,8 +282,8 @@ Buenos Aires Subject — Natal Chart Report
 | Mercury               | sextile ⚹        | Orcus                 | 4.18° | Applying →   |
 | Mercury               | opposition ☍     | Pars Spiritus         | 1.47° | Applying →   |
 | Mercury               | conjunction ☌    | Interpolated Perigee  | 2.59° | Applying →   |
-| Mercury               | semi-square ∠    | White Moon            | 0.47° | Applying →   |
-| Mercury               | conjunction ☌    | Hades                 | 3.36° | Applying →   |
+| Mercury               | semi-square ∠    | White Moon            | 0.46° | Applying →   |
+| Mercury               | conjunction ☌    | Hades                 | 3.35° | Applying →   |
 | Mercury               | biquintile bQ    | Poseidon              | 1.15° | Separating ← |
 | Venus                 | sextile ⚹        | Jupiter               | 3.01° | Separating ← |
 | Venus                 | trine △          | Saturn                | 5.10° | Applying →   |
@@ -301,11 +301,11 @@ Buenos Aires Subject — Natal Chart Report
 | Venus                 | trine △          | Anti Vertex           | 2.13° | Separating ← |
 | Venus                 | opposition ☍     | Interpolated Lilith   | 1.73° | Applying →   |
 | Venus                 | semi-sextile ⚺   | True Priapus          | 0.22° | Applying →   |
-| Venus                 | sextile ⚹        | White Moon            | 2.45° | Applying →   |
+| Venus                 | sextile ⚹        | White Moon            | 2.44° | Applying →   |
 | Venus                 | opposition ☍     | Cupido                | 0.07° | Applying →   |
 | Venus                 | biquintile bQ    | Apollon               | 0.86° | Applying →   |
 | Venus                 | conjunction ☌    | Admetos               | 4.28° | Separating ← |
-| Venus                 | sextile ⚹        | Vulkanus              | 4.07° | Separating ← |
+| Venus                 | sextile ⚹        | Vulkanus              | 4.08° | Separating ← |
 | Mars                  | square □         | Jupiter               | 4.79° | Applying →   |
 | Mars                  | square □         | Uranus                | 2.97° | Separating ← |
 | Mars                  | square □         | Neptune               | 2.58° | Applying →   |
@@ -327,10 +327,10 @@ Buenos Aires Subject — Natal Chart Report
 | Mars                  | trine △          | Pars Spiritus         | 3.75° | Separating ← |
 | Mars                  | semi-square ∠    | Mean Priapus          | 1.17° | Separating ← |
 | Mars                  | sextile ⚹        | Interpolated Perigee  | 2.64° | Separating ← |
-| Mars                  | biquintile bQ    | Cupido                | 1.86° | Applying →   |
-| Mars                  | sextile ⚹        | Hades                 | 1.87° | Separating ← |
-| Mars                  | quintile Q       | Kronos                | 1.79° | Separating ← |
-| Mars                  | opposition ☍     | Apollon               | 2.65° | Applying →   |
+| Mars                  | biquintile bQ    | Cupido                | 1.87° | Applying →   |
+| Mars                  | sextile ⚹        | Hades                 | 1.88° | Separating ← |
+| Mars                  | quintile Q       | Kronos                | 1.80° | Separating ← |
+| Mars                  | opposition ☍     | Apollon               | 2.66° | Applying →   |
 | Mars                  | square □         | Vulkanus              | 3.72° | Applying →   |
 | Jupiter               | opposition ☍     | Neptune               | 2.20° | Separating ← |
 | Jupiter               | trine △          | Pluto                 | 0.52° | Separating ← |
@@ -348,11 +348,11 @@ Buenos Aires Subject — Natal Chart Report
 | Jupiter               | trine △          | Vertex                | 0.88° | Applying →   |
 | Jupiter               | sextile ⚹        | Anti Vertex           | 0.88° | Applying →   |
 | Jupiter               | trine △          | Interpolated Lilith   | 4.73° | Applying →   |
-| Jupiter               | conjunction ☌    | White Moon            | 5.46° | Applying →   |
+| Jupiter               | conjunction ☌    | White Moon            | 5.45° | Applying →   |
 | Jupiter               | trine △          | Cupido                | 3.08° | Applying →   |
 | Jupiter               | square □         | Apollon               | 2.13° | Separating ← |
 | Jupiter               | sextile ⚹        | Admetos               | 1.27° | Separating ← |
-| Jupiter               | conjunction ☌    | Vulkanus              | 1.06° | Separating ← |
+| Jupiter               | conjunction ☌    | Vulkanus              | 1.07° | Separating ← |
 | Saturn                | biquintile bQ    | Ascendant             | 0.14° | Separating ← |
 | Saturn                | sextile ⚹        | Mean Lilith           | 0.94° | Separating ← |
 | Saturn                | opposition ☍     | Ceres                 | 3.91° | Separating ← |
@@ -369,10 +369,10 @@ Buenos Aires Subject — Natal Chart Report
 | Saturn                | trine △          | Mean Priapus          | 0.94° | Separating ← |
 | Saturn                | biquintile bQ    | True Priapus          | 1.12° | Separating ← |
 | Saturn                | sesquiquadrate ⚼ | Interpolated Perigee  | 0.53° | Applying →   |
-| Saturn                | opposition ☍     | White Moon            | 2.65° | Applying →   |
-| Saturn                | sesquiquadrate ⚼ | Hades                 | 0.24° | Separating ← |
+| Saturn                | opposition ☍     | White Moon            | 2.66° | Applying →   |
+| Saturn                | sesquiquadrate ⚼ | Hades                 | 0.23° | Separating ← |
 | Saturn                | trine △          | Zeus                  | 1.78° | Separating ← |
-| Saturn                | square □         | Poseidon              | 4.73° | Separating ← |
+| Saturn                | square □         | Poseidon              | 4.74° | Separating ← |
 | Uranus                | conjunction ☌    | Neptune               | 5.55° | Separating ← |
 | Uranus                | semi-sextile ⚺   | Mean North Lunar Node | 1.53° | Applying →   |
 | Uranus                | semi-sextile ⚺   | True North Lunar Node | 0.04° | Applying →   |
@@ -393,7 +393,7 @@ Buenos Aires Subject — Natal Chart Report
 | Uranus                | sesquiquadrate ⚼ | Mean Priapus          | 1.80° | Separating ← |
 | Uranus                | quincunx ⚻       | Interpolated Perigee  | 0.33° | Separating ← |
 | Uranus                | quincunx ⚻       | Hades                 | 1.10° | Separating ← |
-| Uranus                | square □         | Apollon               | 5.62° | Separating ← |
+| Uranus                | square □         | Apollon               | 5.63° | Separating ← |
 | Neptune               | sextile ⚹        | Pluto                 | 1.69° | Separating ← |
 | Neptune               | opposition ☍     | Chiron                | 2.36° | Separating ← |
 | Neptune               | sesquiquadrate ⚼ | Ascendant             | 1.45° | Separating ← |
@@ -406,10 +406,10 @@ Buenos Aires Subject — Natal Chart Report
 | Neptune               | sextile ⚹        | Vertex                | 3.08° | Separating ← |
 | Neptune               | trine △          | Anti Vertex           | 3.08° | Separating ← |
 | Neptune               | biquintile bQ    | Interpolated Perigee  | 0.78° | Separating ← |
-| Neptune               | biquintile bQ    | Hades                 | 1.55° | Separating ← |
+| Neptune               | biquintile bQ    | Hades                 | 1.54° | Separating ← |
 | Neptune               | square □         | Apollon               | 0.07° | Separating ← |
 | Neptune               | trine △          | Admetos               | 0.93° | Separating ← |
-| Neptune               | opposition ☍     | Vulkanus              | 1.14° | Separating ← |
+| Neptune               | opposition ☍     | Vulkanus              | 1.13° | Separating ← |
 | Pluto                 | square □         | Mean North Lunar Node | 5.71° | Separating ← |
 | Pluto                 | trine △          | Chiron                | 0.67° | Separating ← |
 | Pluto                 | square □         | Mean South Lunar Node | 5.71° | Separating ← |
@@ -422,10 +422,10 @@ Buenos Aires Subject — Natal Chart Report
 | Pluto                 | sextile ⚹        | Anti Vertex           | 1.40° | Separating ← |
 | Pluto                 | conjunction ☌    | Interpolated Lilith   | 5.25° | Separating ← |
 | Pluto                 | trine △          | White Moon            | 5.97° | Separating ← |
-| Pluto                 | conjunction ☌    | Cupido                | 3.59° | Separating ← |
-| Pluto                 | biquintile bQ    | Kronos                | 0.06° | Applying →   |
+| Pluto                 | conjunction ☌    | Cupido                | 3.60° | Separating ← |
+| Pluto                 | biquintile bQ    | Kronos                | 0.07° | Applying →   |
 | Pluto                 | semi-sextile ⚺   | Apollon               | 1.61° | Applying →   |
-| Pluto                 | opposition ☍     | Admetos               | 0.75° | Applying →   |
+| Pluto                 | opposition ☍     | Admetos               | 0.76° | Applying →   |
 | Pluto                 | trine △          | Vulkanus              | 0.55° | Applying →   |
 | Mean North Lunar Node | trine △          | Medium Coeli          | 2.08° | Separating ← |
 | Mean North Lunar Node | sextile ⚹        | Imum Coeli            | 2.08° | Separating ← |
@@ -438,10 +438,10 @@ Buenos Aires Subject — Natal Chart Report
 | Mean North Lunar Node | sextile ⚹        | Pars Spiritus         | 2.31° | Applying →   |
 | Mean North Lunar Node | biquintile bQ    | Anti Vertex           | 1.11° | Separating ← |
 | Mean North Lunar Node | trine △          | Interpolated Perigee  | 1.20° | Applying →   |
-| Mean North Lunar Node | trine △          | Hades                 | 0.43° | Applying →   |
+| Mean North Lunar Node | trine △          | Hades                 | 0.44° | Applying →   |
 | Mean North Lunar Node | sesquiquadrate ⚼ | Zeus                  | 1.11° | Separating ← |
-| Mean North Lunar Node | trine △          | Apollon               | 4.09° | Separating ← |
-| Mean North Lunar Node | square □         | Admetos               | 4.96° | Separating ← |
+| Mean North Lunar Node | trine △          | Apollon               | 4.10° | Separating ← |
+| Mean North Lunar Node | square □         | Admetos               | 4.95° | Separating ← |
 | True North Lunar Node | trine △          | Medium Coeli          | 3.65° | Separating ← |
 | True North Lunar Node | sextile ⚹        | Imum Coeli            | 3.65° | Separating ← |
 | True North Lunar Node | quintile Q       | Mean Lilith           | 1.16° | Applying →   |
@@ -453,8 +453,8 @@ Buenos Aires Subject — Natal Chart Report
 | True North Lunar Node | quintile Q       | Quaoar                | 1.63° | Separating ← |
 | True North Lunar Node | sextile ⚹        | Pars Spiritus         | 0.74° | Separating ← |
 | True North Lunar Node | trine △          | Interpolated Perigee  | 0.37° | Separating ← |
-| True North Lunar Node | trine △          | Hades                 | 1.14° | Separating ← |
-| True North Lunar Node | sesquiquadrate ⚼ | Kronos                | 1.78° | Applying →   |
+| True North Lunar Node | trine △          | Hades                 | 1.13° | Separating ← |
+| True North Lunar Node | sesquiquadrate ⚼ | Kronos                | 1.79° | Applying →   |
 | True North Lunar Node | trine △          | Apollon               | 5.66° | Applying →   |
 | Chiron                | semi-square ∠    | Ascendant             | 0.91° | Applying →   |
 | Chiron                | sesquiquadrate ⚼ | Descendant            | 0.91° | Applying →   |
@@ -469,7 +469,7 @@ Buenos Aires Subject — Natal Chart Report
 | Chiron                | sextile ⚹        | Anti Vertex           | 0.72° | Applying →   |
 | Chiron                | trine △          | Interpolated Lilith   | 4.58° | Applying →   |
 | Chiron                | conjunction ☌    | White Moon            | 5.30° | Separating ← |
-| Chiron                | trine △          | Cupido                | 2.92° | Applying →   |
+| Chiron                | trine △          | Cupido                | 2.93° | Applying →   |
 | Chiron                | square □         | Apollon               | 2.29° | Separating ← |
 | Chiron                | sextile ⚹        | Admetos               | 1.43° | Separating ← |
 | Chiron                | conjunction ☌    | Vulkanus              | 1.22° | Separating ← |
@@ -496,8 +496,8 @@ Buenos Aires Subject — Natal Chart Report
 | Medium Coeli          | square □         | Vertex                | 5.03° | Applying →   |
 | Medium Coeli          | square □         | Anti Vertex           | 5.03° | Applying →   |
 | Medium Coeli          | conjunction ☌    | Interpolated Perigee  | 3.28° | Separating ← |
-| Medium Coeli          | conjunction ☌    | Hades                 | 2.51° | Separating ← |
-| Medium Coeli          | trine △          | Apollon               | 2.01° | Applying →   |
+| Medium Coeli          | conjunction ☌    | Hades                 | 2.52° | Separating ← |
+| Medium Coeli          | trine △          | Apollon               | 2.02° | Applying →   |
 | Medium Coeli          | sesquiquadrate ⚼ | Poseidon              | 1.99° | Applying →   |
 | Descendant            | square □         | Mean Lilith           | 5.20° | Separating ← |
 | Descendant            | quintile Q       | True Lilith           | 0.99° | Applying →   |
@@ -526,8 +526,8 @@ Buenos Aires Subject — Natal Chart Report
 | Imum Coeli            | square □         | Vertex                | 5.03° | Applying →   |
 | Imum Coeli            | square □         | Anti Vertex           | 5.03° | Applying →   |
 | Imum Coeli            | opposition ☍     | Interpolated Perigee  | 3.28° | Separating ← |
-| Imum Coeli            | opposition ☍     | Hades                 | 2.51° | Separating ← |
-| Imum Coeli            | sextile ⚹        | Apollon               | 2.01° | Applying →   |
+| Imum Coeli            | opposition ☍     | Hades                 | 2.52° | Separating ← |
+| Imum Coeli            | sextile ⚹        | Apollon               | 2.02° | Applying →   |
 | Imum Coeli            | semi-square ∠    | Poseidon              | 1.99° | Applying →   |
 | Mean Lilith           | trine △          | Ceres                 | 2.97° | Separating ← |
 | Mean Lilith           | biquintile bQ    | Eris                  | 1.44° | Separating ← |
@@ -538,7 +538,7 @@ Buenos Aires Subject — Natal Chart Report
 | Mean Lilith           | trine △          | Pars Amoris           | 0.13° | Separating ← |
 | Mean Lilith           | square □         | Pars Fidei            | 2.91° | Separating ← |
 | Mean Lilith           | conjunction ☌    | Interpolated Lilith   | 4.32° | Separating ← |
-| Mean Lilith           | trine △          | White Moon            | 3.59° | Applying →   |
+| Mean Lilith           | trine △          | White Moon            | 3.60° | Applying →   |
 | Mean Lilith           | conjunction ☌    | Cupido                | 5.97° | Separating ← |
 | Mean Lilith           | sextile ⚹        | Zeus                  | 0.83° | Applying →   |
 | Mean South Lunar Node | square □         | Juno                  | 0.62° | Applying →   |
@@ -549,10 +549,10 @@ Buenos Aires Subject — Natal Chart Report
 | Mean South Lunar Node | trine △          | Pars Spiritus         | 2.31° | Applying →   |
 | Mean South Lunar Node | biquintile bQ    | Vertex                | 1.11° | Separating ← |
 | Mean South Lunar Node | sextile ⚹        | Interpolated Perigee  | 1.20° | Applying →   |
-| Mean South Lunar Node | sextile ⚹        | Hades                 | 0.43° | Applying →   |
+| Mean South Lunar Node | sextile ⚹        | Hades                 | 0.44° | Applying →   |
 | Mean South Lunar Node | semi-square ∠    | Zeus                  | 1.11° | Separating ← |
-| Mean South Lunar Node | sextile ⚹        | Apollon               | 4.09° | Separating ← |
-| Mean South Lunar Node | square □         | Admetos               | 4.96° | Separating ← |
+| Mean South Lunar Node | sextile ⚹        | Apollon               | 4.10° | Separating ← |
+| Mean South Lunar Node | square □         | Admetos               | 4.95° | Separating ← |
 | True South Lunar Node | square □         | Juno                  | 2.19° | Applying →   |
 | True South Lunar Node | square □         | Vesta                 | 3.27° | Applying →   |
 | True South Lunar Node | square □         | Sedna                 | 3.19° | Applying →   |
@@ -560,8 +560,8 @@ Buenos Aires Subject — Natal Chart Report
 | True South Lunar Node | trine △          | Pars Spiritus         | 0.74° | Separating ← |
 | True South Lunar Node | quintile Q       | Mean Priapus          | 1.16° | Applying →   |
 | True South Lunar Node | sextile ⚹        | Interpolated Perigee  | 0.37° | Separating ← |
-| True South Lunar Node | sextile ⚹        | Hades                 | 1.14° | Separating ← |
-| True South Lunar Node | semi-square ∠    | Kronos                | 1.78° | Applying →   |
+| True South Lunar Node | sextile ⚹        | Hades                 | 1.13° | Separating ← |
+| True South Lunar Node | semi-square ∠    | Kronos                | 1.79° | Applying →   |
 | True Lilith           | opposition ☍     | Pallas                | 3.10° | Separating ← |
 | True Lilith           | sesquiquadrate ⚼ | Vesta                 | 0.71° | Applying →   |
 | True Lilith           | trine △          | Eris                  | 1.62° | Separating ← |
@@ -573,12 +573,12 @@ Buenos Aires Subject — Natal Chart Report
 | True Lilith           | semi-sextile ⚺   | Interpolated Lilith   | 1.50° | Applying →   |
 | True Lilith           | semi-sextile ⚺   | Cupido                | 0.15° | Separating ← |
 | True Lilith           | opposition ☍     | Kronos                | 2.19° | Applying →   |
-| True Lilith           | biquintile bQ    | Admetos               | 1.50° | Applying →   |
+| True Lilith           | biquintile bQ    | Admetos               | 1.49° | Applying →   |
 | Pholus                | sextile ⚹        | Vesta                 | 1.78° | Separating ← |
 | Pholus                | sextile ⚹        | Makemake              | 0.86° | Applying →   |
 | Pholus                | quintile Q       | Anti Vertex           | 1.72° | Applying →   |
 | Pholus                | sesquiquadrate ⚼ | Cupido                | 0.92° | Applying →   |
-| Pholus                | trine △          | Poseidon              | 4.32° | Separating ← |
+| Pholus                | trine △          | Poseidon              | 4.31° | Separating ← |
 | Ceres                 | sextile ⚹        | Haumea                | 1.89° | Separating ← |
 | Ceres                 | trine △          | Ixion                 | 4.82° | Separating ← |
 | Ceres                 | trine △          | Quaoar                | 3.43° | Separating ← |
@@ -586,26 +586,26 @@ Buenos Aires Subject — Natal Chart Report
 | Ceres                 | conjunction ☌    | Pars Amoris           | 3.09° | Separating ← |
 | Ceres                 | sextile ⚹        | Mean Priapus          | 2.97° | Separating ← |
 | Ceres                 | sextile ⚹        | Zeus                  | 2.13° | Separating ← |
-| Ceres                 | quintile Q       | Admetos               | 1.28° | Separating ← |
+| Ceres                 | quintile Q       | Admetos               | 1.29° | Separating ← |
 | Ceres                 | square □         | Poseidon              | 0.83° | Applying →   |
 | Pallas                | biquintile bQ    | Juno                  | 0.26° | Applying →   |
 | Pallas                | sextile ⚹        | Eris                  | 1.48° | Applying →   |
 | Pallas                | square □         | Vertex                | 0.75° | Applying →   |
 | Pallas                | square □         | Anti Vertex           | 0.75° | Applying →   |
 | Pallas                | conjunction ☌    | True Priapus          | 3.10° | Separating ← |
-| Pallas                | conjunction ☌    | Kronos                | 5.29° | Applying →   |
-| Pallas                | trine △          | Apollon               | 2.27° | Separating ← |
-| Pallas                | semi-sextile ⚺   | Admetos               | 1.40° | Separating ← |
+| Pallas                | conjunction ☌    | Kronos                | 5.28° | Applying →   |
+| Pallas                | trine △          | Apollon               | 2.26° | Separating ← |
+| Pallas                | semi-sextile ⚺   | Admetos               | 1.41° | Separating ← |
 | Pallas                | semi-sextile ⚺   | Vulkanus              | 1.20° | Separating ← |
 | Juno                  | opposition ☍     | Vesta                 | 5.46° | Applying →   |
 | Juno                  | opposition ☍     | Sedna                 | 1.00° | Separating ← |
 | Juno                  | semi-square ∠    | Haumea                | 0.73° | Separating ← |
 | Juno                  | square □         | Orcus                 | 0.23° | Applying →   |
 | Juno                  | quincunx ⚻       | Interpolated Perigee  | 1.82° | Applying →   |
-| Juno                  | quincunx ⚻       | Hades                 | 1.05° | Applying →   |
+| Juno                  | quincunx ⚻       | Hades                 | 1.06° | Applying →   |
 | Juno                  | semi-square ∠    | Zeus                  | 0.49° | Separating ← |
 | Juno                  | opposition ☍     | Admetos               | 4.33° | Separating ← |
-| Juno                  | trine △          | Vulkanus              | 4.54° | Separating ← |
+| Juno                  | trine △          | Vulkanus              | 4.53° | Separating ← |
 | Vesta                 | trine △          | Makemake              | 0.92° | Separating ← |
 | Vesta                 | square □         | Orcus                 | 5.23° | Applying →   |
 | Vesta                 | quintile Q       | Pars Fidei            | 0.80° | Separating ← |
@@ -618,9 +618,9 @@ Buenos Aires Subject — Natal Chart Report
 | Eris                  | semi-sextile ⚺   | Vertex                | 0.73° | Separating ← |
 | Eris                  | quincunx ⚻       | Anti Vertex           | 0.73° | Separating ← |
 | Eris                  | sextile ⚹        | True Priapus          | 1.62° | Separating ← |
-| Eris                  | square □         | White Moon            | 3.85° | Separating ← |
-| Eris                  | quincunx ⚻       | Cupido                | 1.46° | Applying →   |
-| Eris                  | sextile ⚹        | Kronos                | 3.81° | Separating ← |
+| Eris                  | square □         | White Moon            | 3.84° | Separating ← |
+| Eris                  | quincunx ⚻       | Cupido                | 1.47° | Applying →   |
+| Eris                  | sextile ⚹        | Kronos                | 3.80° | Separating ← |
 | Eris                  | opposition ☍     | Apollon               | 3.74° | Separating ← |
 | Eris                  | square □         | Vulkanus              | 2.68° | Applying →   |
 | Sedna                 | sesquiquadrate ⚼ | Haumea                | 0.27° | Separating ← |
@@ -629,7 +629,7 @@ Buenos Aires Subject — Natal Chart Report
 | Sedna                 | trine △          | Anti Vertex           | 5.49° | Applying →   |
 | Sedna                 | quintile Q       | White Moon            | 1.94° | Applying →   |
 | Sedna                 | sesquiquadrate ⚼ | Zeus                  | 0.51° | Separating ← |
-| Sedna                 | conjunction ☌    | Admetos               | 3.34° | Separating ← |
+| Sedna                 | conjunction ☌    | Admetos               | 3.33° | Separating ← |
 | Sedna                 | sextile ⚹        | Vulkanus              | 3.54° | Separating ← |
 | Haumea                | sextile ⚹        | Ixion                 | 2.93° | Separating ← |
 | Haumea                | semi-square ∠    | Orcus                 | 0.96° | Applying →   |
@@ -640,7 +640,7 @@ Buenos Aires Subject — Natal Chart Report
 | Haumea                | trine △          | Mean Priapus          | 1.08° | Applying →   |
 | Haumea                | sextile ⚹        | White Moon            | 4.67° | Applying →   |
 | Haumea                | conjunction ☌    | Zeus                  | 0.24° | Static =     |
-| Haumea                | square □         | Kronos                | 4.70° | Applying →   |
+| Haumea                | square □         | Kronos                | 4.71° | Applying →   |
 | Haumea                | quintile Q       | Vulkanus              | 0.81° | Separating ← |
 | Makemake              | square □         | Pars Spiritus         | 3.44° | Applying →   |
 | Makemake              | square □         | Interpolated Perigee  | 4.55° | Separating ← |
@@ -652,7 +652,7 @@ Buenos Aires Subject — Natal Chart Report
 | Ixion                 | square □         | Pars Fidei            | 1.06° | Applying →   |
 | Ixion                 | conjunction ☌    | Interpolated Lilith   | 2.46° | Applying →   |
 | Ixion                 | opposition ☍     | Mean Priapus          | 1.85° | Separating ← |
-| Ixion                 | trine △          | White Moon            | 1.74° | Applying →   |
+| Ixion                 | trine △          | White Moon            | 1.75° | Applying →   |
 | Ixion                 | conjunction ☌    | Cupido                | 4.12° | Static =     |
 | Ixion                 | sextile ⚹        | Zeus                  | 2.69° | Separating ← |
 | Ixion                 | quincunx ⚻       | Kronos                | 1.78° | Applying →   |
@@ -668,7 +668,7 @@ Buenos Aires Subject — Natal Chart Report
 | Quaoar                | square □         | Pars Fidei            | 2.44° | Applying →   |
 | Quaoar                | conjunction ☌    | Interpolated Lilith   | 3.85° | Applying →   |
 | Quaoar                | opposition ☍     | Mean Priapus          | 0.47° | Separating ← |
-| Quaoar                | trine △          | White Moon            | 3.12° | Applying →   |
+| Quaoar                | trine △          | White Moon            | 3.13° | Applying →   |
 | Quaoar                | conjunction ☌    | Cupido                | 5.50° | Static =     |
 | Quaoar                | sextile ⚹        | Zeus                  | 1.30° | Separating ← |
 | Pars Fortunae         | sextile ⚹        | Pars Amoris           | 1.89° | Static =     |
@@ -678,7 +678,7 @@ Buenos Aires Subject — Natal Chart Report
 | Pars Fortunae         | sextile ⚹        | White Moon            | 1.57° | Applying →   |
 | Pars Fortunae         | opposition ☍     | Cupido                | 3.95° | Separating ← |
 | Pars Fortunae         | trine △          | Zeus                  | 2.86° | Separating ← |
-| Pars Fortunae         | semi-sextile ⚺   | Kronos                | 1.60° | Applying →   |
+| Pars Fortunae         | semi-sextile ⚺   | Kronos                | 1.61° | Applying →   |
 | Pars Spiritus         | opposition ☍     | Interpolated Perigee  | 1.11° | Separating ← |
 | Pars Spiritus         | sesquiquadrate ⚼ | White Moon            | 1.01° | Applying →   |
 | Pars Spiritus         | opposition ☍     | Hades                 | 1.88° | Separating ← |
@@ -687,7 +687,7 @@ Buenos Aires Subject — Natal Chart Report
 | Pars Amoris           | trine △          | Interpolated Lilith   | 4.19° | Applying →   |
 | Pars Amoris           | sextile ⚹        | Mean Priapus          | 0.13° | Separating ← |
 | Pars Amoris           | semi-square ∠    | Interpolated Perigee  | 1.35° | Applying →   |
-| Pars Amoris           | conjunction ☌    | White Moon            | 3.46° | Applying →   |
+| Pars Amoris           | conjunction ☌    | White Moon            | 3.47° | Applying →   |
 | Pars Amoris           | trine △          | Cupido                | 5.84° | Separating ← |
 | Pars Amoris           | semi-square ∠    | Hades                 | 0.58° | Applying →   |
 | Pars Amoris           | sextile ⚹        | Zeus                  | 0.96° | Separating ← |
@@ -698,45 +698,45 @@ Buenos Aires Subject — Natal Chart Report
 | Pars Fidei            | trine △          | True Priapus          | 2.91° | Applying →   |
 | Pars Fidei            | quincunx ⚻       | White Moon            | 0.68° | Applying →   |
 | Pars Fidei            | square □         | Cupido                | 3.06° | Separating ← |
-| Pars Fidei            | trine △          | Kronos                | 0.71° | Applying →   |
-| Pars Fidei            | biquintile bQ    | Vulkanus              | 1.20° | Applying →   |
+| Pars Fidei            | trine △          | Kronos                | 0.72° | Applying →   |
+| Pars Fidei            | biquintile bQ    | Vulkanus              | 1.21° | Applying →   |
 | Vertex                | trine △          | Interpolated Lilith   | 3.85° | Separating ← |
 | Vertex                | square □         | True Priapus          | 2.35° | Separating ← |
-| Vertex                | trine △          | White Moon            | 4.58° | Separating ← |
+| Vertex                | trine △          | White Moon            | 4.57° | Separating ← |
 | Vertex                | trine △          | Cupido                | 2.20° | Applying →   |
 | Vertex                | square □         | Kronos                | 4.54° | Separating ← |
 | Vertex                | sextile ⚹        | Admetos               | 2.15° | Applying →   |
-| Vertex                | trine △          | Vulkanus              | 1.94° | Applying →   |
+| Vertex                | trine △          | Vulkanus              | 1.95° | Applying →   |
 | Anti Vertex           | sextile ⚹        | Interpolated Lilith   | 3.85° | Separating ← |
 | Anti Vertex           | square □         | True Priapus          | 2.35° | Separating ← |
-| Anti Vertex           | sextile ⚹        | White Moon            | 4.58° | Separating ← |
+| Anti Vertex           | sextile ⚹        | White Moon            | 4.57° | Separating ← |
 | Anti Vertex           | sextile ⚹        | Cupido                | 2.20° | Applying →   |
 | Anti Vertex           | square □         | Kronos                | 4.54° | Separating ← |
 | Anti Vertex           | trine △          | Admetos               | 2.15° | Applying →   |
-| Anti Vertex           | sextile ⚹        | Vulkanus              | 1.94° | Applying →   |
+| Anti Vertex           | sextile ⚹        | Vulkanus              | 1.95° | Applying →   |
 | Interpolated Lilith   | opposition ☍     | Mean Priapus          | 4.32° | Separating ← |
 | Interpolated Lilith   | quincunx ⚻       | True Priapus          | 1.50° | Applying →   |
 | Interpolated Lilith   | trine △          | White Moon            | 0.72° | Separating ← |
-| Interpolated Lilith   | conjunction ☌    | Cupido                | 1.66° | Separating ← |
-| Interpolated Lilith   | quincunx ⚻       | Kronos                | 0.69° | Applying →   |
+| Interpolated Lilith   | conjunction ☌    | Cupido                | 1.65° | Separating ← |
+| Interpolated Lilith   | quincunx ⚻       | Kronos                | 0.68° | Applying →   |
 | Interpolated Lilith   | trine △          | Vulkanus              | 5.80° | Separating ← |
-| Mean Priapus          | sextile ⚹        | White Moon            | 3.59° | Applying →   |
+| Mean Priapus          | sextile ⚹        | White Moon            | 3.60° | Applying →   |
 | Mean Priapus          | opposition ☍     | Cupido                | 5.97° | Separating ← |
 | Mean Priapus          | trine △          | Zeus                  | 0.83° | Applying →   |
 | True Priapus          | quincunx ⚻       | Cupido                | 0.15° | Separating ← |
 | True Priapus          | conjunction ☌    | Kronos                | 2.19° | Applying →   |
 | True Priapus          | trine △          | Apollon               | 5.36° | Separating ← |
-| Interpolated Perigee  | conjunction ☌    | Hades                 | 0.77° | Applying →   |
+| Interpolated Perigee  | conjunction ☌    | Hades                 | 0.76° | Applying →   |
 | Interpolated Perigee  | trine △          | Apollon               | 5.29° | Applying →   |
-| White Moon            | trine △          | Cupido                | 2.38° | Separating ← |
+| White Moon            | trine △          | Cupido                | 2.37° | Separating ← |
 | White Moon            | sextile ⚹        | Zeus                  | 4.43° | Applying →   |
-| White Moon            | semi-sextile ⚺   | Kronos                | 0.03° | Separating ← |
-| Cupido                | opposition ☍     | Admetos               | 4.35° | Applying →   |
-| Cupido                | trine △          | Vulkanus              | 4.14° | Applying →   |
-| Hades                 | trine △          | Apollon               | 4.52° | Applying →   |
-| Zeus                  | square □         | Kronos                | 4.46° | Applying →   |
+| White Moon            | semi-sextile ⚺   | Kronos                | 0.04° | Separating ← |
+| Cupido                | opposition ☍     | Admetos               | 4.36° | Applying →   |
+| Cupido                | trine △          | Vulkanus              | 4.15° | Applying →   |
+| Hades                 | trine △          | Apollon               | 4.53° | Applying →   |
+| Zeus                  | square □         | Kronos                | 4.47° | Applying →   |
 | Zeus                  | quintile Q       | Vulkanus              | 1.05° | Separating ← |
 | Apollon               | quincunx ⚻       | Admetos               | 0.86° | Separating ← |
-| Apollon               | square □         | Vulkanus              | 1.07° | Separating ← |
+| Apollon               | square □         | Vulkanus              | 1.06° | Separating ← |
 | Admetos               | sextile ⚹        | Vulkanus              | 0.21° | Separating ← |
 +-----------------------+------------------+-----------------------+-------+--------------+

--- a/tests/fixtures/natal_discepolo_aspects_report.txt
+++ b/tests/fixtures/natal_discepolo_aspects_report.txt
@@ -31,8 +31,8 @@ Sample Natal Subject — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+---------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House         |
 +-----------------------+--------+----------+--------------+---------+------+---------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House   |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6390°/d | N/A     | -    | Tenth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House   |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6410°/d | N/A     | -    | Tenth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House   |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House   |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House   |

--- a/tests/fixtures/natal_einstein_all_report.txt
+++ b/tests/fixtures/natal_einstein_all_report.txt
@@ -31,10 +31,10 @@ Einstein Subject — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Can ♋ | 11.65°   | +297.4361°/d | N/A     | -    | First House    |
-| Medium Coeli          | Pis ♓ | 12.84°   | +388.0743°/d | N/A     | -    | Tenth House    |
-| Descendant            | Cap ♑ | 11.65°   | +297.4361°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Vir ♍ | 12.84°   | +388.0743°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Can ♋ | 11.65°   | +297.4377°/d | N/A     | -    | First House    |
+| Medium Coeli          | Pis ♓ | 12.84°   | +388.0763°/d | N/A     | -    | Tenth House    |
+| Descendant            | Cap ♑ | 11.65°   | +297.4377°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Vir ♍ | 12.84°   | +388.0763°/d | N/A     | -    | Fourth House   |
 | Sun                   | Pis ♓ | 23.51°   | +0.9960°/d   | -2.58°  | -    | Tenth House    |
 | Moon                  | Sag ♐ | 14.53°   | +13.9189°/d  | -26.36° | -    | Sixth House    |
 | Mercury               | Ari ♈ | 3.14°    | +1.9519°/d   | +0.89°  | -    | Tenth House    |
@@ -48,7 +48,7 @@ Einstein Subject — Natal Chart Report
 | Mean North Lunar Node | Aqu ♒ | 1.48°    | -0.0529°/d   | -19.84° | R    | Eighth House   |
 | True North Lunar Node | Aqu ♒ | 2.73°    | -0.0193°/d   | -19.56° | R    | Eighth House   |
 | Mean Lilith           | Ari ♈ | 27.98°   | +0.1121°/d   | +15.55° | -    | Eleventh House |
-| True Lilith           | Ari ♈ | 1.62°    | -0.7972°/d   | +4.68°  | R    | Tenth House    |
+| True Lilith           | Ari ♈ | 1.62°    | -0.7974°/d   | +4.68°  | R    | Tenth House    |
 | Chiron                | Tau ♉ | 5.54°    | +0.0525°/d   | +12.39° | -    | Eleventh House |
 | Pholus                | Aqu ♒ | 27.09°   | +0.0403°/d   | -23.59° | -    | Ninth House    |
 | Ceres                 | Tau ♉ | 17.33°   | +0.3513°/d   | +14.54° | -    | Eleventh House |
@@ -57,14 +57,14 @@ Einstein Subject — Natal Chart Report
 | Vesta                 | Can ♋ | 9.76°    | +0.1230°/d   | +25.96° | -    | Twelfth House  |
 | Interpolated Lilith   | Tau ♉ | 3.06°    | +0.1027°/d   | +17.37° | -    | Eleventh House |
 | Interpolated Perigee  | Lib ♎ | 11.88°   | +0.4793°/d   | -9.11°  | -    | Fourth House   |
-| Cupido                | Gem ♊ | 15.20°   | +0.0069°/d   | +21.77° | -    | Twelfth House  |
-| Hades                 | Aqu ♒ | 16.83°   | +0.0184°/d   | -15.39° | -    | Eighth House   |
-| Zeus                  | Gem ♊ | 26.56°   | +0.0011°/d   | +23.41° | -    | Twelfth House  |
+| Cupido                | Gem ♊ | 15.20°   | +0.0068°/d   | +21.77° | -    | Twelfth House  |
+| Hades                 | Aqu ♒ | 16.82°   | +0.0185°/d   | -15.39° | -    | Eighth House   |
+| Zeus                  | Gem ♊ | 26.56°   | +0.0010°/d   | +23.41° | -    | Twelfth House  |
 | Kronos                | Ari ♈ | 3.26°    | +0.0167°/d   | +1.30°  | -    | Tenth House    |
-| Apollon               | Leo ♌ | 4.45°    | -0.0077°/d   | +19.16° | R    | Second House   |
-| Admetos               | Pis ♓ | 9.39°    | +0.0145°/d   | -8.06°  | -    | Ninth House    |
-| Vulkanus              | Tau ♉ | 14.02°   | +0.0094°/d   | +16.05° | -    | Eleventh House |
-| Poseidon              | Vir ♍ | 5.23°    | -0.0101°/d   | +9.60°  | R    | Third House    |
+| Apollon               | Leo ♌ | 4.46°    | -0.0078°/d   | +19.16° | R    | Second House   |
+| Admetos               | Pis ♓ | 9.38°    | +0.0146°/d   | -8.06°  | -    | Ninth House    |
+| Vulkanus              | Tau ♉ | 14.01°   | +0.0094°/d   | +16.05° | -    | Eleventh House |
+| Poseidon              | Vir ♍ | 5.24°    | -0.0101°/d   | +9.60°  | R    | Third House    |
 | Eris                  | Pis ♓ | 14.85°   | +0.0147°/d   | -38.50° | -    | Tenth House    |
 | Sedna                 | Ari ♈ | 2.88°    | +0.0075°/d   | -5.94°  | -    | Tenth House    |
 | Haumea                | Tau ♉ | 24.37°   | +0.0188°/d   | -5.91°  | -    | Eleventh House |
@@ -77,12 +77,12 @@ Einstein Subject — Natal Chart Report
 | Pars Amoris           | Leo ♌ | 5.12°    | N/A          | N/A     | -    | Second House   |
 | Pars Fidei            | Gem ♊ | 4.94°    | N/A          | N/A     | -    | Twelfth House  |
 | Vertex                | Sco ♏ | 27.91°   | N/A          | N/A     | -    | Fifth House    |
-| White Moon            | Leo ♌ | 29.38°   | +0.1408°/d   | +11.70° | -    | Third House    |
+| White Moon            | Leo ♌ | 29.39°   | +0.1408°/d   | +11.70° | -    | Third House    |
 | Anti Vertex           | Tau ♉ | 27.91°   | N/A          | N/A     | -    | Eleventh House |
 | Mean South Lunar Node | Leo ♌ | 1.48°    | -0.0529°/d   | +19.84° | R    | Second House   |
 | True South Lunar Node | Leo ♌ | 2.73°    | -0.0193°/d   | +19.56° | R    | Second House   |
 | Mean Priapus          | Lib ♎ | 27.98°   | +0.1121°/d   | -15.55° | -    | Fifth House    |
-| True Priapus          | Lib ♎ | 1.62°    | -0.7972°/d   | -4.68°  | R    | Fourth House   |
+| True Priapus          | Lib ♎ | 1.62°    | -0.7974°/d   | -4.68°  | R    | Fourth House   |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +Natal Houses (Placidus)--+----------+-------------------+
@@ -249,7 +249,7 @@ Einstein Subject — Natal Chart Report
 | Moon                  | sextile ⚹        | Interpolated Perigee  | 2.65° | Separating ← |
 | Moon                  | opposition ☍     | Cupido                | 0.67° | Applying →   |
 | Moon                  | sextile ⚹        | Hades                 | 2.30° | Applying →   |
-| Moon                  | square □         | Admetos               | 5.14° | Separating ← |
+| Moon                  | square □         | Admetos               | 5.15° | Separating ← |
 | Moon                  | quincunx ⚻       | Vulkanus              | 0.51° | Separating ← |
 | Mercury               | conjunction ☌    | Saturn                | 1.05° | Applying →   |
 | Mercury               | quincunx ⚻       | Uranus                | 1.86° | Separating ← |
@@ -279,7 +279,7 @@ Einstein Subject — Natal Chart Report
 | Venus                 | conjunction ☌    | Makemake              | 3.16° | Separating ← |
 | Venus                 | opposition ☍     | Pars Spiritus         | 3.64° | Applying →   |
 | Venus                 | opposition ☍     | Interpolated Perigee  | 5.11° | Separating ← |
-| Venus                 | sextile ⚹        | Cupido                | 1.78° | Separating ← |
+| Venus                 | sextile ⚹        | Cupido                | 1.79° | Separating ← |
 | Venus                 | sextile ⚹        | Hades                 | 0.16° | Separating ← |
 | Mars                  | semi-sextile ⚺   | Jupiter               | 0.57° | Applying →   |
 | Mars                  | biquintile bQ    | Uranus                | 1.63° | Separating ← |
@@ -339,11 +339,11 @@ Einstein Subject — Natal Chart Report
 | Saturn                | sextile ⚹        | Pars Fidei            | 0.75° | Applying →   |
 | Saturn                | semi-sextile ⚺   | Interpolated Lilith   | 1.13° | Separating ← |
 | Saturn                | opposition ☍     | True Priapus          | 2.57° | Separating ← |
-| Saturn                | biquintile bQ    | White Moon            | 1.19° | Separating ← |
+| Saturn                | biquintile bQ    | White Moon            | 1.20° | Separating ← |
 | Saturn                | quintile Q       | Cupido                | 0.99° | Separating ← |
 | Saturn                | conjunction ☌    | Kronos                | 0.93° | Separating ← |
-| Saturn                | trine △          | Apollon               | 0.26° | Applying →   |
-| Saturn                | quincunx ⚻       | Poseidon              | 1.04° | Applying →   |
+| Saturn                | trine △          | Apollon               | 0.27° | Applying →   |
+| Saturn                | quincunx ⚻       | Poseidon              | 1.05° | Applying →   |
 | Uranus                | quincunx ⚻       | Mean North Lunar Node | 0.19° | Applying →   |
 | Uranus                | quincunx ⚻       | True North Lunar Node | 1.44° | Separating ← |
 | Uranus                | trine △          | Chiron                | 4.26° | Separating ← |
@@ -362,10 +362,10 @@ Einstein Subject — Natal Chart Report
 | Uranus                | trine △          | Interpolated Lilith   | 1.77° | Separating ← |
 | Uranus                | sextile ⚹        | Mean Priapus          | 3.31° | Applying →   |
 | Uranus                | semi-sextile ⚺   | True Priapus          | 0.34° | Applying →   |
-| Uranus                | conjunction ☌    | White Moon            | 1.91° | Applying →   |
+| Uranus                | conjunction ☌    | White Moon            | 1.90° | Applying →   |
 | Uranus                | sextile ⚹        | Zeus                  | 4.73° | Applying →   |
-| Uranus                | quincunx ⚻       | Kronos                | 1.98° | Separating ← |
-| Uranus                | conjunction ☌    | Poseidon              | 3.94° | Separating ← |
+| Uranus                | quincunx ⚻       | Kronos                | 1.97° | Separating ← |
+| Uranus                | conjunction ☌    | Poseidon              | 3.95° | Separating ← |
 | Neptune               | square □         | True North Lunar Node | 5.14° | Separating ← |
 | Neptune               | conjunction ☌    | Chiron                | 2.33° | Applying →   |
 | Neptune               | sextile ⚹        | Ascendant             | 3.78° | Separating ← |
@@ -381,7 +381,7 @@ Einstein Subject — Natal Chart Report
 | Neptune               | biquintile bQ    | True Priapus          | 0.25° | Separating ← |
 | Neptune               | square □         | Apollon               | 3.42° | Separating ← |
 | Neptune               | sextile ⚹        | Admetos               | 1.51° | Applying →   |
-| Neptune               | trine △          | Poseidon              | 2.64° | Separating ← |
+| Neptune               | trine △          | Poseidon              | 2.63° | Separating ← |
 | Pluto                 | semi-square ∠    | Ascendant             | 1.92° | Separating ← |
 | Pluto                 | quintile Q       | Medium Coeli          | 0.11° | Separating ← |
 | Pluto                 | sesquiquadrate ⚼ | Descendant            | 1.92° | Separating ← |
@@ -458,9 +458,9 @@ Einstein Subject — Natal Chart Report
 | Ascendant             | sesquiquadrate ⚼ | Vertex                | 1.26° | Applying →   |
 | Ascendant             | semi-square ∠    | Anti Vertex           | 1.26° | Applying →   |
 | Ascendant             | square □         | Interpolated Perigee  | 0.23° | Applying →   |
-| Ascendant             | biquintile bQ    | Hades                 | 0.82° | Separating ← |
-| Ascendant             | trine △          | Admetos               | 2.26° | Separating ← |
-| Ascendant             | sextile ⚹        | Vulkanus              | 2.37° | Applying →   |
+| Ascendant             | biquintile bQ    | Hades                 | 0.83° | Separating ← |
+| Ascendant             | trine △          | Admetos               | 2.27° | Separating ← |
+| Ascendant             | sextile ⚹        | Vulkanus              | 2.36° | Applying →   |
 | Medium Coeli          | sextile ⚹        | Descendant            | 1.19° | Static =     |
 | Medium Coeli          | semi-square ∠    | Mean Lilith           | 0.14° | Applying →   |
 | Medium Coeli          | sextile ⚹        | Ceres                 | 4.49° | Applying →   |
@@ -476,8 +476,8 @@ Einstein Subject — Natal Chart Report
 | Medium Coeli          | sesquiquadrate ⚼ | Mean Priapus          | 0.14° | Applying →   |
 | Medium Coeli          | quincunx ⚻       | Interpolated Perigee  | 0.96° | Separating ← |
 | Medium Coeli          | square □         | Cupido                | 2.36° | Applying →   |
-| Medium Coeli          | conjunction ☌    | Admetos               | 3.45° | Separating ← |
-| Medium Coeli          | sextile ⚹        | Vulkanus              | 1.18° | Applying →   |
+| Medium Coeli          | conjunction ☌    | Admetos               | 3.46° | Separating ← |
+| Medium Coeli          | sextile ⚹        | Vulkanus              | 1.17° | Applying →   |
 | Descendant            | trine △          | Imum Coeli            | 1.19° | Static =     |
 | Descendant            | semi-square ∠    | Pholus                | 0.44° | Applying →   |
 | Descendant            | trine △          | Ceres                 | 5.68° | Applying →   |
@@ -491,8 +491,8 @@ Einstein Subject — Natal Chart Report
 | Descendant            | sesquiquadrate ⚼ | Anti Vertex           | 1.26° | Applying →   |
 | Descendant            | quintile Q       | Mean Priapus          | 1.67° | Separating ← |
 | Descendant            | square □         | Interpolated Perigee  | 0.23° | Applying →   |
-| Descendant            | sextile ⚹        | Admetos               | 2.26° | Separating ← |
-| Descendant            | trine △          | Vulkanus              | 2.37° | Applying →   |
+| Descendant            | sextile ⚹        | Admetos               | 2.27° | Separating ← |
+| Descendant            | trine △          | Vulkanus              | 2.36° | Applying →   |
 | Imum Coeli            | sesquiquadrate ⚼ | Mean Lilith           | 0.14° | Applying →   |
 | Imum Coeli            | trine △          | Ceres                 | 4.49° | Applying →   |
 | Imum Coeli            | sextile ⚹        | Vesta                 | 3.08° | Separating ← |
@@ -504,8 +504,8 @@ Einstein Subject — Natal Chart Report
 | Imum Coeli            | semi-square ∠    | Mean Priapus          | 0.14° | Applying →   |
 | Imum Coeli            | semi-sextile ⚺   | Interpolated Perigee  | 0.96° | Separating ← |
 | Imum Coeli            | square □         | Cupido                | 2.36° | Applying →   |
-| Imum Coeli            | opposition ☍     | Admetos               | 3.45° | Separating ← |
-| Imum Coeli            | trine △          | Vulkanus              | 1.18° | Applying →   |
+| Imum Coeli            | opposition ☍     | Admetos               | 3.46° | Separating ← |
+| Imum Coeli            | trine △          | Vulkanus              | 1.17° | Applying →   |
 | Mean Lilith           | square □         | Mean South Lunar Node | 3.50° | Applying →   |
 | Mean Lilith           | square □         | True South Lunar Node | 4.75° | Applying →   |
 | Mean Lilith           | sextile ⚹        | Pholus                | 0.89° | Separating ← |
@@ -518,7 +518,7 @@ Einstein Subject — Natal Chart Report
 | Mean Lilith           | quincunx ⚻       | Vertex                | 0.07° | Separating ← |
 | Mean Lilith           | semi-sextile ⚺   | Anti Vertex           | 0.07° | Separating ← |
 | Mean Lilith           | conjunction ☌    | Interpolated Lilith   | 5.08° | Applying →   |
-| Mean Lilith           | trine △          | White Moon            | 1.40° | Separating ← |
+| Mean Lilith           | trine △          | White Moon            | 1.41° | Separating ← |
 | Mean Lilith           | quintile Q       | Hades                 | 0.85° | Applying →   |
 | Mean Lilith           | sextile ⚹        | Zeus                  | 1.42° | Separating ← |
 | Mean South Lunar Node | trine △          | True Lilith           | 0.14° | Applying →   |
@@ -538,7 +538,7 @@ Einstein Subject — Natal Chart Report
 | Mean South Lunar Node | semi-square ∠    | Cupido                | 1.28° | Applying →   |
 | Mean South Lunar Node | trine △          | Kronos                | 1.78° | Separating ← |
 | Mean South Lunar Node | conjunction ☌    | Apollon               | 2.97° | Separating ← |
-| Mean South Lunar Node | biquintile bQ    | Admetos               | 1.91° | Separating ← |
+| Mean South Lunar Node | biquintile bQ    | Admetos               | 1.90° | Separating ← |
 | True South Lunar Node | trine △          | True Lilith           | 1.11° | Separating ← |
 | True South Lunar Node | trine △          | Sedna                 | 0.15° | Separating ← |
 | True South Lunar Node | opposition ☍     | Orcus                 | 3.37° | Applying →   |
@@ -565,8 +565,8 @@ Einstein Subject — Natal Chart Report
 | True Lilith           | semi-sextile ⚺   | Interpolated Lilith   | 1.43° | Separating ← |
 | True Lilith           | quintile Q       | Cupido                | 1.58° | Separating ← |
 | True Lilith           | semi-square ∠    | Hades                 | 0.20° | Separating ← |
-| True Lilith           | square □         | Zeus                  | 5.07° | Applying →   |
-| True Lilith           | conjunction ☌    | Kronos                | 1.64° | Separating ← |
+| True Lilith           | square □         | Zeus                  | 5.06° | Applying →   |
+| True Lilith           | conjunction ☌    | Kronos                | 1.63° | Separating ← |
 | True Lilith           | trine △          | Apollon               | 2.83° | Separating ← |
 | Pholus                | sextile ⚹        | Juno                  | 1.62° | Applying →   |
 | Pholus                | square □         | Haumea                | 2.71° | Separating ← |
@@ -594,8 +594,8 @@ Einstein Subject — Natal Chart Report
 | Pallas                | square □         | Quaoar                | 0.07° | Separating ← |
 | Pallas                | trine △          | Pars Amoris           | 4.91° | Separating ← |
 | Pallas                | opposition ☍     | Interpolated Perigee  | 1.84° | Separating ← |
-| Pallas                | trine △          | Apollon               | 5.59° | Separating ← |
-| Pallas                | semi-sextile ⚺   | Admetos               | 0.65° | Separating ← |
+| Pallas                | trine △          | Apollon               | 5.58° | Separating ← |
+| Pallas                | semi-sextile ⚺   | Admetos               | 0.66° | Separating ← |
 | Pallas                | biquintile bQ    | Poseidon              | 1.20° | Applying →   |
 | Juno                  | semi-sextile ⚺   | Haumea                | 1.09° | Separating ← |
 | Juno                  | square □         | Ixion                 | 0.68° | Applying →   |
@@ -610,8 +610,8 @@ Einstein Subject — Natal Chart Report
 | Vesta                 | square □         | Makemake              | 4.07° | Applying →   |
 | Vesta                 | conjunction ☌    | Quaoar                | 0.21° | Applying →   |
 | Vesta                 | square □         | Interpolated Perigee  | 2.12° | Separating ← |
-| Vesta                 | biquintile bQ    | Hades                 | 1.07° | Applying →   |
-| Vesta                 | trine △          | Admetos               | 0.37° | Separating ← |
+| Vesta                 | biquintile bQ    | Hades                 | 1.06° | Applying →   |
+| Vesta                 | trine △          | Admetos               | 0.38° | Separating ← |
 | Vesta                 | sextile ⚹        | Vulkanus              | 4.26° | Applying →   |
 | Vesta                 | sextile ⚹        | Poseidon              | 4.52° | Separating ← |
 | Eris                  | semi-sextile ⚺   | Makemake              | 1.02° | Applying →   |
@@ -621,9 +621,9 @@ Einstein Subject — Natal Chart Report
 | Eris                  | quintile Q       | Anti Vertex           | 1.06° | Applying →   |
 | Eris                  | sesquiquadrate ⚼ | Mean Priapus          | 1.87° | Applying →   |
 | Eris                  | square □         | Cupido                | 0.35° | Applying →   |
-| Eris                  | semi-sextile ⚺   | Hades                 | 1.98° | Separating ← |
-| Eris                  | conjunction ☌    | Admetos               | 5.46° | Static =     |
-| Eris                  | sextile ⚹        | Vulkanus              | 0.83° | Separating ← |
+| Eris                  | semi-sextile ⚺   | Hades                 | 1.97° | Separating ← |
+| Eris                  | conjunction ☌    | Admetos               | 5.47° | Static =     |
+| Eris                  | sextile ⚹        | Vulkanus              | 0.84° | Separating ← |
 | Sedna                 | sextile ⚹        | Orcus                 | 3.51° | Applying →   |
 | Sedna                 | conjunction ☌    | Pars Fortunae         | 0.21° | Separating ← |
 | Sedna                 | trine △          | Pars Amoris           | 2.25° | Applying →   |
@@ -633,9 +633,9 @@ Einstein Subject — Natal Chart Report
 | Sedna                 | semi-sextile ⚺   | Interpolated Lilith   | 0.18° | Separating ← |
 | Sedna                 | opposition ☍     | True Priapus          | 1.25° | Separating ← |
 | Sedna                 | quintile Q       | Cupido                | 0.32° | Static =     |
-| Sedna                 | semi-square ∠    | Hades                 | 1.05° | Applying →   |
-| Sedna                 | conjunction ☌    | Kronos                | 0.39° | Separating ← |
-| Sedna                 | trine △          | Apollon               | 1.57° | Applying →   |
+| Sedna                 | semi-square ∠    | Hades                 | 1.06° | Applying →   |
+| Sedna                 | conjunction ☌    | Kronos                | 0.38° | Separating ← |
+| Sedna                 | trine △          | Apollon               | 1.58° | Applying →   |
 | Haumea                | sextile ⚹        | Ixion                 | 1.77° | Applying →   |
 | Haumea                | trine △          | Orcus                 | 4.99° | Separating ← |
 | Haumea                | semi-square ∠    | Quaoar                | 0.59° | Applying →   |
@@ -648,19 +648,19 @@ Einstein Subject — Natal Chart Report
 | Makemake              | sesquiquadrate ⚼ | Vertex                | 0.92° | Separating ← |
 | Makemake              | semi-square ∠    | Anti Vertex           | 0.92° | Separating ← |
 | Makemake              | opposition ☍     | Interpolated Perigee  | 1.95° | Applying →   |
-| Makemake              | sesquiquadrate ⚼ | White Moon            | 0.55° | Separating ← |
+| Makemake              | sesquiquadrate ⚼ | White Moon            | 0.56° | Separating ← |
 | Makemake              | sextile ⚹        | Cupido                | 1.37° | Applying →   |
-| Makemake              | sextile ⚹        | Hades                 | 3.00° | Applying →   |
+| Makemake              | sextile ⚹        | Hades                 | 2.99° | Applying →   |
 | Makemake              | quintile Q       | Zeus                  | 0.73° | Applying →   |
-| Makemake              | semi-sextile ⚺   | Vulkanus              | 0.19° | Applying →   |
+| Makemake              | semi-sextile ⚺   | Vulkanus              | 0.18° | Applying →   |
 | Ixion                 | opposition ☍     | Orcus                 | 3.23° | Separating ← |
 | Ixion                 | square □         | Pars Spiritus         | 5.51° | Applying →   |
 | Ixion                 | trine △          | Vertex                | 1.77° | Separating ← |
 | Ixion                 | sextile ⚹        | Anti Vertex           | 1.77° | Separating ← |
 | Ixion                 | square □         | Mean Priapus          | 1.84° | Separating ← |
 | Ixion                 | semi-sextile ⚺   | Zeus                  | 0.42° | Separating ← |
-| Ixion                 | sesquiquadrate ⚼ | Admetos               | 1.75° | Applying →   |
-| Ixion                 | quintile Q       | Vulkanus              | 0.12° | Applying →   |
+| Ixion                 | sesquiquadrate ⚼ | Admetos               | 1.76° | Applying →   |
+| Ixion                 | quintile Q       | Vulkanus              | 0.13° | Applying →   |
 | Orcus                 | sextile ⚹        | Pars Fortunae         | 3.30° | Applying →   |
 | Orcus                 | opposition ☍     | Pars Amoris           | 5.76° | Applying →   |
 | Orcus                 | trine △          | Pars Fidei            | 5.58° | Applying →   |
@@ -671,14 +671,14 @@ Einstein Subject — Natal Chart Report
 | Orcus                 | trine △          | True Priapus          | 2.26° | Applying →   |
 | Orcus                 | quincunx ⚻       | White Moon            | 0.02° | Separating ← |
 | Orcus                 | sesquiquadrate ⚼ | Cupido                | 0.84° | Applying →   |
-| Orcus                 | sextile ⚹        | Kronos                | 3.90° | Applying →   |
+| Orcus                 | sextile ⚹        | Kronos                | 3.89° | Applying →   |
 | Orcus                 | opposition ☍     | Apollon               | 5.09° | Applying →   |
 | Orcus                 | biquintile bQ    | Poseidon              | 0.13° | Separating ← |
 | Quaoar                | square □         | Interpolated Perigee  | 1.91° | Separating ← |
 | Quaoar                | biquintile bQ    | Hades                 | 0.86° | Separating ← |
 | Quaoar                | trine △          | Admetos               | 0.58° | Applying →   |
 | Quaoar                | sextile ⚹        | Vulkanus              | 4.05° | Separating ← |
-| Quaoar                | sextile ⚹        | Poseidon              | 4.73° | Separating ← |
+| Quaoar                | sextile ⚹        | Poseidon              | 4.72° | Separating ← |
 | Pars Fortunae         | trine △          | Pars Amoris           | 2.46° | Static =     |
 | Pars Fortunae         | sextile ⚹        | Pars Fidei            | 2.28° | Static =     |
 | Pars Fortunae         | trine △          | Vertex                | 4.76° | Static =     |
@@ -687,18 +687,18 @@ Einstein Subject — Natal Chart Report
 | Pars Fortunae         | opposition ☍     | True Priapus          | 1.04° | Separating ← |
 | Pars Fortunae         | quintile Q       | Cupido                | 0.53° | Separating ← |
 | Pars Fortunae         | semi-square ∠    | Hades                 | 0.84° | Applying →   |
-| Pars Fortunae         | conjunction ☌    | Kronos                | 0.60° | Separating ← |
+| Pars Fortunae         | conjunction ☌    | Kronos                | 0.59° | Separating ← |
 | Pars Fortunae         | trine △          | Apollon               | 1.79° | Applying →   |
 | Pars Spiritus         | sesquiquadrate ⚼ | Pars Fidei            | 0.69° | Static =     |
 | Pars Spiritus         | biquintile bQ    | Anti Vertex           | 1.28° | Static =     |
 | Pars Spiritus         | trine △          | Cupido                | 5.43° | Applying →   |
-| Pars Spiritus         | trine △          | Hades                 | 3.80° | Applying →   |
-| Pars Spiritus         | trine △          | Zeus                  | 5.93° | Separating ← |
-| Pars Spiritus         | semi-square ∠    | Poseidon              | 0.40° | Separating ← |
+| Pars Spiritus         | trine △          | Hades                 | 3.81° | Applying →   |
+| Pars Spiritus         | trine △          | Zeus                  | 5.93° | Static =     |
+| Pars Spiritus         | semi-square ∠    | Poseidon              | 0.39° | Separating ← |
 | Pars Amoris           | sextile ⚹        | Pars Fidei            | 0.18° | Static =     |
 | Pars Amoris           | square □         | Interpolated Lilith   | 2.07° | Applying →   |
 | Pars Amoris           | sextile ⚹        | True Priapus          | 3.50° | Separating ← |
-| Pars Amoris           | trine △          | Kronos                | 1.86° | Applying →   |
+| Pars Amoris           | trine △          | Kronos                | 1.87° | Applying →   |
 | Pars Amoris           | conjunction ☌    | Apollon               | 0.67° | Separating ← |
 | Pars Amoris           | biquintile bQ    | Admetos               | 1.74° | Applying →   |
 | Pars Amoris           | semi-sextile ⚺   | Poseidon              | 0.11° | Applying →   |
@@ -709,44 +709,44 @@ Einstein Subject — Natal Chart Report
 | Pars Fidei            | sextile ⚹        | Kronos                | 1.68° | Applying →   |
 | Pars Fidei            | sextile ⚹        | Apollon               | 0.49° | Separating ← |
 | Pars Fidei            | square □         | Admetos               | 4.44° | Separating ← |
-| Pars Fidei            | square □         | Poseidon              | 0.29° | Applying →   |
+| Pars Fidei            | square □         | Poseidon              | 0.30° | Applying →   |
 | Vertex                | semi-sextile ⚺   | Mean Priapus          | 0.07° | Separating ← |
 | Vertex                | sextile ⚹        | True Priapus          | 3.72° | Applying →   |
 | Vertex                | semi-square ∠    | Interpolated Perigee  | 1.03° | Applying →   |
 | Vertex                | square □         | White Moon            | 1.48° | Separating ← |
-| Vertex                | quincunx ⚻       | Zeus                  | 1.35° | Applying →   |
-| Vertex                | trine △          | Kronos                | 5.36° | Separating ← |
+| Vertex                | quincunx ⚻       | Zeus                  | 1.35° | Static =     |
+| Vertex                | trine △          | Kronos                | 5.35° | Separating ← |
 | Anti Vertex           | quincunx ⚻       | Mean Priapus          | 0.07° | Separating ← |
 | Anti Vertex           | trine △          | True Priapus          | 3.72° | Applying →   |
 | Anti Vertex           | sesquiquadrate ⚼ | Interpolated Perigee  | 1.03° | Applying →   |
 | Anti Vertex           | square □         | White Moon            | 1.48° | Separating ← |
-| Anti Vertex           | semi-sextile ⚺   | Zeus                  | 1.35° | Applying →   |
+| Anti Vertex           | semi-sextile ⚺   | Zeus                  | 1.35° | Static =     |
 | Interpolated Lilith   | opposition ☍     | Mean Priapus          | 5.08° | Applying →   |
 | Interpolated Lilith   | quincunx ⚻       | True Priapus          | 1.43° | Separating ← |
-| Interpolated Lilith   | trine △          | White Moon            | 3.68° | Applying →   |
-| Interpolated Lilith   | semi-sextile ⚺   | Kronos                | 0.21° | Applying →   |
-| Interpolated Lilith   | square □         | Apollon               | 1.39° | Applying →   |
-| Interpolated Lilith   | trine △          | Poseidon              | 2.17° | Applying →   |
-| Mean Priapus          | sextile ⚹        | White Moon            | 1.40° | Separating ← |
+| Interpolated Lilith   | trine △          | White Moon            | 3.67° | Applying →   |
+| Interpolated Lilith   | semi-sextile ⚺   | Kronos                | 0.20° | Applying →   |
+| Interpolated Lilith   | square □         | Apollon               | 1.40° | Applying →   |
+| Interpolated Lilith   | trine △          | Poseidon              | 2.18° | Applying →   |
+| Mean Priapus          | sextile ⚹        | White Moon            | 1.41° | Separating ← |
 | Mean Priapus          | trine △          | Zeus                  | 1.42° | Separating ← |
 | True Priapus          | sesquiquadrate ⚼ | Hades                 | 0.20° | Separating ← |
-| True Priapus          | square □         | Zeus                  | 5.07° | Applying →   |
-| True Priapus          | opposition ☍     | Kronos                | 1.64° | Separating ← |
+| True Priapus          | square □         | Zeus                  | 5.06° | Applying →   |
+| True Priapus          | opposition ☍     | Kronos                | 1.63° | Separating ← |
 | True Priapus          | sextile ⚹        | Apollon               | 2.83° | Separating ← |
 | Interpolated Perigee  | trine △          | Cupido                | 3.32° | Applying →   |
 | Interpolated Perigee  | trine △          | Hades                 | 4.95° | Applying →   |
-| White Moon            | sextile ⚹        | Zeus                  | 2.82° | Separating ← |
+| White Moon            | sextile ⚹        | Zeus                  | 2.83° | Separating ← |
 | White Moon            | conjunction ☌    | Poseidon              | 5.85° | Applying →   |
-| Cupido                | trine △          | Hades                 | 1.63° | Separating ← |
+| Cupido                | trine △          | Hades                 | 1.62° | Separating ← |
 | Cupido                | quintile Q       | Kronos                | 0.06° | Separating ← |
-| Cupido                | square □         | Admetos               | 5.81° | Applying →   |
-| Cupido                | semi-sextile ⚺   | Vulkanus              | 1.18° | Applying →   |
+| Cupido                | square □         | Admetos               | 5.82° | Applying →   |
+| Cupido                | semi-sextile ⚺   | Vulkanus              | 1.19° | Applying →   |
 | Hades                 | semi-square ∠    | Kronos                | 1.44° | Applying →   |
 | Hades                 | square □         | Vulkanus              | 2.81° | Separating ← |
-| Kronos                | trine △          | Apollon               | 1.19° | Applying →   |
-| Kronos                | quincunx ⚻       | Poseidon              | 1.97° | Applying →   |
+| Kronos                | trine △          | Apollon               | 1.20° | Applying →   |
+| Kronos                | quincunx ⚻       | Poseidon              | 1.98° | Applying →   |
 | Apollon               | biquintile bQ    | Admetos               | 1.07° | Applying →   |
 | Apollon               | semi-sextile ⚺   | Poseidon              | 0.78° | Applying →   |
 | Admetos               | sextile ⚹        | Vulkanus              | 4.63° | Applying →   |
-| Admetos               | opposition ☍     | Poseidon              | 4.15° | Separating ← |
+| Admetos               | opposition ☍     | Poseidon              | 4.14° | Separating ← |
 +-----------------------+------------------+-----------------------+-------+--------------+

--- a/tests/fixtures/natal_future_2050_all_report.txt
+++ b/tests/fixtures/natal_future_2050_all_report.txt
@@ -31,10 +31,10 @@ Future 2050 Subject — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Lib ♎ | 27.10°   | +296.3200°/d | N/A     | -    | First House    |
-| Medium Coeli          | Leo ♌ | 0.55°    | +347.2897°/d | N/A     | -    | Tenth House    |
-| Descendant            | Ari ♈ | 27.10°   | +296.3200°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Aqu ♒ | 0.55°    | +347.2897°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Lib ♎ | 27.10°   | +296.3217°/d | N/A     | -    | First House    |
+| Medium Coeli          | Leo ♌ | 0.55°    | +347.2916°/d | N/A     | -    | Tenth House    |
+| Descendant            | Ari ♈ | 27.10°   | +296.3217°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Aqu ♒ | 0.55°    | +347.2916°/d | N/A     | -    | Fourth House   |
 | Sun                   | Can ♋ | 27.64°   | +0.9548°/d   | +20.63° | -    | Ninth House    |
 | Moon                  | Leo ♌ | 11.55°   | +12.0994°/d  | +12.51° | -    | Tenth House    |
 | Mercury               | Leo ♌ | 23.28°   | +1.3012°/d   | +14.03° | -    | Tenth House    |
@@ -48,7 +48,7 @@ Future 2050 Subject — Natal Chart Report
 | Mean North Lunar Node | Sco ♏ | 17.38°   | -0.0530°/d   | -17.02° | R    | First House    |
 | True North Lunar Node | Sco ♏ | 18.28°   | -0.2080°/d   | -17.27° | R    | First House    |
 | Mean Lilith           | Vir ♍ | 10.24°   | +0.1119°/d   | +3.33°  | -    | Eleventh House |
-| True Lilith           | Vir ♍ | 11.79°   | +1.3025°/d   | +2.87°  | -    | Eleventh House |
+| True Lilith           | Vir ♍ | 11.79°   | +1.3024°/d   | +2.87°  | -    | Eleventh House |
 | Chiron                | Sag ♐ | 5.76°    | -0.0272°/d   | -16.50° | R    | Second House   |
 | Pholus                | Aqu ♒ | 11.94°   | -0.0286°/d   | -22.36° | R    | Fourth House   |
 | Ceres                 | Leo ♌ | 23.69°   | +0.4438°/d   | +20.75° | -    | Tenth House    |
@@ -57,14 +57,14 @@ Future 2050 Subject — Natal Chart Report
 | Vesta                 | Vir ♍ | 27.63°   | +0.4303°/d   | +6.61°  | -    | Eleventh House |
 | Interpolated Lilith   | Vir ♍ | 13.77°   | +0.1374°/d   | +2.12°  | -    | Eleventh House |
 | Interpolated Perigee  | Aqu ♒ | 21.37°   | +0.3890°/d   | -9.56°  | -    | Fourth House   |
-| Cupido                | Aqu ♒ | 14.06°   | -0.0195°/d   | -16.65° | R    | Fourth House   |
-| Hades                 | Leo ♌ | 9.32°    | +0.0211°/d   | +17.37° | -    | Tenth House    |
-| Zeus                  | Sco ♏ | 14.14°   | -0.0024°/d   | -16.09° | R    | First House    |
+| Cupido                | Aqu ♒ | 14.07°   | -0.0194°/d   | -16.65° | R    | Fourth House   |
+| Hades                 | Leo ♌ | 9.32°    | +0.0210°/d   | +17.38° | -    | Tenth House    |
+| Zeus                  | Sco ♏ | 14.14°   | -0.0025°/d   | -16.09° | R    | First House    |
 | Kronos                | Leo ♌ | 3.42°    | +0.0166°/d   | +19.40° | -    | Tenth House    |
-| Apollon               | Sco ♏ | 21.35°   | -0.0038°/d   | -18.11° | R    | First House    |
-| Admetos               | Gem ♊ | 19.71°   | +0.0118°/d   | +23.05° | -    | Eighth House   |
-| Vulkanus              | Leo ♌ | 17.56°   | +0.0132°/d   | +15.58° | -    | Tenth House    |
-| Poseidon              | Sco ♏ | 27.84°   | -0.0045°/d   | -19.69° | R    | Second House   |
+| Apollon               | Sco ♏ | 21.35°   | -0.0039°/d   | -18.11° | R    | First House    |
+| Admetos               | Gem ♊ | 19.71°   | +0.0119°/d   | +23.05° | -    | Eighth House   |
+| Vulkanus              | Leo ♌ | 17.56°   | +0.0131°/d   | +15.58° | -    | Tenth House    |
+| Poseidon              | Sco ♏ | 27.84°   | -0.0046°/d   | -19.69° | R    | Second House   |
 | Eris                  | Tau ♉ | 1.60°    | +0.0014°/d   | +6.87°  | -    | Seventh House  |
 | Sedna                 | Gem ♊ | 18.78°   | +0.0118°/d   | +12.12° | -    | Eighth House   |
 | Haumea                | Sco ♏ | 29.21°   | -0.0090°/d   | +5.15°  | R    | Second House   |
@@ -82,7 +82,7 @@ Future 2050 Subject — Natal Chart Report
 | Mean South Lunar Node | Tau ♉ | 17.38°   | -0.0530°/d   | +17.02° | R    | Seventh House  |
 | True South Lunar Node | Tau ♉ | 18.28°   | -0.2080°/d   | +17.27° | R    | Seventh House  |
 | Mean Priapus          | Pis ♓ | 10.24°   | +0.1119°/d   | -3.33°  | -    | Fifth House    |
-| True Priapus          | Pis ♓ | 11.79°   | +1.3025°/d   | -2.87°  | -    | Fifth House    |
+| True Priapus          | Pis ♓ | 11.79°   | +1.3024°/d   | -2.87°  | -    | Fifth House    |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +Natal Houses (Placidus)--+----------+-------------------+
@@ -228,7 +228,7 @@ Future 2050 Subject — Natal Chart Report
 | Sun                   | semi-square ∠    | Interpolated Lilith   | 1.13° | Applying →   |
 | Sun                   | sesquiquadrate ⚼ | Mean Priapus          | 2.40° | Separating ← |
 | Sun                   | sesquiquadrate ⚼ | True Priapus          | 0.85° | Applying →   |
-| Sun                   | conjunction ☌    | Kronos                | 5.79° | Applying →   |
+| Sun                   | conjunction ☌    | Kronos                | 5.78° | Applying →   |
 | Sun                   | trine △          | Apollon               | 6.29° | Separating ← |
 | Sun                   | trine △          | Poseidon              | 0.20° | Applying →   |
 | Moon                  | semi-sextile ⚺   | Venus                 | 0.83° | Applying →   |
@@ -258,7 +258,7 @@ Future 2050 Subject — Natal Chart Report
 | Moon                  | quincunx ⚻       | Mean Priapus          | 1.31° | Separating ← |
 | Moon                  | quincunx ⚻       | True Priapus          | 0.24° | Applying →   |
 | Moon                  | opposition ☍     | Cupido                | 2.52° | Applying →   |
-| Moon                  | conjunction ☌    | Hades                 | 2.22° | Separating ← |
+| Moon                  | conjunction ☌    | Hades                 | 2.23° | Separating ← |
 | Moon                  | square □         | Zeus                  | 2.59° | Applying →   |
 | Moon                  | conjunction ☌    | Vulkanus              | 6.01° | Applying →   |
 | Mercury               | opposition ☍     | Mars                  | 3.27° | Applying →   |
@@ -275,11 +275,11 @@ Future 2050 Subject — Natal Chart Report
 | Mercury               | square □         | Haumea                | 5.93° | Applying →   |
 | Mercury               | opposition ☍     | Ixion                 | 0.74° | Applying →   |
 | Mercury               | opposition ☍     | Interpolated Perigee  | 1.91° | Separating ← |
-| Mercury               | opposition ☍     | White Moon            | 1.12° | Separating ← |
+| Mercury               | opposition ☍     | White Moon            | 1.11° | Separating ← |
 | Mercury               | square □         | Apollon               | 1.93° | Separating ← |
 | Mercury               | sextile ⚹        | Admetos               | 3.57° | Separating ← |
-| Mercury               | conjunction ☌    | Vulkanus              | 5.72° | Separating ← |
-| Mercury               | square □         | Poseidon              | 4.55° | Applying →   |
+| Mercury               | conjunction ☌    | Vulkanus              | 5.73° | Separating ← |
+| Mercury               | square □         | Poseidon              | 4.56° | Applying →   |
 | Venus                 | semi-sextile ⚺   | Jupiter               | 0.99° | Separating ← |
 | Venus                 | biquintile bQ    | Saturn                | 0.17° | Separating ← |
 | Venus                 | conjunction ☌    | Uranus                | 5.60° | Applying →   |
@@ -303,7 +303,7 @@ Future 2050 Subject — Natal Chart Report
 | Venus                 | opposition ☍     | Mean Priapus          | 2.14° | Separating ← |
 | Venus                 | opposition ☍     | True Priapus          | 0.59° | Applying →   |
 | Venus                 | quincunx ⚻       | Cupido                | 1.69° | Applying →   |
-| Venus                 | sextile ⚹        | Zeus                  | 1.76° | Applying →   |
+| Venus                 | sextile ⚹        | Zeus                  | 1.77° | Applying →   |
 | Mars                  | square □         | Neptune               | 1.35° | Separating ← |
 | Mars                  | trine △          | Ascendant             | 0.55° | Separating ← |
 | Mars                  | sextile ⚹        | Descendant            | 0.55° | Separating ← |
@@ -316,7 +316,7 @@ Future 2050 Subject — Natal Chart Report
 | Mars                  | conjunction ☌    | Interpolated Perigee  | 5.18° | Applying →   |
 | Mars                  | conjunction ☌    | White Moon            | 4.38° | Applying →   |
 | Mars                  | square □         | Apollon               | 5.20° | Applying →   |
-| Mars                  | square □         | Poseidon              | 1.28° | Separating ← |
+| Mars                  | square □         | Poseidon              | 1.29° | Separating ← |
 | Jupiter               | opposition ☍     | Saturn                | 5.18° | Separating ← |
 | Jupiter               | quintile Q       | Neptune               | 1.49° | Separating ← |
 | Jupiter               | quincunx ⚻       | Pluto                 | 1.00° | Separating ← |
@@ -337,7 +337,7 @@ Future 2050 Subject — Natal Chart Report
 | Jupiter               | quincunx ⚻       | Mean Priapus          | 1.15° | Separating ← |
 | Jupiter               | quincunx ⚻       | True Priapus          | 0.40° | Separating ← |
 | Jupiter               | opposition ☍     | Cupido                | 2.68° | Applying →   |
-| Jupiter               | conjunction ☌    | Hades                 | 2.06° | Separating ← |
+| Jupiter               | conjunction ☌    | Hades                 | 2.07° | Separating ← |
 | Jupiter               | square □         | Zeus                  | 2.75° | Applying →   |
 | Saturn                | sextile ⚹        | Chiron                | 0.44° | Applying →   |
 | Saturn                | opposition ☍     | Medium Coeli          | 5.65° | Applying →   |
@@ -354,9 +354,9 @@ Future 2050 Subject — Natal Chart Report
 | Saturn                | trine △          | Vertex                | 1.87° | Separating ← |
 | Saturn                | sextile ⚹        | Anti Vertex           | 1.87° | Separating ← |
 | Saturn                | biquintile bQ    | Interpolated Lilith   | 1.57° | Separating ← |
-| Saturn                | opposition ☍     | Hades                 | 3.12° | Separating ← |
-| Saturn                | opposition ☍     | Kronos                | 2.78° | Applying →   |
-| Saturn                | sesquiquadrate ⚼ | Admetos               | 1.49° | Applying →   |
+| Saturn                | opposition ☍     | Hades                 | 3.11° | Separating ← |
+| Saturn                | opposition ☍     | Kronos                | 2.79° | Applying →   |
+| Saturn                | sesquiquadrate ⚼ | Admetos               | 1.50° | Applying →   |
 | Uranus                | sextile ⚹        | Mean North Lunar Node | 0.59° | Separating ← |
 | Uranus                | sextile ⚹        | True North Lunar Node | 0.31° | Applying →   |
 | Uranus                | trine △          | Mean South Lunar Node | 0.59° | Separating ← |
@@ -373,7 +373,7 @@ Future 2050 Subject — Natal Chart Report
 | Uranus                | semi-square ∠    | Kronos                | 0.45° | Applying →   |
 | Uranus                | sextile ⚹        | Apollon               | 3.38° | Applying →   |
 | Uranus                | square □         | Admetos               | 1.74° | Applying →   |
-| Uranus                | semi-sextile ⚺   | Vulkanus              | 0.41° | Separating ← |
+| Uranus                | semi-sextile ⚺   | Vulkanus              | 0.42° | Separating ← |
 | Neptune               | quincunx ⚻       | Ascendant             | 0.80° | Applying →   |
 | Neptune               | sextile ⚹        | Medium Coeli          | 2.65° | Separating ← |
 | Neptune               | semi-sextile ⚺   | Descendant            | 0.80° | Applying →   |
@@ -384,8 +384,8 @@ Future 2050 Subject — Natal Chart Report
 | Neptune               | square □         | Ixion                 | 3.87° | Separating ← |
 | Neptune               | sesquiquadrate ⚼ | Orcus                 | 0.96° | Separating ← |
 | Neptune               | sesquiquadrate ⚼ | Pars Spiritus         | 0.30° | Applying →   |
-| Neptune               | square □         | White Moon            | 5.73° | Applying →   |
-| Neptune               | quintile Q       | Hades                 | 0.57° | Separating ← |
+| Neptune               | square □         | White Moon            | 5.72° | Applying →   |
+| Neptune               | quintile Q       | Hades                 | 0.58° | Separating ← |
 | Neptune               | opposition ☍     | Poseidon              | 0.06° | Separating ← |
 | Pluto                 | square □         | Chiron                | 4.63° | Separating ← |
 | Pluto                 | sesquiquadrate ⚼ | Ascendant             | 1.71° | Separating ← |
@@ -414,11 +414,11 @@ Future 2050 Subject — Natal Chart Report
 | Mean North Lunar Node | sextile ⚹        | Interpolated Lilith   | 3.61° | Applying →   |
 | Mean North Lunar Node | trine △          | True Priapus          | 5.60° | Applying →   |
 | Mean North Lunar Node | square □         | Interpolated Perigee  | 3.99° | Separating ← |
-| Mean North Lunar Node | square □         | White Moon            | 4.78° | Separating ← |
+| Mean North Lunar Node | square □         | White Moon            | 4.79° | Separating ← |
 | Mean North Lunar Node | square □         | Cupido                | 3.32° | Applying →   |
-| Mean North Lunar Node | conjunction ☌    | Zeus                  | 3.25° | Applying →   |
+| Mean North Lunar Node | conjunction ☌    | Zeus                  | 3.24° | Applying →   |
 | Mean North Lunar Node | conjunction ☌    | Apollon               | 3.97° | Separating ← |
-| Mean North Lunar Node | square □         | Vulkanus              | 0.18° | Separating ← |
+| Mean North Lunar Node | square □         | Vulkanus              | 0.17° | Separating ← |
 | True North Lunar Node | quintile Q       | Imum Coeli            | 0.27° | Separating ← |
 | True North Lunar Node | square □         | Ceres                 | 5.41° | Separating ← |
 | True North Lunar Node | sextile ⚹        | Juno                  | 4.27° | Applying →   |
@@ -427,20 +427,20 @@ Future 2050 Subject — Natal Chart Report
 | True North Lunar Node | square □         | Quaoar                | 3.73° | Applying →   |
 | True North Lunar Node | sextile ⚹        | Interpolated Lilith   | 4.51° | Applying →   |
 | True North Lunar Node | square □         | Interpolated Perigee  | 3.09° | Separating ← |
-| True North Lunar Node | square □         | White Moon            | 3.88° | Separating ← |
+| True North Lunar Node | square □         | White Moon            | 3.89° | Separating ← |
 | True North Lunar Node | square □         | Cupido                | 4.22° | Applying →   |
-| True North Lunar Node | conjunction ☌    | Zeus                  | 4.15° | Applying →   |
+| True North Lunar Node | conjunction ☌    | Zeus                  | 4.14° | Applying →   |
 | True North Lunar Node | conjunction ☌    | Apollon               | 3.07° | Separating ← |
-| True North Lunar Node | quincunx ⚻       | Admetos               | 1.43° | Separating ← |
-| True North Lunar Node | square □         | Vulkanus              | 0.72° | Applying →   |
+| True North Lunar Node | quincunx ⚻       | Admetos               | 1.42° | Separating ← |
+| True North Lunar Node | square □         | Vulkanus              | 0.73° | Applying →   |
 | Chiron                | trine △          | Medium Coeli          | 5.21° | Applying →   |
 | Chiron                | square □         | Mean Lilith           | 4.47° | Separating ← |
 | Chiron                | biquintile bQ    | Eris                  | 1.83° | Separating ← |
 | Chiron                | opposition ☍     | Vertex                | 2.31° | Separating ← |
 | Chiron                | conjunction ☌    | Anti Vertex           | 2.31° | Separating ← |
 | Chiron                | square □         | Mean Priapus          | 4.47° | Separating ← |
-| Chiron                | trine △          | Hades                 | 3.56° | Separating ← |
-| Chiron                | trine △          | Kronos                | 2.34° | Applying →   |
+| Chiron                | trine △          | Hades                 | 3.55° | Separating ← |
+| Chiron                | trine △          | Kronos                | 2.35° | Applying →   |
 | Ascendant             | square □         | Medium Coeli          | 3.45° | Static =     |
 | Ascendant             | square □         | Imum Coeli            | 3.45° | Static =     |
 | Ascendant             | semi-square ∠    | Mean Lilith           | 1.86° | Separating ← |
@@ -457,7 +457,7 @@ Future 2050 Subject — Natal Chart Report
 | Ascendant             | sesquiquadrate ⚼ | True Priapus          | 0.31° | Separating ← |
 | Ascendant             | trine △          | Interpolated Perigee  | 5.73° | Separating ← |
 | Ascendant             | trine △          | White Moon            | 4.93° | Separating ← |
-| Ascendant             | semi-sextile ⚺   | Poseidon              | 0.73° | Applying →   |
+| Ascendant             | semi-sextile ⚺   | Poseidon              | 0.74° | Applying →   |
 | Medium Coeli          | square □         | Descendant            | 3.45° | Static =     |
 | Medium Coeli          | quintile Q       | Mean South Lunar Node | 1.17° | Separating ← |
 | Medium Coeli          | quintile Q       | True South Lunar Node | 0.27° | Separating ← |
@@ -488,8 +488,8 @@ Future 2050 Subject — Natal Chart Report
 | Descendant            | semi-square ∠    | Mean Priapus          | 1.86° | Separating ← |
 | Descendant            | semi-square ∠    | True Priapus          | 0.31° | Separating ← |
 | Descendant            | sextile ⚹        | White Moon            | 4.93° | Separating ← |
-| Descendant            | quintile Q       | Cupido                | 1.04° | Separating ← |
-| Descendant            | quincunx ⚻       | Poseidon              | 0.73° | Applying →   |
+| Descendant            | quintile Q       | Cupido                | 1.03° | Separating ← |
+| Descendant            | quincunx ⚻       | Poseidon              | 0.74° | Applying →   |
 | Imum Coeli            | sesquiquadrate ⚼ | Juno                  | 1.53° | Separating ← |
 | Imum Coeli            | trine △          | Vesta                 | 2.92° | Separating ← |
 | Imum Coeli            | square □         | Eris                  | 1.05° | Applying →   |
@@ -522,11 +522,11 @@ Future 2050 Subject — Natal Chart Report
 | Mean South Lunar Node | biquintile bQ    | Pars Spiritus         | 1.81° | Separating ← |
 | Mean South Lunar Node | trine △          | Interpolated Lilith   | 3.61° | Applying →   |
 | Mean South Lunar Node | square □         | Interpolated Perigee  | 3.99° | Separating ← |
-| Mean South Lunar Node | square □         | White Moon            | 4.78° | Separating ← |
+| Mean South Lunar Node | square □         | White Moon            | 4.79° | Separating ← |
 | Mean South Lunar Node | square □         | Cupido                | 3.32° | Applying →   |
-| Mean South Lunar Node | opposition ☍     | Zeus                  | 3.25° | Applying →   |
+| Mean South Lunar Node | opposition ☍     | Zeus                  | 3.24° | Applying →   |
 | Mean South Lunar Node | opposition ☍     | Apollon               | 3.97° | Separating ← |
-| Mean South Lunar Node | square □         | Vulkanus              | 0.18° | Separating ← |
+| Mean South Lunar Node | square □         | Vulkanus              | 0.17° | Separating ← |
 | True South Lunar Node | square □         | Ceres                 | 5.41° | Separating ← |
 | True South Lunar Node | trine △          | Juno                  | 4.27° | Applying →   |
 | True South Lunar Node | semi-sextile ⚺   | Sedna                 | 0.50° | Separating ← |
@@ -536,12 +536,12 @@ Future 2050 Subject — Natal Chart Report
 | True South Lunar Node | biquintile bQ    | Pars Spiritus         | 0.91° | Separating ← |
 | True South Lunar Node | trine △          | Interpolated Lilith   | 4.51° | Applying →   |
 | True South Lunar Node | square □         | Interpolated Perigee  | 3.09° | Separating ← |
-| True South Lunar Node | square □         | White Moon            | 3.88° | Separating ← |
+| True South Lunar Node | square □         | White Moon            | 3.89° | Separating ← |
 | True South Lunar Node | square □         | Cupido                | 4.22° | Applying →   |
-| True South Lunar Node | opposition ☍     | Zeus                  | 4.15° | Applying →   |
+| True South Lunar Node | opposition ☍     | Zeus                  | 4.14° | Applying →   |
 | True South Lunar Node | opposition ☍     | Apollon               | 3.07° | Separating ← |
-| True South Lunar Node | semi-sextile ⚺   | Admetos               | 1.43° | Separating ← |
-| True South Lunar Node | square □         | Vulkanus              | 0.72° | Applying →   |
+| True South Lunar Node | semi-sextile ⚺   | Admetos               | 1.42° | Separating ← |
+| True South Lunar Node | square □         | Vulkanus              | 0.73° | Applying →   |
 | True Lilith           | quincunx ⚻       | Pholus                | 0.16° | Applying →   |
 | True Lilith           | sextile ⚹        | Pallas                | 2.41° | Separating ← |
 | True Lilith           | conjunction ☌    | Juno                  | 2.23° | Applying →   |
@@ -567,17 +567,17 @@ Future 2050 Subject — Natal Chart Report
 | Pholus                | semi-sextile ⚺   | Mean Priapus          | 1.71° | Applying →   |
 | Pholus                | semi-sextile ⚺   | True Priapus          | 0.16° | Applying →   |
 | Pholus                | conjunction ☌    | Cupido                | 2.12° | Separating ← |
-| Pholus                | opposition ☍     | Hades                 | 2.62° | Applying →   |
+| Pholus                | opposition ☍     | Hades                 | 2.63° | Applying →   |
 | Pholus                | square □         | Zeus                  | 2.19° | Separating ← |
-| Pholus                | opposition ☍     | Vulkanus              | 5.62° | Separating ← |
+| Pholus                | opposition ☍     | Vulkanus              | 5.61° | Separating ← |
 | Ceres                 | semi-square ∠    | Pallas                | 0.68° | Separating ← |
 | Ceres                 | sextile ⚹        | Sedna                 | 4.91° | Separating ← |
 | Ceres                 | square □         | Haumea                | 5.52° | Applying →   |
 | Ceres                 | opposition ☍     | Ixion                 | 0.33° | Applying →   |
 | Ceres                 | opposition ☍     | Interpolated Perigee  | 2.32° | Separating ← |
-| Ceres                 | opposition ☍     | White Moon            | 1.53° | Separating ← |
+| Ceres                 | opposition ☍     | White Moon            | 1.52° | Separating ← |
 | Ceres                 | square □         | Apollon               | 2.34° | Separating ← |
-| Ceres                 | sextile ⚹        | Admetos               | 3.98° | Separating ← |
+| Ceres                 | sextile ⚹        | Admetos               | 3.99° | Separating ← |
 | Ceres                 | square □         | Poseidon              | 4.14° | Applying →   |
 | Pallas                | sextile ⚹        | Juno                  | 4.64° | Applying →   |
 | Pallas                | sesquiquadrate ⚼ | Ixion                 | 0.35° | Separating ← |
@@ -590,8 +590,8 @@ Future 2050 Subject — Natal Chart Report
 | Pallas                | sextile ⚹        | Interpolated Lilith   | 4.39° | Applying →   |
 | Pallas                | trine △          | Mean Priapus          | 0.86° | Applying →   |
 | Pallas                | trine △          | True Priapus          | 2.41° | Separating ← |
-| Pallas                | biquintile bQ    | Cupido                | 1.32° | Separating ← |
-| Pallas                | semi-sextile ⚺   | Hades                 | 0.05° | Separating ← |
+| Pallas                | biquintile bQ    | Cupido                | 1.31° | Separating ← |
+| Pallas                | semi-sextile ⚺   | Hades                 | 0.06° | Separating ← |
 | Pallas                | trine △          | Zeus                  | 4.76° | Applying →   |
 | Juno                  | square □         | Sedna                 | 4.77° | Applying →   |
 | Juno                  | quincunx ⚻       | Quaoar                | 0.53° | Applying →   |
@@ -603,7 +603,7 @@ Future 2050 Subject — Natal Chart Report
 | Juno                  | conjunction ☌    | Interpolated Lilith   | 0.25° | Separating ← |
 | Juno                  | opposition ☍     | Mean Priapus          | 3.78° | Separating ← |
 | Juno                  | opposition ☍     | True Priapus          | 2.23° | Applying →   |
-| Juno                  | quincunx ⚻       | Cupido                | 0.04° | Applying →   |
+| Juno                  | quincunx ⚻       | Cupido                | 0.05° | Applying →   |
 | Juno                  | sextile ⚹        | Zeus                  | 0.12° | Applying →   |
 | Juno                  | square □         | Admetos               | 5.69° | Applying →   |
 | Juno                  | quintile Q       | Poseidon              | 1.82° | Applying →   |
@@ -613,7 +613,7 @@ Future 2050 Subject — Natal Chart Report
 | Vesta                 | biquintile bQ    | Pars Fidei            | 1.35° | Separating ← |
 | Vesta                 | quintile Q       | Anti Vertex           | 1.56° | Separating ← |
 | Vesta                 | biquintile bQ    | Interpolated Perigee  | 0.26° | Separating ← |
-| Vesta                 | biquintile bQ    | White Moon            | 0.53° | Applying →   |
+| Vesta                 | biquintile bQ    | White Moon            | 0.54° | Applying →   |
 | Vesta                 | sesquiquadrate ⚼ | Cupido                | 1.43° | Applying →   |
 | Vesta                 | semi-square ∠    | Zeus                  | 1.50° | Applying →   |
 | Vesta                 | sextile ⚹        | Poseidon              | 0.20° | Applying →   |
@@ -621,7 +621,7 @@ Future 2050 Subject — Natal Chart Report
 | Eris                  | conjunction ☌    | Pars Fidei            | 0.69° | Applying →   |
 | Eris                  | biquintile bQ    | Anti Vertex           | 0.47° | Applying →   |
 | Eris                  | quintile Q       | Interpolated Perigee  | 1.78° | Separating ← |
-| Eris                  | square □         | Kronos                | 1.83° | Separating ← |
+| Eris                  | square □         | Kronos                | 1.82° | Separating ← |
 | Sedna                 | sesquiquadrate ⚼ | Makemake              | 0.63° | Separating ← |
 | Sedna                 | trine △          | Ixion                 | 5.24° | Applying →   |
 | Sedna                 | trine △          | Quaoar                | 4.23° | Separating ← |
@@ -630,26 +630,26 @@ Future 2050 Subject — Natal Chart Report
 | Sedna                 | semi-square ∠    | Pars Fidei            | 1.50° | Separating ← |
 | Sedna                 | square □         | Interpolated Lilith   | 5.01° | Applying →   |
 | Sedna                 | trine △          | Interpolated Perigee  | 2.59° | Separating ← |
-| Sedna                 | trine △          | White Moon            | 3.38° | Separating ← |
+| Sedna                 | trine △          | White Moon            | 3.39° | Separating ← |
 | Sedna                 | trine △          | Cupido                | 4.72° | Separating ← |
-| Sedna                 | biquintile bQ    | Zeus                  | 1.35° | Applying →   |
-| Sedna                 | semi-square ∠    | Kronos                | 0.36° | Applying →   |
-| Sedna                 | conjunction ☌    | Admetos               | 0.93° | Static =     |
-| Sedna                 | sextile ⚹        | Vulkanus              | 1.22° | Applying →   |
+| Sedna                 | biquintile bQ    | Zeus                  | 1.36° | Applying →   |
+| Sedna                 | semi-square ∠    | Kronos                | 0.37° | Applying →   |
+| Sedna                 | conjunction ☌    | Admetos               | 0.92° | Static =     |
+| Sedna                 | sextile ⚹        | Vulkanus              | 1.23° | Applying →   |
 | Haumea                | square □         | Ixion                 | 5.19° | Separating ← |
 | Haumea                | semi-square ∠    | Pars Spiritus         | 1.02° | Applying →   |
-| Haumea                | trine △          | Kronos                | 4.21° | Separating ← |
+| Haumea                | trine △          | Kronos                | 4.20° | Separating ← |
 | Haumea                | conjunction ☌    | Poseidon              | 1.38° | Applying →   |
 | Makemake              | opposition ☍     | Pars Fidei            | 0.87° | Static =     |
 | Makemake              | biquintile bQ    | Vertex                | 1.08° | Static =     |
-| Makemake              | square □         | Kronos                | 0.27° | Separating ← |
-| Makemake              | sesquiquadrate ⚼ | Admetos               | 1.56° | Separating ← |
+| Makemake              | square □         | Kronos                | 0.26° | Separating ← |
+| Makemake              | sesquiquadrate ⚼ | Admetos               | 1.55° | Separating ← |
 | Ixion                 | quintile Q       | Pars Amoris           | 0.19° | Applying →   |
 | Ixion                 | conjunction ☌    | Interpolated Perigee  | 2.65° | Applying →   |
-| Ixion                 | conjunction ☌    | White Moon            | 1.86° | Applying →   |
+| Ixion                 | conjunction ☌    | White Moon            | 1.85° | Applying →   |
 | Ixion                 | square □         | Apollon               | 2.67° | Applying →   |
-| Ixion                 | trine △          | Admetos               | 4.31° | Applying →   |
-| Ixion                 | square □         | Poseidon              | 3.81° | Separating ← |
+| Ixion                 | trine △          | Admetos               | 4.32° | Applying →   |
+| Ixion                 | square □         | Poseidon              | 3.82° | Separating ← |
 | Orcus                 | trine △          | Quaoar                | 2.62° | Applying →   |
 | Orcus                 | semi-sextile ⚺   | Pars Fortunae         | 0.92° | Separating ← |
 | Orcus                 | conjunction ☌    | Pars Spiritus         | 1.26° | Applying →   |
@@ -660,33 +660,33 @@ Future 2050 Subject — Natal Chart Report
 | Orcus                 | quincunx ⚻       | Mean Priapus          | 1.69° | Applying →   |
 | Orcus                 | quincunx ⚻       | True Priapus          | 0.15° | Applying →   |
 | Orcus                 | trine △          | Cupido                | 2.13° | Applying →   |
-| Orcus                 | sextile ⚹        | Hades                 | 2.61° | Applying →   |
-| Orcus                 | semi-square ∠    | Poseidon              | 0.90° | Applying →   |
+| Orcus                 | sextile ⚹        | Hades                 | 2.62° | Applying →   |
+| Orcus                 | semi-square ∠    | Poseidon              | 0.91° | Applying →   |
 | Quaoar                | square □         | Pars Fortunae         | 3.54° | Applying →   |
 | Quaoar                | trine △          | Pars Spiritus         | 1.36° | Applying →   |
 | Quaoar                | sextile ⚹        | Pars Amoris           | 2.72° | Applying →   |
 | Quaoar                | quincunx ⚻       | Interpolated Lilith   | 0.78° | Applying →   |
 | Quaoar                | conjunction ☌    | Cupido                | 0.49° | Static =     |
-| Quaoar                | opposition ☍     | Hades                 | 5.23° | Applying →   |
-| Quaoar                | square □         | Zeus                  | 0.42° | Applying →   |
-| Quaoar                | trine △          | Admetos               | 5.16° | Separating ← |
-| Quaoar                | opposition ☍     | Vulkanus              | 3.01° | Separating ← |
+| Quaoar                | opposition ☍     | Hades                 | 5.24° | Applying →   |
+| Quaoar                | square □         | Zeus                  | 0.41° | Applying →   |
+| Quaoar                | trine △          | Admetos               | 5.15° | Separating ← |
+| Quaoar                | opposition ☍     | Vulkanus              | 3.00° | Separating ← |
 | Pars Fortunae         | semi-sextile ⚺   | Pars Amoris           | 0.83° | Static =     |
 | Pars Fortunae         | sextile ⚹        | Interpolated Lilith   | 2.76° | Separating ← |
 | Pars Fortunae         | trine △          | Mean Priapus          | 0.77° | Applying →   |
 | Pars Fortunae         | trine △          | True Priapus          | 0.78° | Separating ← |
-| Pars Fortunae         | square □         | Cupido                | 3.05° | Applying →   |
+| Pars Fortunae         | square □         | Cupido                | 3.06° | Applying →   |
 | Pars Fortunae         | square □         | Hades                 | 1.69° | Applying →   |
 | Pars Fortunae         | conjunction ☌    | Zeus                  | 3.13° | Applying →   |
 | Pars Spiritus         | sextile ⚹        | Pars Amoris           | 1.36° | Static =     |
 | Pars Spiritus         | trine △          | Vertex                | 5.12° | Static =     |
 | Pars Spiritus         | semi-sextile ⚺   | Interpolated Lilith   | 0.58° | Separating ← |
 | Pars Spiritus         | quincunx ⚻       | True Priapus          | 1.40° | Applying →   |
-| Pars Spiritus         | trine △          | Cupido                | 0.87° | Applying →   |
+| Pars Spiritus         | trine △          | Cupido                | 0.88° | Applying →   |
 | Pars Spiritus         | sextile ⚹        | Hades                 | 3.87° | Applying →   |
-| Pars Spiritus         | semi-sextile ⚺   | Zeus                  | 0.94° | Applying →   |
-| Pars Spiritus         | sextile ⚹        | Vulkanus              | 4.37° | Separating ← |
-| Pars Spiritus         | semi-square ∠    | Poseidon              | 0.36° | Separating ← |
+| Pars Spiritus         | semi-sextile ⚺   | Zeus                  | 0.95° | Applying →   |
+| Pars Spiritus         | sextile ⚹        | Vulkanus              | 4.36° | Separating ← |
+| Pars Spiritus         | semi-square ∠    | Poseidon              | 0.35° | Separating ← |
 | Pars Amoris           | opposition ☍     | Vertex                | 3.77° | Static =     |
 | Pars Amoris           | conjunction ☌    | Anti Vertex           | 3.77° | Static =     |
 | Pars Amoris           | square □         | Interpolated Lilith   | 1.93° | Separating ← |
@@ -694,16 +694,16 @@ Future 2050 Subject — Natal Chart Report
 | Pars Amoris           | square □         | True Priapus          | 0.05° | Applying →   |
 | Pars Amoris           | quintile Q       | White Moon            | 1.67° | Applying →   |
 | Pars Amoris           | sextile ⚹        | Cupido                | 2.23° | Applying →   |
-| Pars Amoris           | trine △          | Hades                 | 2.51° | Applying →   |
+| Pars Amoris           | trine △          | Hades                 | 2.52° | Applying →   |
 | Pars Amoris           | trine △          | Vulkanus              | 5.72° | Separating ← |
 | Pars Fidei            | biquintile bQ    | Anti Vertex           | 0.21° | Static =     |
 | Pars Fidei            | quintile Q       | Interpolated Perigee  | 1.09° | Separating ← |
-| Pars Fidei            | quintile Q       | White Moon            | 1.88° | Separating ← |
-| Pars Fidei            | square □         | Kronos                | 1.14° | Separating ← |
+| Pars Fidei            | quintile Q       | White Moon            | 1.89° | Separating ← |
+| Pars Fidei            | square □         | Kronos                | 1.13° | Separating ← |
 | Vertex                | square □         | Interpolated Lilith   | 5.70° | Separating ← |
 | Vertex                | square □         | Mean Priapus          | 2.17° | Separating ← |
 | Vertex                | square □         | True Priapus          | 3.72° | Separating ← |
-| Vertex                | trine △          | Cupido                | 5.99° | Applying →   |
+| Vertex                | trine △          | Cupido                | 6.00° | Applying →   |
 | Vertex                | sextile ⚹        | Hades                 | 1.25° | Separating ← |
 | Vertex                | sextile ⚹        | Kronos                | 4.65° | Applying →   |
 | Anti Vertex           | square □         | Interpolated Lilith   | 5.70° | Separating ← |
@@ -714,7 +714,7 @@ Future 2050 Subject — Natal Chart Report
 | Anti Vertex           | trine △          | Kronos                | 4.65° | Applying →   |
 | Interpolated Lilith   | opposition ☍     | Mean Priapus          | 3.53° | Separating ← |
 | Interpolated Lilith   | opposition ☍     | True Priapus          | 1.98° | Applying →   |
-| Interpolated Lilith   | quincunx ⚻       | Cupido                | 0.29° | Applying →   |
+| Interpolated Lilith   | quincunx ⚻       | Cupido                | 0.30° | Applying →   |
 | Interpolated Lilith   | sextile ⚹        | Zeus                  | 0.37° | Applying →   |
 | Interpolated Lilith   | square □         | Admetos               | 5.94° | Applying →   |
 | Mean Priapus          | conjunction ☌    | True Priapus          | 1.55° | Separating ← |
@@ -722,25 +722,25 @@ Future 2050 Subject — Natal Chart Report
 | Mean Priapus          | trine △          | Zeus                  | 3.90° | Applying →   |
 | Mean Priapus          | biquintile bQ    | Kronos                | 0.82° | Separating ← |
 | True Priapus          | trine △          | Zeus                  | 2.35° | Applying →   |
-| Interpolated Perigee  | conjunction ☌    | White Moon            | 0.79° | Applying →   |
+| Interpolated Perigee  | conjunction ☌    | White Moon            | 0.80° | Applying →   |
 | Interpolated Perigee  | square □         | Apollon               | 0.02° | Separating ← |
-| Interpolated Perigee  | trine △          | Admetos               | 1.66° | Separating ← |
-| Interpolated Perigee  | opposition ☍     | Vulkanus              | 3.81° | Separating ← |
+| Interpolated Perigee  | trine △          | Admetos               | 1.67° | Separating ← |
+| Interpolated Perigee  | opposition ☍     | Vulkanus              | 3.82° | Separating ← |
 | White Moon            | square □         | Apollon               | 0.82° | Separating ← |
-| White Moon            | trine △          | Admetos               | 2.45° | Separating ← |
-| White Moon            | opposition ☍     | Vulkanus              | 4.61° | Separating ← |
+| White Moon            | trine △          | Admetos               | 2.46° | Separating ← |
+| White Moon            | opposition ☍     | Vulkanus              | 4.62° | Separating ← |
 | White Moon            | square □         | Poseidon              | 5.67° | Applying →   |
-| Cupido                | opposition ☍     | Hades                 | 4.74° | Applying →   |
-| Cupido                | square □         | Zeus                  | 0.08° | Separating ← |
-| Cupido                | trine △          | Admetos               | 5.65° | Separating ← |
-| Cupido                | opposition ☍     | Vulkanus              | 3.50° | Separating ← |
-| Hades                 | square □         | Zeus                  | 4.81° | Applying →   |
+| Cupido                | opposition ☍     | Hades                 | 4.75° | Applying →   |
+| Cupido                | square □         | Zeus                  | 0.07° | Separating ← |
+| Cupido                | trine △          | Admetos               | 5.64° | Separating ← |
+| Cupido                | opposition ☍     | Vulkanus              | 3.49° | Separating ← |
+| Hades                 | square □         | Zeus                  | 4.82° | Applying →   |
 | Hades                 | conjunction ☌    | Kronos                | 5.90° | Separating ← |
 | Zeus                  | biquintile bQ    | Admetos               | 0.43° | Applying →   |
 | Zeus                  | square □         | Vulkanus              | 3.42° | Separating ← |
 | Kronos                | semi-square ∠    | Admetos               | 1.29° | Applying →   |
-| Kronos                | trine △          | Poseidon              | 5.59° | Separating ← |
+| Kronos                | trine △          | Poseidon              | 5.58° | Separating ← |
 | Apollon               | quincunx ⚻       | Admetos               | 1.64° | Applying →   |
-| Apollon               | square □         | Vulkanus              | 3.79° | Applying →   |
+| Apollon               | square □         | Vulkanus              | 3.80° | Applying →   |
 | Admetos               | sextile ⚹        | Vulkanus              | 2.15° | Applying →   |
 +-----------------------+------------------+-----------------------+-------+--------------+

--- a/tests/fixtures/natal_john_lennon_chart_report.txt
+++ b/tests/fixtures/natal_john_lennon_chart_report.txt
@@ -31,8 +31,8 @@ John Lennon — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Ari ♈ | 19.71°   | +886.9396°/d | N/A     | -    | First House    |
-| Medium Coeli          | Cap ♑ | 7.06°    | +332.1233°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Ari ♈ | 19.71°   | +886.9442°/d | N/A     | -    | First House    |
+| Medium Coeli          | Cap ♑ | 7.06°    | +332.1251°/d | N/A     | -    | Tenth House    |
 | Sun                   | Lib ♎ | 16.27°   | +0.9885°/d   | -6.40°  | -    | Sixth House    |
 | Moon                  | Aqu ♒ | 3.55°    | +12.5291°/d  | -14.60° | -    | Eleventh House |
 | Mercury               | Sco ♏ | 8.56°    | +1.3195°/d   | -16.23° | -    | Seventh House  |

--- a/tests/fixtures/natal_john_lennon_subject_report.txt
+++ b/tests/fixtures/natal_john_lennon_subject_report.txt
@@ -31,8 +31,8 @@ John Lennon — Subject Report
 +Celestial Points-------+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Ari ♈ | 19.71°   | +886.9396°/d | N/A     | -    | First House    |
-| Medium Coeli          | Cap ♑ | 7.06°    | +332.1233°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Ari ♈ | 19.71°   | +886.9442°/d | N/A     | -    | First House    |
+| Medium Coeli          | Cap ♑ | 7.06°    | +332.1251°/d | N/A     | -    | Tenth House    |
 | Sun                   | Lib ♎ | 16.27°   | +0.9885°/d   | -6.40°  | -    | Sixth House    |
 | Moon                  | Aqu ♒ | 3.55°    | +12.5291°/d  | -14.60° | -    | Eleventh House |
 | Mercury               | Sco ♏ | 8.56°    | +1.3195°/d   | -16.23° | -    | Seventh House  |

--- a/tests/fixtures/natal_johnny_depp_chart_report.txt
+++ b/tests/fixtures/natal_johnny_depp_chart_report.txt
@@ -31,8 +31,8 @@ Johnny Depp — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Aqu ♒ | 20.70°   | +507.7850°/d | N/A     | -    | First House    |
-| Medium Coeli          | Sag ♐ | 6.59°    | +341.0190°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Aqu ♒ | 20.70°   | +507.7877°/d | N/A     | -    | First House    |
+| Medium Coeli          | Sag ♐ | 6.59°    | +341.0208°/d | N/A     | -    | Tenth House    |
 | Sun                   | Gem ♊ | 17.66°   | +0.9560°/d   | +22.87° | -    | Fourth House   |
 | Moon                  | Cap ♑ | 8.74°    | +12.4796°/d  | -22.08° | -    | Eleventh House |
 | Mercury               | Tau ♉ | 25.00°   | +0.6817°/d   | +15.27° | -    | Third House    |

--- a/tests/fixtures/natal_johnny_depp_subject_report.txt
+++ b/tests/fixtures/natal_johnny_depp_subject_report.txt
@@ -31,8 +31,8 @@ Johnny Depp — Subject Report
 +Celestial Points-------+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Aqu ♒ | 20.70°   | +507.7850°/d | N/A     | -    | First House    |
-| Medium Coeli          | Sag ♐ | 6.59°    | +341.0190°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Aqu ♒ | 20.70°   | +507.7877°/d | N/A     | -    | First House    |
+| Medium Coeli          | Sag ♐ | 6.59°    | +341.0208°/d | N/A     | -    | Tenth House    |
 | Sun                   | Gem ♊ | 17.66°   | +0.9560°/d   | +22.87° | -    | Fourth House   |
 | Moon                  | Cap ♑ | 8.74°    | +12.4796°/d  | -22.08° | -    | Eleventh House |
 | Mercury               | Tau ♉ | 25.00°   | +0.6817°/d   | +15.27° | -    | Third House    |

--- a/tests/fixtures/natal_quito_all_report.txt
+++ b/tests/fixtures/natal_quito_all_report.txt
@@ -31,10 +31,10 @@ Quito Subject — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Vir ♍ | 19.41°   | +390.8268°/d | N/A     | -    | First House    |
-| Medium Coeli          | Gem ♊ | 21.04°   | +332.6995°/d | N/A     | -    | Tenth House    |
-| Descendant            | Pis ♓ | 19.41°   | +390.8268°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Sag ♐ | 21.04°   | +332.6995°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Vir ♍ | 19.41°   | +390.8289°/d | N/A     | -    | First House    |
+| Medium Coeli          | Gem ♊ | 21.04°   | +332.7013°/d | N/A     | -    | Tenth House    |
+| Descendant            | Pis ♓ | 19.41°   | +390.8289°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Sag ♐ | 21.04°   | +332.7013°/d | N/A     | -    | Fourth House   |
 | Sun                   | Gem ♊ | 24.33°   | +0.9551°/d   | +23.32° | -    | Tenth House    |
 | Moon                  | Pis ♓ | 18.15°   | +13.4369°/d  | -1.62°  | -    | Sixth House    |
 | Mercury               | Gem ♊ | 6.05°    | +1.7255°/d   | +19.72° | -    | Ninth House    |
@@ -47,7 +47,7 @@ Quito Subject — Natal Chart Report
 | Pluto                 | Sco ♏ | 15.40°   | -0.0201°/d   | -1.25°  | R    | Second House   |
 | Mean North Lunar Node | Aqu ♒ | 9.69°    | -0.0530°/d   | -17.83° | R    | Fifth House    |
 | True North Lunar Node | Aqu ♒ | 8.12°    | +0.0101°/d   | -18.24° | -    | Fifth House    |
-| Mean Lilith           | Sco ♏ | 24.97°   | +0.1120°/d   | -23.82° | -    | Third House    |
+| Mean Lilith           | Sco ♏ | 24.97°   | +0.1120°/d   | -23.83° | -    | Third House    |
 | True Lilith           | Sag ♐ | 19.22°   | +0.7992°/d   | -26.89° | -    | Third House    |
 | Chiron                | Can ♋ | 16.08°   | +0.1013°/d   | +16.25° | -    | Tenth House    |
 | Pholus                | Can ♋ | 3.09°    | +0.1368°/d   | +13.47° | -    | Tenth House    |
@@ -57,14 +57,14 @@ Quito Subject — Natal Chart Report
 | Vesta                 | Tau ♉ | 4.89°    | +0.4034°/d   | +7.63°  | -    | Eighth House   |
 | Interpolated Lilith   | Sco ♏ | 20.66°   | +0.0786°/d   | -22.78° | -    | Second House   |
 | Interpolated Perigee  | Gem ♊ | 8.53°    | +0.4457°/d   | +26.13° | -    | Ninth House    |
-| Cupido                | Sco ♏ | 18.99°   | -0.0160°/d   | -16.43° | R    | Second House   |
-| Hades                 | Gem ♊ | 9.26°    | +0.0208°/d   | +20.84° | -    | Ninth House    |
-| Zeus                  | Vir ♍ | 25.80°   | +0.0017°/d   | +1.67°  | -    | First House    |
+| Cupido                | Sco ♏ | 19.00°   | -0.0160°/d   | -16.43° | R    | Second House   |
+| Hades                 | Gem ♊ | 9.26°    | +0.0209°/d   | +20.84° | -    | Ninth House    |
+| Zeus                  | Vir ♍ | 25.80°   | +0.0016°/d   | +1.67°  | -    | First House    |
 | Kronos                | Gem ♊ | 21.34°   | +0.0166°/d   | +23.17° | -    | Tenth House    |
-| Apollon               | Lib ♎ | 13.78°   | -0.0030°/d   | -5.44°  | R    | First House    |
-| Admetos               | Tau ♉ | 14.65°   | +0.0116°/d   | +16.24° | -    | Eighth House   |
+| Apollon               | Lib ♎ | 13.79°   | -0.0031°/d   | -5.44°  | R    | First House    |
+| Admetos               | Tau ♉ | 14.64°   | +0.0117°/d   | +16.24° | -    | Eighth House   |
 | Vulkanus              | Can ♋ | 14.85°   | +0.0130°/d   | +22.63° | -    | Tenth House    |
-| Poseidon              | Lib ♎ | 28.76°   | -0.0053°/d   | -11.04° | R    | Second House   |
+| Poseidon              | Lib ♎ | 28.76°   | -0.0054°/d   | -11.04° | R    | Second House   |
 | Eris                  | Ari ♈ | 17.53°   | +0.0049°/d   | -9.10°  | -    | Seventh House  |
 | Sedna                 | Tau ♉ | 11.31°   | +0.0091°/d   | +4.25°  | -    | Eighth House   |
 | Haumea                | Vir ♍ | 26.04°   | +0.0017°/d   | +23.34° | -    | First House    |
@@ -77,11 +77,11 @@ Quito Subject — Natal Chart Report
 | Pars Amoris           | Leo ♌ | 14.10°   | N/A          | N/A     | -    | Eleventh House |
 | Pars Fidei            | Pis ♓ | 11.32°   | N/A          | N/A     | -    | Sixth House    |
 | Vertex                | Ari ♈ | 0.08°    | N/A          | N/A     | -    | Seventh House  |
-| White Moon            | Can ♋ | 21.39°   | +0.1408°/d   | +21.74° | -    | Eleventh House |
+| White Moon            | Can ♋ | 21.38°   | +0.1408°/d   | +21.74° | -    | Eleventh House |
 | Anti Vertex           | Lib ♎ | 0.08°    | N/A          | N/A     | -    | First House    |
 | Mean South Lunar Node | Leo ♌ | 9.69°    | -0.0530°/d   | +17.83° | R    | Eleventh House |
 | True South Lunar Node | Leo ♌ | 8.12°    | +0.0101°/d   | +18.24° | -    | Eleventh House |
-| Mean Priapus          | Tau ♉ | 24.97°   | +0.1120°/d   | +23.82° | -    | Ninth House    |
+| Mean Priapus          | Tau ♉ | 24.97°   | +0.1120°/d   | +23.83° | -    | Ninth House    |
 | True Priapus          | Gem ♊ | 19.22°   | +0.7992°/d   | +26.89° | -    | Ninth House    |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
@@ -232,8 +232,8 @@ Quito Subject — Natal Chart Report
 | Sun                   | biquintile bQ    | Interpolated Lilith   | 2.33° | Applying →   |
 | Sun                   | semi-sextile ⚺   | Mean Priapus          | 0.65° | Applying →   |
 | Sun                   | conjunction ☌    | True Priapus          | 5.11° | Separating ← |
-| Sun                   | semi-sextile ⚺   | White Moon            | 2.94° | Separating ← |
-| Sun                   | biquintile bQ    | Cupido                | 0.66° | Applying →   |
+| Sun                   | semi-sextile ⚺   | White Moon            | 2.95° | Separating ← |
+| Sun                   | biquintile bQ    | Cupido                | 0.67° | Applying →   |
 | Sun                   | square □         | Zeus                  | 1.47° | Applying →   |
 | Sun                   | conjunction ☌    | Kronos                | 2.99° | Separating ← |
 | Sun                   | trine △          | Poseidon              | 4.43° | Applying →   |
@@ -263,11 +263,11 @@ Quito Subject — Natal Chart Report
 | Moon                  | conjunction ☌    | Pars Fidei            | 6.83° | Separating ← |
 | Moon                  | trine △          | Interpolated Lilith   | 2.51° | Applying →   |
 | Moon                  | square □         | True Priapus          | 1.07° | Applying →   |
-| Moon                  | trine △          | White Moon            | 3.24° | Applying →   |
-| Moon                  | trine △          | Cupido                | 0.84° | Applying →   |
+| Moon                  | trine △          | White Moon            | 3.23° | Applying →   |
+| Moon                  | trine △          | Cupido                | 0.85° | Applying →   |
 | Moon                  | square □         | Kronos                | 3.19° | Applying →   |
-| Moon                  | sextile ⚹        | Admetos               | 3.50° | Separating ← |
-| Moon                  | trine △          | Vulkanus              | 3.29° | Separating ← |
+| Moon                  | sextile ⚹        | Admetos               | 3.51° | Separating ← |
+| Moon                  | trine △          | Vulkanus              | 3.30° | Separating ← |
 | Mercury               | biquintile bQ    | Neptune               | 1.66° | Applying →   |
 | Mercury               | trine △          | Mean North Lunar Node | 3.64° | Applying →   |
 | Mercury               | trine △          | True North Lunar Node | 2.08° | Applying →   |
@@ -279,7 +279,7 @@ Quito Subject — Natal Chart Report
 | Mercury               | square □         | Pars Fidei            | 5.27° | Applying →   |
 | Mercury               | trine △          | Anti Vertex           | 5.97° | Separating ← |
 | Mercury               | conjunction ☌    | Interpolated Perigee  | 2.48° | Applying →   |
-| Mercury               | semi-square ∠    | White Moon            | 0.34° | Applying →   |
+| Mercury               | semi-square ∠    | White Moon            | 0.33° | Applying →   |
 | Mercury               | conjunction ☌    | Hades                 | 3.21° | Applying →   |
 | Mercury               | biquintile bQ    | Poseidon              | 1.29° | Separating ← |
 | Venus                 | sextile ⚹        | Jupiter               | 3.09° | Separating ← |
@@ -303,7 +303,7 @@ Quito Subject — Natal Chart Report
 | Venus                 | sextile ⚹        | White Moon            | 2.36° | Applying →   |
 | Venus                 | opposition ☍     | Cupido                | 0.03° | Separating ← |
 | Venus                 | biquintile bQ    | Apollon               | 0.76° | Applying →   |
-| Venus                 | conjunction ☌    | Admetos               | 4.37° | Separating ← |
+| Venus                 | conjunction ☌    | Admetos               | 4.38° | Separating ← |
 | Venus                 | sextile ⚹        | Vulkanus              | 4.17° | Separating ← |
 | Mars                  | square □         | Jupiter               | 4.74° | Applying →   |
 | Mars                  | square □         | Uranus                | 3.03° | Separating ← |
@@ -326,10 +326,10 @@ Quito Subject — Natal Chart Report
 | Mars                  | semi-sextile ⚺   | Pars Fidei            | 0.13° | Applying →   |
 | Mars                  | semi-square ∠    | Mean Priapus          | 1.22° | Separating ← |
 | Mars                  | sextile ⚹        | Interpolated Perigee  | 2.66° | Separating ← |
-| Mars                  | biquintile bQ    | Cupido                | 1.80° | Applying →   |
+| Mars                  | biquintile bQ    | Cupido                | 1.81° | Applying →   |
 | Mars                  | sextile ⚹        | Hades                 | 1.93° | Separating ← |
-| Mars                  | quintile Q       | Kronos                | 1.85° | Separating ← |
-| Mars                  | opposition ☍     | Apollon               | 2.59° | Applying →   |
+| Mars                  | quintile Q       | Kronos                | 1.86° | Separating ← |
+| Mars                  | opposition ☍     | Apollon               | 2.60° | Applying →   |
 | Mars                  | square □         | Vulkanus              | 3.66° | Applying →   |
 | Jupiter               | opposition ☍     | Neptune               | 2.22° | Separating ← |
 | Jupiter               | trine △          | Pluto                 | 0.54° | Separating ← |
@@ -364,7 +364,7 @@ Quito Subject — Natal Chart Report
 | Saturn                | trine △          | Mean Priapus          | 0.95° | Separating ← |
 | Saturn                | biquintile bQ    | True Priapus          | 1.20° | Separating ← |
 | Saturn                | sesquiquadrate ⚼ | Interpolated Perigee  | 0.49° | Applying →   |
-| Saturn                | opposition ☍     | White Moon            | 2.63° | Applying →   |
+| Saturn                | opposition ☍     | White Moon            | 2.64° | Applying →   |
 | Saturn                | sesquiquadrate ⚼ | Hades                 | 0.24° | Separating ← |
 | Saturn                | trine △          | Zeus                  | 1.78° | Separating ← |
 | Saturn                | square □         | Poseidon              | 4.74° | Separating ← |
@@ -387,7 +387,7 @@ Quito Subject — Natal Chart Report
 | Uranus                | sextile ⚹        | Pars Fidei            | 3.16° | Separating ← |
 | Uranus                | sesquiquadrate ⚼ | Mean Priapus          | 1.82° | Separating ← |
 | Uranus                | quincunx ⚻       | Interpolated Perigee  | 0.37° | Separating ← |
-| Uranus                | quincunx ⚻       | Hades                 | 1.11° | Separating ← |
+| Uranus                | quincunx ⚻       | Hades                 | 1.10° | Separating ← |
 | Uranus                | square □         | Apollon               | 5.63° | Separating ← |
 | Neptune               | sextile ⚹        | Pluto                 | 1.69° | Separating ← |
 | Neptune               | opposition ☍     | Chiron                | 2.37° | Separating ← |
@@ -401,7 +401,7 @@ Quito Subject — Natal Chart Report
 | Neptune               | biquintile bQ    | Interpolated Perigee  | 0.82° | Separating ← |
 | Neptune               | biquintile bQ    | Hades                 | 1.55° | Separating ← |
 | Neptune               | square □         | Apollon               | 0.07° | Separating ← |
-| Neptune               | trine △          | Admetos               | 0.94° | Separating ← |
+| Neptune               | trine △          | Admetos               | 0.93° | Separating ← |
 | Neptune               | opposition ☍     | Vulkanus              | 1.14° | Separating ← |
 | Pluto                 | square □         | Mean North Lunar Node | 5.71° | Separating ← |
 | Pluto                 | trine △          | Chiron                | 0.68° | Separating ← |
@@ -419,12 +419,12 @@ Quito Subject — Natal Chart Report
 | Pluto                 | sesquiquadrate ⚼ | Vertex                | 0.32° | Applying →   |
 | Pluto                 | semi-square ∠    | Anti Vertex           | 0.32° | Applying →   |
 | Pluto                 | conjunction ☌    | Interpolated Lilith   | 5.26° | Separating ← |
-| Pluto                 | trine △          | White Moon            | 5.99° | Separating ← |
+| Pluto                 | trine △          | White Moon            | 5.98° | Separating ← |
 | Pluto                 | conjunction ☌    | Cupido                | 3.60° | Separating ← |
 | Pluto                 | biquintile bQ    | Kronos                | 0.06° | Applying →   |
 | Pluto                 | semi-sextile ⚺   | Apollon               | 1.61° | Applying →   |
 | Pluto                 | opposition ☍     | Admetos               | 0.75° | Applying →   |
-| Pluto                 | trine △          | Vulkanus              | 0.54° | Applying →   |
+| Pluto                 | trine △          | Vulkanus              | 0.55° | Applying →   |
 | Mean North Lunar Node | biquintile bQ    | Pholus                | 0.60° | Applying →   |
 | Mean North Lunar Node | square □         | Juno                  | 0.62° | Applying →   |
 | Mean North Lunar Node | square □         | Vesta                 | 4.80° | Applying →   |
@@ -436,7 +436,7 @@ Quito Subject — Natal Chart Report
 | Mean North Lunar Node | opposition ☍     | Pars Amoris           | 4.41° | Separating ← |
 | Mean North Lunar Node | semi-sextile ⚺   | Pars Fidei            | 1.63° | Separating ← |
 | Mean North Lunar Node | trine △          | Interpolated Perigee  | 1.16° | Applying →   |
-| Mean North Lunar Node | trine △          | Hades                 | 0.42° | Applying →   |
+| Mean North Lunar Node | trine △          | Hades                 | 0.43° | Applying →   |
 | Mean North Lunar Node | sesquiquadrate ⚼ | Zeus                  | 1.11° | Separating ← |
 | Mean North Lunar Node | trine △          | Apollon               | 4.10° | Separating ← |
 | Mean North Lunar Node | square □         | Admetos               | 4.96° | Separating ← |
@@ -450,8 +450,8 @@ Quito Subject — Natal Chart Report
 | True North Lunar Node | trine △          | Pars Fortunae         | 5.10° | Applying →   |
 | True North Lunar Node | opposition ☍     | Pars Amoris           | 5.98° | Applying →   |
 | True North Lunar Node | trine △          | Interpolated Perigee  | 0.40° | Separating ← |
-| True North Lunar Node | trine △          | Hades                 | 1.14° | Separating ← |
-| True North Lunar Node | sesquiquadrate ⚼ | Kronos                | 1.78° | Applying →   |
+| True North Lunar Node | trine △          | Hades                 | 1.13° | Separating ← |
+| True North Lunar Node | sesquiquadrate ⚼ | Kronos                | 1.79° | Applying →   |
 | True North Lunar Node | trine △          | Apollon               | 5.66° | Applying →   |
 | Chiron                | sextile ⚹        | Ascendant             | 3.32° | Separating ← |
 | Chiron                | trine △          | Descendant            | 3.32° | Separating ← |
@@ -465,9 +465,9 @@ Quito Subject — Natal Chart Report
 | Chiron                | quintile Q       | Anti Vertex           | 2.00° | Applying →   |
 | Chiron                | trine △          | Interpolated Lilith   | 4.58° | Applying →   |
 | Chiron                | conjunction ☌    | White Moon            | 5.30° | Separating ← |
-| Chiron                | trine △          | Cupido                | 2.91° | Applying →   |
+| Chiron                | trine △          | Cupido                | 2.92° | Applying →   |
 | Chiron                | square □         | Apollon               | 2.30° | Separating ← |
-| Chiron                | sextile ⚹        | Admetos               | 1.43° | Separating ← |
+| Chiron                | sextile ⚹        | Admetos               | 1.44° | Separating ← |
 | Chiron                | conjunction ☌    | Vulkanus              | 1.23° | Separating ← |
 | Ascendant             | square □         | Medium Coeli          | 1.63° | Static =     |
 | Ascendant             | square □         | Imum Coeli            | 1.63° | Static =     |
@@ -481,9 +481,9 @@ Quito Subject — Natal Chart Report
 | Ascendant             | square □         | True Priapus          | 0.19° | Separating ← |
 | Ascendant             | sextile ⚹        | White Moon            | 1.98° | Applying →   |
 | Ascendant             | sextile ⚹        | Cupido                | 0.41° | Separating ← |
-| Ascendant             | square □         | Kronos                | 1.94° | Applying →   |
+| Ascendant             | square □         | Kronos                | 1.93° | Applying →   |
 | Ascendant             | trine △          | Admetos               | 4.76° | Separating ← |
-| Ascendant             | sextile ⚹        | Vulkanus              | 4.55° | Separating ← |
+| Ascendant             | sextile ⚹        | Vulkanus              | 4.56° | Separating ← |
 | Medium Coeli          | square □         | Descendant            | 1.63° | Static =     |
 | Medium Coeli          | opposition ☍     | True Lilith           | 1.82° | Separating ← |
 | Medium Coeli          | conjunction ☌    | Pallas                | 4.94° | Separating ← |
@@ -494,9 +494,9 @@ Quito Subject — Natal Chart Report
 | Medium Coeli          | opposition ☍     | Pars Spiritus         | 4.54° | Applying →   |
 | Medium Coeli          | quincunx ⚻       | Interpolated Lilith   | 0.38° | Separating ← |
 | Medium Coeli          | conjunction ☌    | True Priapus          | 1.82° | Separating ← |
-| Medium Coeli          | semi-sextile ⚺   | White Moon            | 0.35° | Applying →   |
+| Medium Coeli          | semi-sextile ⚺   | White Moon            | 0.34° | Applying →   |
 | Medium Coeli          | square □         | Zeus                  | 4.76° | Applying →   |
-| Medium Coeli          | conjunction ☌    | Kronos                | 0.30° | Applying →   |
+| Medium Coeli          | conjunction ☌    | Kronos                | 0.29° | Applying →   |
 | Descendant            | square □         | Imum Coeli            | 1.63° | Static =     |
 | Descendant            | trine △          | Mean Lilith           | 5.57° | Applying →   |
 | Descendant            | square □         | True Lilith           | 0.19° | Separating ← |
@@ -510,9 +510,9 @@ Quito Subject — Natal Chart Report
 | Descendant            | square □         | True Priapus          | 0.19° | Separating ← |
 | Descendant            | trine △          | White Moon            | 1.98° | Applying →   |
 | Descendant            | trine △          | Cupido                | 0.41° | Separating ← |
-| Descendant            | square □         | Kronos                | 1.94° | Applying →   |
+| Descendant            | square □         | Kronos                | 1.93° | Applying →   |
 | Descendant            | sextile ⚹        | Admetos               | 4.76° | Separating ← |
-| Descendant            | trine △          | Vulkanus              | 4.55° | Separating ← |
+| Descendant            | trine △          | Vulkanus              | 4.56° | Separating ← |
 | Imum Coeli            | conjunction ☌    | True Lilith           | 1.82° | Separating ← |
 | Imum Coeli            | biquintile bQ    | Ceres                 | 0.93° | Applying →   |
 | Imum Coeli            | opposition ☍     | Pallas                | 4.94° | Separating ← |
@@ -522,10 +522,10 @@ Quito Subject — Natal Chart Report
 | Imum Coeli            | conjunction ☌    | Pars Spiritus         | 4.54° | Applying →   |
 | Imum Coeli            | semi-sextile ⚺   | Interpolated Lilith   | 0.38° | Separating ← |
 | Imum Coeli            | opposition ☍     | True Priapus          | 1.82° | Separating ← |
-| Imum Coeli            | quincunx ⚻       | White Moon            | 0.35° | Applying →   |
+| Imum Coeli            | quincunx ⚻       | White Moon            | 0.34° | Applying →   |
 | Imum Coeli            | square □         | Zeus                  | 4.76° | Applying →   |
-| Imum Coeli            | opposition ☍     | Kronos                | 0.30° | Applying →   |
-| Imum Coeli            | biquintile bQ    | Admetos               | 0.39° | Separating ← |
+| Imum Coeli            | opposition ☍     | Kronos                | 0.29° | Applying →   |
+| Imum Coeli            | biquintile bQ    | Admetos               | 0.40° | Separating ← |
 | Mean Lilith           | trine △          | Ceres                 | 2.99° | Separating ← |
 | Mean Lilith           | biquintile bQ    | Eris                  | 1.45° | Separating ← |
 | Mean Lilith           | sextile ⚹        | Haumea                | 1.07° | Applying →   |
@@ -547,7 +547,7 @@ Quito Subject — Natal Chart Report
 | Mean South Lunar Node | conjunction ☌    | Pars Amoris           | 4.41° | Separating ← |
 | Mean South Lunar Node | quincunx ⚻       | Pars Fidei            | 1.63° | Separating ← |
 | Mean South Lunar Node | sextile ⚹        | Interpolated Perigee  | 1.16° | Applying →   |
-| Mean South Lunar Node | sextile ⚹        | Hades                 | 0.42° | Applying →   |
+| Mean South Lunar Node | sextile ⚹        | Hades                 | 0.43° | Applying →   |
 | Mean South Lunar Node | semi-square ∠    | Zeus                  | 1.11° | Separating ← |
 | Mean South Lunar Node | sextile ⚹        | Apollon               | 4.10° | Separating ← |
 | Mean South Lunar Node | square □         | Admetos               | 4.96° | Separating ← |
@@ -558,8 +558,8 @@ Quito Subject — Natal Chart Report
 | True South Lunar Node | conjunction ☌    | Pars Amoris           | 5.98° | Applying →   |
 | True South Lunar Node | quintile Q       | Mean Priapus          | 1.15° | Applying →   |
 | True South Lunar Node | sextile ⚹        | Interpolated Perigee  | 0.40° | Separating ← |
-| True South Lunar Node | sextile ⚹        | Hades                 | 1.14° | Separating ← |
-| True South Lunar Node | semi-square ∠    | Kronos                | 1.78° | Applying →   |
+| True South Lunar Node | sextile ⚹        | Hades                 | 1.13° | Separating ← |
+| True South Lunar Node | semi-square ∠    | Kronos                | 1.79° | Applying →   |
 | True Lilith           | opposition ☍     | Pallas                | 3.12° | Separating ← |
 | True Lilith           | sesquiquadrate ⚼ | Vesta                 | 0.67° | Applying →   |
 | True Lilith           | trine △          | Eris                  | 1.69° | Separating ← |
@@ -567,9 +567,9 @@ Quito Subject — Natal Chart Report
 | True Lilith           | opposition ☍     | Pars Fortunae         | 5.99° | Separating ← |
 | True Lilith           | trine △          | Pars Amoris           | 5.12° | Separating ← |
 | True Lilith           | semi-sextile ⚺   | Interpolated Lilith   | 1.44° | Applying →   |
-| True Lilith           | semi-sextile ⚺   | Cupido                | 0.23° | Separating ← |
+| True Lilith           | semi-sextile ⚺   | Cupido                | 0.22° | Separating ← |
 | True Lilith           | opposition ☍     | Kronos                | 2.12° | Applying →   |
-| True Lilith           | biquintile bQ    | Admetos               | 1.43° | Applying →   |
+| True Lilith           | biquintile bQ    | Admetos               | 1.42° | Applying →   |
 | Pholus                | sextile ⚹        | Vesta                 | 1.81° | Separating ← |
 | Pholus                | sextile ⚹        | Makemake              | 0.85° | Applying →   |
 | Pholus                | square □         | Vertex                | 3.01° | Separating ← |
@@ -596,7 +596,7 @@ Quito Subject — Natal Chart Report
 | Pallas                | conjunction ☌    | Kronos                | 5.24° | Applying →   |
 | Pallas                | trine △          | Apollon               | 2.31° | Separating ← |
 | Pallas                | semi-sextile ⚺   | Admetos               | 1.45° | Separating ← |
-| Pallas                | semi-sextile ⚺   | Vulkanus              | 1.24° | Separating ← |
+| Pallas                | semi-sextile ⚺   | Vulkanus              | 1.25° | Separating ← |
 | Juno                  | opposition ☍     | Vesta                 | 5.41° | Applying →   |
 | Juno                  | opposition ☍     | Sedna                 | 1.01° | Separating ← |
 | Juno                  | semi-square ∠    | Haumea                | 0.74° | Separating ← |
@@ -605,26 +605,26 @@ Quito Subject — Natal Chart Report
 | Juno                  | square □         | Pars Amoris           | 3.79° | Separating ← |
 | Juno                  | trine △          | Pars Fidei            | 1.02° | Separating ← |
 | Juno                  | quincunx ⚻       | Interpolated Perigee  | 1.78° | Applying →   |
-| Juno                  | quincunx ⚻       | Hades                 | 1.04° | Applying →   |
-| Juno                  | semi-square ∠    | Zeus                  | 0.49° | Separating ← |
+| Juno                  | quincunx ⚻       | Hades                 | 1.05° | Applying →   |
+| Juno                  | semi-square ∠    | Zeus                  | 0.50° | Separating ← |
 | Juno                  | opposition ☍     | Admetos               | 4.34° | Separating ← |
-| Juno                  | trine △          | Vulkanus              | 4.55° | Separating ← |
+| Juno                  | trine △          | Vulkanus              | 4.54° | Separating ← |
 | Vesta                 | trine △          | Makemake              | 0.95° | Separating ← |
 | Vesta                 | square □         | Orcus                 | 5.20° | Applying →   |
 | Vesta                 | biquintile bQ    | Anti Vertex           | 1.19° | Applying →   |
 | Vesta                 | semi-square ∠    | True Priapus          | 0.67° | Applying →   |
-| Vesta                 | semi-square ∠    | Kronos                | 1.45° | Applying →   |
+| Vesta                 | semi-square ∠    | Kronos                | 1.44° | Applying →   |
 | Eris                  | sesquiquadrate ⚼ | Makemake              | 1.41° | Separating ← |
 | Eris                  | biquintile bQ    | Ixion                 | 0.42° | Separating ← |
 | Eris                  | biquintile bQ    | Quaoar                | 0.97° | Applying →   |
 | Eris                  | sextile ⚹        | Pars Fortunae         | 4.30° | Separating ← |
 | Eris                  | trine △          | Pars Amoris           | 3.43° | Separating ← |
 | Eris                  | sextile ⚹        | True Priapus          | 1.69° | Separating ← |
-| Eris                  | square □         | White Moon            | 3.86° | Separating ← |
-| Eris                  | quincunx ⚻       | Cupido                | 1.46° | Applying →   |
+| Eris                  | square □         | White Moon            | 3.85° | Separating ← |
+| Eris                  | quincunx ⚻       | Cupido                | 1.47° | Applying →   |
 | Eris                  | sextile ⚹        | Kronos                | 3.81° | Separating ← |
 | Eris                  | opposition ☍     | Apollon               | 3.74° | Separating ← |
-| Eris                  | square □         | Vulkanus              | 2.67° | Applying →   |
+| Eris                  | square □         | Vulkanus              | 2.68° | Applying →   |
 | Sedna                 | sesquiquadrate ⚼ | Haumea                | 0.27° | Separating ← |
 | Sedna                 | square □         | Orcus                 | 1.22° | Applying →   |
 | Sedna                 | semi-sextile ⚺   | Pars Fortunae         | 1.92° | Applying →   |
@@ -633,7 +633,7 @@ Quito Subject — Natal Chart Report
 | Sedna                 | sextile ⚹        | Pars Fidei            | 0.01° | Applying →   |
 | Sedna                 | quintile Q       | White Moon            | 1.93° | Applying →   |
 | Sedna                 | sesquiquadrate ⚼ | Zeus                  | 0.51° | Separating ← |
-| Sedna                 | conjunction ☌    | Admetos               | 3.34° | Separating ← |
+| Sedna                 | conjunction ☌    | Admetos               | 3.33° | Separating ← |
 | Sedna                 | sextile ⚹        | Vulkanus              | 3.54° | Separating ← |
 | Haumea                | sextile ⚹        | Ixion                 | 2.93° | Separating ← |
 | Haumea                | semi-square ∠    | Orcus                 | 0.96° | Applying →   |
@@ -644,7 +644,7 @@ Quito Subject — Natal Chart Report
 | Haumea                | trine △          | Mean Priapus          | 1.07° | Applying →   |
 | Haumea                | sextile ⚹        | White Moon            | 4.66° | Applying →   |
 | Haumea                | conjunction ☌    | Zeus                  | 0.24° | Static =     |
-| Haumea                | square □         | Kronos                | 4.70° | Applying →   |
+| Haumea                | square □         | Kronos                | 4.71° | Applying →   |
 | Haumea                | quintile Q       | Vulkanus              | 0.81° | Separating ← |
 | Makemake              | square □         | Interpolated Perigee  | 4.59° | Separating ← |
 | Makemake              | square □         | Hades                 | 5.32° | Separating ← |
@@ -655,7 +655,7 @@ Quito Subject — Natal Chart Report
 | Ixion                 | trine △          | White Moon            | 1.73° | Applying →   |
 | Ixion                 | conjunction ☌    | Cupido                | 4.12° | Static =     |
 | Ixion                 | sextile ⚹        | Zeus                  | 2.69° | Separating ← |
-| Ixion                 | quincunx ⚻       | Kronos                | 1.77° | Applying →   |
+| Ixion                 | quincunx ⚻       | Kronos                | 1.78° | Applying →   |
 | Orcus                 | sextile ⚹        | Pars Fortunae         | 3.14° | Applying →   |
 | Orcus                 | sesquiquadrate ⚼ | Pars Spiritus         | 0.50° | Applying →   |
 | Orcus                 | conjunction ☌    | Pars Amoris           | 4.01° | Applying →   |
@@ -677,29 +677,29 @@ Quito Subject — Natal Chart Report
 | Pars Fortunae         | quintile Q       | Vertex                | 1.15° | Static =     |
 | Pars Fortunae         | conjunction ☌    | True Priapus          | 5.99° | Separating ← |
 | Pars Fortunae         | conjunction ☌    | Interpolated Perigee  | 4.70° | Applying →   |
-| Pars Fortunae         | conjunction ☌    | Hades                 | 3.96° | Applying →   |
+| Pars Fortunae         | conjunction ☌    | Hades                 | 3.97° | Applying →   |
 | Pars Fortunae         | trine △          | Apollon               | 0.56° | Applying →   |
 | Pars Fortunae         | semi-sextile ⚺   | Admetos               | 1.42° | Separating ← |
-| Pars Fortunae         | semi-sextile ⚺   | Vulkanus              | 1.63° | Separating ← |
+| Pars Fortunae         | semi-sextile ⚺   | Vulkanus              | 1.62° | Separating ← |
 | Pars Fortunae         | sesquiquadrate ⚼ | Poseidon              | 0.53° | Applying →   |
 | Pars Spiritus         | square □         | Vertex                | 4.49° | Static =     |
 | Pars Spiritus         | square □         | Anti Vertex           | 4.49° | Static =     |
 | Pars Spiritus         | quincunx ⚻       | Mean Priapus          | 0.61° | Applying →   |
 | Pars Spiritus         | square □         | Zeus                  | 0.22° | Separating ← |
-| Pars Spiritus         | opposition ☍     | Kronos                | 4.24° | Applying →   |
+| Pars Spiritus         | opposition ☍     | Kronos                | 4.25° | Applying →   |
 | Pars Spiritus         | quintile Q       | Apollon               | 0.20° | Applying →   |
-| Pars Spiritus         | sextile ⚹        | Poseidon              | 3.17° | Applying →   |
+| Pars Spiritus         | sextile ⚹        | Poseidon              | 3.18° | Applying →   |
 | Pars Amoris           | sesquiquadrate ⚼ | Vertex                | 0.98° | Static =     |
 | Pars Amoris           | semi-square ∠    | Anti Vertex           | 0.98° | Static =     |
-| Pars Amoris           | square □         | Cupido                | 4.89° | Applying →   |
+| Pars Amoris           | square □         | Cupido                | 4.90° | Applying →   |
 | Pars Amoris           | sextile ⚹        | Hades                 | 4.84° | Applying →   |
-| Pars Amoris           | sextile ⚹        | Apollon               | 0.32° | Separating ← |
-| Pars Amoris           | square □         | Admetos               | 0.55° | Separating ← |
-| Pars Amoris           | semi-sextile ⚺   | Vulkanus              | 0.76° | Separating ← |
+| Pars Amoris           | sextile ⚹        | Apollon               | 0.31° | Separating ← |
+| Pars Amoris           | square □         | Admetos               | 0.54° | Separating ← |
+| Pars Amoris           | semi-sextile ⚺   | Vulkanus              | 0.75° | Separating ← |
 | Pars Fidei            | quintile Q       | Mean Priapus          | 1.65° | Separating ← |
 | Pars Fidei            | square □         | Interpolated Perigee  | 2.79° | Applying →   |
 | Pars Fidei            | square □         | Hades                 | 2.06° | Applying →   |
-| Pars Fidei            | sextile ⚹        | Admetos               | 3.33° | Separating ← |
+| Pars Fidei            | sextile ⚹        | Admetos               | 3.32° | Separating ← |
 | Pars Fidei            | trine △          | Vulkanus              | 3.53° | Separating ← |
 | Vertex                | opposition ☍     | Zeus                  | 4.28° | Applying →   |
 | Vertex                | semi-square ∠    | Admetos               | 0.43° | Applying →   |
@@ -710,27 +710,27 @@ Quito Subject — Natal Chart Report
 | Anti Vertex           | semi-sextile ⚺   | Poseidon              | 1.32° | Separating ← |
 | Interpolated Lilith   | opposition ☍     | Mean Priapus          | 4.32° | Separating ← |
 | Interpolated Lilith   | quincunx ⚻       | True Priapus          | 1.44° | Applying →   |
-| Interpolated Lilith   | trine △          | White Moon            | 0.73° | Separating ← |
+| Interpolated Lilith   | trine △          | White Moon            | 0.72° | Separating ← |
 | Interpolated Lilith   | conjunction ☌    | Cupido                | 1.66° | Separating ← |
 | Interpolated Lilith   | quincunx ⚻       | Kronos                | 0.68° | Applying →   |
-| Interpolated Lilith   | trine △          | Vulkanus              | 5.80° | Separating ← |
+| Interpolated Lilith   | trine △          | Vulkanus              | 5.81° | Separating ← |
 | Mean Priapus          | sextile ⚹        | White Moon            | 3.59° | Applying →   |
 | Mean Priapus          | opposition ☍     | Cupido                | 5.98° | Separating ← |
 | Mean Priapus          | trine △          | Zeus                  | 0.83° | Applying →   |
-| True Priapus          | quincunx ⚻       | Cupido                | 0.23° | Separating ← |
+| True Priapus          | quincunx ⚻       | Cupido                | 0.22° | Separating ← |
 | True Priapus          | conjunction ☌    | Kronos                | 2.12° | Applying →   |
-| True Priapus          | trine △          | Apollon               | 5.44° | Separating ← |
+| True Priapus          | trine △          | Apollon               | 5.43° | Separating ← |
 | Interpolated Perigee  | conjunction ☌    | Hades                 | 0.73° | Applying →   |
 | Interpolated Perigee  | trine △          | Apollon               | 5.26° | Applying →   |
-| White Moon            | trine △          | Cupido                | 2.39° | Separating ← |
-| White Moon            | sextile ⚹        | Zeus                  | 4.41° | Applying →   |
-| White Moon            | semi-sextile ⚺   | Kronos                | 0.04° | Separating ← |
-| Cupido                | opposition ☍     | Admetos               | 4.34° | Applying →   |
-| Cupido                | trine △          | Vulkanus              | 4.14° | Applying →   |
-| Hades                 | trine △          | Apollon               | 4.52° | Applying →   |
-| Zeus                  | square □         | Kronos                | 4.46° | Applying →   |
+| White Moon            | trine △          | Cupido                | 2.38° | Separating ← |
+| White Moon            | sextile ⚹        | Zeus                  | 4.42° | Applying →   |
+| White Moon            | semi-sextile ⚺   | Kronos                | 0.05° | Separating ← |
+| Cupido                | opposition ☍     | Admetos               | 4.35° | Applying →   |
+| Cupido                | trine △          | Vulkanus              | 4.15° | Applying →   |
+| Hades                 | trine △          | Apollon               | 4.53° | Applying →   |
+| Zeus                  | square □         | Kronos                | 4.47° | Applying →   |
 | Zeus                  | quintile Q       | Vulkanus              | 1.05° | Separating ← |
 | Apollon               | quincunx ⚻       | Admetos               | 0.86° | Separating ← |
-| Apollon               | square □         | Vulkanus              | 1.07° | Separating ← |
+| Apollon               | square □         | Vulkanus              | 1.06° | Separating ← |
 | Admetos               | sextile ⚹        | Vulkanus              | 0.21° | Separating ← |
 +-----------------------+------------------+-----------------------+-------+--------------+

--- a/tests/fixtures/natal_tokyo_all_report.txt
+++ b/tests/fixtures/natal_tokyo_all_report.txt
@@ -31,10 +31,10 @@ Tokyo Subject — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Vir ♍ | 28.16°   | +300.0297°/d | N/A     | -    | First House    |
-| Medium Coeli          | Gem ♊ | 27.97°   | +331.2670°/d | N/A     | -    | Tenth House    |
-| Descendant            | Pis ♓ | 28.16°   | +300.0297°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Sag ♐ | 27.97°   | +331.2670°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Vir ♍ | 28.16°   | +300.0313°/d | N/A     | -    | First House    |
+| Medium Coeli          | Gem ♊ | 27.97°   | +331.2688°/d | N/A     | -    | Tenth House    |
+| Descendant            | Pis ♓ | 28.16°   | +300.0313°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Sag ♐ | 27.97°   | +331.2688°/d | N/A     | -    | Fourth House   |
 | Sun                   | Gem ♊ | 23.77°   | +0.9551°/d   | +23.30° | -    | Ninth House    |
 | Moon                  | Pis ♓ | 10.37°   | +13.2309°/d  | -5.12°  | -    | Sixth House    |
 | Mercury               | Gem ♊ | 5.05°    | +1.6987°/d   | +19.44° | -    | Ninth House    |
@@ -48,7 +48,7 @@ Tokyo Subject — Natal Chart Report
 | Mean North Lunar Node | Aqu ♒ | 9.72°    | -0.0530°/d   | -17.82° | R    | Fifth House    |
 | True North Lunar Node | Aqu ♒ | 8.12°    | +0.0183°/d   | -18.24° | -    | Fifth House    |
 | Mean Lilith           | Sco ♏ | 24.91°   | +0.1120°/d   | -23.81° | -    | Second House   |
-| True Lilith           | Sag ♐ | 18.52°   | +1.5852°/d   | -26.87° | -    | Third House    |
+| True Lilith           | Sag ♐ | 18.52°   | +1.5853°/d   | -26.87° | -    | Third House    |
 | Chiron                | Can ♋ | 16.02°   | +0.1011°/d   | +16.26° | -    | Tenth House    |
 | Pholus                | Can ♋ | 3.01°    | +0.1367°/d   | +13.46° | -    | Tenth House    |
 | Ceres                 | Can ♋ | 27.72°   | +0.4257°/d   | +26.76° | -    | Tenth House    |
@@ -56,15 +56,15 @@ Tokyo Subject — Natal Chart Report
 | Juno                  | Sco ♏ | 10.37°   | -0.1042°/d   | -0.49°  | R    | Second House   |
 | Vesta                 | Tau ♉ | 4.66°    | +0.4043°/d   | +7.56°  | -    | Eighth House   |
 | Interpolated Lilith   | Sco ♏ | 20.61°   | +0.0759°/d   | -22.77° | -    | Second House   |
-| Interpolated Perigee  | Gem ♊ | 8.27°    | +0.4468°/d   | +26.10° | -    | Ninth House    |
-| Cupido                | Sco ♏ | 19.00°   | -0.0161°/d   | -16.43° | R    | Second House   |
+| Interpolated Perigee  | Gem ♊ | 8.27°    | +0.4467°/d   | +26.10° | -    | Ninth House    |
+| Cupido                | Sco ♏ | 19.01°   | -0.0161°/d   | -16.43° | R    | Second House   |
 | Hades                 | Gem ♊ | 9.25°    | +0.0209°/d   | +20.83° | -    | Ninth House    |
-| Zeus                  | Vir ♍ | 25.80°   | +0.0015°/d   | +1.67°  | -    | Twelfth House  |
+| Zeus                  | Vir ♍ | 25.80°   | +0.0014°/d   | +1.67°  | -    | Twelfth House  |
 | Kronos                | Gem ♊ | 21.33°   | +0.0166°/d   | +23.17° | -    | Ninth House    |
-| Apollon               | Lib ♎ | 13.79°   | -0.0031°/d   | -5.44°  | R    | First House    |
-| Admetos               | Tau ♉ | 14.64°   | +0.0117°/d   | +16.24° | -    | Eighth House   |
-| Vulkanus              | Can ♋ | 14.85°   | +0.0130°/d   | +22.63° | -    | Tenth House    |
-| Poseidon              | Lib ♎ | 28.76°   | -0.0054°/d   | -11.04° | R    | Second House   |
+| Apollon               | Lib ♎ | 13.79°   | -0.0032°/d   | -5.44°  | R    | First House    |
+| Admetos               | Tau ♉ | 14.64°   | +0.0118°/d   | +16.24° | -    | Eighth House   |
+| Vulkanus              | Can ♋ | 14.84°   | +0.0130°/d   | +22.63° | -    | Tenth House    |
+| Poseidon              | Lib ♎ | 28.76°   | -0.0055°/d   | -11.04° | R    | Second House   |
 | Eris                  | Ari ♈ | 17.53°   | +0.0050°/d   | -9.10°  | -    | Seventh House  |
 | Sedna                 | Tau ♉ | 11.31°   | +0.0092°/d   | +4.25°  | -    | Eighth House   |
 | Haumea                | Vir ♍ | 26.04°   | +0.0015°/d   | +23.34° | -    | Twelfth House  |
@@ -77,12 +77,12 @@ Tokyo Subject — Natal Chart Report
 | Pars Amoris           | Leo ♌ | 22.73°   | N/A          | N/A     | -    | Eleventh House |
 | Pars Fidei            | Pis ♓ | 19.92°   | N/A          | N/A     | -    | Sixth House    |
 | Vertex                | Pis ♓ | 23.94°   | N/A          | N/A     | -    | Sixth House    |
-| White Moon            | Can ♋ | 21.30°   | +0.1408°/d   | +21.75° | -    | Tenth House    |
+| White Moon            | Can ♋ | 21.30°   | +0.1408°/d   | +21.76° | -    | Tenth House    |
 | Anti Vertex           | Vir ♍ | 23.94°   | N/A          | N/A     | -    | Twelfth House  |
 | Mean South Lunar Node | Leo ♌ | 9.72°    | -0.0530°/d   | +17.82° | R    | Eleventh House |
 | True South Lunar Node | Leo ♌ | 8.12°    | +0.0183°/d   | +18.24° | -    | Eleventh House |
 | Mean Priapus          | Tau ♉ | 24.91°   | +0.1120°/d   | +23.81° | -    | Eighth House   |
-| True Priapus          | Gem ♊ | 18.52°   | +1.5852°/d   | +26.87° | -    | Ninth House    |
+| True Priapus          | Gem ♊ | 18.52°   | +1.5853°/d   | +26.87° | -    | Ninth House    |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +Natal Houses (Placidus)--+----------+-------------------+
@@ -234,9 +234,9 @@ Tokyo Subject — Natal Chart Report
 | Sun                   | semi-sextile ⚺   | Mean Priapus          | 1.14° | Applying →   |
 | Sun                   | conjunction ☌    | True Priapus          | 5.25° | Applying →   |
 | Sun                   | semi-sextile ⚺   | White Moon            | 2.47° | Separating ← |
-| Sun                   | biquintile bQ    | Cupido                | 1.23° | Applying →   |
+| Sun                   | biquintile bQ    | Cupido                | 1.24° | Applying →   |
 | Sun                   | square □         | Zeus                  | 2.03° | Applying →   |
-| Sun                   | conjunction ☌    | Kronos                | 2.44° | Separating ← |
+| Sun                   | conjunction ☌    | Kronos                | 2.45° | Separating ← |
 | Sun                   | trine △          | Poseidon              | 4.99° | Applying →   |
 | Moon                  | square □         | Mercury               | 5.32° | Separating ← |
 | Moon                  | semi-sextile ⚺   | Mars                  | 0.40° | Applying →   |
@@ -263,10 +263,10 @@ Tokyo Subject — Natal Chart Report
 | Moon                  | sextile ⚹        | Pars Spiritus         | 1.19° | Applying →   |
 | Moon                  | quintile Q       | Mean Priapus          | 2.54° | Applying →   |
 | Moon                  | square □         | Interpolated Perigee  | 2.10° | Separating ← |
-| Moon                  | square □         | Hades                 | 1.12° | Separating ← |
-| Moon                  | biquintile bQ    | Apollon               | 2.59° | Separating ← |
-| Moon                  | sextile ⚹        | Admetos               | 4.27° | Applying →   |
-| Moon                  | trine △          | Vulkanus              | 4.48° | Applying →   |
+| Moon                  | square □         | Hades                 | 1.13° | Separating ← |
+| Moon                  | biquintile bQ    | Apollon               | 2.58° | Separating ← |
+| Moon                  | sextile ⚹        | Admetos               | 4.26° | Applying →   |
+| Moon                  | trine △          | Vulkanus              | 4.47° | Applying →   |
 | Moon                  | sesquiquadrate ⚼ | Poseidon              | 3.39° | Applying →   |
 | Mercury               | trine △          | Mean North Lunar Node | 4.67° | Applying →   |
 | Mercury               | trine △          | True North Lunar Node | 3.07° | Applying →   |
@@ -278,7 +278,7 @@ Tokyo Subject — Natal Chart Report
 | Mercury               | quintile Q       | Vertex                | 0.89° | Applying →   |
 | Mercury               | conjunction ☌    | Interpolated Perigee  | 3.22° | Applying →   |
 | Mercury               | semi-square ∠    | White Moon            | 1.25° | Applying →   |
-| Mercury               | conjunction ☌    | Hades                 | 4.20° | Applying →   |
+| Mercury               | conjunction ☌    | Hades                 | 4.19° | Applying →   |
 | Mercury               | biquintile bQ    | Poseidon              | 0.29° | Separating ← |
 | Venus                 | sextile ⚹        | Jupiter               | 2.53° | Separating ← |
 | Venus                 | trine △          | Saturn                | 5.72° | Applying →   |
@@ -294,7 +294,7 @@ Tokyo Subject — Natal Chart Report
 | Venus                 | trine △          | Anti Vertex           | 5.60° | Applying →   |
 | Venus                 | opposition ☍     | Interpolated Lilith   | 2.28° | Applying →   |
 | Venus                 | semi-sextile ⚺   | True Priapus          | 0.19° | Separating ← |
-| Venus                 | sextile ⚹        | White Moon            | 2.97° | Applying →   |
+| Venus                 | sextile ⚹        | White Moon            | 2.96° | Applying →   |
 | Venus                 | opposition ☍     | Cupido                | 0.67° | Applying →   |
 | Venus                 | biquintile bQ    | Apollon               | 1.45° | Applying →   |
 | Venus                 | conjunction ☌    | Admetos               | 3.70° | Separating ← |
@@ -319,10 +319,10 @@ Tokyo Subject — Natal Chart Report
 | Mars                  | square □         | Pars Spiritus         | 0.79° | Applying →   |
 | Mars                  | semi-square ∠    | Mean Priapus          | 0.86° | Separating ← |
 | Mars                  | sextile ⚹        | Interpolated Perigee  | 2.50° | Separating ← |
-| Mars                  | sextile ⚹        | Hades                 | 1.52° | Separating ← |
-| Mars                  | quintile Q       | Kronos                | 1.44° | Separating ← |
-| Mars                  | opposition ☍     | Apollon               | 3.01° | Applying →   |
-| Mars                  | square □         | Vulkanus              | 4.08° | Applying →   |
+| Mars                  | sextile ⚹        | Hades                 | 1.53° | Separating ← |
+| Mars                  | quintile Q       | Kronos                | 1.45° | Separating ← |
+| Mars                  | opposition ☍     | Apollon               | 3.02° | Applying →   |
+| Mars                  | square □         | Vulkanus              | 4.07° | Applying →   |
 | Jupiter               | opposition ☍     | Neptune               | 2.08° | Separating ← |
 | Jupiter               | trine △          | Pluto                 | 0.40° | Separating ← |
 | Jupiter               | conjunction ☌    | Chiron                | 0.21° | Applying →   |
@@ -337,11 +337,11 @@ Tokyo Subject — Natal Chart Report
 | Jupiter               | opposition ☍     | Pars Spiritus         | 4.24° | Separating ← |
 | Jupiter               | trine △          | Pars Fidei            | 4.11° | Applying →   |
 | Jupiter               | trine △          | Interpolated Lilith   | 4.80° | Applying →   |
-| Jupiter               | conjunction ☌    | White Moon            | 5.50° | Applying →   |
-| Jupiter               | trine △          | Cupido                | 3.19° | Applying →   |
+| Jupiter               | conjunction ☌    | White Moon            | 5.49° | Applying →   |
+| Jupiter               | trine △          | Cupido                | 3.20° | Applying →   |
 | Jupiter               | square □         | Apollon               | 2.02° | Separating ← |
 | Jupiter               | sextile ⚹        | Admetos               | 1.17° | Separating ← |
-| Jupiter               | conjunction ☌    | Vulkanus              | 0.96° | Separating ← |
+| Jupiter               | conjunction ☌    | Vulkanus              | 0.97° | Separating ← |
 | Saturn                | trine △          | Ascendant             | 4.11° | Separating ← |
 | Saturn                | sextile ⚹        | Descendant            | 4.11° | Separating ← |
 | Saturn                | sextile ⚹        | Mean Lilith           | 0.86° | Separating ← |
@@ -358,8 +358,8 @@ Tokyo Subject — Natal Chart Report
 | Saturn                | trine △          | Mean Priapus          | 0.86° | Separating ← |
 | Saturn                | biquintile bQ    | True Priapus          | 0.47° | Separating ← |
 | Saturn                | sesquiquadrate ⚼ | Interpolated Perigee  | 0.79° | Applying →   |
-| Saturn                | opposition ☍     | White Moon            | 2.75° | Applying →   |
-| Saturn                | sesquiquadrate ⚼ | Hades                 | 0.20° | Separating ← |
+| Saturn                | opposition ☍     | White Moon            | 2.76° | Applying →   |
+| Saturn                | sesquiquadrate ⚼ | Hades                 | 0.19° | Separating ← |
 | Saturn                | trine △          | Zeus                  | 1.75° | Separating ← |
 | Saturn                | square □         | Poseidon              | 4.71° | Separating ← |
 | Uranus                | conjunction ☌    | Neptune               | 5.55° | Separating ← |
@@ -409,11 +409,11 @@ Tokyo Subject — Natal Chart Report
 | Pluto                 | trine △          | Pars Fidei            | 4.51° | Separating ← |
 | Pluto                 | conjunction ☌    | Interpolated Lilith   | 5.20° | Separating ← |
 | Pluto                 | trine △          | White Moon            | 5.89° | Separating ← |
-| Pluto                 | conjunction ☌    | Cupido                | 3.59° | Separating ← |
+| Pluto                 | conjunction ☌    | Cupido                | 3.60° | Separating ← |
 | Pluto                 | biquintile bQ    | Kronos                | 0.08° | Applying →   |
 | Pluto                 | semi-sextile ⚺   | Apollon               | 1.62° | Applying →   |
 | Pluto                 | opposition ☍     | Admetos               | 0.77° | Applying →   |
-| Pluto                 | trine △          | Vulkanus              | 0.56° | Applying →   |
+| Pluto                 | trine △          | Vulkanus              | 0.57° | Applying →   |
 | Mean North Lunar Node | biquintile bQ    | Pholus                | 0.71° | Applying →   |
 | Mean North Lunar Node | square □         | Juno                  | 0.65° | Applying →   |
 | Mean North Lunar Node | square □         | Vesta                 | 5.06° | Applying →   |
@@ -440,7 +440,7 @@ Tokyo Subject — Natal Chart Report
 | True North Lunar Node | sesquiquadrate ⚼ | Anti Vertex           | 0.82° | Applying →   |
 | True North Lunar Node | trine △          | Interpolated Perigee  | 0.15° | Separating ← |
 | True North Lunar Node | trine △          | Hades                 | 1.13° | Separating ← |
-| True North Lunar Node | sesquiquadrate ⚼ | Kronos                | 1.78° | Separating ← |
+| True North Lunar Node | sesquiquadrate ⚼ | Kronos                | 1.79° | Separating ← |
 | True North Lunar Node | trine △          | Apollon               | 5.67° | Applying →   |
 | Chiron                | quintile Q       | Ascendant             | 0.14° | Separating ← |
 | Chiron                | semi-sextile ⚺   | Pallas                | 0.26° | Applying →   |
@@ -455,8 +455,8 @@ Tokyo Subject — Natal Chart Report
 | Chiron                | trine △          | Interpolated Lilith   | 4.59° | Applying →   |
 | Chiron                | conjunction ☌    | White Moon            | 5.28° | Separating ← |
 | Chiron                | trine △          | Cupido                | 2.98° | Applying →   |
-| Chiron                | square □         | Apollon               | 2.24° | Separating ← |
-| Chiron                | sextile ⚹        | Admetos               | 1.38° | Separating ← |
+| Chiron                | square □         | Apollon               | 2.23° | Separating ← |
+| Chiron                | sextile ⚹        | Admetos               | 1.39° | Separating ← |
 | Chiron                | conjunction ☌    | Vulkanus              | 1.18° | Separating ← |
 | Ascendant             | square □         | Medium Coeli          | 0.19° | Static =     |
 | Ascendant             | square □         | Imum Coeli            | 0.19° | Static =     |
@@ -471,9 +471,9 @@ Tokyo Subject — Natal Chart Report
 | Ascendant             | conjunction ☌    | Anti Vertex           | 4.23° | Separating ← |
 | Ascendant             | trine △          | Mean Priapus          | 3.26° | Separating ← |
 | Ascendant             | conjunction ☌    | Zeus                  | 2.37° | Separating ← |
-| Ascendant             | sesquiquadrate ⚼ | Admetos               | 1.48° | Applying →   |
+| Ascendant             | sesquiquadrate ⚼ | Admetos               | 1.47° | Applying →   |
 | Ascendant             | quintile Q       | Vulkanus              | 1.32° | Separating ← |
-| Ascendant             | semi-sextile ⚺   | Poseidon              | 0.59° | Applying →   |
+| Ascendant             | semi-sextile ⚺   | Poseidon              | 0.60° | Applying →   |
 | Medium Coeli          | square □         | Descendant            | 0.19° | Static =     |
 | Medium Coeli          | conjunction ☌    | Pholus                | 5.03° | Applying →   |
 | Medium Coeli          | semi-sextile ⚺   | Ceres                 | 0.26° | Separating ← |
@@ -484,8 +484,8 @@ Tokyo Subject — Natal Chart Report
 | Medium Coeli          | square □         | Vertex                | 4.04° | Separating ← |
 | Medium Coeli          | square □         | Anti Vertex           | 4.04° | Separating ← |
 | Medium Coeli          | biquintile bQ    | Interpolated Lilith   | 1.36° | Separating ← |
-| Medium Coeli          | square □         | Zeus                  | 2.18° | Separating ← |
-| Medium Coeli          | semi-square ∠    | Admetos               | 1.67° | Applying →   |
+| Medium Coeli          | square □         | Zeus                  | 2.17° | Separating ← |
+| Medium Coeli          | semi-square ∠    | Admetos               | 1.66° | Applying →   |
 | Medium Coeli          | trine △          | Poseidon              | 0.79° | Applying →   |
 | Descendant            | square □         | Imum Coeli            | 0.19° | Static =     |
 | Descendant            | trine △          | Mean Lilith           | 3.26° | Separating ← |
@@ -500,10 +500,10 @@ Tokyo Subject — Natal Chart Report
 | Descendant            | opposition ☍     | Anti Vertex           | 4.23° | Separating ← |
 | Descendant            | sextile ⚹        | Mean Priapus          | 3.26° | Separating ← |
 | Descendant            | quintile Q       | Interpolated Perigee  | 1.90° | Separating ← |
-| Descendant            | quintile Q       | Hades                 | 0.91° | Separating ← |
+| Descendant            | quintile Q       | Hades                 | 0.92° | Separating ← |
 | Descendant            | opposition ☍     | Zeus                  | 2.37° | Separating ← |
-| Descendant            | semi-square ∠    | Admetos               | 1.48° | Applying →   |
-| Descendant            | quincunx ⚻       | Poseidon              | 0.59° | Applying →   |
+| Descendant            | semi-square ∠    | Admetos               | 1.47° | Applying →   |
+| Descendant            | quincunx ⚻       | Poseidon              | 0.60° | Applying →   |
 | Imum Coeli            | opposition ☍     | Pholus                | 5.03° | Applying →   |
 | Imum Coeli            | quincunx ⚻       | Ceres                 | 0.26° | Separating ← |
 | Imum Coeli            | sesquiquadrate ⚼ | Sedna                 | 1.67° | Separating ← |
@@ -512,8 +512,8 @@ Tokyo Subject — Natal Chart Report
 | Imum Coeli            | trine △          | Pars Amoris           | 5.24° | Separating ← |
 | Imum Coeli            | square □         | Vertex                | 4.04° | Separating ← |
 | Imum Coeli            | square □         | Anti Vertex           | 4.04° | Separating ← |
-| Imum Coeli            | square □         | Zeus                  | 2.18° | Separating ← |
-| Imum Coeli            | sesquiquadrate ⚼ | Admetos               | 1.67° | Applying →   |
+| Imum Coeli            | square □         | Zeus                  | 2.17° | Separating ← |
+| Imum Coeli            | sesquiquadrate ⚼ | Admetos               | 1.66° | Applying →   |
 | Imum Coeli            | sextile ⚹        | Poseidon              | 0.79° | Applying →   |
 | Mean Lilith           | trine △          | Ceres                 | 2.81° | Separating ← |
 | Mean Lilith           | biquintile bQ    | Eris                  | 1.38° | Separating ← |
@@ -527,7 +527,7 @@ Tokyo Subject — Natal Chart Report
 | Mean Lilith           | sextile ⚹        | Anti Vertex           | 0.97° | Separating ← |
 | Mean Lilith           | conjunction ☌    | Interpolated Lilith   | 4.30° | Separating ← |
 | Mean Lilith           | trine △          | White Moon            | 3.61° | Applying →   |
-| Mean Lilith           | conjunction ☌    | Cupido                | 5.91° | Separating ← |
+| Mean Lilith           | conjunction ☌    | Cupido                | 5.90° | Separating ← |
 | Mean Lilith           | sextile ⚹        | Zeus                  | 0.89° | Applying →   |
 | Mean South Lunar Node | square □         | Juno                  | 0.65° | Applying →   |
 | Mean South Lunar Node | square □         | Vesta                 | 5.06° | Applying →   |
@@ -551,7 +551,7 @@ Tokyo Subject — Natal Chart Report
 | True South Lunar Node | quintile Q       | Mean Priapus          | 1.21° | Applying →   |
 | True South Lunar Node | sextile ⚹        | Interpolated Perigee  | 0.15° | Separating ← |
 | True South Lunar Node | sextile ⚹        | Hades                 | 1.13° | Separating ← |
-| True South Lunar Node | semi-square ∠    | Kronos                | 1.78° | Separating ← |
+| True South Lunar Node | semi-square ∠    | Kronos                | 1.79° | Separating ← |
 | True Lilith           | opposition ☍     | Pallas                | 2.76° | Separating ← |
 | True Lilith           | sesquiquadrate ⚼ | Vesta                 | 1.13° | Applying →   |
 | True Lilith           | trine △          | Eris                  | 1.00° | Separating ← |
@@ -562,12 +562,12 @@ Tokyo Subject — Natal Chart Report
 | True Lilith           | square □         | Vertex                | 5.41° | Applying →   |
 | True Lilith           | square □         | Anti Vertex           | 5.41° | Applying →   |
 | True Lilith           | semi-sextile ⚺   | Cupido                | 0.48° | Applying →   |
-| True Lilith           | opposition ☍     | Kronos                | 2.81° | Applying →   |
-| True Lilith           | sextile ⚹        | Apollon               | 4.74° | Separating ← |
+| True Lilith           | opposition ☍     | Kronos                | 2.80° | Applying →   |
+| True Lilith           | sextile ⚹        | Apollon               | 4.73° | Separating ← |
 | Pholus                | sextile ⚹        | Vesta                 | 1.65° | Separating ← |
 | Pholus                | sextile ⚹        | Makemake              | 0.93° | Applying →   |
 | Pholus                | sesquiquadrate ⚼ | Cupido                | 1.00° | Applying →   |
-| Pholus                | trine △          | Poseidon              | 4.25° | Separating ← |
+| Pholus                | trine △          | Poseidon              | 4.24° | Separating ← |
 | Ceres                 | sextile ⚹        | Haumea                | 1.68° | Separating ← |
 | Ceres                 | trine △          | Ixion                 | 4.60° | Separating ← |
 | Ceres                 | trine △          | Quaoar                | 3.21° | Separating ← |
@@ -576,7 +576,7 @@ Tokyo Subject — Natal Chart Report
 | Ceres                 | sextile ⚹        | Mean Priapus          | 2.81° | Separating ← |
 | Ceres                 | sextile ⚹        | Zeus                  | 1.92° | Separating ← |
 | Ceres                 | quintile Q       | Admetos               | 1.08° | Separating ← |
-| Ceres                 | square □         | Poseidon              | 1.04° | Applying →   |
+| Ceres                 | square □         | Poseidon              | 1.05° | Applying →   |
 | Pallas                | biquintile bQ    | Juno                  | 0.61° | Applying →   |
 | Pallas                | sextile ⚹        | Eris                  | 1.77° | Applying →   |
 | Pallas                | conjunction ☌    | Pars Fortunae         | 0.99° | Separating ← |
@@ -585,7 +585,8 @@ Tokyo Subject — Natal Chart Report
 | Pallas                | conjunction ☌    | Kronos                | 5.57° | Applying →   |
 | Pallas                | trine △          | Apollon               | 1.97° | Separating ← |
 | Pallas                | semi-sextile ⚺   | Admetos               | 1.12° | Separating ← |
-| Pallas                | semi-sextile ⚺   | Vulkanus              | 0.91° | Separating ← |
+| Pallas                | semi-sextile ⚺   | Vulkanus              | 0.92° | Separating ← |
+| Pallas                | sesquiquadrate ⚼ | Poseidon              | 2.00° | Separating ← |
 | Juno                  | opposition ☍     | Vesta                 | 5.71° | Applying →   |
 | Juno                  | opposition ☍     | Sedna                 | 0.94° | Separating ← |
 | Juno                  | semi-square ∠    | Haumea                | 0.68° | Separating ← |
@@ -594,17 +595,17 @@ Tokyo Subject — Natal Chart Report
 | Juno                  | sextile ⚹        | Pars Spiritus         | 1.20° | Separating ← |
 | Juno                  | sesquiquadrate ⚼ | Vertex                | 1.43° | Applying →   |
 | Juno                  | semi-square ∠    | Anti Vertex           | 1.43° | Applying →   |
-| Juno                  | quincunx ⚻       | Hades                 | 1.11° | Applying →   |
+| Juno                  | quincunx ⚻       | Hades                 | 1.12° | Applying →   |
 | Juno                  | semi-square ∠    | Zeus                  | 0.43° | Separating ← |
-| Juno                  | opposition ☍     | Admetos               | 4.28° | Separating ← |
+| Juno                  | opposition ☍     | Admetos               | 4.27° | Separating ← |
 | Juno                  | trine △          | Vulkanus              | 4.48° | Separating ← |
 | Vesta                 | trine △          | Makemake              | 0.72° | Separating ← |
 | Vesta                 | square □         | Orcus                 | 5.42° | Applying →   |
 | Vesta                 | semi-square ∠    | Pars Fidei            | 0.26° | Applying →   |
 | Vesta                 | semi-square ∠    | True Priapus          | 1.13° | Applying →   |
-| Vesta                 | semi-square ∠    | Kronos                | 1.68° | Applying →   |
+| Vesta                 | semi-square ∠    | Kronos                | 1.67° | Applying →   |
 | Vesta                 | quintile Q       | Vulkanus              | 1.81° | Separating ← |
-| Vesta                 | opposition ☍     | Poseidon              | 5.90° | Separating ← |
+| Vesta                 | opposition ☍     | Poseidon              | 5.89° | Separating ← |
 | Eris                  | sesquiquadrate ⚼ | Makemake              | 1.41° | Separating ← |
 | Eris                  | biquintile bQ    | Ixion                 | 0.40° | Separating ← |
 | Eris                  | biquintile bQ    | Quaoar                | 0.98° | Applying →   |
@@ -612,7 +613,7 @@ Tokyo Subject — Natal Chart Report
 | Eris                  | square □         | Pars Spiritus         | 5.96° | Separating ← |
 | Eris                  | trine △          | Pars Amoris           | 5.20° | Applying →   |
 | Eris                  | sextile ⚹        | True Priapus          | 1.00° | Separating ← |
-| Eris                  | square □         | White Moon            | 3.78° | Separating ← |
+| Eris                  | square □         | White Moon            | 3.77° | Separating ← |
 | Eris                  | quincunx ⚻       | Cupido                | 1.48° | Applying →   |
 | Eris                  | sextile ⚹        | Kronos                | 3.80° | Separating ← |
 | Eris                  | opposition ☍     | Apollon               | 3.74° | Separating ← |
@@ -621,7 +622,7 @@ Tokyo Subject — Natal Chart Report
 | Sedna                 | square □         | Orcus                 | 1.23° | Applying →   |
 | Sedna                 | trine △          | Pars Spiritus         | 0.26° | Applying →   |
 | Sedna                 | sesquiquadrate ⚼ | Zeus                  | 0.51° | Separating ← |
-| Sedna                 | conjunction ☌    | Admetos               | 3.34° | Separating ← |
+| Sedna                 | conjunction ☌    | Admetos               | 3.33° | Separating ← |
 | Sedna                 | sextile ⚹        | Vulkanus              | 3.54° | Separating ← |
 | Haumea                | sextile ⚹        | Ixion                 | 2.92° | Separating ← |
 | Haumea                | semi-square ∠    | Orcus                 | 0.96° | Applying →   |
@@ -631,11 +632,11 @@ Tokyo Subject — Natal Chart Report
 | Haumea                | trine △          | Mean Priapus          | 1.13° | Applying →   |
 | Haumea                | sextile ⚹        | White Moon            | 4.74° | Applying →   |
 | Haumea                | conjunction ☌    | Zeus                  | 0.24° | Static =     |
-| Haumea                | square □         | Kronos                | 4.71° | Applying →   |
+| Haumea                | square □         | Kronos                | 4.72° | Applying →   |
 | Haumea                | quintile Q       | Vulkanus              | 0.80° | Separating ← |
 | Makemake              | square □         | Interpolated Perigee  | 4.34° | Separating ← |
-| Makemake              | square □         | Hades                 | 5.32° | Separating ← |
-| Makemake              | quintile Q       | Kronos                | 0.60° | Applying →   |
+| Makemake              | square □         | Hades                 | 5.31° | Separating ← |
+| Makemake              | quintile Q       | Kronos                | 0.61° | Applying →   |
 | Ixion                 | conjunction ☌    | Quaoar                | 1.38° | Static =     |
 | Ixion                 | square □         | Pars Amoris           | 0.39° | Applying →   |
 | Ixion                 | trine △          | Pars Fidei            | 3.20° | Applying →   |
@@ -646,7 +647,7 @@ Tokyo Subject — Natal Chart Report
 | Ixion                 | trine △          | White Moon            | 1.82° | Applying →   |
 | Ixion                 | conjunction ☌    | Cupido                | 4.12° | Static =     |
 | Ixion                 | sextile ⚹        | Zeus                  | 2.68° | Separating ← |
-| Ixion                 | quincunx ⚻       | Kronos                | 1.79° | Applying →   |
+| Ixion                 | quincunx ⚻       | Kronos                | 1.80° | Applying →   |
 | Orcus                 | sextile ⚹        | Pars Fortunae         | 4.69° | Applying →   |
 | Orcus                 | quincunx ⚻       | Pars Spiritus         | 1.49° | Applying →   |
 | Orcus                 | sesquiquadrate ⚼ | Vertex                | 1.14° | Separating ← |
@@ -662,20 +663,20 @@ Tokyo Subject — Natal Chart Report
 | Quaoar                | sextile ⚹        | Anti Vertex           | 0.57° | Applying →   |
 | Quaoar                | conjunction ☌    | Interpolated Lilith   | 3.89° | Applying →   |
 | Quaoar                | opposition ☍     | Mean Priapus          | 0.40° | Separating ← |
-| Quaoar                | trine △          | White Moon            | 3.20° | Applying →   |
+| Quaoar                | trine △          | White Moon            | 3.21° | Applying →   |
 | Quaoar                | conjunction ☌    | Cupido                | 5.50° | Static =     |
 | Quaoar                | sextile ⚹        | Zeus                  | 1.29° | Separating ← |
 | Pars Fortunae         | square □         | Pars Fidei            | 5.15° | Static =     |
 | Pars Fortunae         | conjunction ☌    | True Priapus          | 3.76° | Separating ← |
 | Pars Fortunae         | conjunction ☌    | Hades                 | 5.52° | Applying →   |
 | Pars Fortunae         | trine △          | Apollon               | 0.98° | Separating ← |
-| Pars Fortunae         | semi-sextile ⚺   | Admetos               | 0.12° | Applying →   |
+| Pars Fortunae         | semi-sextile ⚺   | Admetos               | 0.13° | Applying →   |
 | Pars Fortunae         | semi-sextile ⚺   | Vulkanus              | 0.08° | Separating ← |
-| Pars Fortunae         | sesquiquadrate ⚼ | Poseidon              | 1.01° | Separating ← |
+| Pars Fortunae         | sesquiquadrate ⚼ | Poseidon              | 1.00° | Separating ← |
 | Pars Spiritus         | quintile Q       | Vertex                | 0.37° | Static =     |
 | Pars Spiritus         | sesquiquadrate ⚼ | Mean Priapus          | 1.65° | Applying →   |
 | Pars Spiritus         | square □         | Apollon               | 2.22° | Applying →   |
-| Pars Spiritus         | trine △          | Admetos               | 3.08° | Separating ← |
+| Pars Spiritus         | trine △          | Admetos               | 3.07° | Separating ← |
 | Pars Spiritus         | opposition ☍     | Vulkanus              | 3.28° | Separating ← |
 | Pars Spiritus         | quintile Q       | Poseidon              | 0.80° | Separating ← |
 | Pars Amoris           | quincunx ⚻       | Vertex                | 1.21° | Static =     |
@@ -684,8 +685,8 @@ Tokyo Subject — Natal Chart Report
 | Pars Amoris           | square □         | Mean Priapus          | 2.18° | Separating ← |
 | Pars Amoris           | sextile ⚹        | True Priapus          | 4.21° | Applying →   |
 | Pars Amoris           | semi-sextile ⚺   | White Moon            | 1.43° | Applying →   |
-| Pars Amoris           | square □         | Cupido                | 3.73° | Separating ← |
-| Pars Amoris           | quintile Q       | Hades                 | 1.48° | Applying →   |
+| Pars Amoris           | square □         | Cupido                | 3.72° | Separating ← |
+| Pars Amoris           | quintile Q       | Hades                 | 1.49° | Applying →   |
 | Pars Amoris           | sextile ⚹        | Kronos                | 1.40° | Applying →   |
 | Pars Fidei            | conjunction ☌    | Vertex                | 4.02° | Static =     |
 | Pars Fidei            | opposition ☍     | Anti Vertex           | 4.02° | Static =     |
@@ -693,49 +694,49 @@ Tokyo Subject — Natal Chart Report
 | Pars Fidei            | sextile ⚹        | Mean Priapus          | 4.99° | Separating ← |
 | Pars Fidei            | square □         | True Priapus          | 1.40° | Applying →   |
 | Pars Fidei            | trine △          | White Moon            | 1.38° | Separating ← |
-| Pars Fidei            | trine △          | Cupido                | 0.92° | Separating ← |
+| Pars Fidei            | trine △          | Cupido                | 0.91° | Separating ← |
 | Pars Fidei            | opposition ☍     | Zeus                  | 5.88° | Separating ← |
 | Pars Fidei            | square □         | Kronos                | 1.41° | Separating ← |
-| Pars Fidei            | trine △          | Vulkanus              | 5.07° | Applying →   |
+| Pars Fidei            | trine △          | Vulkanus              | 5.08° | Applying →   |
 | Vertex                | trine △          | Interpolated Lilith   | 3.32° | Applying →   |
 | Vertex                | sextile ⚹        | Mean Priapus          | 0.97° | Separating ← |
 | Vertex                | square □         | True Priapus          | 5.41° | Applying →   |
-| Vertex                | trine △          | White Moon            | 2.63° | Applying →   |
+| Vertex                | trine △          | White Moon            | 2.64° | Applying →   |
 | Vertex                | trine △          | Cupido                | 4.93° | Separating ← |
 | Vertex                | opposition ☍     | Zeus                  | 1.86° | Separating ← |
 | Vertex                | square □         | Kronos                | 2.61° | Applying →   |
-| Vertex                | biquintile bQ    | Poseidon              | 1.18° | Separating ← |
+| Vertex                | biquintile bQ    | Poseidon              | 1.17° | Separating ← |
 | Anti Vertex           | sextile ⚹        | Interpolated Lilith   | 3.32° | Applying →   |
 | Anti Vertex           | trine △          | Mean Priapus          | 0.97° | Separating ← |
 | Anti Vertex           | square □         | True Priapus          | 5.41° | Applying →   |
-| Anti Vertex           | sextile ⚹        | White Moon            | 2.63° | Applying →   |
+| Anti Vertex           | sextile ⚹        | White Moon            | 2.64° | Applying →   |
 | Anti Vertex           | sextile ⚹        | Cupido                | 4.93° | Separating ← |
 | Anti Vertex           | conjunction ☌    | Zeus                  | 1.86° | Separating ← |
 | Anti Vertex           | square □         | Kronos                | 2.61° | Applying →   |
 | Interpolated Lilith   | opposition ☍     | Mean Priapus          | 4.30° | Separating ← |
 | Interpolated Lilith   | trine △          | White Moon            | 0.69° | Separating ← |
 | Interpolated Lilith   | conjunction ☌    | Cupido                | 1.61° | Separating ← |
-| Interpolated Lilith   | quincunx ⚻       | Kronos                | 0.72° | Applying →   |
+| Interpolated Lilith   | quincunx ⚻       | Kronos                | 0.71° | Applying →   |
 | Interpolated Lilith   | opposition ☍     | Admetos               | 5.97° | Separating ← |
-| Interpolated Lilith   | trine △          | Vulkanus              | 5.76° | Separating ← |
+| Interpolated Lilith   | trine △          | Vulkanus              | 5.77° | Separating ← |
 | Mean Priapus          | sextile ⚹        | White Moon            | 3.61° | Applying →   |
-| Mean Priapus          | opposition ☍     | Cupido                | 5.91° | Separating ← |
+| Mean Priapus          | opposition ☍     | Cupido                | 5.90° | Separating ← |
 | Mean Priapus          | trine △          | Zeus                  | 0.89° | Applying →   |
 | True Priapus          | quincunx ⚻       | Cupido                | 0.48° | Applying →   |
-| True Priapus          | conjunction ☌    | Kronos                | 2.81° | Applying →   |
-| True Priapus          | trine △          | Apollon               | 4.74° | Separating ← |
+| True Priapus          | conjunction ☌    | Kronos                | 2.80° | Applying →   |
+| True Priapus          | trine △          | Apollon               | 4.73° | Separating ← |
 | Interpolated Perigee  | semi-square ∠    | White Moon            | 1.97° | Separating ← |
 | Interpolated Perigee  | conjunction ☌    | Hades                 | 0.98° | Applying →   |
 | Interpolated Perigee  | trine △          | Apollon               | 5.52° | Applying →   |
-| White Moon            | trine △          | Cupido                | 2.30° | Separating ← |
+| White Moon            | trine △          | Cupido                | 2.29° | Separating ← |
 | White Moon            | sextile ⚹        | Zeus                  | 4.50° | Applying →   |
 | White Moon            | semi-sextile ⚺   | Kronos                | 0.03° | Applying →   |
-| Cupido                | opposition ☍     | Admetos               | 4.36° | Applying →   |
-| Cupido                | trine △          | Vulkanus              | 4.15° | Applying →   |
+| Cupido                | opposition ☍     | Admetos               | 4.37° | Applying →   |
+| Cupido                | trine △          | Vulkanus              | 4.16° | Applying →   |
 | Hades                 | trine △          | Apollon               | 4.54° | Applying →   |
 | Zeus                  | square □         | Kronos                | 4.47° | Applying →   |
-| Zeus                  | quintile Q       | Vulkanus              | 1.05° | Separating ← |
-| Apollon               | quincunx ⚻       | Admetos               | 0.86° | Separating ← |
-| Apollon               | square □         | Vulkanus              | 1.06° | Separating ← |
+| Zeus                  | quintile Q       | Vulkanus              | 1.04° | Separating ← |
+| Apollon               | quincunx ⚻       | Admetos               | 0.85° | Separating ← |
+| Apollon               | square □         | Vulkanus              | 1.05° | Separating ← |
 | Admetos               | sextile ⚹        | Vulkanus              | 0.21° | Separating ← |
 +-----------------------+------------------+-----------------------+-------+--------------+

--- a/tests/fixtures/natal_yoko_ono_chart_report.txt
+++ b/tests/fixtures/natal_yoko_ono_chart_report.txt
@@ -31,8 +31,8 @@ Yoko Ono — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Lib ♎ | 8.41°    | +299.6082°/d | N/A     | -    | First House    |
-| Medium Coeli          | Can ♋ | 9.31°    | +332.7977°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Lib ♎ | 8.41°    | +299.6098°/d | N/A     | -    | First House    |
+| Medium Coeli          | Can ♋ | 9.31°    | +332.7995°/d | N/A     | -    | Tenth House    |
 | Sun                   | Aqu ♒ | 29.38°   | +1.0085°/d   | -11.70° | -    | Fifth House    |
 | Moon                  | Sag ♐ | 11.13°   | +14.2185°/d  | -27.33° | -    | Third House    |
 | Mercury               | Pis ♓ | 7.89°    | +1.8561°/d   | -9.86°  | -    | Fifth House    |

--- a/tests/fixtures/natal_yoko_ono_subject_report.txt
+++ b/tests/fixtures/natal_yoko_ono_subject_report.txt
@@ -31,8 +31,8 @@ Yoko Ono — Subject Report
 +Celestial Points-------+--------+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Lib ♎ | 8.41°    | +299.6082°/d | N/A     | -    | First House    |
-| Medium Coeli          | Can ♋ | 9.31°    | +332.7977°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Lib ♎ | 8.41°    | +299.6098°/d | N/A     | -    | First House    |
+| Medium Coeli          | Can ♋ | 9.31°    | +332.7995°/d | N/A     | -    | Tenth House    |
 | Sun                   | Aqu ♒ | 29.38°   | +1.0085°/d   | -11.70° | -    | Fifth House    |
 | Moon                  | Sag ♐ | 11.13°   | +14.2185°/d  | -27.33° | -    | Third House    |
 | Mercury               | Pis ♓ | 7.89°    | +1.8561°/d   | -9.86°  | -    | Fifth House    |

--- a/tests/fixtures/new_moon_test_natal_report.txt
+++ b/tests/fixtures/new_moon_test_natal_report.txt
@@ -31,8 +31,8 @@ New Moon - Test — Natal Chart Report
 +Natal Celestial Points-+--------+----------+--------------+---------+------+---------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House         |
 +-----------------------+--------+----------+--------------+---------+------+---------------+
-| Ascendant             | Vir ♍ | 22.88°   | +287.0307°/d | N/A     | -    | First House   |
-| Medium Coeli          | Gem ♊ | 21.77°   | +332.4727°/d | N/A     | -    | Tenth House   |
+| Ascendant             | Vir ♍ | 22.88°   | +287.0322°/d | N/A     | -    | First House   |
+| Medium Coeli          | Gem ♊ | 21.77°   | +332.4746°/d | N/A     | -    | Tenth House   |
 | Sun                   | Sco ♏ | 28.20°   | +1.0097°/d   | -19.76° | -    | Third House   |
 | Moon                  | Sco ♏ | 28.19°   | +11.8608°/d  | -24.41° | -    | Third House   |
 | Mercury               | Sco ♏ | 28.46°   | -1.3593°/d   | -19.32° | R    | Third House   |

--- a/tests/fixtures/solar_return_all_points_report.txt
+++ b/tests/fixtures/solar_return_all_points_report.txt
@@ -30,10 +30,10 @@ Sample Natal Subject Solar Return — Solar Return 1990
 +Solar Return Chart Celestial Points--------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House    |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6344°/d | N/A     | -    | Tenth House    |
-| Descendant            | Tau ♉ | 5.82°    | +245.7237°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6344°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House    |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6364°/d | N/A     | -    | Tenth House    |
+| Descendant            | Tau ♉ | 5.82°    | +245.7250°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6364°/d | N/A     | -    | Fourth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House    |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House    |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House    |
@@ -46,8 +46,8 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Pluto                 | Sco ♏ | 14.97°   | -0.0025°/d   | -1.42°  | R    | First House    |
 | Mean North Lunar Node | Aqu ♒ | 7.79°    | -0.0529°/d   | -18.32° | R    | Third House    |
 | True North Lunar Node | Aqu ♒ | 7.26°    | -0.0080°/d   | -18.46° | R    | Third House    |
-| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.61° | -    | First House    |
-| True Lilith           | Sag ♐ | 18.01°   | -1.4331°/d   | -26.88° | R    | Second House   |
+| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.62° | -    | First House    |
+| True Lilith           | Sag ♐ | 18.01°   | -1.4330°/d   | -26.88° | R    | Second House   |
 | Chiron                | Can ♋ | 19.88°   | +0.1071°/d   | +15.79° | -    | Ninth House    |
 | Pholus                | Can ♋ | 7.99°    | +0.1329°/d   | +13.79° | -    | Eighth House   |
 | Ceres                 | Leo ♌ | 13.71°   | +0.4493°/d   | +23.05° | -    | Ninth House    |
@@ -55,15 +55,15 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Juno                  | Sco ♏ | 10.10°   | +0.0843°/d   | -2.06°  | -    | First House    |
 | Vesta                 | Tau ♉ | 18.15°   | +0.3292°/d   | +10.88° | -    | Seventh House  |
 | Interpolated Lilith   | Sco ♏ | 25.48°   | +0.1694°/d   | -23.89° | -    | First House    |
-| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1732°/d   | +26.84° | -    | Eighth House   |
-| Cupido                | Sco ♏ | 18.62°   | -0.0042°/d   | -16.34° | R    | First House    |
-| Hades                 | Gem ♊ | 9.93°    | +0.0152°/d   | +20.93° | -    | Eighth House   |
-| Zeus                  | Vir ♍ | 26.03°   | +0.0110°/d   | +1.58°  | -    | Eleventh House |
-| Kronos                | Gem ♊ | 21.90°   | +0.0137°/d   | +23.21° | -    | Eighth House   |
-| Apollon               | Lib ♎ | 13.83°   | +0.0053°/d   | -5.46°  | -    | Eleventh House |
-| Admetos               | Tau ♉ | 14.96°   | +0.0053°/d   | +16.33° | -    | Seventh House  |
-| Vulkanus              | Can ♋ | 15.35°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
-| Poseidon              | Lib ♎ | 28.68°   | +0.0014°/d   | -11.01° | -    | Twelfth House  |
+| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1733°/d   | +26.84° | -    | Eighth House   |
+| Cupido                | Sco ♏ | 18.62°   | -0.0043°/d   | -16.34° | R    | First House    |
+| Hades                 | Gem ♊ | 9.92°    | +0.0153°/d   | +20.93° | -    | Eighth House   |
+| Zeus                  | Vir ♍ | 26.03°   | +0.0109°/d   | +1.58°  | -    | Eleventh House |
+| Kronos                | Gem ♊ | 21.89°   | +0.0138°/d   | +23.21° | -    | Eighth House   |
+| Apollon               | Lib ♎ | 13.82°   | +0.0052°/d   | -5.46°  | -    | Eleventh House |
+| Admetos               | Tau ♉ | 14.96°   | +0.0054°/d   | +16.33° | -    | Seventh House  |
+| Vulkanus              | Can ♋ | 15.34°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
+| Poseidon              | Lib ♎ | 28.68°   | +0.0013°/d   | -11.01° | -    | Twelfth House  |
 | Eris                  | Ari ♈ | 17.60°   | -0.0013°/d   | -9.16°  | R    | Sixth House    |
 | Sedna                 | Tau ♉ | 11.55°   | +0.0038°/d   | +4.25°  | -    | Seventh House  |
 | Haumea                | Vir ♍ | 26.32°   | +0.0134°/d   | +23.02° | -    | Eleventh House |
@@ -76,12 +76,12 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Pars Amoris           | Lib ♎ | 8.98°    | N/A          | N/A     | -    | Eleventh House |
 | Pars Fidei            | Tau ♉ | 8.21°    | N/A          | N/A     | -    | Seventh House  |
 | Vertex                | Gem ♊ | 11.46°   | N/A          | N/A     | -    | Eighth House   |
-| White Moon            | Can ♋ | 26.44°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
+| White Moon            | Can ♋ | 26.43°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
 | Anti Vertex           | Sag ♐ | 11.46°   | N/A          | N/A     | -    | Second House   |
 | Mean South Lunar Node | Leo ♌ | 7.79°    | -0.0529°/d   | +18.32° | R    | Ninth House    |
 | True South Lunar Node | Leo ♌ | 7.26°    | -0.0080°/d   | +18.46° | R    | Ninth House    |
-| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.61° | -    | Seventh House  |
-| True Priapus          | Gem ♊ | 18.01°   | -1.4331°/d   | +26.88° | R    | Eighth House   |
+| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.62° | -    | Seventh House  |
+| True Priapus          | Gem ♊ | 18.01°   | -1.4330°/d   | +26.88° | R    | Eighth House   |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +Solar Return Chart Houses (Placidus)+-------------------+
@@ -231,11 +231,11 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Moon                  | quintile Q       | Pars Fidei            | 0.99° | Separating ← |
 | Moon                  | trine △          | Interpolated Lilith   | 4.27° | Applying →   |
 | Moon                  | semi-sextile ⚺   | Interpolated Perigee  | 0.23° | Separating ← |
-| Moon                  | conjunction ☌    | White Moon            | 5.23° | Applying →   |
+| Moon                  | conjunction ☌    | White Moon            | 5.22° | Applying →   |
 | Moon                  | trine △          | Cupido                | 2.59° | Separating ← |
 | Moon                  | sextile ⚹        | Zeus                  | 4.82° | Applying →   |
 | Moon                  | semi-sextile ⚺   | Kronos                | 0.69° | Applying →   |
-| Moon                  | conjunction ☌    | Vulkanus              | 5.86° | Separating ← |
+| Moon                  | conjunction ☌    | Vulkanus              | 5.87° | Separating ← |
 | Mercury               | semi-square ∠    | Venus                 | 0.90° | Separating ← |
 | Mercury               | biquintile bQ    | Neptune               | 1.15° | Applying →   |
 | Mercury               | square □         | Pluto                 | 2.63° | Separating ← |
@@ -302,7 +302,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Jupiter               | square □         | Pars Fortunae         | 4.57° | Applying →   |
 | Jupiter               | trine △          | Interpolated Lilith   | 1.56° | Applying →   |
 | Jupiter               | conjunction ☌    | White Moon            | 2.52° | Applying →   |
-| Jupiter               | trine △          | Cupido                | 5.30° | Separating ← |
+| Jupiter               | trine △          | Cupido                | 5.29° | Separating ← |
 | Jupiter               | semi-square ∠    | Hades                 | 1.01° | Applying →   |
 | Jupiter               | sextile ⚹        | Zeus                  | 2.12° | Applying →   |
 | Jupiter               | square □         | Poseidon              | 4.77° | Applying →   |
@@ -319,7 +319,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Saturn                | quincunx ⚻       | Interpolated Perigee  | 0.53° | Applying →   |
 | Saturn                | opposition ☍     | White Moon            | 4.92° | Separating ← |
 | Saturn                | sextile ⚹        | Cupido                | 2.90° | Applying →   |
-| Saturn                | trine △          | Zeus                  | 4.52° | Separating ← |
+| Saturn                | trine △          | Zeus                  | 4.51° | Separating ← |
 | Saturn                | quincunx ⚻       | Kronos                | 0.38° | Separating ← |
 | Uranus                | semi-sextile ⚺   | Mean North Lunar Node | 1.05° | Applying →   |
 | Uranus                | semi-sextile ⚺   | True North Lunar Node | 0.53° | Separating ← |
@@ -374,7 +374,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Pluto                 | conjunction ☌    | Cupido                | 3.64° | Applying →   |
 | Pluto                 | biquintile bQ    | Kronos                | 0.92° | Separating ← |
 | Pluto                 | semi-sextile ⚺   | Apollon               | 1.15° | Applying →   |
-| Pluto                 | opposition ☍     | Admetos               | 0.01° | Applying →   |
+| Pluto                 | opposition ☍     | Admetos               | 0.02° | Applying →   |
 | Pluto                 | trine △          | Vulkanus              | 0.37° | Separating ← |
 | Mean North Lunar Node | square □         | Ascendant             | 1.97° | Applying →   |
 | Mean North Lunar Node | square □         | Descendant            | 1.97° | Applying →   |
@@ -392,7 +392,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Mean North Lunar Node | sextile ⚹        | Anti Vertex           | 3.67° | Separating ← |
 | Mean North Lunar Node | quintile Q       | Interpolated Lilith   | 0.31° | Applying →   |
 | Mean North Lunar Node | sesquiquadrate ⚼ | Interpolated Perigee  | 1.81° | Applying →   |
-| Mean North Lunar Node | trine △          | Hades                 | 2.14° | Separating ← |
+| Mean North Lunar Node | trine △          | Hades                 | 2.13° | Separating ← |
 | Mean North Lunar Node | sesquiquadrate ⚼ | Kronos                | 0.89° | Applying →   |
 | True North Lunar Node | square □         | Ascendant             | 1.45° | Applying →   |
 | True North Lunar Node | square □         | Descendant            | 1.45° | Applying →   |
@@ -426,7 +426,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Chiron                | semi-sextile ⚺   | Interpolated Perigee  | 1.10° | Separating ← |
 | Chiron                | trine △          | Cupido                | 1.26° | Separating ← |
 | Chiron                | sextile ⚹        | Admetos               | 4.92° | Separating ← |
-| Chiron                | conjunction ☌    | Vulkanus              | 4.53° | Separating ← |
+| Chiron                | conjunction ☌    | Vulkanus              | 4.54° | Separating ← |
 | Ascendant             | square □         | Mean South Lunar Node | 1.97° | Applying →   |
 | Ascendant             | square □         | True South Lunar Node | 1.45° | Applying →   |
 | Ascendant             | trine △          | Pholus                | 2.17° | Applying →   |
@@ -438,7 +438,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Ascendant             | opposition ☍     | Pars Fidei            | 2.40° | Applying →   |
 | Ascendant             | biquintile bQ    | Vertex                | 0.36° | Separating ← |
 | Ascendant             | sesquiquadrate ⚼ | Interpolated Perigee  | 0.16° | Applying →   |
-| Ascendant             | biquintile bQ    | Hades                 | 1.89° | Separating ← |
+| Ascendant             | biquintile bQ    | Hades                 | 1.90° | Separating ← |
 | Ascendant             | sesquiquadrate ⚼ | Kronos                | 1.08° | Applying →   |
 | Medium Coeli          | trine △          | True Lilith           | 1.90° | Separating ← |
 | Medium Coeli          | square □         | Vesta                 | 1.76° | Separating ← |
@@ -449,7 +449,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Medium Coeli          | sextile ⚹        | True Priapus          | 1.90° | Separating ← |
 | Medium Coeli          | sextile ⚹        | Interpolated Perigee  | 1.07° | Applying →   |
 | Medium Coeli          | square □         | Cupido                | 1.29° | Separating ← |
-| Medium Coeli          | sextile ⚹        | Kronos                | 1.99° | Applying →   |
+| Medium Coeli          | sextile ⚹        | Kronos                | 1.98° | Applying →   |
 | Medium Coeli          | square □         | Admetos               | 4.95° | Separating ← |
 | Descendant            | square □         | Mean South Lunar Node | 1.97° | Applying →   |
 | Descendant            | square □         | True South Lunar Node | 1.45° | Applying →   |
@@ -474,7 +474,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Imum Coeli            | trine △          | Interpolated Perigee  | 1.07° | Applying →   |
 | Imum Coeli            | square □         | Cupido                | 1.29° | Separating ← |
 | Imum Coeli            | biquintile bQ    | Zeus                  | 0.12° | Applying →   |
-| Imum Coeli            | trine △          | Kronos                | 1.99° | Applying →   |
+| Imum Coeli            | trine △          | Kronos                | 1.98° | Applying →   |
 | Imum Coeli            | square □         | Admetos               | 4.95° | Separating ← |
 | Imum Coeli            | biquintile bQ    | Vulkanus              | 1.43° | Applying →   |
 | Mean Lilith           | sextile ⚹        | Haumea                | 2.67° | Separating ← |
@@ -482,10 +482,10 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Mean Lilith           | conjunction ☌    | Quaoar                | 4.91° | Separating ← |
 | Mean Lilith           | semi-sextile ⚺   | Pars Fortunae         | 0.51° | Separating ← |
 | Mean Lilith           | conjunction ☌    | Interpolated Lilith   | 3.51° | Applying →   |
-| Mean Lilith           | trine △          | White Moon            | 2.55° | Applying →   |
+| Mean Lilith           | trine △          | White Moon            | 2.56° | Applying →   |
 | Mean Lilith           | sextile ⚹        | Zeus                  | 2.96° | Separating ← |
-| Mean Lilith           | semi-square ∠    | Apollon               | 0.16° | Separating ← |
-| Mean Lilith           | sesquiquadrate ⚼ | Vulkanus              | 1.36° | Applying →   |
+| Mean Lilith           | semi-square ∠    | Apollon               | 0.17° | Separating ← |
+| Mean Lilith           | sesquiquadrate ⚼ | Vulkanus              | 1.35° | Applying →   |
 | Mean Lilith           | semi-sextile ⚺   | Poseidon              | 0.31° | Separating ← |
 | Mean South Lunar Node | semi-sextile ⚺   | Pholus                | 0.20° | Separating ← |
 | Mean South Lunar Node | conjunction ☌    | Ceres                 | 5.93° | Separating ← |
@@ -499,7 +499,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Mean South Lunar Node | sextile ⚹        | Vertex                | 3.67° | Separating ← |
 | Mean South Lunar Node | trine △          | Anti Vertex           | 3.67° | Separating ← |
 | Mean South Lunar Node | semi-square ∠    | Interpolated Perigee  | 1.81° | Applying →   |
-| Mean South Lunar Node | sextile ⚹        | Hades                 | 2.14° | Separating ← |
+| Mean South Lunar Node | sextile ⚹        | Hades                 | 2.13° | Separating ← |
 | Mean South Lunar Node | semi-square ∠    | Kronos                | 0.89° | Applying →   |
 | True South Lunar Node | semi-sextile ⚺   | Pholus                | 0.73° | Separating ← |
 | True South Lunar Node | semi-sextile ⚺   | Pallas                | 0.02° | Applying →   |
@@ -531,8 +531,8 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Pholus                | trine △          | Pars Spiritus         | 5.16° | Applying →   |
 | Pholus                | square □         | Pars Amoris           | 0.99° | Applying →   |
 | Pholus                | sextile ⚹        | Pars Fidei            | 0.22° | Applying →   |
-| Pholus                | semi-sextile ⚺   | Hades                 | 1.94° | Applying →   |
-| Pholus                | square □         | Apollon               | 5.84° | Applying →   |
+| Pholus                | semi-sextile ⚺   | Hades                 | 1.93° | Applying →   |
+| Pholus                | square □         | Apollon               | 5.83° | Applying →   |
 | Ceres                 | square □         | Juno                  | 3.62° | Separating ← |
 | Ceres                 | square □         | Vesta                 | 4.43° | Applying →   |
 | Ceres                 | trine △          | Eris                  | 3.88° | Applying →   |
@@ -547,7 +547,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Ceres                 | square □         | Cupido                | 4.90° | Applying →   |
 | Ceres                 | sextile ⚹        | Hades                 | 3.79° | Separating ← |
 | Ceres                 | sextile ⚹        | Apollon               | 0.11° | Applying →   |
-| Ceres                 | square □         | Admetos               | 1.25° | Applying →   |
+| Ceres                 | square □         | Admetos               | 1.24° | Applying →   |
 | Ceres                 | semi-sextile ⚺   | Vulkanus              | 1.63° | Applying →   |
 | Pallas                | trine △          | Juno                  | 2.85° | Applying →   |
 | Pallas                | sextile ⚹        | Sedna                 | 4.30° | Applying →   |
@@ -567,9 +567,9 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Juno                  | semi-sextile ⚺   | Anti Vertex           | 1.36° | Applying →   |
 | Juno                  | biquintile bQ    | True Priapus          | 1.92° | Applying →   |
 | Juno                  | quincunx ⚻       | Hades                 | 0.17° | Separating ← |
-| Juno                  | semi-square ∠    | Zeus                  | 0.94° | Applying →   |
+| Juno                  | semi-square ∠    | Zeus                  | 0.93° | Applying →   |
 | Juno                  | opposition ☍     | Admetos               | 4.86° | Applying →   |
-| Juno                  | trine △          | Vulkanus              | 5.25° | Applying →   |
+| Juno                  | trine △          | Vulkanus              | 5.24° | Applying →   |
 | Vesta                 | semi-sextile ⚺   | Eris                  | 0.55° | Separating ← |
 | Vesta                 | opposition ☍     | Ixion                 | 4.56° | Applying →   |
 | Vesta                 | opposition ☍     | Quaoar                | 5.93° | Applying →   |
@@ -578,7 +578,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Vesta                 | opposition ☍     | Cupido                | 0.47° | Applying →   |
 | Vesta                 | biquintile bQ    | Apollon               | 1.68° | Applying →   |
 | Vesta                 | conjunction ☌    | Admetos               | 3.19° | Separating ← |
-| Vesta                 | sextile ⚹        | Vulkanus              | 2.80° | Separating ← |
+| Vesta                 | sextile ⚹        | Vulkanus              | 2.81° | Separating ← |
 | Eris                  | sesquiquadrate ⚼ | Makemake              | 1.90° | Separating ← |
 | Eris                  | biquintile bQ    | Ixion                 | 0.89° | Separating ← |
 | Eris                  | biquintile bQ    | Quaoar                | 0.48° | Applying →   |
@@ -588,17 +588,17 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Eris                  | quincunx ⚻       | Cupido                | 1.02° | Applying →   |
 | Eris                  | sextile ⚹        | Kronos                | 4.30° | Separating ← |
 | Eris                  | opposition ☍     | Apollon               | 3.77° | Applying →   |
-| Eris                  | square □         | Vulkanus              | 2.25° | Applying →   |
+| Eris                  | square □         | Vulkanus              | 2.26° | Applying →   |
 | Sedna                 | sesquiquadrate ⚼ | Haumea                | 0.23° | Applying →   |
 | Sedna                 | square □         | Orcus                 | 0.71° | Applying →   |
 | Sedna                 | opposition ☍     | Pars Spiritus         | 1.60° | Applying →   |
 | Sedna                 | conjunction ☌    | Pars Fidei            | 3.33° | Separating ← |
 | Sedna                 | semi-sextile ⚺   | Vertex                | 0.09° | Separating ← |
 | Sedna                 | quincunx ⚻       | Anti Vertex           | 0.09° | Separating ← |
-| Sedna                 | semi-sextile ⚺   | Hades                 | 1.62° | Applying →   |
+| Sedna                 | semi-sextile ⚺   | Hades                 | 1.63° | Applying →   |
 | Sedna                 | sesquiquadrate ⚼ | Zeus                  | 0.52° | Applying →   |
 | Sedna                 | conjunction ☌    | Admetos               | 3.41° | Separating ← |
-| Sedna                 | sextile ⚹        | Vulkanus              | 3.80° | Separating ← |
+| Sedna                 | sextile ⚹        | Vulkanus              | 3.79° | Separating ← |
 | Haumea                | sextile ⚹        | Ixion                 | 3.62° | Separating ← |
 | Haumea                | semi-square ∠    | Orcus                 | 0.48° | Applying →   |
 | Haumea                | sextile ⚹        | Quaoar                | 2.25° | Separating ← |
@@ -608,12 +608,12 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Haumea                | square □         | Interpolated Perigee  | 5.34° | Applying →   |
 | Haumea                | sextile ⚹        | White Moon            | 0.11° | Separating ← |
 | Haumea                | conjunction ☌    | Zeus                  | 0.29° | Separating ← |
-| Haumea                | square □         | Kronos                | 4.42° | Static =     |
+| Haumea                | square □         | Kronos                | 4.43° | Static =     |
 | Haumea                | quintile Q       | Vulkanus              | 1.02° | Static =     |
 | Makemake              | trine △          | Pars Fidei            | 3.72° | Applying →   |
 | Makemake              | square □         | Mean Priapus          | 5.51° | Applying →   |
 | Makemake              | quintile Q       | Interpolated Perigee  | 1.51° | Applying →   |
-| Makemake              | square □         | Hades                 | 5.43° | Applying →   |
+| Makemake              | square □         | Hades                 | 5.42° | Applying →   |
 | Makemake              | quintile Q       | Kronos                | 0.60° | Separating ← |
 | Ixion                 | conjunction ☌    | Quaoar                | 1.37° | Static =     |
 | Ixion                 | semi-square ∠    | Pars Amoris           | 1.28° | Separating ← |
@@ -622,14 +622,14 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Ixion                 | trine △          | White Moon            | 3.73° | Separating ← |
 | Ixion                 | conjunction ☌    | Cupido                | 4.09° | Applying →   |
 | Ixion                 | sextile ⚹        | Zeus                  | 3.33° | Separating ← |
-| Ixion                 | quincunx ⚻       | Kronos                | 0.80° | Applying →   |
+| Ixion                 | quincunx ⚻       | Kronos                | 0.81° | Applying →   |
 | Orcus                 | square □         | Pars Spiritus         | 2.31° | Applying →   |
 | Orcus                 | sextile ⚹        | Pars Amoris           | 1.86° | Separating ← |
 | Orcus                 | square □         | Pars Fidei            | 2.62° | Separating ← |
 | Orcus                 | sextile ⚹        | Vertex                | 0.62° | Applying →   |
 | Orcus                 | trine △          | Anti Vertex           | 0.62° | Applying →   |
 | Orcus                 | quintile Q       | Mean Priapus          | 0.15° | Separating ← |
-| Orcus                 | sextile ⚹        | Hades                 | 0.91° | Separating ← |
+| Orcus                 | sextile ⚹        | Hades                 | 0.92° | Separating ← |
 | Orcus                 | semi-square ∠    | Zeus                  | 0.19° | Applying →   |
 | Orcus                 | sextile ⚹        | Apollon               | 2.99° | Applying →   |
 | Orcus                 | square □         | Admetos               | 4.12° | Applying →   |
@@ -638,7 +638,7 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Quaoar                | opposition ☍     | Mean Priapus          | 4.91° | Separating ← |
 | Quaoar                | trine △          | White Moon            | 2.36° | Separating ← |
 | Quaoar                | conjunction ☌    | Cupido                | 5.46° | Applying →   |
-| Quaoar                | sextile ⚹        | Zeus                  | 1.96° | Separating ← |
+| Quaoar                | sextile ⚹        | Zeus                  | 1.95° | Separating ← |
 | Pars Fortunae         | quincunx ⚻       | Mean Priapus          | 0.51° | Separating ← |
 | Pars Fortunae         | square □         | White Moon            | 2.05° | Applying →   |
 | Pars Fortunae         | conjunction ☌    | Poseidon              | 0.20° | Separating ← |
@@ -658,39 +658,39 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Pars Amoris           | quintile Q       | White Moon            | 0.55° | Applying →   |
 | Pars Amoris           | trine △          | Hades                 | 0.94° | Separating ← |
 | Pars Amoris           | conjunction ☌    | Apollon               | 4.84° | Separating ← |
-| Pars Amoris           | biquintile bQ    | Admetos               | 0.02° | Applying →   |
+| Pars Amoris           | biquintile bQ    | Admetos               | 0.03° | Applying →   |
 | Pars Fidei            | semi-sextile ⚺   | Hades                 | 1.71° | Separating ← |
 | Pars Fidei            | semi-square ∠    | Kronos                | 1.32° | Applying →   |
-| Vertex                | semi-square ∠    | White Moon            | 0.02° | Applying →   |
-| Vertex                | conjunction ☌    | Hades                 | 1.53° | Applying →   |
-| Vertex                | trine △          | Apollon               | 2.37° | Separating ← |
-| Anti Vertex           | sesquiquadrate ⚼ | White Moon            | 0.02° | Applying →   |
-| Anti Vertex           | opposition ☍     | Hades                 | 1.53° | Applying →   |
-| Anti Vertex           | sextile ⚹        | Apollon               | 2.37° | Separating ← |
+| Vertex                | semi-square ∠    | White Moon            | 0.03° | Applying →   |
+| Vertex                | conjunction ☌    | Hades                 | 1.54° | Applying →   |
+| Vertex                | trine △          | Apollon               | 2.36° | Separating ← |
+| Anti Vertex           | sesquiquadrate ⚼ | White Moon            | 0.03° | Applying →   |
+| Anti Vertex           | opposition ☍     | Hades                 | 1.54° | Applying →   |
+| Anti Vertex           | sextile ⚹        | Apollon               | 2.36° | Separating ← |
 | Interpolated Lilith   | opposition ☍     | Mean Priapus          | 3.51° | Applying →   |
 | Interpolated Lilith   | trine △          | White Moon            | 0.96° | Applying →   |
-| Interpolated Lilith   | sextile ⚹        | Zeus                  | 0.56° | Applying →   |
-| Mean Priapus          | sextile ⚹        | White Moon            | 2.55° | Applying →   |
+| Interpolated Lilith   | sextile ⚹        | Zeus                  | 0.55° | Applying →   |
+| Mean Priapus          | sextile ⚹        | White Moon            | 2.56° | Applying →   |
 | Mean Priapus          | trine △          | Zeus                  | 2.96° | Separating ← |
-| Mean Priapus          | sesquiquadrate ⚼ | Apollon               | 0.16° | Separating ← |
-| Mean Priapus          | semi-square ∠    | Vulkanus              | 1.36° | Applying →   |
+| Mean Priapus          | sesquiquadrate ⚼ | Apollon               | 0.17° | Separating ← |
+| Mean Priapus          | semi-square ∠    | Vulkanus              | 1.35° | Applying →   |
 | Mean Priapus          | quincunx ⚻       | Poseidon              | 0.31° | Separating ← |
 | True Priapus          | conjunction ☌    | Interpolated Perigee  | 2.97° | Separating ← |
 | True Priapus          | quincunx ⚻       | Cupido                | 0.60° | Separating ← |
 | True Priapus          | conjunction ☌    | Kronos                | 3.88° | Separating ← |
 | True Priapus          | trine △          | Apollon               | 4.19° | Applying →   |
 | Interpolated Perigee  | square □         | Zeus                  | 5.05° | Applying →   |
-| Interpolated Perigee  | conjunction ☌    | Kronos                | 0.92° | Applying →   |
+| Interpolated Perigee  | conjunction ☌    | Kronos                | 0.91° | Applying →   |
 | White Moon            | semi-square ∠    | Hades                 | 1.51° | Separating ← |
 | White Moon            | sextile ⚹        | Zeus                  | 0.40° | Separating ← |
-| White Moon            | quintile Q       | Admetos               | 0.52° | Applying →   |
+| White Moon            | quintile Q       | Admetos               | 0.53° | Applying →   |
 | White Moon            | square □         | Poseidon              | 2.25° | Applying →   |
 | Cupido                | opposition ☍     | Admetos               | 3.66° | Applying →   |
-| Cupido                | trine △          | Vulkanus              | 3.27° | Applying →   |
+| Cupido                | trine △          | Vulkanus              | 3.28° | Applying →   |
 | Hades                 | trine △          | Apollon               | 3.90° | Applying →   |
-| Zeus                  | square □         | Kronos                | 4.13° | Applying →   |
+| Zeus                  | square □         | Kronos                | 4.14° | Applying →   |
 | Zeus                  | quintile Q       | Vulkanus              | 1.31° | Separating ← |
 | Apollon               | quincunx ⚻       | Admetos               | 1.13° | Static =     |
 | Apollon               | square □         | Vulkanus              | 1.52° | Separating ← |
-| Admetos               | sextile ⚹        | Vulkanus              | 0.39° | Separating ← |
+| Admetos               | sextile ⚹        | Vulkanus              | 0.38° | Separating ← |
 +-----------------------+------------------+-----------------------+-------+--------------+

--- a/tests/fixtures/solar_return_johnny_depp_report.txt
+++ b/tests/fixtures/solar_return_johnny_depp_report.txt
@@ -56,8 +56,8 @@ Johnny Depp — Solar Return Comparison 2024
 +Natal Subject Celestial Points--+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Aqu ♒ | 20.70°   | +507.7850°/d | N/A     | -    | First House    |
-| Medium Coeli          | Sag ♐ | 6.59°    | +341.0190°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Aqu ♒ | 20.70°   | +507.7877°/d | N/A     | -    | First House    |
+| Medium Coeli          | Sag ♐ | 6.59°    | +341.0208°/d | N/A     | -    | Tenth House    |
 | Sun                   | Gem ♊ | 17.66°   | +0.9560°/d   | +22.87° | -    | Fourth House   |
 | Moon                  | Cap ♑ | 8.74°    | +12.4796°/d  | -22.08° | -    | Eleventh House |
 | Mercury               | Tau ♉ | 25.00°   | +0.6817°/d   | +15.27° | -    | Third House    |
@@ -75,8 +75,8 @@ Johnny Depp — Solar Return Comparison 2024
 +Return Subject Celestial Points-+----------+--------------+---------+------+---------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House         |
 +-----------------------+--------+----------+--------------+---------+------+---------------+
-| Ascendant             | Sco ♏ | 20.42°   | +289.2845°/d | N/A     | -    | First House   |
-| Medium Coeli          | Vir ♍ | 0.36°    | +378.2238°/d | N/A     | -    | Tenth House   |
+| Ascendant             | Sco ♏ | 20.42°   | +289.2861°/d | N/A     | -    | First House   |
+| Medium Coeli          | Vir ♍ | 0.36°    | +378.2258°/d | N/A     | -    | Tenth House   |
 | Sun                   | Gem ♊ | 17.66°   | +0.9570°/d   | +22.87° | -    | Seventh House |
 | Moon                  | Can ♋ | 5.70°    | +13.3858°/d  | +28.32° | -    | Eighth House  |
 | Mercury               | Gem ♊ | 9.47°    | +2.1121°/d   | +21.68° | -    | Seventh House |

--- a/tests/fixtures/solar_return_report.txt
+++ b/tests/fixtures/solar_return_report.txt
@@ -30,8 +30,8 @@ Sample Natal Subject Solar Return — Solar Return 1990
 +Solar Return Chart Celestial Points--------+--------------+---------+------+---------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House         |
 +-----------------------+--------+----------+--------------+---------+------+---------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House   |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6344°/d | N/A     | -    | Tenth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House   |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6364°/d | N/A     | -    | Tenth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House   |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House   |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House   |

--- a/tests/fixtures/synastry_all_points_all_aspects_report.txt
+++ b/tests/fixtures/synastry_all_points_all_aspects_report.txt
@@ -57,10 +57,10 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 +First Subject Celestial Points--+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House    |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6390°/d | N/A     | -    | Tenth House    |
-| Descendant            | Tau ♉ | 5.82°    | +245.7237°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6390°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House    |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6410°/d | N/A     | -    | Tenth House    |
+| Descendant            | Tau ♉ | 5.82°    | +245.7250°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6410°/d | N/A     | -    | Fourth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House    |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House    |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House    |
@@ -73,8 +73,8 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Pluto                 | Sco ♏ | 14.97°   | -0.0025°/d   | -1.42°  | R    | First House    |
 | Mean North Lunar Node | Aqu ♒ | 7.79°    | -0.0529°/d   | -18.32° | R    | Third House    |
 | True North Lunar Node | Aqu ♒ | 7.26°    | -0.0080°/d   | -18.46° | R    | Third House    |
-| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.61° | -    | First House    |
-| True Lilith           | Sag ♐ | 18.01°   | -1.4331°/d   | -26.88° | R    | Second House   |
+| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.62° | -    | First House    |
+| True Lilith           | Sag ♐ | 18.01°   | -1.4330°/d   | -26.88° | R    | Second House   |
 | Chiron                | Can ♋ | 19.88°   | +0.1071°/d   | +15.79° | -    | Ninth House    |
 | Pholus                | Can ♋ | 7.99°    | +0.1329°/d   | +13.79° | -    | Eighth House   |
 | Ceres                 | Leo ♌ | 13.71°   | +0.4493°/d   | +23.05° | -    | Ninth House    |
@@ -82,15 +82,15 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Juno                  | Sco ♏ | 10.10°   | +0.0843°/d   | -2.06°  | -    | First House    |
 | Vesta                 | Tau ♉ | 18.15°   | +0.3292°/d   | +10.88° | -    | Seventh House  |
 | Interpolated Lilith   | Sco ♏ | 25.48°   | +0.1694°/d   | -23.89° | -    | First House    |
-| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1732°/d   | +26.84° | -    | Eighth House   |
-| Cupido                | Sco ♏ | 18.62°   | -0.0042°/d   | -16.34° | R    | First House    |
-| Hades                 | Gem ♊ | 9.93°    | +0.0152°/d   | +20.93° | -    | Eighth House   |
-| Zeus                  | Vir ♍ | 26.03°   | +0.0110°/d   | +1.58°  | -    | Eleventh House |
-| Kronos                | Gem ♊ | 21.90°   | +0.0137°/d   | +23.21° | -    | Eighth House   |
-| Apollon               | Lib ♎ | 13.83°   | +0.0053°/d   | -5.46°  | -    | Eleventh House |
-| Admetos               | Tau ♉ | 14.96°   | +0.0053°/d   | +16.33° | -    | Seventh House  |
-| Vulkanus              | Can ♋ | 15.35°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
-| Poseidon              | Lib ♎ | 28.68°   | +0.0014°/d   | -11.01° | -    | Twelfth House  |
+| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1733°/d   | +26.84° | -    | Eighth House   |
+| Cupido                | Sco ♏ | 18.62°   | -0.0043°/d   | -16.34° | R    | First House    |
+| Hades                 | Gem ♊ | 9.92°    | +0.0153°/d   | +20.93° | -    | Eighth House   |
+| Zeus                  | Vir ♍ | 26.03°   | +0.0109°/d   | +1.58°  | -    | Eleventh House |
+| Kronos                | Gem ♊ | 21.89°   | +0.0138°/d   | +23.21° | -    | Eighth House   |
+| Apollon               | Lib ♎ | 13.82°   | +0.0052°/d   | -5.46°  | -    | Eleventh House |
+| Admetos               | Tau ♉ | 14.96°   | +0.0054°/d   | +16.33° | -    | Seventh House  |
+| Vulkanus              | Can ♋ | 15.34°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
+| Poseidon              | Lib ♎ | 28.68°   | +0.0013°/d   | -11.01° | -    | Twelfth House  |
 | Eris                  | Ari ♈ | 17.60°   | -0.0013°/d   | -9.16°  | R    | Sixth House    |
 | Sedna                 | Tau ♉ | 11.55°   | +0.0038°/d   | +4.25°  | -    | Seventh House  |
 | Haumea                | Vir ♍ | 26.32°   | +0.0134°/d   | +23.02° | -    | Eleventh House |
@@ -103,21 +103,21 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Pars Amoris           | Lib ♎ | 8.99°    | N/A          | N/A     | -    | Eleventh House |
 | Pars Fidei            | Tau ♉ | 8.22°    | N/A          | N/A     | -    | Seventh House  |
 | Vertex                | Gem ♊ | 11.46°   | N/A          | N/A     | -    | Eighth House   |
-| White Moon            | Can ♋ | 26.44°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
+| White Moon            | Can ♋ | 26.43°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
 | Anti Vertex           | Sag ♐ | 11.46°   | N/A          | N/A     | -    | Second House   |
 | Mean South Lunar Node | Leo ♌ | 7.79°    | -0.0529°/d   | +18.32° | R    | Ninth House    |
 | True South Lunar Node | Leo ♌ | 7.26°    | -0.0080°/d   | +18.46° | R    | Ninth House    |
-| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.61° | -    | Seventh House  |
-| True Priapus          | Gem ♊ | 18.01°   | -1.4331°/d   | +26.88° | R    | Eighth House   |
+| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.62° | -    | Seventh House  |
+| True Priapus          | Gem ♊ | 18.01°   | -1.4330°/d   | +26.88° | R    | Eighth House   |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +Second Subject Celestial Points-+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Lib ♎ | 8.41°    | +299.6082°/d | N/A     | -    | First House    |
-| Medium Coeli          | Can ♋ | 9.31°    | +332.7977°/d | N/A     | -    | Tenth House    |
-| Descendant            | Ari ♈ | 8.41°    | +299.6082°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Cap ♑ | 9.31°    | +332.7977°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Lib ♎ | 8.41°    | +299.6098°/d | N/A     | -    | First House    |
+| Medium Coeli          | Can ♋ | 9.31°    | +332.7995°/d | N/A     | -    | Tenth House    |
+| Descendant            | Ari ♈ | 8.41°    | +299.6098°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Cap ♑ | 9.31°    | +332.7995°/d | N/A     | -    | Fourth House   |
 | Sun                   | Aqu ♒ | 29.38°   | +1.0085°/d   | -11.70° | -    | Fifth House    |
 | Moon                  | Sag ♐ | 11.13°   | +14.2185°/d  | -27.33° | -    | Third House    |
 | Mercury               | Pis ♓ | 7.89°    | +1.8561°/d   | -9.86°  | -    | Fifth House    |
@@ -131,7 +131,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Mean North Lunar Node | Pis ♓ | 8.34°    | -0.0529°/d   | -8.45°  | R    | Fifth House    |
 | True North Lunar Node | Pis ♓ | 7.80°    | -0.0063°/d   | -8.65°  | R    | Fifth House    |
 | Mean Lilith           | Gem ♊ | 2.52°    | +0.1121°/d   | +25.69° | -    | Eighth House   |
-| True Lilith           | Gem ♊ | 10.83°   | +2.3826°/d   | +27.29° | -    | Ninth House    |
+| True Lilith           | Gem ♊ | 10.83°   | +2.3824°/d   | +27.29° | -    | Ninth House    |
 | Chiron                | Tau ♉ | 23.74°   | +0.0192°/d   | +15.49° | -    | Eighth House   |
 | Pholus                | Cap ♑ | 8.20°    | +0.0251°/d   | -13.72° | -    | Third House    |
 | Ceres                 | Pis ♓ | 0.49°    | +0.3938°/d   | -18.31° | -    | Fifth House    |
@@ -139,15 +139,15 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Juno                  | Sco ♏ | 5.83°    | +0.0211°/d   | -6.33°  | -    | Second House   |
 | Vesta                 | Tau ♉ | 27.23°   | +0.2334°/d   | +16.54° | -    | Eighth House   |
 | Interpolated Lilith   | Gem ♊ | 2.38°    | +0.2274°/d   | +25.66° | -    | Eighth House   |
-| Interpolated Perigee  | Sag ♐ | 10.72°   | -1.7664°/d   | -27.09° | R    | Third House    |
-| Cupido                | Vir ♍ | 0.68°    | -0.0209°/d   | +11.60° | R    | Eleventh House |
-| Hades                 | Ari ♈ | 10.21°   | +0.0173°/d   | +3.58°  | -    | Seventh House  |
-| Zeus                  | Leo ♌ | 10.47°   | -0.0140°/d   | +17.62° | R    | Tenth House    |
-| Kronos                | Tau ♉ | 10.33°   | +0.0067°/d   | +14.93° | -    | Eighth House   |
+| Interpolated Perigee  | Sag ♐ | 10.72°   | -1.7670°/d   | -27.09° | R    | Third House    |
+| Cupido                | Vir ♍ | 0.69°    | -0.0209°/d   | +11.60° | R    | Eleventh House |
+| Hades                 | Ari ♈ | 10.21°   | +0.0172°/d   | +3.58°  | -    | Seventh House  |
+| Zeus                  | Leo ♌ | 10.48°   | -0.0140°/d   | +17.62° | R    | Tenth House    |
+| Kronos                | Tau ♉ | 10.32°   | +0.0066°/d   | +14.93° | -    | Eighth House   |
 | Apollon               | Vir ♍ | 8.89°    | -0.0124°/d   | +8.24°  | R    | Eleventh House |
-| Admetos               | Ari ♈ | 10.18°   | +0.0117°/d   | +4.03°  | -    | Seventh House  |
-| Vulkanus              | Gem ♊ | 13.22°   | -0.0017°/d   | +22.40° | R    | Ninth House    |
-| Poseidon              | Lib ♎ | 1.93°    | -0.0087°/d   | -0.77°  | R    | Twelfth House  |
+| Admetos               | Ari ♈ | 10.17°   | +0.0116°/d   | +4.03°  | -    | Seventh House  |
+| Vulkanus              | Gem ♊ | 13.22°   | -0.0018°/d   | +22.40° | R    | Ninth House    |
+| Poseidon              | Lib ♎ | 1.94°    | -0.0086°/d   | -0.77°  | R    | Twelfth House  |
 | Eris                  | Ari ♈ | 2.05°    | +0.0104°/d   | -24.06° | -    | Sixth House    |
 | Sedna                 | Ari ♈ | 17.18°   | +0.0065°/d   | -2.18°  | -    | Seventh House  |
 | Haumea                | Leo ♌ | 5.02°    | -0.0173°/d   | +21.39° | R    | Tenth House    |
@@ -165,7 +165,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Mean South Lunar Node | Vir ♍ | 8.34°    | -0.0529°/d   | +8.45°  | R    | Eleventh House |
 | True South Lunar Node | Vir ♍ | 7.80°    | -0.0063°/d   | +8.65°  | R    | Eleventh House |
 | Mean Priapus          | Sag ♐ | 2.52°    | +0.1121°/d   | -25.69° | -    | Second House   |
-| True Priapus          | Sag ♐ | 10.83°   | +2.3826°/d   | -27.29° | -    | Third House    |
+| True Priapus          | Sag ♐ | 10.83°   | +2.3824°/d   | -27.29° | -    | Third House    |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +First Subject Houses (Placidus)-----+-------------------+
@@ -255,12 +255,12 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Sample Natal Subject – Interpolated Lilith   | 1 (First House)     | 2 (Second House)    | Sco  | 25.48° |
 | Sample Natal Subject – Interpolated Perigee  | 8 (Eighth House)    | 9 (Ninth House)     | Gem  | 20.98° |
 | Sample Natal Subject – Cupido                | 1 (First House)     | 2 (Second House)    | Sco  | 18.62° |
-| Sample Natal Subject – Hades                 | 8 (Eighth House)    | 9 (Ninth House)     | Gem  | 9.93°  |
+| Sample Natal Subject – Hades                 | 8 (Eighth House)    | 9 (Ninth House)     | Gem  | 9.92°  |
 | Sample Natal Subject – Zeus                  | 11 (Eleventh House) | 12 (Twelfth House)  | Vir  | 26.03° |
-| Sample Natal Subject – Kronos                | 8 (Eighth House)    | 9 (Ninth House)     | Gem  | 21.90° |
-| Sample Natal Subject – Apollon               | 11 (Eleventh House) | 1 (First House)     | Lib  | 13.83° |
+| Sample Natal Subject – Kronos                | 8 (Eighth House)    | 9 (Ninth House)     | Gem  | 21.89° |
+| Sample Natal Subject – Apollon               | 11 (Eleventh House) | 1 (First House)     | Lib  | 13.82° |
 | Sample Natal Subject – Admetos               | 7 (Seventh House)   | 8 (Eighth House)    | Tau  | 14.96° |
-| Sample Natal Subject – Vulkanus              | 9 (Ninth House)     | 10 (Tenth House)    | Can  | 15.35° |
+| Sample Natal Subject – Vulkanus              | 9 (Ninth House)     | 10 (Tenth House)    | Can  | 15.34° |
 | Sample Natal Subject – Poseidon              | 12 (Twelfth House)  | 1 (First House)     | Lib  | 28.68° |
 | Sample Natal Subject – Eris                  | 6 (Sixth House)     | 7 (Seventh House)   | Ari  | 17.60° |
 | Sample Natal Subject – Sedna                 | 7 (Seventh House)   | 8 (Eighth House)    | Tau  | 11.55° |
@@ -274,7 +274,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Sample Natal Subject – Pars Amoris           | 11 (Eleventh House) | 1 (First House)     | Lib  | 8.99°  |
 | Sample Natal Subject – Pars Fidei            | 7 (Seventh House)   | 8 (Eighth House)    | Tau  | 8.22°  |
 | Sample Natal Subject – Vertex                | 8 (Eighth House)    | 9 (Ninth House)     | Gem  | 11.46° |
-| Sample Natal Subject – White Moon            | 9 (Ninth House)     | 10 (Tenth House)    | Can  | 26.44° |
+| Sample Natal Subject – White Moon            | 9 (Ninth House)     | 10 (Tenth House)    | Can  | 26.43° |
 | Sample Natal Subject – Descendant            | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 5.82°  |
 | Sample Natal Subject – Imum Coeli            | 4 (Fourth House)    | 5 (Fifth House)     | Aqu  | 19.91° |
 | Sample Natal Subject – Anti Vertex           | 2 (Second House)    | 3 (Third House)     | Sag  | 11.46° |
@@ -311,14 +311,14 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Yoko Ono – Vesta                 | 8 (Eighth House)    | 7 (Seventh House)   | Tau  | 27.23° |
 | Yoko Ono – Interpolated Lilith   | 8 (Eighth House)    | 7 (Seventh House)   | Gem  | 2.38°  |
 | Yoko Ono – Interpolated Perigee  | 3 (Third House)     | 2 (Second House)    | Sag  | 10.72° |
-| Yoko Ono – Cupido                | 11 (Eleventh House) | 10 (Tenth House)    | Vir  | 0.68°  |
+| Yoko Ono – Cupido                | 11 (Eleventh House) | 10 (Tenth House)    | Vir  | 0.69°  |
 | Yoko Ono – Hades                 | 7 (Seventh House)   | 5 (Fifth House)     | Ari  | 10.21° |
-| Yoko Ono – Zeus                  | 10 (Tenth House)    | 9 (Ninth House)     | Leo  | 10.47° |
-| Yoko Ono – Kronos                | 8 (Eighth House)    | 7 (Seventh House)   | Tau  | 10.33° |
+| Yoko Ono – Zeus                  | 10 (Tenth House)    | 9 (Ninth House)     | Leo  | 10.48° |
+| Yoko Ono – Kronos                | 8 (Eighth House)    | 7 (Seventh House)   | Tau  | 10.32° |
 | Yoko Ono – Apollon               | 11 (Eleventh House) | 10 (Tenth House)    | Vir  | 8.89°  |
-| Yoko Ono – Admetos               | 7 (Seventh House)   | 5 (Fifth House)     | Ari  | 10.18° |
+| Yoko Ono – Admetos               | 7 (Seventh House)   | 5 (Fifth House)     | Ari  | 10.17° |
 | Yoko Ono – Vulkanus              | 9 (Ninth House)     | 8 (Eighth House)    | Gem  | 13.22° |
-| Yoko Ono – Poseidon              | 12 (Twelfth House)  | 11 (Eleventh House) | Lib  | 1.93°  |
+| Yoko Ono – Poseidon              | 12 (Twelfth House)  | 11 (Eleventh House) | Lib  | 1.94°  |
 | Yoko Ono – Eris                  | 6 (Sixth House)     | 5 (Fifth House)     | Ari  | 2.05°  |
 | Yoko Ono – Sedna                 | 7 (Seventh House)   | 5 (Fifth House)     | Ari  | 17.18° |
 | Yoko Ono – Haumea                | 10 (Tenth House)    | 9 (Ninth House)     | Leo  | 5.02°  |
@@ -497,7 +497,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Sun                   | Sample Natal Subject | sesquiquadrate ⚼ | Interpolated Perigee  | Yoko Ono | 2.82° | Static = |
 | Sun                   | Sample Natal Subject | quintile Q       | White Moon            | Yoko Ono | 3.27° | Static = |
 | Sun                   | Sample Natal Subject | semi-sextile ⚺   | Cupido                | Yoko Ono | 2.14° | Static = |
-| Sun                   | Sample Natal Subject | semi-square ∠    | Vulkanus              | Yoko Ono | 0.33° | Static = |
+| Sun                   | Sample Natal Subject | semi-square ∠    | Vulkanus              | Yoko Ono | 0.32° | Static = |
 | Sun                   | Sample Natal Subject | sextile ⚹        | Poseidon              | Yoko Ono | 3.39° | Static = |
 | Moon                  | Sample Natal Subject | biquintile bQ    | Sun                   | Yoko Ono | 2.17° | Static = |
 | Moon                  | Sample Natal Subject | sesquiquadrate ⚼ | Mercury               | Yoko Ono | 1.68° | Static = |
@@ -522,7 +522,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Moon                  | Sample Natal Subject | square □         | Anti Vertex           | Yoko Ono | 5.54° | Static = |
 | Moon                  | Sample Natal Subject | quintile Q       | Kronos                | Yoko Ono | 1.12° | Static = |
 | Moon                  | Sample Natal Subject | semi-square ∠    | Apollon               | Yoko Ono | 2.68° | Static = |
-| Moon                  | Sample Natal Subject | quintile Q       | Poseidon              | Yoko Ono | 1.28° | Static = |
+| Moon                  | Sample Natal Subject | quintile Q       | Poseidon              | Yoko Ono | 1.27° | Static = |
 | Mercury               | Sample Natal Subject | trine △          | Moon                  | Yoko Ono | 6.48° | Static = |
 | Mercury               | Sample Natal Subject | opposition ☍     | Venus                 | Yoko Ono | 3.82° | Static = |
 | Mercury               | Sample Natal Subject | trine △          | Uranus                | Yoko Ono | 2.94° | Static = |
@@ -531,9 +531,9 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Mercury               | Sample Natal Subject | semi-square ∠    | Makemake              | Yoko Ono | 1.79° | Static = |
 | Mercury               | Sample Natal Subject | semi-sextile ⚺   | Quaoar                | Yoko Ono | 0.84° | Static = |
 | Mercury               | Sample Natal Subject | square □         | Pars Fidei            | Yoko Ono | 1.76° | Static = |
-| Mercury               | Sample Natal Subject | square □         | White Moon            | Yoko Ono | 4.33° | Static = |
+| Mercury               | Sample Natal Subject | square □         | White Moon            | Yoko Ono | 4.34° | Static = |
 | Mercury               | Sample Natal Subject | sextile ⚹        | Vulkanus              | Yoko Ono | 4.39° | Static = |
-| Mercury               | Sample Natal Subject | semi-square ∠    | Poseidon              | Yoko Ono | 0.68° | Static = |
+| Mercury               | Sample Natal Subject | semi-square ∠    | Poseidon              | Yoko Ono | 0.67° | Static = |
 | Venus                 | Sample Natal Subject | trine △          | Sun                   | Yoko Ono | 2.33° | Static = |
 | Venus                 | Sample Natal Subject | quintile Q       | Mars                  | Yoko Ono | 1.42° | Static = |
 | Venus                 | Sample Natal Subject | quintile Q       | Uranus                | Yoko Ono | 0.84° | Static = |
@@ -548,8 +548,8 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Venus                 | Sample Natal Subject | trine △          | Anti Vertex           | Yoko Ono | 4.96° | Static = |
 | Venus                 | Sample Natal Subject | semi-sextile ⚺   | Interpolated Lilith   | Yoko Ono | 0.67° | Static = |
 | Venus                 | Sample Natal Subject | quincunx ⚻       | Mean Priapus          | Yoko Ono | 0.81° | Static = |
-| Venus                 | Sample Natal Subject | sextile ⚹        | Cupido                | Yoko Ono | 1.03° | Static = |
-| Venus                 | Sample Natal Subject | square □         | Poseidon              | Yoko Ono | 0.22° | Static = |
+| Venus                 | Sample Natal Subject | sextile ⚹        | Cupido                | Yoko Ono | 1.02° | Static = |
+| Venus                 | Sample Natal Subject | square □         | Poseidon              | Yoko Ono | 0.23° | Static = |
 | Mars                  | Sample Natal Subject | biquintile bQ    | Moon                  | Yoko Ono | 0.84° | Static = |
 | Mars                  | Sample Natal Subject | sextile ⚹        | Mercury               | Yoko Ono | 1.92° | Static = |
 | Mars                  | Sample Natal Subject | sesquiquadrate ⚼ | Jupiter               | Yoko Ono | 0.27° | Static = |
@@ -569,11 +569,11 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Mars                  | Sample Natal Subject | sesquiquadrate ⚼ | Pars Amoris           | Yoko Ono | 1.85° | Static = |
 | Mars                  | Sample Natal Subject | biquintile bQ    | True Priapus          | Yoko Ono | 1.14° | Static = |
 | Mars                  | Sample Natal Subject | biquintile bQ    | Interpolated Perigee  | Yoko Ono | 1.25° | Static = |
-| Mars                  | Sample Natal Subject | trine △          | Cupido                | Yoko Ono | 5.29° | Static = |
+| Mars                  | Sample Natal Subject | trine △          | Cupido                | Yoko Ono | 5.28° | Static = |
 | Mars                  | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 4.51° | Static = |
 | Mars                  | Sample Natal Subject | conjunction ☌    | Kronos                | Yoko Ono | 4.36° | Static = |
-| Mars                  | Sample Natal Subject | trine △          | Apollon               | Yoko Ono | 2.92° | Static = |
-| Mars                  | Sample Natal Subject | biquintile bQ    | Poseidon              | Yoko Ono | 1.96° | Static = |
+| Mars                  | Sample Natal Subject | trine △          | Apollon               | Yoko Ono | 2.93° | Static = |
+| Mars                  | Sample Natal Subject | biquintile bQ    | Poseidon              | Yoko Ono | 1.97° | Static = |
 | Jupiter               | Sample Natal Subject | biquintile bQ    | Sun                   | Yoko Ono | 0.53° | Static = |
 | Jupiter               | Sample Natal Subject | sesquiquadrate ⚼ | Moon                  | Yoko Ono | 2.22° | Static = |
 | Jupiter               | Sample Natal Subject | sesquiquadrate ⚼ | Mercury               | Yoko Ono | 1.02° | Static = |
@@ -639,8 +639,8 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Uranus                | Sample Natal Subject | square □         | Hades                 | Yoko Ono | 3.47° | Static = |
 | Uranus                | Sample Natal Subject | trine △          | Kronos                | Yoko Ono | 3.59° | Static = |
 | Uranus                | Sample Natal Subject | trine △          | Apollon               | Yoko Ono | 2.15° | Static = |
-| Uranus                | Sample Natal Subject | square □         | Admetos               | Yoko Ono | 3.44° | Static = |
-| Uranus                | Sample Natal Subject | square □         | Poseidon              | Yoko Ono | 4.81° | Static = |
+| Uranus                | Sample Natal Subject | square □         | Admetos               | Yoko Ono | 3.43° | Static = |
+| Uranus                | Sample Natal Subject | square □         | Poseidon              | Yoko Ono | 4.80° | Static = |
 | Neptune               | Sample Natal Subject | semi-square ∠    | Sun                   | Yoko Ono | 1.62° | Static = |
 | Neptune               | Sample Natal Subject | semi-sextile ⚺   | Moon                  | Yoko Ono | 1.63° | Static = |
 | Neptune               | Sample Natal Subject | sextile ⚹        | Mercury               | Yoko Ono | 4.87° | Static = |
@@ -663,11 +663,11 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Neptune               | Sample Natal Subject | trine △          | Quaoar                | Yoko Ono | 4.01° | Static = |
 | Neptune               | Sample Natal Subject | semi-sextile ⚺   | True Priapus          | Yoko Ono | 1.94° | Static = |
 | Neptune               | Sample Natal Subject | trine △          | White Moon            | Yoko Ono | 0.51° | Static = |
-| Neptune               | Sample Natal Subject | square □         | Hades                 | Yoko Ono | 2.55° | Static = |
+| Neptune               | Sample Natal Subject | square □         | Hades                 | Yoko Ono | 2.56° | Static = |
 | Neptune               | Sample Natal Subject | trine △          | Kronos                | Yoko Ono | 2.44° | Static = |
 | Neptune               | Sample Natal Subject | trine △          | Apollon               | Yoko Ono | 3.87° | Static = |
 | Neptune               | Sample Natal Subject | square □         | Admetos               | Yoko Ono | 2.59° | Static = |
-| Neptune               | Sample Natal Subject | quincunx ⚻       | Vulkanus              | Yoko Ono | 0.45° | Static = |
+| Neptune               | Sample Natal Subject | quincunx ⚻       | Vulkanus              | Yoko Ono | 0.46° | Static = |
 | Pluto                 | Sample Natal Subject | square □         | Venus                 | Yoko Ono | 1.19° | Static = |
 | Pluto                 | Sample Natal Subject | sextile ⚹        | Mars                  | Yoko Ono | 0.15° | Static = |
 | Pluto                 | Sample Natal Subject | square □         | Saturn                | Yoko Ono | 5.24° | Static = |
@@ -680,7 +680,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Pluto                 | Sample Natal Subject | trine △          | Pars Spiritus         | Yoko Ono | 5.19° | Static = |
 | Pluto                 | Sample Natal Subject | opposition ☍     | Pars Fidei            | Yoko Ono | 4.40° | Static = |
 | Pluto                 | Sample Natal Subject | opposition ☍     | White Moon            | Yoko Ono | 1.70° | Static = |
-| Pluto                 | Sample Natal Subject | biquintile bQ    | Hades                 | Yoko Ono | 1.24° | Static = |
+| Pluto                 | Sample Natal Subject | biquintile bQ    | Hades                 | Yoko Ono | 1.23° | Static = |
 | Pluto                 | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 4.50° | Static = |
 | Pluto                 | Sample Natal Subject | opposition ☍     | Kronos                | Yoko Ono | 4.65° | Static = |
 | Pluto                 | Sample Natal Subject | biquintile bQ    | Admetos               | Yoko Ono | 1.20° | Static = |
@@ -712,14 +712,14 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Mean North Lunar Node | Sample Natal Subject | trine △          | Interpolated Lilith   | Yoko Ono | 5.41° | Static = |
 | Mean North Lunar Node | Sample Natal Subject | sextile ⚹        | True Priapus          | Yoko Ono | 3.04° | Static = |
 | Mean North Lunar Node | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | Yoko Ono | 2.93° | Static = |
-| Mean North Lunar Node | Sample Natal Subject | square □         | White Moon            | Yoko Ono | 5.49° | Static = |
+| Mean North Lunar Node | Sample Natal Subject | square □         | White Moon            | Yoko Ono | 5.48° | Static = |
 | Mean North Lunar Node | Sample Natal Subject | sextile ⚹        | Hades                 | Yoko Ono | 2.42° | Static = |
-| Mean North Lunar Node | Sample Natal Subject | opposition ☍     | Zeus                  | Yoko Ono | 2.68° | Static = |
+| Mean North Lunar Node | Sample Natal Subject | opposition ☍     | Zeus                  | Yoko Ono | 2.69° | Static = |
 | Mean North Lunar Node | Sample Natal Subject | square □         | Kronos                | Yoko Ono | 2.54° | Static = |
 | Mean North Lunar Node | Sample Natal Subject | quincunx ⚻       | Apollon               | Yoko Ono | 1.10° | Static = |
-| Mean North Lunar Node | Sample Natal Subject | sextile ⚹        | Admetos               | Yoko Ono | 2.39° | Static = |
+| Mean North Lunar Node | Sample Natal Subject | sextile ⚹        | Admetos               | Yoko Ono | 2.38° | Static = |
 | Mean North Lunar Node | Sample Natal Subject | trine △          | Vulkanus              | Yoko Ono | 5.43° | Static = |
-| Mean North Lunar Node | Sample Natal Subject | trine △          | Poseidon              | Yoko Ono | 5.86° | Static = |
+| Mean North Lunar Node | Sample Natal Subject | trine △          | Poseidon              | Yoko Ono | 5.85° | Static = |
 | True North Lunar Node | Sample Natal Subject | sextile ⚹        | Moon                  | Yoko Ono | 3.86° | Static = |
 | True North Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Mercury               | Yoko Ono | 0.63° | Static = |
 | True North Lunar Node | Sample Natal Subject | biquintile bQ    | Mars                  | Yoko Ono | 1.86° | Static = |
@@ -748,7 +748,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | True North Lunar Node | Sample Natal Subject | sextile ⚹        | Hades                 | Yoko Ono | 2.94° | Static = |
 | True North Lunar Node | Sample Natal Subject | opposition ☍     | Zeus                  | Yoko Ono | 3.21° | Static = |
 | True North Lunar Node | Sample Natal Subject | square □         | Kronos                | Yoko Ono | 3.06° | Static = |
-| True North Lunar Node | Sample Natal Subject | quincunx ⚻       | Apollon               | Yoko Ono | 1.62° | Static = |
+| True North Lunar Node | Sample Natal Subject | quincunx ⚻       | Apollon               | Yoko Ono | 1.63° | Static = |
 | True North Lunar Node | Sample Natal Subject | sextile ⚹        | Admetos               | Yoko Ono | 2.91° | Static = |
 | True North Lunar Node | Sample Natal Subject | trine △          | Vulkanus              | Yoko Ono | 5.95° | Static = |
 | True North Lunar Node | Sample Natal Subject | trine △          | Poseidon              | Yoko Ono | 5.33° | Static = |
@@ -764,7 +764,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Chiron                | Sample Natal Subject | conjunction ☌    | Pars Spiritus         | Yoko Ono | 0.28° | Static = |
 | Chiron                | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Yoko Ono | 2.94° | Static = |
 | Chiron                | Sample Natal Subject | sextile ⚹        | Pars Fidei            | Yoko Ono | 0.51° | Static = |
-| Chiron                | Sample Natal Subject | quintile Q       | Poseidon              | Yoko Ono | 0.05° | Static = |
+| Chiron                | Sample Natal Subject | quintile Q       | Poseidon              | Yoko Ono | 0.06° | Static = |
 | Ascendant             | Sample Natal Subject | trine △          | Sun                   | Yoko Ono | 6.44° | Static = |
 | Ascendant             | Sample Natal Subject | trine △          | Mercury               | Yoko Ono | 2.07° | Static = |
 | Ascendant             | Sample Natal Subject | semi-square ∠    | Jupiter               | Yoko Ono | 0.13° | Static = |
@@ -784,7 +784,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Ascendant             | Sample Natal Subject | square □         | Haumea                | Yoko Ono | 0.80° | Static = |
 | Ascendant             | Sample Natal Subject | trine △          | Makemake              | Yoko Ono | 5.01° | Static = |
 | Ascendant             | Sample Natal Subject | semi-square ∠    | Pars Amoris           | Yoko Ono | 2.00° | Static = |
-| Ascendant             | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 4.65° | Static = |
+| Ascendant             | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 4.66° | Static = |
 | Ascendant             | Sample Natal Subject | opposition ☍     | Kronos                | Yoko Ono | 4.50° | Static = |
 | Ascendant             | Sample Natal Subject | sextile ⚹        | Apollon               | Yoko Ono | 3.07° | Static = |
 | Ascendant             | Sample Natal Subject | biquintile bQ    | Vulkanus              | Yoko Ono | 1.40° | Static = |
@@ -816,7 +816,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Descendant            | Sample Natal Subject | biquintile bQ    | True Priapus          | Yoko Ono | 1.00° | Static = |
 | Descendant            | Sample Natal Subject | biquintile bQ    | Interpolated Perigee  | Yoko Ono | 1.10° | Static = |
 | Descendant            | Sample Natal Subject | trine △          | Cupido                | Yoko Ono | 5.14° | Static = |
-| Descendant            | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 4.65° | Static = |
+| Descendant            | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 4.66° | Static = |
 | Descendant            | Sample Natal Subject | conjunction ☌    | Kronos                | Yoko Ono | 4.50° | Static = |
 | Descendant            | Sample Natal Subject | trine △          | Apollon               | Yoko Ono | 3.07° | Static = |
 | Imum Coeli            | Sample Natal Subject | quintile Q       | Moon                  | Yoko Ono | 3.21° | Static = |
@@ -842,8 +842,8 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Mean Lilith           | Sample Natal Subject | quintile Q       | Quaoar                | Yoko Ono | 0.22° | Static = |
 | Mean Lilith           | Sample Natal Subject | opposition ☍     | Interpolated Lilith   | Yoko Ono | 3.39° | Static = |
 | Mean Lilith           | Sample Natal Subject | conjunction ☌    | Mean Priapus          | Yoko Ono | 3.53° | Static = |
-| Mean Lilith           | Sample Natal Subject | square □         | Cupido                | Yoko Ono | 1.69° | Static = |
-| Mean Lilith           | Sample Natal Subject | sextile ⚹        | Poseidon              | Yoko Ono | 2.94° | Static = |
+| Mean Lilith           | Sample Natal Subject | square □         | Cupido                | Yoko Ono | 1.70° | Static = |
+| Mean Lilith           | Sample Natal Subject | sextile ⚹        | Poseidon              | Yoko Ono | 2.95° | Static = |
 | Mean South Lunar Node | Sample Natal Subject | trine △          | Moon                  | Yoko Ono | 3.34° | Static = |
 | Mean South Lunar Node | Sample Natal Subject | quincunx ⚻       | Mercury               | Yoko Ono | 0.10° | Static = |
 | Mean South Lunar Node | Sample Natal Subject | opposition ☍     | Venus                 | Yoko Ono | 6.00° | Static = |
@@ -869,12 +869,12 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Mean South Lunar Node | Sample Natal Subject | trine △          | Mean Priapus          | Yoko Ono | 5.27° | Static = |
 | Mean South Lunar Node | Sample Natal Subject | trine △          | True Priapus          | Yoko Ono | 3.04° | Static = |
 | Mean South Lunar Node | Sample Natal Subject | trine △          | Interpolated Perigee  | Yoko Ono | 2.93° | Static = |
-| Mean South Lunar Node | Sample Natal Subject | square □         | White Moon            | Yoko Ono | 5.49° | Static = |
+| Mean South Lunar Node | Sample Natal Subject | square □         | White Moon            | Yoko Ono | 5.48° | Static = |
 | Mean South Lunar Node | Sample Natal Subject | trine △          | Hades                 | Yoko Ono | 2.42° | Static = |
-| Mean South Lunar Node | Sample Natal Subject | conjunction ☌    | Zeus                  | Yoko Ono | 2.68° | Static = |
+| Mean South Lunar Node | Sample Natal Subject | conjunction ☌    | Zeus                  | Yoko Ono | 2.69° | Static = |
 | Mean South Lunar Node | Sample Natal Subject | square □         | Kronos                | Yoko Ono | 2.54° | Static = |
 | Mean South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Yoko Ono | 1.10° | Static = |
-| Mean South Lunar Node | Sample Natal Subject | trine △          | Admetos               | Yoko Ono | 2.39° | Static = |
+| Mean South Lunar Node | Sample Natal Subject | trine △          | Admetos               | Yoko Ono | 2.38° | Static = |
 | True South Lunar Node | Sample Natal Subject | trine △          | Moon                  | Yoko Ono | 3.86° | Static = |
 | True South Lunar Node | Sample Natal Subject | quincunx ⚻       | Mercury               | Yoko Ono | 0.63° | Static = |
 | True South Lunar Node | Sample Natal Subject | semi-square ∠    | Jupiter               | Yoko Ono | 1.57° | Static = |
@@ -903,7 +903,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | True South Lunar Node | Sample Natal Subject | trine △          | Hades                 | Yoko Ono | 2.94° | Static = |
 | True South Lunar Node | Sample Natal Subject | conjunction ☌    | Zeus                  | Yoko Ono | 3.21° | Static = |
 | True South Lunar Node | Sample Natal Subject | square □         | Kronos                | Yoko Ono | 3.06° | Static = |
-| True South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Yoko Ono | 1.62° | Static = |
+| True South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Yoko Ono | 1.63° | Static = |
 | True South Lunar Node | Sample Natal Subject | trine △          | Admetos               | Yoko Ono | 2.91° | Static = |
 | True Lilith           | Sample Natal Subject | quintile Q       | Sun                   | Yoko Ono | 0.64° | Static = |
 | True Lilith           | Sample Natal Subject | conjunction ☌    | Moon                  | Yoko Ono | 6.89° | Static = |
@@ -940,9 +940,9 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Pholus                | Sample Natal Subject | quintile Q       | Vertex                | Yoko Ono | 0.76° | Static = |
 | Pholus                | Sample Natal Subject | biquintile bQ    | Mean Priapus          | Yoko Ono | 0.53° | Static = |
 | Pholus                | Sample Natal Subject | square □         | Hades                 | Yoko Ono | 2.22° | Static = |
-| Pholus                | Sample Natal Subject | sextile ⚹        | Kronos                | Yoko Ono | 2.34° | Static = |
+| Pholus                | Sample Natal Subject | sextile ⚹        | Kronos                | Yoko Ono | 2.33° | Static = |
 | Pholus                | Sample Natal Subject | sextile ⚹        | Apollon               | Yoko Ono | 0.90° | Static = |
-| Pholus                | Sample Natal Subject | square □         | Admetos               | Yoko Ono | 2.19° | Static = |
+| Pholus                | Sample Natal Subject | square □         | Admetos               | Yoko Ono | 2.18° | Static = |
 | Ceres                 | Sample Natal Subject | trine △          | Moon                  | Yoko Ono | 2.59° | Static = |
 | Ceres                 | Sample Natal Subject | opposition ☍     | Venus                 | Yoko Ono | 0.07° | Static = |
 | Ceres                 | Sample Natal Subject | semi-sextile ⚺   | Mars                  | Yoko Ono | 1.41° | Static = |
@@ -961,7 +961,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Ceres                 | Sample Natal Subject | trine △          | True Priapus          | Yoko Ono | 2.89° | Static = |
 | Ceres                 | Sample Natal Subject | trine △          | Interpolated Perigee  | Yoko Ono | 2.99° | Static = |
 | Ceres                 | Sample Natal Subject | square □         | White Moon            | Yoko Ono | 0.44° | Static = |
-| Ceres                 | Sample Natal Subject | trine △          | Hades                 | Yoko Ono | 3.50° | Static = |
+| Ceres                 | Sample Natal Subject | trine △          | Hades                 | Yoko Ono | 3.51° | Static = |
 | Ceres                 | Sample Natal Subject | conjunction ☌    | Zeus                  | Yoko Ono | 3.24° | Static = |
 | Ceres                 | Sample Natal Subject | square □         | Kronos                | Yoko Ono | 3.39° | Static = |
 | Ceres                 | Sample Natal Subject | trine △          | Admetos               | Yoko Ono | 3.54° | Static = |
@@ -987,8 +987,8 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Pallas                | Sample Natal Subject | square □         | Hades                 | Yoko Ono | 2.96° | Static = |
 | Pallas                | Sample Natal Subject | sextile ⚹        | Kronos                | Yoko Ono | 3.08° | Static = |
 | Pallas                | Sample Natal Subject | sextile ⚹        | Apollon               | Yoko Ono | 1.64° | Static = |
-| Pallas                | Sample Natal Subject | square □         | Admetos               | Yoko Ono | 2.93° | Static = |
-| Pallas                | Sample Natal Subject | square □         | Poseidon              | Yoko Ono | 5.32° | Static = |
+| Pallas                | Sample Natal Subject | square □         | Admetos               | Yoko Ono | 2.92° | Static = |
+| Pallas                | Sample Natal Subject | square □         | Poseidon              | Yoko Ono | 5.31° | Static = |
 | Juno                  | Sample Natal Subject | semi-sextile ⚺   | Moon                  | Yoko Ono | 1.03° | Static = |
 | Juno                  | Sample Natal Subject | trine △          | Mercury               | Yoko Ono | 2.21° | Static = |
 | Juno                  | Sample Natal Subject | square □         | Venus                 | Yoko Ono | 3.69° | Static = |
@@ -1014,7 +1014,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Juno                  | Sample Natal Subject | quincunx ⚻       | Hades                 | Yoko Ono | 0.11° | Static = |
 | Juno                  | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 0.38° | Static = |
 | Juno                  | Sample Natal Subject | opposition ☍     | Kronos                | Yoko Ono | 0.23° | Static = |
-| Juno                  | Sample Natal Subject | sextile ⚹        | Apollon               | Yoko Ono | 1.21° | Static = |
+| Juno                  | Sample Natal Subject | sextile ⚹        | Apollon               | Yoko Ono | 1.20° | Static = |
 | Juno                  | Sample Natal Subject | quincunx ⚻       | Admetos               | Yoko Ono | 0.08° | Static = |
 | Vesta                 | Sample Natal Subject | quintile Q       | Mercury               | Yoko Ono | 1.74° | Static = |
 | Vesta                 | Sample Natal Subject | square □         | Venus                 | Yoko Ono | 4.36° | Static = |
@@ -1030,7 +1030,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Vesta                 | Sample Natal Subject | trine △          | Pars Amoris           | Yoko Ono | 4.67° | Static = |
 | Vesta                 | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Yoko Ono | 1.23° | Static = |
 | Vesta                 | Sample Natal Subject | conjunction ☌    | White Moon            | Yoko Ono | 4.87° | Static = |
-| Vesta                 | Sample Natal Subject | sesquiquadrate ⚼ | Poseidon              | Yoko Ono | 1.22° | Static = |
+| Vesta                 | Sample Natal Subject | sesquiquadrate ⚼ | Poseidon              | Yoko Ono | 1.21° | Static = |
 | Eris                  | Sample Natal Subject | semi-square ∠    | Sun                   | Yoko Ono | 3.22° | Static = |
 | Eris                  | Sample Natal Subject | trine △          | Moon                  | Yoko Ono | 6.47° | Static = |
 | Eris                  | Sample Natal Subject | sextile ⚹        | Venus                 | Yoko Ono | 3.81° | Static = |
@@ -1044,7 +1044,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Eris                  | Sample Natal Subject | semi-sextile ⚺   | Pars Fidei            | Yoko Ono | 1.78° | Static = |
 | Eris                  | Sample Natal Subject | semi-square ∠    | Interpolated Lilith   | Yoko Ono | 0.22° | Static = |
 | Eris                  | Sample Natal Subject | sesquiquadrate ⚼ | Mean Priapus          | Yoko Ono | 0.08° | Static = |
-| Eris                  | Sample Natal Subject | sesquiquadrate ⚼ | Cupido                | Yoko Ono | 1.92° | Static = |
+| Eris                  | Sample Natal Subject | sesquiquadrate ⚼ | Cupido                | Yoko Ono | 1.91° | Static = |
 | Eris                  | Sample Natal Subject | sextile ⚹        | Vulkanus              | Yoko Ono | 4.38° | Static = |
 | Sedna                 | Sample Natal Subject | quintile Q       | Sun                   | Yoko Ono | 0.17° | Static = |
 | Sedna                 | Sample Natal Subject | quincunx ⚻       | Moon                  | Yoko Ono | 0.42° | Static = |
@@ -1069,12 +1069,12 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Sedna                 | Sample Natal Subject | sesquiquadrate ⚼ | Pars Fortunae         | Yoko Ono | 0.11° | Static = |
 | Sedna                 | Sample Natal Subject | quincunx ⚻       | True Priapus          | Yoko Ono | 0.72° | Static = |
 | Sedna                 | Sample Natal Subject | quincunx ⚻       | Interpolated Perigee  | Yoko Ono | 0.83° | Static = |
-| Sedna                 | Sample Natal Subject | conjunction ☌    | White Moon            | Yoko Ono | 1.73° | Static = |
+| Sedna                 | Sample Natal Subject | conjunction ☌    | White Moon            | Yoko Ono | 1.72° | Static = |
 | Sedna                 | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Yoko Ono | 1.34° | Static = |
-| Sedna                 | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 1.08° | Static = |
+| Sedna                 | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 1.07° | Static = |
 | Sedna                 | Sample Natal Subject | conjunction ☌    | Kronos                | Yoko Ono | 1.22° | Static = |
 | Sedna                 | Sample Natal Subject | trine △          | Apollon               | Yoko Ono | 2.66° | Static = |
-| Sedna                 | Sample Natal Subject | semi-sextile ⚺   | Admetos               | Yoko Ono | 1.37° | Static = |
+| Sedna                 | Sample Natal Subject | semi-sextile ⚺   | Admetos               | Yoko Ono | 1.38° | Static = |
 | Sedna                 | Sample Natal Subject | semi-sextile ⚺   | Vulkanus              | Yoko Ono | 1.67° | Static = |
 | Haumea                | Sample Natal Subject | quincunx ⚻       | Sun                   | Yoko Ono | 3.06° | Static = |
 | Haumea                | Sample Natal Subject | quintile Q       | Moon                  | Yoko Ono | 2.81° | Static = |
@@ -1093,7 +1093,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Haumea                | Sample Natal Subject | quincunx ⚻       | Vertex                | Yoko Ono | 0.43° | Static = |
 | Haumea                | Sample Natal Subject | semi-sextile ⚺   | Anti Vertex           | Yoko Ono | 0.43° | Static = |
 | Haumea                | Sample Natal Subject | sesquiquadrate ⚼ | White Moon            | Yoko Ono | 1.95° | Static = |
-| Haumea                | Sample Natal Subject | semi-square ∠    | Zeus                  | Yoko Ono | 0.85° | Static = |
+| Haumea                | Sample Natal Subject | semi-square ∠    | Zeus                  | Yoko Ono | 0.84° | Static = |
 | Haumea                | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | Yoko Ono | 1.00° | Static = |
 | Haumea                | Sample Natal Subject | conjunction ☌    | Poseidon              | Yoko Ono | 5.61° | Static = |
 | Makemake              | Sample Natal Subject | opposition ☍     | Sun                   | Yoko Ono | 5.12° | Static = |
@@ -1116,10 +1116,10 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Makemake              | Sample Natal Subject | semi-square ∠    | Pars Spiritus         | Yoko Ono | 0.67° | Static = |
 | Makemake              | Sample Natal Subject | square □         | Interpolated Lilith   | Yoko Ono | 2.12° | Static = |
 | Makemake              | Sample Natal Subject | square □         | Mean Priapus          | Yoko Ono | 1.98° | Static = |
-| Makemake              | Sample Natal Subject | conjunction ☌    | Cupido                | Yoko Ono | 3.82° | Static = |
+| Makemake              | Sample Natal Subject | conjunction ☌    | Cupido                | Yoko Ono | 3.81° | Static = |
 | Makemake              | Sample Natal Subject | biquintile bQ    | Hades                 | Yoko Ono | 0.29° | Static = |
 | Makemake              | Sample Natal Subject | trine △          | Kronos                | Yoko Ono | 5.83° | Static = |
-| Makemake              | Sample Natal Subject | conjunction ☌    | Apollon               | Yoko Ono | 4.39° | Static = |
+| Makemake              | Sample Natal Subject | conjunction ☌    | Apollon               | Yoko Ono | 4.40° | Static = |
 | Makemake              | Sample Natal Subject | biquintile bQ    | Admetos               | Yoko Ono | 0.32° | Static = |
 | Ixion                 | Sample Natal Subject | square □         | Sun                   | Yoko Ono | 6.68° | Static = |
 | Ixion                 | Sample Natal Subject | sextile ⚹        | Jupiter               | Yoko Ono | 2.01° | Static = |
@@ -1137,7 +1137,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Ixion                 | Sample Natal Subject | trine △          | Pars Spiritus         | Yoko Ono | 2.54° | Static = |
 | Ixion                 | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Yoko Ono | 0.12° | Static = |
 | Ixion                 | Sample Natal Subject | opposition ☍     | Pars Fidei            | Yoko Ono | 3.33° | Static = |
-| Ixion                 | Sample Natal Subject | quintile Q       | Apollon               | Yoko Ono | 1.82° | Static = |
+| Ixion                 | Sample Natal Subject | quintile Q       | Apollon               | Yoko Ono | 1.81° | Static = |
 | Orcus                 | Sample Natal Subject | trine △          | Moon                  | Yoko Ono | 0.29° | Static = |
 | Orcus                 | Sample Natal Subject | opposition ☍     | Venus                 | Yoko Ono | 2.95° | Static = |
 | Orcus                 | Sample Natal Subject | opposition ☍     | Saturn                | Yoko Ono | 1.10° | Static = |
@@ -1157,10 +1157,10 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Orcus                 | Sample Natal Subject | trine △          | Interpolated Perigee  | Yoko Ono | 0.12° | Static = |
 | Orcus                 | Sample Natal Subject | square □         | White Moon            | Yoko Ono | 2.43° | Static = |
 | Orcus                 | Sample Natal Subject | trine △          | Hades                 | Yoko Ono | 0.63° | Static = |
-| Orcus                 | Sample Natal Subject | conjunction ☌    | Zeus                  | Yoko Ono | 0.37° | Static = |
+| Orcus                 | Sample Natal Subject | conjunction ☌    | Zeus                  | Yoko Ono | 0.36° | Static = |
 | Orcus                 | Sample Natal Subject | square □         | Kronos                | Yoko Ono | 0.51° | Static = |
 | Orcus                 | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Yoko Ono | 1.95° | Static = |
-| Orcus                 | Sample Natal Subject | trine △          | Admetos               | Yoko Ono | 0.66° | Static = |
+| Orcus                 | Sample Natal Subject | trine △          | Admetos               | Yoko Ono | 0.67° | Static = |
 | Orcus                 | Sample Natal Subject | sextile ⚹        | Vulkanus              | Yoko Ono | 2.38° | Static = |
 | Quaoar                | Sample Natal Subject | square □         | Sun                   | Yoko Ono | 5.30° | Static = |
 | Quaoar                | Sample Natal Subject | sextile ⚹        | Jupiter               | Yoko Ono | 3.38° | Static = |
@@ -1193,7 +1193,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Pars Fortunae         | Sample Natal Subject | sextile ⚹        | Pars Fortunae         | Yoko Ono | 1.82° | Static = |
 | Pars Fortunae         | Sample Natal Subject | opposition ☍     | Vertex                | Yoko Ono | 1.74° | Static = |
 | Pars Fortunae         | Sample Natal Subject | conjunction ☌    | Anti Vertex           | Yoko Ono | 1.74° | Static = |
-| Pars Fortunae         | Sample Natal Subject | sextile ⚹        | Cupido                | Yoko Ono | 2.19° | Static = |
+| Pars Fortunae         | Sample Natal Subject | sextile ⚹        | Cupido                | Yoko Ono | 2.20° | Static = |
 | Pars Fortunae         | Sample Natal Subject | sesquiquadrate ⚼ | Vulkanus              | Yoko Ono | 0.27° | Static = |
 | Pars Spiritus         | Sample Natal Subject | semi-sextile ⚺   | Moon                  | Yoko Ono | 2.03° | Static = |
 | Pars Spiritus         | Sample Natal Subject | trine △          | Mercury               | Yoko Ono | 5.26° | Static = |
@@ -1213,10 +1213,10 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Pars Spiritus         | Sample Natal Subject | sextile ⚹        | Quaoar                | Yoko Ono | 3.61° | Static = |
 | Pars Spiritus         | Sample Natal Subject | semi-square ∠    | Pars Fortunae         | Yoko Ono | 1.49° | Static = |
 | Pars Spiritus         | Sample Natal Subject | opposition ☍     | White Moon            | Yoko Ono | 0.12° | Static = |
-| Pars Spiritus         | Sample Natal Subject | quintile Q       | Cupido                | Yoko Ono | 0.48° | Static = |
+| Pars Spiritus         | Sample Natal Subject | quintile Q       | Cupido                | Yoko Ono | 0.47° | Static = |
 | Pars Spiritus         | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 2.68° | Static = |
 | Pars Spiritus         | Sample Natal Subject | opposition ☍     | Kronos                | Yoko Ono | 2.83° | Static = |
-| Pars Spiritus         | Sample Natal Subject | sextile ⚹        | Apollon               | Yoko Ono | 4.27° | Static = |
+| Pars Spiritus         | Sample Natal Subject | sextile ⚹        | Apollon               | Yoko Ono | 4.26° | Static = |
 | Pars Spiritus         | Sample Natal Subject | quincunx ⚻       | Vulkanus              | Yoko Ono | 0.06° | Static = |
 | Pars Amoris           | Sample Natal Subject | sextile ⚹        | Moon                  | Yoko Ono | 2.14° | Static = |
 | Pars Amoris           | Sample Natal Subject | quincunx ⚻       | Mercury               | Yoko Ono | 1.10° | Static = |
@@ -1242,7 +1242,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Pars Amoris           | Sample Natal Subject | opposition ☍     | Hades                 | Yoko Ono | 1.22° | Static = |
 | Pars Amoris           | Sample Natal Subject | sextile ⚹        | Zeus                  | Yoko Ono | 1.49° | Static = |
 | Pars Amoris           | Sample Natal Subject | quincunx ⚻       | Kronos                | Yoko Ono | 1.34° | Static = |
-| Pars Amoris           | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Yoko Ono | 0.10° | Static = |
+| Pars Amoris           | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Yoko Ono | 0.09° | Static = |
 | Pars Amoris           | Sample Natal Subject | opposition ☍     | Admetos               | Yoko Ono | 1.19° | Static = |
 | Pars Amoris           | Sample Natal Subject | trine △          | Vulkanus              | Yoko Ono | 4.23° | Static = |
 | Pars Fidei            | Sample Natal Subject | quintile Q       | Sun                   | Yoko Ono | 3.16° | Static = |
@@ -1266,13 +1266,13 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Pars Fidei            | Sample Natal Subject | square □         | Haumea                | Yoko Ono | 3.20° | Static = |
 | Pars Fidei            | Sample Natal Subject | quintile Q       | Pars Spiritus         | Yoko Ono | 0.05° | Static = |
 | Pars Fidei            | Sample Natal Subject | sesquiquadrate ⚼ | Pars Amoris           | Yoko Ono | 0.40° | Static = |
-| Pars Fidei            | Sample Natal Subject | conjunction ☌    | White Moon            | Yoko Ono | 5.06° | Static = |
+| Pars Fidei            | Sample Natal Subject | conjunction ☌    | White Moon            | Yoko Ono | 5.05° | Static = |
 | Pars Fidei            | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Yoko Ono | 1.99° | Static = |
-| Pars Fidei            | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 2.25° | Static = |
+| Pars Fidei            | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 2.26° | Static = |
 | Pars Fidei            | Sample Natal Subject | conjunction ☌    | Kronos                | Yoko Ono | 2.11° | Static = |
-| Pars Fidei            | Sample Natal Subject | trine △          | Apollon               | Yoko Ono | 0.67° | Static = |
+| Pars Fidei            | Sample Natal Subject | trine △          | Apollon               | Yoko Ono | 0.68° | Static = |
 | Pars Fidei            | Sample Natal Subject | semi-sextile ⚺   | Admetos               | Yoko Ono | 1.96° | Static = |
-| Pars Fidei            | Sample Natal Subject | biquintile bQ    | Poseidon              | Yoko Ono | 0.29° | Static = |
+| Pars Fidei            | Sample Natal Subject | biquintile bQ    | Poseidon              | Yoko Ono | 0.28° | Static = |
 | Vertex                | Sample Natal Subject | opposition ☍     | Moon                  | Yoko Ono | 0.34° | Static = |
 | Vertex                | Sample Natal Subject | square □         | Mercury               | Yoko Ono | 3.57° | Static = |
 | Vertex                | Sample Natal Subject | trine △          | Venus                 | Yoko Ono | 2.32° | Static = |
@@ -1297,7 +1297,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Vertex                | Sample Natal Subject | sextile ⚹        | Hades                 | Yoko Ono | 1.26° | Static = |
 | Vertex                | Sample Natal Subject | sextile ⚹        | Zeus                  | Yoko Ono | 0.99° | Static = |
 | Vertex                | Sample Natal Subject | semi-sextile ⚺   | Kronos                | Yoko Ono | 1.14° | Static = |
-| Vertex                | Sample Natal Subject | square □         | Apollon               | Yoko Ono | 2.58° | Static = |
+| Vertex                | Sample Natal Subject | square □         | Apollon               | Yoko Ono | 2.57° | Static = |
 | Vertex                | Sample Natal Subject | sextile ⚹        | Admetos               | Yoko Ono | 1.29° | Static = |
 | Vertex                | Sample Natal Subject | conjunction ☌    | Vulkanus              | Yoko Ono | 1.75° | Static = |
 | Anti Vertex           | Sample Natal Subject | conjunction ☌    | Moon                  | Yoko Ono | 0.34° | Static = |
@@ -1325,7 +1325,7 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Anti Vertex           | Sample Natal Subject | trine △          | Hades                 | Yoko Ono | 1.26° | Static = |
 | Anti Vertex           | Sample Natal Subject | trine △          | Zeus                  | Yoko Ono | 0.99° | Static = |
 | Anti Vertex           | Sample Natal Subject | quincunx ⚻       | Kronos                | Yoko Ono | 1.14° | Static = |
-| Anti Vertex           | Sample Natal Subject | square □         | Apollon               | Yoko Ono | 2.58° | Static = |
+| Anti Vertex           | Sample Natal Subject | square □         | Apollon               | Yoko Ono | 2.57° | Static = |
 | Anti Vertex           | Sample Natal Subject | trine △          | Admetos               | Yoko Ono | 1.29° | Static = |
 | Anti Vertex           | Sample Natal Subject | opposition ☍     | Vulkanus              | Yoko Ono | 1.75° | Static = |
 | Interpolated Lilith   | Sample Natal Subject | square □         | Sun                   | Yoko Ono | 3.90° | Static = |
@@ -1360,9 +1360,9 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Mean Priapus          | Sample Natal Subject | conjunction ☌    | Orcus                 | Yoko Ono | 1.21° | Static = |
 | Mean Priapus          | Sample Natal Subject | conjunction ☌    | Interpolated Lilith   | Yoko Ono | 3.39° | Static = |
 | Mean Priapus          | Sample Natal Subject | opposition ☍     | Mean Priapus          | Yoko Ono | 3.53° | Static = |
-| Mean Priapus          | Sample Natal Subject | square □         | Cupido                | Yoko Ono | 1.69° | Static = |
-| Mean Priapus          | Sample Natal Subject | quintile Q       | Zeus                  | Yoko Ono | 0.52° | Static = |
-| Mean Priapus          | Sample Natal Subject | trine △          | Poseidon              | Yoko Ono | 2.94° | Static = |
+| Mean Priapus          | Sample Natal Subject | square □         | Cupido                | Yoko Ono | 1.70° | Static = |
+| Mean Priapus          | Sample Natal Subject | quintile Q       | Zeus                  | Yoko Ono | 0.51° | Static = |
+| Mean Priapus          | Sample Natal Subject | trine △          | Poseidon              | Yoko Ono | 2.95° | Static = |
 | True Priapus          | Sample Natal Subject | opposition ☍     | Moon                  | Yoko Ono | 6.89° | Static = |
 | True Priapus          | Sample Natal Subject | trine △          | Venus                 | Yoko Ono | 4.23° | Static = |
 | True Priapus          | Sample Natal Subject | square □         | Mars                  | Yoko Ono | 2.89° | Static = |
@@ -1388,28 +1388,28 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Interpolated Perigee  | Sample Natal Subject | square □         | Pars Amoris           | Yoko Ono | 1.84° | Static = |
 | Interpolated Perigee  | Sample Natal Subject | semi-sextile ⚺   | Pars Fidei            | Yoko Ono | 1.61° | Static = |
 | Interpolated Perigee  | Sample Natal Subject | trine △          | Anti Vertex           | Yoko Ono | 5.77° | Static = |
-| Interpolated Perigee  | Sample Natal Subject | quintile Q       | Hades                 | Yoko Ono | 1.23° | Static = |
+| Interpolated Perigee  | Sample Natal Subject | quintile Q       | Hades                 | Yoko Ono | 1.22° | Static = |
 | Interpolated Perigee  | Sample Natal Subject | quintile Q       | Admetos               | Yoko Ono | 1.19° | Static = |
-| White Moon            | Sample Natal Subject | quincunx ⚻       | Sun                   | Yoko Ono | 2.94° | Static = |
-| White Moon            | Sample Natal Subject | sesquiquadrate ⚼ | Moon                  | Yoko Ono | 0.31° | Static = |
-| White Moon            | Sample Natal Subject | square □         | Uranus                | Yoko Ono | 5.89° | Static = |
-| White Moon            | Sample Natal Subject | conjunction ☌    | Pluto                 | Yoko Ono | 4.81° | Static = |
-| White Moon            | Sample Natal Subject | sextile ⚹        | Chiron                | Yoko Ono | 2.70° | Static = |
+| White Moon            | Sample Natal Subject | quincunx ⚻       | Sun                   | Yoko Ono | 2.95° | Static = |
+| White Moon            | Sample Natal Subject | sesquiquadrate ⚼ | Moon                  | Yoko Ono | 0.30° | Static = |
+| White Moon            | Sample Natal Subject | square □         | Uranus                | Yoko Ono | 5.88° | Static = |
+| White Moon            | Sample Natal Subject | conjunction ☌    | Pluto                 | Yoko Ono | 4.80° | Static = |
+| White Moon            | Sample Natal Subject | sextile ⚹        | Chiron                | Yoko Ono | 2.69° | Static = |
 | White Moon            | Sample Natal Subject | quintile Q       | Ascendant             | Yoko Ono | 0.02° | Static = |
-| White Moon            | Sample Natal Subject | semi-square ∠    | True Lilith           | Yoko Ono | 0.61° | Static = |
-| White Moon            | Sample Natal Subject | biquintile bQ    | Ceres                 | Yoko Ono | 1.95° | Static = |
+| White Moon            | Sample Natal Subject | semi-square ∠    | True Lilith           | Yoko Ono | 0.60° | Static = |
+| White Moon            | Sample Natal Subject | biquintile bQ    | Ceres                 | Yoko Ono | 1.94° | Static = |
 | White Moon            | Sample Natal Subject | sextile ⚹        | Vesta                 | Yoko Ono | 0.80° | Static = |
 | White Moon            | Sample Natal Subject | trine △          | Eris                  | Yoko Ono | 5.62° | Static = |
-| White Moon            | Sample Natal Subject | sextile ⚹        | Ixion                 | Yoko Ono | 2.78° | Static = |
+| White Moon            | Sample Natal Subject | sextile ⚹        | Ixion                 | Yoko Ono | 2.79° | Static = |
 | White Moon            | Sample Natal Subject | sextile ⚹        | Orcus                 | Yoko Ono | 1.35° | Static = |
 | White Moon            | Sample Natal Subject | quincunx ⚻       | Pars Fortunae         | Yoko Ono | 0.23° | Static = |
-| White Moon            | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Yoko Ono | 3.62° | Static = |
+| White Moon            | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Yoko Ono | 3.61° | Static = |
 | White Moon            | Sample Natal Subject | square □         | Vertex                | Yoko Ono | 0.32° | Static = |
 | White Moon            | Sample Natal Subject | square □         | Anti Vertex           | Yoko Ono | 0.32° | Static = |
-| White Moon            | Sample Natal Subject | sesquiquadrate ⚼ | True Priapus          | Yoko Ono | 0.61° | Static = |
-| White Moon            | Sample Natal Subject | sesquiquadrate ⚼ | Interpolated Perigee  | Yoko Ono | 0.72° | Static = |
+| White Moon            | Sample Natal Subject | sesquiquadrate ⚼ | True Priapus          | Yoko Ono | 0.60° | Static = |
+| White Moon            | Sample Natal Subject | sesquiquadrate ⚼ | Interpolated Perigee  | Yoko Ono | 0.71° | Static = |
 | White Moon            | Sample Natal Subject | quintile Q       | White Moon            | Yoko Ono | 1.16° | Static = |
-| White Moon            | Sample Natal Subject | semi-square ∠    | Vulkanus              | Yoko Ono | 1.78° | Static = |
+| White Moon            | Sample Natal Subject | semi-square ∠    | Vulkanus              | Yoko Ono | 1.79° | Static = |
 | Cupido                | Sample Natal Subject | square □         | Venus                 | Yoko Ono | 4.83° | Static = |
 | Cupido                | Sample Natal Subject | sextile ⚹        | Mars                  | Yoko Ono | 3.49° | Static = |
 | Cupido                | Sample Natal Subject | sextile ⚹        | Jupiter               | Yoko Ono | 2.08° | Static = |
@@ -1418,49 +1418,49 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Cupido                | Sample Natal Subject | opposition ☍     | Chiron                | Yoko Ono | 5.12° | Static = |
 | Cupido                | Sample Natal Subject | quintile Q       | Mean South Lunar Node | Yoko Ono | 1.72° | Static = |
 | Cupido                | Sample Natal Subject | quintile Q       | True South Lunar Node | Yoko Ono | 1.18° | Static = |
-| Cupido                | Sample Natal Subject | sesquiquadrate ⚼ | Eris                  | Yoko Ono | 1.56° | Static = |
-| Cupido                | Sample Natal Subject | quincunx ⚻       | Sedna                 | Yoko Ono | 1.43° | Static = |
+| Cupido                | Sample Natal Subject | sesquiquadrate ⚼ | Eris                  | Yoko Ono | 1.57° | Static = |
+| Cupido                | Sample Natal Subject | quincunx ⚻       | Sedna                 | Yoko Ono | 1.44° | Static = |
 | Cupido                | Sample Natal Subject | sextile ⚹        | Quaoar                | Yoko Ono | 1.85° | Static = |
 | Cupido                | Sample Natal Subject | trine △          | Pars Spiritus         | Yoko Ono | 1.55° | Static = |
 | Cupido                | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Yoko Ono | 4.20° | Static = |
-| Cupido                | Sample Natal Subject | opposition ☍     | Pars Fidei            | Yoko Ono | 0.76° | Static = |
-| Cupido                | Sample Natal Subject | opposition ☍     | White Moon            | Yoko Ono | 5.34° | Static = |
-| Cupido                | Sample Natal Subject | semi-square ∠    | Poseidon              | Yoko Ono | 1.69° | Static = |
-| Hades                 | Sample Natal Subject | opposition ☍     | Moon                  | Yoko Ono | 1.20° | Static = |
+| Cupido                | Sample Natal Subject | opposition ☍     | Pars Fidei            | Yoko Ono | 0.75° | Static = |
+| Cupido                | Sample Natal Subject | opposition ☍     | White Moon            | Yoko Ono | 5.35° | Static = |
+| Cupido                | Sample Natal Subject | semi-square ∠    | Poseidon              | Yoko Ono | 1.68° | Static = |
+| Hades                 | Sample Natal Subject | opposition ☍     | Moon                  | Yoko Ono | 1.21° | Static = |
 | Hades                 | Sample Natal Subject | square □         | Mercury               | Yoko Ono | 2.03° | Static = |
 | Hades                 | Sample Natal Subject | trine △          | Venus                 | Yoko Ono | 3.86° | Static = |
 | Hades                 | Sample Natal Subject | square □         | Mars                  | Yoko Ono | 5.20° | Static = |
-| Hades                 | Sample Natal Subject | trine △          | Saturn                | Yoko Ono | 0.19° | Static = |
+| Hades                 | Sample Natal Subject | trine △          | Saturn                | Yoko Ono | 0.18° | Static = |
 | Hades                 | Sample Natal Subject | square □         | Neptune               | Yoko Ono | 0.85° | Static = |
-| Hades                 | Sample Natal Subject | square □         | Mean North Lunar Node | Yoko Ono | 1.59° | Static = |
+| Hades                 | Sample Natal Subject | square □         | Mean North Lunar Node | Yoko Ono | 1.58° | Static = |
 | Hades                 | Sample Natal Subject | square □         | True North Lunar Node | Yoko Ono | 2.12° | Static = |
 | Hades                 | Sample Natal Subject | trine △          | Ascendant             | Yoko Ono | 1.51° | Static = |
 | Hades                 | Sample Natal Subject | semi-sextile ⚺   | Medium Coeli          | Yoko Ono | 0.62° | Static = |
 | Hades                 | Sample Natal Subject | sextile ⚹        | Descendant            | Yoko Ono | 1.51° | Static = |
 | Hades                 | Sample Natal Subject | quincunx ⚻       | Imum Coeli            | Yoko Ono | 0.62° | Static = |
-| Hades                 | Sample Natal Subject | square □         | Mean South Lunar Node | Yoko Ono | 1.59° | Static = |
+| Hades                 | Sample Natal Subject | square □         | Mean South Lunar Node | Yoko Ono | 1.58° | Static = |
 | Hades                 | Sample Natal Subject | square □         | True South Lunar Node | Yoko Ono | 2.12° | Static = |
-| Hades                 | Sample Natal Subject | conjunction ☌    | True Lilith           | Yoko Ono | 0.90° | Static = |
-| Hades                 | Sample Natal Subject | quincunx ⚻       | Pholus                | Yoko Ono | 1.73° | Static = |
-| Hades                 | Sample Natal Subject | trine △          | Pallas                | Yoko Ono | 0.52° | Static = |
+| Hades                 | Sample Natal Subject | conjunction ☌    | True Lilith           | Yoko Ono | 0.91° | Static = |
+| Hades                 | Sample Natal Subject | quincunx ⚻       | Pholus                | Yoko Ono | 1.72° | Static = |
+| Hades                 | Sample Natal Subject | trine △          | Pallas                | Yoko Ono | 0.53° | Static = |
 | Hades                 | Sample Natal Subject | biquintile bQ    | Juno                  | Yoko Ono | 1.91° | Static = |
-| Hades                 | Sample Natal Subject | sextile ⚹        | Haumea                | Yoko Ono | 4.91° | Static = |
+| Hades                 | Sample Natal Subject | sextile ⚹        | Haumea                | Yoko Ono | 4.90° | Static = |
 | Hades                 | Sample Natal Subject | semi-square ∠    | Vertex                | Yoko Ono | 1.83° | Static = |
 | Hades                 | Sample Natal Subject | sesquiquadrate ⚼ | Anti Vertex           | Yoko Ono | 1.83° | Static = |
-| Hades                 | Sample Natal Subject | opposition ☍     | True Priapus          | Yoko Ono | 0.90° | Static = |
-| Hades                 | Sample Natal Subject | opposition ☍     | Interpolated Perigee  | Yoko Ono | 0.79° | Static = |
+| Hades                 | Sample Natal Subject | opposition ☍     | True Priapus          | Yoko Ono | 0.91° | Static = |
+| Hades                 | Sample Natal Subject | opposition ☍     | Interpolated Perigee  | Yoko Ono | 0.80° | Static = |
 | Hades                 | Sample Natal Subject | sextile ⚹        | Hades                 | Yoko Ono | 0.28° | Static = |
-| Hades                 | Sample Natal Subject | sextile ⚹        | Zeus                  | Yoko Ono | 0.55° | Static = |
+| Hades                 | Sample Natal Subject | sextile ⚹        | Zeus                  | Yoko Ono | 0.56° | Static = |
 | Hades                 | Sample Natal Subject | semi-sextile ⚺   | Kronos                | Yoko Ono | 0.40° | Static = |
-| Hades                 | Sample Natal Subject | square □         | Apollon               | Yoko Ono | 1.04° | Static = |
+| Hades                 | Sample Natal Subject | square □         | Apollon               | Yoko Ono | 1.03° | Static = |
 | Hades                 | Sample Natal Subject | sextile ⚹        | Admetos               | Yoko Ono | 0.25° | Static = |
-| Hades                 | Sample Natal Subject | conjunction ☌    | Vulkanus              | Yoko Ono | 3.29° | Static = |
+| Hades                 | Sample Natal Subject | conjunction ☌    | Vulkanus              | Yoko Ono | 3.30° | Static = |
 | Zeus                  | Sample Natal Subject | quincunx ⚻       | Sun                   | Yoko Ono | 3.35° | Static = |
 | Zeus                  | Sample Natal Subject | quintile Q       | Moon                  | Yoko Ono | 3.10° | Static = |
-| Zeus                  | Sample Natal Subject | conjunction ☌    | Jupiter               | Yoko Ono | 5.34° | Static = |
-| Zeus                  | Sample Natal Subject | sesquiquadrate ⚼ | Saturn                | Yoko Ono | 1.30° | Static = |
+| Zeus                  | Sample Natal Subject | conjunction ☌    | Jupiter               | Yoko Ono | 5.33° | Static = |
+| Zeus                  | Sample Natal Subject | sesquiquadrate ⚼ | Saturn                | Yoko Ono | 1.29° | Static = |
 | Zeus                  | Sample Natal Subject | sextile ⚹        | Pluto                 | Yoko Ono | 4.40° | Static = |
-| Zeus                  | Sample Natal Subject | trine △          | Chiron                | Yoko Ono | 2.30° | Static = |
+| Zeus                  | Sample Natal Subject | trine △          | Chiron                | Yoko Ono | 2.29° | Static = |
 | Zeus                  | Sample Natal Subject | sesquiquadrate ⚼ | Pallas                | Yoko Ono | 0.58° | Static = |
 | Zeus                  | Sample Natal Subject | trine △          | Vesta                 | Yoko Ono | 1.20° | Static = |
 | Zeus                  | Sample Natal Subject | square □         | Makemake              | Yoko Ono | 4.78° | Static = |
@@ -1470,51 +1470,51 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Zeus                  | Sample Natal Subject | conjunction ☌    | Pars Amoris           | Yoko Ono | 3.21° | Static = |
 | Zeus                  | Sample Natal Subject | quincunx ⚻       | Vertex                | Yoko Ono | 0.72° | Static = |
 | Zeus                  | Sample Natal Subject | semi-sextile ⚺   | Anti Vertex           | Yoko Ono | 0.72° | Static = |
-| Zeus                  | Sample Natal Subject | semi-square ∠    | Zeus                  | Yoko Ono | 0.56° | Static = |
+| Zeus                  | Sample Natal Subject | semi-square ∠    | Zeus                  | Yoko Ono | 0.55° | Static = |
 | Zeus                  | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | Yoko Ono | 0.71° | Static = |
-| Zeus                  | Sample Natal Subject | conjunction ☌    | Poseidon              | Yoko Ono | 5.90° | Static = |
-| Kronos                | Sample Natal Subject | trine △          | Sun                   | Yoko Ono | 7.48° | Static = |
+| Zeus                  | Sample Natal Subject | conjunction ☌    | Poseidon              | Yoko Ono | 5.91° | Static = |
+| Kronos                | Sample Natal Subject | trine △          | Sun                   | Yoko Ono | 7.49° | Static = |
 | Kronos                | Sample Natal Subject | square □         | Jupiter               | Yoko Ono | 1.20° | Static = |
 | Kronos                | Sample Natal Subject | sextile ⚹        | Uranus                | Yoko Ono | 1.35° | Static = |
 | Kronos                | Sample Natal Subject | semi-sextile ⚺   | Pluto                 | Yoko Ono | 0.27° | Static = |
 | Kronos                | Sample Natal Subject | semi-sextile ⚺   | Chiron                | Yoko Ono | 1.84° | Static = |
-| Kronos                | Sample Natal Subject | quintile Q       | Descendant            | Yoko Ono | 1.49° | Static = |
+| Kronos                | Sample Natal Subject | quintile Q       | Descendant            | Yoko Ono | 1.48° | Static = |
 | Kronos                | Sample Natal Subject | sesquiquadrate ⚼ | Juno                  | Yoko Ono | 1.06° | Static = |
-| Kronos                | Sample Natal Subject | sextile ⚹        | Sedna                 | Yoko Ono | 4.72° | Static = |
-| Kronos                | Sample Natal Subject | semi-square ∠    | Haumea                | Yoko Ono | 1.88° | Static = |
+| Kronos                | Sample Natal Subject | sextile ⚹        | Sedna                 | Yoko Ono | 4.71° | Static = |
+| Kronos                | Sample Natal Subject | semi-square ∠    | Haumea                | Yoko Ono | 1.87° | Static = |
 | Kronos                | Sample Natal Subject | square □         | Quaoar                | Yoko Ono | 5.13° | Static = |
-| Kronos                | Sample Natal Subject | opposition ☍     | Pars Fortunae         | Yoko Ono | 4.76° | Static = |
-| Kronos                | Sample Natal Subject | semi-sextile ⚺   | Pars Spiritus         | Yoko Ono | 1.74° | Static = |
-| Kronos                | Sample Natal Subject | square □         | Pars Amoris           | Yoko Ono | 0.92° | Static = |
-| Kronos                | Sample Natal Subject | sextile ⚹        | Vertex                | Yoko Ono | 4.85° | Static = |
-| Kronos                | Sample Natal Subject | trine △          | Anti Vertex           | Yoko Ono | 4.85° | Static = |
+| Kronos                | Sample Natal Subject | opposition ☍     | Pars Fortunae         | Yoko Ono | 4.77° | Static = |
+| Kronos                | Sample Natal Subject | semi-sextile ⚺   | Pars Spiritus         | Yoko Ono | 1.73° | Static = |
+| Kronos                | Sample Natal Subject | square □         | Pars Amoris           | Yoko Ono | 0.93° | Static = |
+| Kronos                | Sample Natal Subject | sextile ⚹        | Vertex                | Yoko Ono | 4.86° | Static = |
+| Kronos                | Sample Natal Subject | trine △          | Anti Vertex           | Yoko Ono | 4.86° | Static = |
 | Kronos                | Sample Natal Subject | quintile Q       | Hades                 | Yoko Ono | 0.31° | Static = |
 | Kronos                | Sample Natal Subject | quintile Q       | Admetos               | Yoko Ono | 0.28° | Static = |
 | Apollon               | Sample Natal Subject | sesquiquadrate ⚼ | Sun                   | Yoko Ono | 0.55° | Static = |
-| Apollon               | Sample Natal Subject | sextile ⚹        | Moon                  | Yoko Ono | 2.70° | Static = |
+| Apollon               | Sample Natal Subject | sextile ⚹        | Moon                  | Yoko Ono | 2.69° | Static = |
 | Apollon               | Sample Natal Subject | biquintile bQ    | Mercury               | Yoko Ono | 0.07° | Static = |
 | Apollon               | Sample Natal Subject | trine △          | Venus                 | Yoko Ono | 0.04° | Static = |
 | Apollon               | Sample Natal Subject | semi-sextile ⚺   | Mars                  | Yoko Ono | 1.30° | Static = |
 | Apollon               | Sample Natal Subject | trine △          | Saturn                | Yoko Ono | 4.09° | Static = |
 | Apollon               | Sample Natal Subject | biquintile bQ    | Mean North Lunar Node | Yoko Ono | 0.51° | Static = |
-| Apollon               | Sample Natal Subject | biquintile bQ    | True North Lunar Node | Yoko Ono | 0.03° | Static = |
+| Apollon               | Sample Natal Subject | biquintile bQ    | True North Lunar Node | Yoko Ono | 0.02° | Static = |
 | Apollon               | Sample Natal Subject | conjunction ☌    | Ascendant             | Yoko Ono | 5.41° | Static = |
 | Apollon               | Sample Natal Subject | square □         | Medium Coeli          | Yoko Ono | 4.52° | Static = |
 | Apollon               | Sample Natal Subject | opposition ☍     | Descendant            | Yoko Ono | 5.41° | Static = |
 | Apollon               | Sample Natal Subject | square □         | Imum Coeli            | Yoko Ono | 4.52° | Static = |
 | Apollon               | Sample Natal Subject | trine △          | True Lilith           | Yoko Ono | 3.00° | Static = |
 | Apollon               | Sample Natal Subject | square □         | Pholus                | Yoko Ono | 5.63° | Static = |
-| Apollon               | Sample Natal Subject | sesquiquadrate ⚼ | Ceres                 | Yoko Ono | 1.66° | Static = |
-| Apollon               | Sample Natal Subject | trine △          | Pallas                | Yoko Ono | 3.38° | Static = |
+| Apollon               | Sample Natal Subject | sesquiquadrate ⚼ | Ceres                 | Yoko Ono | 1.67° | Static = |
+| Apollon               | Sample Natal Subject | trine △          | Pallas                | Yoko Ono | 3.37° | Static = |
 | Apollon               | Sample Natal Subject | sesquiquadrate ⚼ | Vesta                 | Yoko Ono | 1.59° | Static = |
 | Apollon               | Sample Natal Subject | opposition ☍     | Sedna                 | Yoko Ono | 3.36° | Static = |
 | Apollon               | Sample Natal Subject | sesquiquadrate ⚼ | Orcus                 | Yoko Ono | 1.04° | Static = |
 | Apollon               | Sample Natal Subject | quintile Q       | Pars Fortunae         | Yoko Ono | 0.84° | Static = |
 | Apollon               | Sample Natal Subject | biquintile bQ    | Pars Fidei            | Yoko Ono | 0.45° | Static = |
 | Apollon               | Sample Natal Subject | sextile ⚹        | True Priapus          | Yoko Ono | 3.00° | Static = |
-| Apollon               | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | Yoko Ono | 3.11° | Static = |
+| Apollon               | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | Yoko Ono | 3.10° | Static = |
 | Apollon               | Sample Natal Subject | quincunx ⚻       | White Moon            | Yoko Ono | 0.55° | Static = |
-| Apollon               | Sample Natal Subject | semi-square ∠    | Cupido                | Yoko Ono | 1.85° | Static = |
+| Apollon               | Sample Natal Subject | semi-square ∠    | Cupido                | Yoko Ono | 1.86° | Static = |
 | Apollon               | Sample Natal Subject | opposition ☍     | Hades                 | Yoko Ono | 3.62° | Static = |
 | Apollon               | Sample Natal Subject | sextile ⚹        | Zeus                  | Yoko Ono | 3.35° | Static = |
 | Apollon               | Sample Natal Subject | opposition ☍     | Admetos               | Yoko Ono | 3.65° | Static = |
@@ -1527,31 +1527,31 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Admetos               | Sample Natal Subject | biquintile bQ    | Ascendant             | Yoko Ono | 0.55° | Static = |
 | Admetos               | Sample Natal Subject | trine △          | Imum Coeli            | Yoko Ono | 5.65° | Static = |
 | Admetos               | Sample Natal Subject | square □         | Pallas                | Yoko Ono | 4.51° | Static = |
-| Admetos               | Sample Natal Subject | semi-square ∠    | Makemake              | Yoko Ono | 0.85° | Static = |
+| Admetos               | Sample Natal Subject | semi-square ∠    | Makemake              | Yoko Ono | 0.86° | Static = |
 | Admetos               | Sample Natal Subject | sesquiquadrate ⚼ | Ixion                 | Yoko Ono | 0.74° | Static = |
 | Admetos               | Sample Natal Subject | trine △          | Quaoar                | Yoko Ono | 1.81° | Static = |
 | Admetos               | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Yoko Ono | 4.41° | Static = |
 | Admetos               | Sample Natal Subject | conjunction ☌    | White Moon            | Yoko Ono | 1.69° | Static = |
-| Admetos               | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 4.49° | Static = |
+| Admetos               | Sample Natal Subject | square □         | Zeus                  | Yoko Ono | 4.48° | Static = |
 | Admetos               | Sample Natal Subject | conjunction ☌    | Kronos                | Yoko Ono | 4.63° | Static = |
 | Admetos               | Sample Natal Subject | semi-sextile ⚺   | Vulkanus              | Yoko Ono | 1.74° | Static = |
-| Admetos               | Sample Natal Subject | sesquiquadrate ⚼ | Poseidon              | Yoko Ono | 1.97° | Static = |
-| Vulkanus              | Sample Natal Subject | sesquiquadrate ⚼ | Sun                   | Yoko Ono | 0.97° | Static = |
-| Vulkanus              | Sample Natal Subject | biquintile bQ    | Moon                  | Yoko Ono | 1.78° | Static = |
-| Vulkanus              | Sample Natal Subject | quincunx ⚻       | Venus                 | Yoko Ono | 1.56° | Static = |
-| Vulkanus              | Sample Natal Subject | sextile ⚹        | Mars                  | Yoko Ono | 0.22° | Static = |
-| Vulkanus              | Sample Natal Subject | square □         | Uranus                | Yoko Ono | 5.20° | Static = |
+| Admetos               | Sample Natal Subject | sesquiquadrate ⚼ | Poseidon              | Yoko Ono | 1.98° | Static = |
+| Vulkanus              | Sample Natal Subject | sesquiquadrate ⚼ | Sun                   | Yoko Ono | 0.96° | Static = |
+| Vulkanus              | Sample Natal Subject | biquintile bQ    | Moon                  | Yoko Ono | 1.79° | Static = |
+| Vulkanus              | Sample Natal Subject | quincunx ⚻       | Venus                 | Yoko Ono | 1.55° | Static = |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | Mars                  | Yoko Ono | 0.21° | Static = |
+| Vulkanus              | Sample Natal Subject | square □         | Uranus                | Yoko Ono | 5.21° | Static = |
 | Vulkanus              | Sample Natal Subject | sesquiquadrate ⚼ | Ceres                 | Yoko Ono | 0.15° | Static = |
 | Vulkanus              | Sample Natal Subject | square □         | Sedna                 | Yoko Ono | 1.84° | Static = |
-| Vulkanus              | Sample Natal Subject | quintile Q       | Ixion                 | Yoko Ono | 1.87° | Static = |
-| Vulkanus              | Sample Natal Subject | sextile ⚹        | Quaoar                | Yoko Ono | 1.42° | Static = |
+| Vulkanus              | Sample Natal Subject | quintile Q       | Ixion                 | Yoko Ono | 1.88° | Static = |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | Quaoar                | Yoko Ono | 1.43° | Static = |
 | Vulkanus              | Sample Natal Subject | conjunction ☌    | Pars Spiritus         | Yoko Ono | 4.82° | Static = |
 | Vulkanus              | Sample Natal Subject | sextile ⚹        | Pars Fidei            | Yoko Ono | 4.03° | Static = |
-| Vulkanus              | Sample Natal Subject | biquintile bQ    | True Priapus          | Yoko Ono | 1.48° | Static = |
+| Vulkanus              | Sample Natal Subject | biquintile bQ    | True Priapus          | Yoko Ono | 1.49° | Static = |
 | Vulkanus              | Sample Natal Subject | biquintile bQ    | Interpolated Perigee  | Yoko Ono | 1.38° | Static = |
 | Vulkanus              | Sample Natal Subject | sextile ⚹        | White Moon            | Yoko Ono | 2.07° | Static = |
-| Vulkanus              | Sample Natal Subject | semi-square ∠    | Cupido                | Yoko Ono | 0.34° | Static = |
-| Vulkanus              | Sample Natal Subject | square □         | Hades                 | Yoko Ono | 5.14° | Static = |
+| Vulkanus              | Sample Natal Subject | semi-square ∠    | Cupido                | Yoko Ono | 0.35° | Static = |
+| Vulkanus              | Sample Natal Subject | square □         | Hades                 | Yoko Ono | 5.13° | Static = |
 | Vulkanus              | Sample Natal Subject | square □         | Admetos               | Yoko Ono | 5.17° | Static = |
 | Poseidon              | Sample Natal Subject | trine △          | Sun                   | Yoko Ono | 0.70° | Static = |
 | Poseidon              | Sample Natal Subject | semi-square ∠    | Moon                  | Yoko Ono | 2.55° | Static = |
@@ -1566,5 +1566,5 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 | Poseidon              | Sample Natal Subject | opposition ☍     | Vertex                | Yoko Ono | 1.93° | Static = |
 | Poseidon              | Sample Natal Subject | conjunction ☌    | Anti Vertex           | Yoko Ono | 1.93° | Static = |
 | Poseidon              | Sample Natal Subject | sextile ⚹        | Cupido                | Yoko Ono | 2.00° | Static = |
-| Poseidon              | Sample Natal Subject | sesquiquadrate ⚼ | Vulkanus              | Yoko Ono | 0.47° | Static = |
+| Poseidon              | Sample Natal Subject | sesquiquadrate ⚼ | Vulkanus              | Yoko Ono | 0.46° | Static = |
 +-----------------------+----------------------+------------------+-----------------------+----------+-------+----------+

--- a/tests/fixtures/synastry_john_yoko_report.txt
+++ b/tests/fixtures/synastry_john_yoko_report.txt
@@ -57,8 +57,8 @@ John Lennon & Yoko Ono — Synastry Report
 +First Subject Celestial Points--+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Ari ♈ | 19.71°   | +886.9396°/d | N/A     | -    | First House    |
-| Medium Coeli          | Cap ♑ | 7.06°    | +332.1233°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Ari ♈ | 19.71°   | +886.9442°/d | N/A     | -    | First House    |
+| Medium Coeli          | Cap ♑ | 7.06°    | +332.1251°/d | N/A     | -    | Tenth House    |
 | Sun                   | Lib ♎ | 16.27°   | +0.9885°/d   | -6.40°  | -    | Sixth House    |
 | Moon                  | Aqu ♒ | 3.55°    | +12.5291°/d  | -14.60° | -    | Eleventh House |
 | Mercury               | Sco ♏ | 8.56°    | +1.3195°/d   | -16.23° | -    | Seventh House  |
@@ -76,8 +76,8 @@ John Lennon & Yoko Ono — Synastry Report
 +Second Subject Celestial Points-+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Lib ♎ | 8.41°    | +299.6082°/d | N/A     | -    | First House    |
-| Medium Coeli          | Can ♋ | 9.31°    | +332.7977°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Lib ♎ | 8.41°    | +299.6098°/d | N/A     | -    | First House    |
+| Medium Coeli          | Can ♋ | 9.31°    | +332.7995°/d | N/A     | -    | Tenth House    |
 | Sun                   | Aqu ♒ | 29.38°   | +1.0085°/d   | -11.70° | -    | Fifth House    |
 | Moon                  | Sag ♐ | 11.13°   | +14.2185°/d  | -27.33° | -    | Third House    |
 | Mercury               | Pis ♓ | 7.89°    | +1.8561°/d   | -9.86°  | -    | Fifth House    |

--- a/tests/fixtures/synastry_report.txt
+++ b/tests/fixtures/synastry_report.txt
@@ -57,8 +57,8 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 +First Subject Celestial Points--+----------+--------------+---------+------+---------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House         |
 +-----------------------+--------+----------+--------------+---------+------+---------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House   |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6390°/d | N/A     | -    | Tenth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House   |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6410°/d | N/A     | -    | Tenth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House   |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House   |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House   |
@@ -76,8 +76,8 @@ Sample Natal Subject & Yoko Ono — Synastry Report
 +Second Subject Celestial Points-+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Lib ♎ | 8.41°    | +299.6082°/d | N/A     | -    | First House    |
-| Medium Coeli          | Can ♋ | 9.31°    | +332.7977°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Lib ♎ | 8.41°    | +299.6098°/d | N/A     | -    | First House    |
+| Medium Coeli          | Can ♋ | 9.31°    | +332.7995°/d | N/A     | -    | Tenth House    |
 | Sun                   | Aqu ♒ | 29.38°   | +1.0085°/d   | -11.70° | -    | Fifth House    |
 | Moon                  | Sag ♐ | 11.13°   | +14.2185°/d  | -27.33° | -    | Third House    |
 | Mercury               | Pis ♓ | 7.89°    | +1.8561°/d   | -9.86°  | -    | Fifth House    |

--- a/tests/fixtures/transit_all_points_all_aspects_report.txt
+++ b/tests/fixtures/transit_all_points_all_aspects_report.txt
@@ -57,10 +57,10 @@ Sample Natal Subject — Transit 1980-12-08
 +Natal Subject Celestial Points--+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House    |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6390°/d | N/A     | -    | Tenth House    |
-| Descendant            | Tau ♉ | 5.82°    | +245.7237°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6390°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House    |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6410°/d | N/A     | -    | Tenth House    |
+| Descendant            | Tau ♉ | 5.82°    | +245.7250°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6410°/d | N/A     | -    | Fourth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House    |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House    |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House    |
@@ -73,8 +73,8 @@ Sample Natal Subject — Transit 1980-12-08
 | Pluto                 | Sco ♏ | 14.97°   | -0.0025°/d   | -1.42°  | R    | First House    |
 | Mean North Lunar Node | Aqu ♒ | 7.79°    | -0.0529°/d   | -18.32° | R    | Third House    |
 | True North Lunar Node | Aqu ♒ | 7.26°    | -0.0080°/d   | -18.46° | R    | Third House    |
-| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.61° | -    | First House    |
-| True Lilith           | Sag ♐ | 18.01°   | -1.4331°/d   | -26.88° | R    | Second House   |
+| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -24.62° | -    | First House    |
+| True Lilith           | Sag ♐ | 18.01°   | -1.4330°/d   | -26.88° | R    | Second House   |
 | Chiron                | Can ♋ | 19.88°   | +0.1071°/d   | +15.79° | -    | Ninth House    |
 | Pholus                | Can ♋ | 7.99°    | +0.1329°/d   | +13.79° | -    | Eighth House   |
 | Ceres                 | Leo ♌ | 13.71°   | +0.4493°/d   | +23.05° | -    | Ninth House    |
@@ -82,15 +82,15 @@ Sample Natal Subject — Transit 1980-12-08
 | Juno                  | Sco ♏ | 10.10°   | +0.0843°/d   | -2.06°  | -    | First House    |
 | Vesta                 | Tau ♉ | 18.15°   | +0.3292°/d   | +10.88° | -    | Seventh House  |
 | Interpolated Lilith   | Sco ♏ | 25.48°   | +0.1694°/d   | -23.89° | -    | First House    |
-| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1732°/d   | +26.84° | -    | Eighth House   |
-| Cupido                | Sco ♏ | 18.62°   | -0.0042°/d   | -16.34° | R    | First House    |
-| Hades                 | Gem ♊ | 9.93°    | +0.0152°/d   | +20.93° | -    | Eighth House   |
-| Zeus                  | Vir ♍ | 26.03°   | +0.0110°/d   | +1.58°  | -    | Eleventh House |
-| Kronos                | Gem ♊ | 21.90°   | +0.0137°/d   | +23.21° | -    | Eighth House   |
-| Apollon               | Lib ♎ | 13.83°   | +0.0053°/d   | -5.46°  | -    | Eleventh House |
-| Admetos               | Tau ♉ | 14.96°   | +0.0053°/d   | +16.33° | -    | Seventh House  |
-| Vulkanus              | Can ♋ | 15.35°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
-| Poseidon              | Lib ♎ | 28.68°   | +0.0014°/d   | -11.01° | -    | Twelfth House  |
+| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1733°/d   | +26.84° | -    | Eighth House   |
+| Cupido                | Sco ♏ | 18.62°   | -0.0043°/d   | -16.34° | R    | First House    |
+| Hades                 | Gem ♊ | 9.92°    | +0.0153°/d   | +20.93° | -    | Eighth House   |
+| Zeus                  | Vir ♍ | 26.03°   | +0.0109°/d   | +1.58°  | -    | Eleventh House |
+| Kronos                | Gem ♊ | 21.89°   | +0.0138°/d   | +23.21° | -    | Eighth House   |
+| Apollon               | Lib ♎ | 13.82°   | +0.0052°/d   | -5.46°  | -    | Eleventh House |
+| Admetos               | Tau ♉ | 14.96°   | +0.0054°/d   | +16.33° | -    | Seventh House  |
+| Vulkanus              | Can ♋ | 15.34°   | +0.0136°/d   | +22.57° | -    | Ninth House    |
+| Poseidon              | Lib ♎ | 28.68°   | +0.0013°/d   | -11.01° | -    | Twelfth House  |
 | Eris                  | Ari ♈ | 17.60°   | -0.0013°/d   | -9.16°  | R    | Sixth House    |
 | Sedna                 | Tau ♉ | 11.55°   | +0.0038°/d   | +4.25°  | -    | Seventh House  |
 | Haumea                | Vir ♍ | 26.32°   | +0.0134°/d   | +23.02° | -    | Eleventh House |
@@ -103,21 +103,21 @@ Sample Natal Subject — Transit 1980-12-08
 | Pars Amoris           | Lib ♎ | 8.99°    | N/A          | N/A     | -    | Eleventh House |
 | Pars Fidei            | Tau ♉ | 8.22°    | N/A          | N/A     | -    | Seventh House  |
 | Vertex                | Gem ♊ | 11.46°   | N/A          | N/A     | -    | Eighth House   |
-| White Moon            | Can ♋ | 26.44°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
+| White Moon            | Can ♋ | 26.43°   | +0.1409°/d   | +20.87° | -    | Ninth House    |
 | Anti Vertex           | Sag ♐ | 11.46°   | N/A          | N/A     | -    | Second House   |
 | Mean South Lunar Node | Leo ♌ | 7.79°    | -0.0529°/d   | +18.32° | R    | Ninth House    |
 | True South Lunar Node | Leo ♌ | 7.26°    | -0.0080°/d   | +18.46° | R    | Ninth House    |
-| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.61° | -    | Seventh House  |
-| True Priapus          | Gem ♊ | 18.01°   | -1.4331°/d   | +26.88° | R    | Eighth House   |
+| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | +24.62° | -    | Seventh House  |
+| True Priapus          | Gem ♊ | 18.01°   | -1.4330°/d   | +26.88° | R    | Eighth House   |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +Transit Subject Celestial Points+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Vir ♍ | 7.47°    | +284.2957°/d | N/A     | -    | First House    |
-| Medium Coeli          | Gem ♊ | 3.56°    | +343.5404°/d | N/A     | -    | Tenth House    |
-| Descendant            | Pis ♓ | 7.47°    | +284.2957°/d | N/A     | -    | Seventh House  |
-| Imum Coeli            | Sag ♐ | 3.56°    | +343.5404°/d | N/A     | -    | Fourth House   |
+| Ascendant             | Vir ♍ | 7.47°    | +284.2972°/d | N/A     | -    | First House    |
+| Medium Coeli          | Gem ♊ | 3.56°    | +343.5423°/d | N/A     | -    | Tenth House    |
+| Descendant            | Pis ♓ | 7.47°    | +284.2972°/d | N/A     | -    | Seventh House  |
+| Imum Coeli            | Sag ♐ | 3.56°    | +343.5423°/d | N/A     | -    | Fourth House   |
 | Sun                   | Sag ♐ | 17.24°   | +1.0165°/d   | -22.83° | -    | Fourth House   |
 | Moon                  | Cap ♑ | 5.06°    | +12.6292°/d  | -20.27° | -    | Fourth House   |
 | Mercury               | Sag ♐ | 5.09°    | +1.5319°/d   | -20.71° | -    | Fourth House   |
@@ -131,7 +131,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Mean North Lunar Node | Leo ♌ | 13.72°   | -0.0529°/d   | +16.71° | R    | Twelfth House  |
 | True North Lunar Node | Leo ♌ | 12.16°   | -0.1140°/d   | +17.15° | R    | Twelfth House  |
 | Mean Lilith           | Lib ♎ | 27.66°   | +0.1120°/d   | -6.02°  | -    | Second House   |
-| True Lilith           | Sco ♏ | 1.17°    | +4.5156°/d   | -7.19°  | -    | Third House    |
+| True Lilith           | Sco ♏ | 1.17°    | +4.5158°/d   | -7.19°  | -    | Third House    |
 | Chiron                | Tau ♉ | 14.36°   | -0.0403°/d   | +14.10° | R    | Ninth House    |
 | Pholus                | Pis ♓ | 27.38°   | +0.0019°/d   | -21.42° | -    | Seventh House  |
 | Ceres                 | Can ♋ | 26.68°   | -0.0960°/d   | +26.67° | R    | Eleventh House |
@@ -139,15 +139,15 @@ Sample Natal Subject — Transit 1980-12-08
 | Juno                  | Lib ♎ | 24.32°   | +0.3022°/d   | -6.02°  | -    | Second House   |
 | Vesta                 | Vir ♍ | 7.30°    | +0.1941°/d   | +12.75° | -    | Twelfth House  |
 | Interpolated Lilith   | Lib ♎ | 23.28°   | +0.1827°/d   | -4.56°  | -    | Second House   |
-| Interpolated Perigee  | Tau ♉ | 19.65°   | +0.4054°/d   | +12.77° | -    | Ninth House    |
-| Cupido                | Sco ♏ | 7.48°    | +0.0221°/d   | -13.01° | -    | Third House    |
-| Hades                 | Tau ♉ | 28.99°   | -0.0162°/d   | +18.93° | R    | Ninth House    |
-| Zeus                  | Vir ♍ | 20.09°   | +0.0029°/d   | +3.93°  | -    | First House    |
+| Interpolated Perigee  | Tau ♉ | 19.65°   | +0.4058°/d   | +12.77° | -    | Ninth House    |
+| Cupido                | Sco ♏ | 7.48°    | +0.0222°/d   | -13.01° | -    | Third House    |
+| Hades                 | Tau ♉ | 29.00°   | -0.0162°/d   | +18.93° | R    | Ninth House    |
+| Zeus                  | Vir ♍ | 20.09°   | +0.0030°/d   | +3.93°  | -    | First House    |
 | Kronos                | Gem ♊ | 14.58°   | -0.0136°/d   | +22.56° | R    | Tenth House    |
-| Apollon               | Lib ♎ | 9.36°    | +0.0070°/d   | -3.71°  | -    | Second House   |
-| Admetos               | Tau ♉ | 8.10°    | -0.0089°/d   | +14.21° | R    | Ninth House    |
-| Vulkanus              | Can ♋ | 10.22°   | -0.0106°/d   | +23.06° | R    | Eleventh House |
-| Poseidon              | Lib ♎ | 25.25°   | +0.0086°/d   | -9.77°  | -    | Second House   |
+| Apollon               | Lib ♎ | 9.35°    | +0.0071°/d   | -3.71°  | -    | Second House   |
+| Admetos               | Tau ♉ | 8.10°    | -0.0090°/d   | +14.22° | R    | Ninth House    |
+| Vulkanus              | Can ♋ | 10.22°   | -0.0105°/d   | +23.06° | R    | Eleventh House |
+| Poseidon              | Lib ♎ | 25.24°   | +0.0087°/d   | -9.77°  | -    | Second House   |
 | Eris                  | Ari ♈ | 14.15°   | -0.0043°/d   | -12.11° | R    | Eighth House   |
 | Sedna                 | Tau ♉ | 5.87°    | -0.0066°/d   | +2.65°  | R    | Ninth House    |
 | Haumea                | Vir ♍ | 19.69°   | +0.0034°/d   | +23.59° | -    | First House    |
@@ -165,7 +165,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Mean South Lunar Node | Aqu ♒ | 13.72°   | -0.0529°/d   | -16.71° | R    | Sixth House    |
 | True South Lunar Node | Aqu ♒ | 12.16°   | -0.1140°/d   | -17.15° | R    | Sixth House    |
 | Mean Priapus          | Ari ♈ | 27.66°   | +0.1120°/d   | +6.02°  | -    | Eighth House   |
-| True Priapus          | Tau ♉ | 1.17°    | +4.5156°/d   | +7.19°  | -    | Ninth House    |
+| True Priapus          | Tau ♉ | 1.17°    | +4.5158°/d   | +7.19°  | -    | Ninth House    |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
 
 +Natal Subject Houses (Placidus)-----+-------------------+
@@ -255,12 +255,12 @@ Sample Natal Subject — Transit 1980-12-08
 | Sample Natal Subject – Interpolated Lilith   | 1 (First House)     | 3 (Third House)     | Sco  | 25.48° |
 | Sample Natal Subject – Interpolated Perigee  | 8 (Eighth House)    | 10 (Tenth House)    | Gem  | 20.98° |
 | Sample Natal Subject – Cupido                | 1 (First House)     | 3 (Third House)     | Sco  | 18.62° |
-| Sample Natal Subject – Hades                 | 8 (Eighth House)    | 10 (Tenth House)    | Gem  | 9.93°  |
+| Sample Natal Subject – Hades                 | 8 (Eighth House)    | 10 (Tenth House)    | Gem  | 9.92°  |
 | Sample Natal Subject – Zeus                  | 11 (Eleventh House) | 1 (First House)     | Vir  | 26.03° |
-| Sample Natal Subject – Kronos                | 8 (Eighth House)    | 10 (Tenth House)    | Gem  | 21.90° |
-| Sample Natal Subject – Apollon               | 11 (Eleventh House) | 2 (Second House)    | Lib  | 13.83° |
+| Sample Natal Subject – Kronos                | 8 (Eighth House)    | 10 (Tenth House)    | Gem  | 21.89° |
+| Sample Natal Subject – Apollon               | 11 (Eleventh House) | 2 (Second House)    | Lib  | 13.82° |
 | Sample Natal Subject – Admetos               | 7 (Seventh House)   | 9 (Ninth House)     | Tau  | 14.96° |
-| Sample Natal Subject – Vulkanus              | 9 (Ninth House)     | 11 (Eleventh House) | Can  | 15.35° |
+| Sample Natal Subject – Vulkanus              | 9 (Ninth House)     | 11 (Eleventh House) | Can  | 15.34° |
 | Sample Natal Subject – Poseidon              | 12 (Twelfth House)  | 2 (Second House)    | Lib  | 28.68° |
 | Sample Natal Subject – Eris                  | 6 (Sixth House)     | 8 (Eighth House)    | Ari  | 17.60° |
 | Sample Natal Subject – Sedna                 | 7 (Seventh House)   | 9 (Ninth House)     | Tau  | 11.55° |
@@ -274,7 +274,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Sample Natal Subject – Pars Amoris           | 11 (Eleventh House) | 2 (Second House)    | Lib  | 8.99°  |
 | Sample Natal Subject – Pars Fidei            | 7 (Seventh House)   | 9 (Ninth House)     | Tau  | 8.22°  |
 | Sample Natal Subject – Vertex                | 8 (Eighth House)    | 10 (Tenth House)    | Gem  | 11.46° |
-| Sample Natal Subject – White Moon            | 9 (Ninth House)     | 11 (Eleventh House) | Can  | 26.44° |
+| Sample Natal Subject – White Moon            | 9 (Ninth House)     | 11 (Eleventh House) | Can  | 26.43° |
 | Sample Natal Subject – Descendant            | 7 (Seventh House)   | 9 (Ninth House)     | Tau  | 5.82°  |
 | Sample Natal Subject – Imum Coeli            | 4 (Fourth House)    | 6 (Sixth House)     | Aqu  | 19.91° |
 | Sample Natal Subject – Anti Vertex           | 2 (Second House)    | 4 (Fourth House)    | Sag  | 11.46° |
@@ -312,13 +312,13 @@ Sample Natal Subject — Transit 1980-12-08
 | 1980 Transit – Interpolated Lilith   | 2 (Second House)    | 12 (Twelfth House)  | Lib  | 23.28° |
 | 1980 Transit – Interpolated Perigee  | 9 (Ninth House)     | 7 (Seventh House)   | Tau  | 19.65° |
 | 1980 Transit – Cupido                | 3 (Third House)     | 1 (First House)     | Sco  | 7.48°  |
-| 1980 Transit – Hades                 | 9 (Ninth House)     | 7 (Seventh House)   | Tau  | 28.99° |
+| 1980 Transit – Hades                 | 9 (Ninth House)     | 7 (Seventh House)   | Tau  | 29.00° |
 | 1980 Transit – Zeus                  | 1 (First House)     | 10 (Tenth House)    | Vir  | 20.09° |
 | 1980 Transit – Kronos                | 10 (Tenth House)    | 8 (Eighth House)    | Gem  | 14.58° |
-| 1980 Transit – Apollon               | 2 (Second House)    | 11 (Eleventh House) | Lib  | 9.36°  |
+| 1980 Transit – Apollon               | 2 (Second House)    | 11 (Eleventh House) | Lib  | 9.35°  |
 | 1980 Transit – Admetos               | 9 (Ninth House)     | 7 (Seventh House)   | Tau  | 8.10°  |
 | 1980 Transit – Vulkanus              | 11 (Eleventh House) | 9 (Ninth House)     | Can  | 10.22° |
-| 1980 Transit – Poseidon              | 2 (Second House)    | 12 (Twelfth House)  | Lib  | 25.25° |
+| 1980 Transit – Poseidon              | 2 (Second House)    | 12 (Twelfth House)  | Lib  | 25.24° |
 | 1980 Transit – Eris                  | 8 (Eighth House)    | 5 (Fifth House)     | Ari  | 14.15° |
 | 1980 Transit – Sedna                 | 9 (Ninth House)     | 7 (Seventh House)   | Tau  | 5.87°  |
 | 1980 Transit – Haumea                | 1 (First House)     | 10 (Tenth House)    | Vir  | 19.69° |
@@ -468,8 +468,8 @@ Sample Natal Subject — Transit 1980-12-08
 | Sun                   | Sample Natal Subject | square □         | Mean Priapus          | 1980 Transit | 0.88° | Applying →   |
 | Sun                   | Sample Natal Subject | square □         | True Priapus          | 1980 Transit | 2.63° | Separating ← |
 | Sun                   | Sample Natal Subject | sesquiquadrate ⚼ | White Moon            | 1980 Transit | 1.57° | Applying →   |
-| Sun                   | Sample Natal Subject | sextile ⚹        | Hades                 | 1980 Transit | 0.45° | Applying →   |
-| Sun                   | Sample Natal Subject | semi-square ∠    | Kronos                | 1980 Transit | 1.03° | Applying →   |
+| Sun                   | Sample Natal Subject | sextile ⚹        | Hades                 | 1980 Transit | 0.46° | Applying →   |
+| Sun                   | Sample Natal Subject | semi-square ∠    | Kronos                | 1980 Transit | 1.04° | Applying →   |
 | Sun                   | Sample Natal Subject | quintile Q       | Apollon               | 1980 Transit | 1.19° | Applying →   |
 | Sun                   | Sample Natal Subject | square □         | Poseidon              | 1980 Transit | 3.30° | Applying →   |
 | Moon                  | Sample Natal Subject | sesquiquadrate ⚼ | Mercury               | 1980 Transit | 1.12° | Applying →   |
@@ -491,7 +491,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Moon                  | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | 1980 Transit | 1.56° | Applying →   |
 | Moon                  | Sample Natal Subject | sextile ⚹        | Zeus                  | 1980 Transit | 1.12° | Applying →   |
 | Moon                  | Sample Natal Subject | quintile Q       | Admetos               | 1980 Transit | 1.11° | Separating ← |
-| Moon                  | Sample Natal Subject | square □         | Poseidon              | 1980 Transit | 4.04° | Separating ← |
+| Moon                  | Sample Natal Subject | square □         | Poseidon              | 1980 Transit | 4.03° | Separating ← |
 | Mercury               | Sample Natal Subject | trine △          | Sun                   | 1980 Transit | 0.37° | Applying →   |
 | Mercury               | Sample Natal Subject | square □         | Venus                 | 1980 Transit | 1.07° | Separating ← |
 | Mercury               | Sample Natal Subject | biquintile bQ    | Mars                  | 1980 Transit | 1.45° | Separating ← |
@@ -547,7 +547,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Mars                  | Sample Natal Subject | opposition ☍     | Cupido                | 1980 Transit | 1.51° | Separating ← |
 | Mars                  | Sample Natal Subject | sesquiquadrate ⚼ | Zeus                  | 1980 Transit | 0.88° | Applying →   |
 | Mars                  | Sample Natal Subject | conjunction ☌    | Admetos               | 1980 Transit | 2.13° | Applying →   |
-| Mars                  | Sample Natal Subject | sextile ⚹        | Vulkanus              | 1980 Transit | 4.25° | Applying →   |
+| Mars                  | Sample Natal Subject | sextile ⚹        | Vulkanus              | 1980 Transit | 4.26° | Applying →   |
 | Jupiter               | Sample Natal Subject | biquintile bQ    | Sun                   | 1980 Transit | 0.68° | Applying →   |
 | Jupiter               | Sample Natal Subject | trine △          | Venus                 | 1980 Transit | 5.24° | Applying →   |
 | Jupiter               | Sample Natal Subject | quintile Q       | Jupiter               | 1980 Transit | 1.25° | Separating ← |
@@ -586,7 +586,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Saturn                | Sample Natal Subject | square □         | Interpolated Lilith   | 1980 Transit | 1.76° | Separating ← |
 | Saturn                | Sample Natal Subject | trine △          | Interpolated Perigee  | 1980 Transit | 1.87° | Applying →   |
 | Saturn                | Sample Natal Subject | trine △          | Zeus                  | 1980 Transit | 1.43° | Applying →   |
-| Saturn                | Sample Natal Subject | biquintile bQ    | Kronos                | 1980 Transit | 0.94° | Separating ← |
+| Saturn                | Sample Natal Subject | biquintile bQ    | Kronos                | 1980 Transit | 0.93° | Separating ← |
 | Saturn                | Sample Natal Subject | square □         | Poseidon              | 1980 Transit | 3.73° | Separating ← |
 | Uranus                | Sample Natal Subject | conjunction ☌    | Moon                  | 1980 Transit | 1.68° | Applying →   |
 | Uranus                | Sample Natal Subject | semi-sextile ⚺   | Mercury               | 1980 Transit | 1.65° | Applying →   |
@@ -609,8 +609,8 @@ Sample Natal Subject — Transit 1980-12-08
 | Uranus                | Sample Natal Subject | biquintile bQ    | Hades                 | 1980 Transit | 1.74° | Separating ← |
 | Uranus                | Sample Natal Subject | square □         | Apollon               | 1980 Transit | 2.62° | Separating ← |
 | Uranus                | Sample Natal Subject | trine △          | Admetos               | 1980 Transit | 1.36° | Applying →   |
-| Uranus                | Sample Natal Subject | opposition ☍     | Vulkanus              | 1980 Transit | 3.48° | Applying →   |
-| Uranus                | Sample Natal Subject | quintile Q       | Poseidon              | 1980 Transit | 0.51° | Separating ← |
+| Uranus                | Sample Natal Subject | opposition ☍     | Vulkanus              | 1980 Transit | 3.49° | Applying →   |
+| Uranus                | Sample Natal Subject | quintile Q       | Poseidon              | 1980 Transit | 0.50° | Separating ← |
 | Neptune               | Sample Natal Subject | conjunction ☌    | Mars                  | 1980 Transit | 0.30° | Separating ← |
 | Neptune               | Sample Natal Subject | square □         | Jupiter               | 1980 Transit | 5.60° | Applying →   |
 | Neptune               | Sample Natal Subject | square □         | Saturn                | 1980 Transit | 4.42° | Applying →   |
@@ -630,8 +630,8 @@ Sample Natal Subject — Transit 1980-12-08
 | Neptune               | Sample Natal Subject | sextile ⚹        | Quaoar                | 1980 Transit | 1.32° | Separating ← |
 | Neptune               | Sample Natal Subject | biquintile bQ    | Pars Fortunae         | 1980 Transit | 0.89° | Static =     |
 | Neptune               | Sample Natal Subject | sextile ⚹        | White Moon            | 1980 Transit | 0.79° | Applying →   |
-| Neptune               | Sample Natal Subject | sesquiquadrate ⚼ | Hades                 | 1980 Transit | 1.23° | Applying →   |
-| Neptune               | Sample Natal Subject | quincunx ⚻       | Kronos                | 1980 Transit | 1.81° | Applying →   |
+| Neptune               | Sample Natal Subject | sesquiquadrate ⚼ | Hades                 | 1980 Transit | 1.24° | Applying →   |
+| Neptune               | Sample Natal Subject | quincunx ⚻       | Kronos                | 1980 Transit | 1.82° | Applying →   |
 | Neptune               | Sample Natal Subject | square □         | Apollon               | 1980 Transit | 3.41° | Applying →   |
 | Neptune               | Sample Natal Subject | trine △          | Admetos               | 1980 Transit | 4.66° | Separating ← |
 | Neptune               | Sample Natal Subject | opposition ☍     | Vulkanus              | 1980 Transit | 2.54° | Separating ← |
@@ -650,7 +650,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Pluto                 | Sample Natal Subject | square □         | Pars Fortunae         | 1980 Transit | 4.68° | Static =     |
 | Pluto                 | Sample Natal Subject | opposition ☍     | Interpolated Perigee  | 1980 Transit | 4.67° | Separating ← |
 | Pluto                 | Sample Natal Subject | trine △          | White Moon            | 1980 Transit | 3.00° | Applying →   |
-| Pluto                 | Sample Natal Subject | quincunx ⚻       | Kronos                | 1980 Transit | 0.40° | Separating ← |
+| Pluto                 | Sample Natal Subject | quincunx ⚻       | Kronos                | 1980 Transit | 0.39° | Separating ← |
 | Pluto                 | Sample Natal Subject | trine △          | Vulkanus              | 1980 Transit | 4.75° | Separating ← |
 | Mean North Lunar Node | Sample Natal Subject | sextile ⚹        | Mercury               | 1980 Transit | 2.70° | Applying →   |
 | Mean North Lunar Node | Sample Natal Subject | trine △          | Jupiter               | 1980 Transit | 0.63° | Applying →   |
@@ -693,9 +693,9 @@ Sample Natal Subject — Transit 1980-12-08
 | True North Lunar Node | Sample Natal Subject | quincunx ⚻       | Pars Fidei            | 1980 Transit | 0.98° | Static =     |
 | True North Lunar Node | Sample Natal Subject | conjunction ☌    | Vertex                | 1980 Transit | 1.42° | Static =     |
 | True North Lunar Node | Sample Natal Subject | opposition ☍     | Anti Vertex           | 1980 Transit | 1.42° | Static =     |
-| True North Lunar Node | Sample Natal Subject | square □         | Cupido                | 1980 Transit | 0.22° | Separating ← |
+| True North Lunar Node | Sample Natal Subject | square □         | Cupido                | 1980 Transit | 0.21° | Separating ← |
 | True North Lunar Node | Sample Natal Subject | trine △          | Apollon               | 1980 Transit | 2.09° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | square □         | Admetos               | 1980 Transit | 0.83° | Applying →   |
+| True North Lunar Node | Sample Natal Subject | square □         | Admetos               | 1980 Transit | 0.84° | Applying →   |
 | Chiron                | Sample Natal Subject | sesquiquadrate ⚼ | Mercury               | 1980 Transit | 0.21° | Separating ← |
 | Chiron                | Sample Natal Subject | trine △          | Venus                 | 1980 Transit | 1.21° | Applying →   |
 | Chiron                | Sample Natal Subject | square □         | Pluto                 | 1980 Transit | 3.78° | Separating ← |
@@ -713,7 +713,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Chiron                | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | 1980 Transit | 0.23° | Applying →   |
 | Chiron                | Sample Natal Subject | sextile ⚹        | Zeus                  | 1980 Transit | 0.21° | Separating ← |
 | Chiron                | Sample Natal Subject | quintile Q       | Admetos               | 1980 Transit | 0.22° | Applying →   |
-| Chiron                | Sample Natal Subject | square □         | Poseidon              | 1980 Transit | 5.37° | Separating ← |
+| Chiron                | Sample Natal Subject | square □         | Poseidon              | 1980 Transit | 5.36° | Separating ← |
 | Ascendant             | Sample Natal Subject | sextile ⚹        | Moon                  | 1980 Transit | 0.76° | Applying →   |
 | Ascendant             | Sample Natal Subject | semi-sextile ⚺   | Mercury               | 1980 Transit | 0.73° | Applying →   |
 | Ascendant             | Sample Natal Subject | semi-sextile ⚺   | Jupiter               | 1980 Transit | 1.34° | Separating ← |
@@ -790,7 +790,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Imum Coeli            | Sample Natal Subject | quintile Q       | True Priapus          | 1980 Transit | 0.74° | Applying →   |
 | Imum Coeli            | Sample Natal Subject | square □         | Interpolated Perigee  | 1980 Transit | 0.27° | Applying →   |
 | Imum Coeli            | Sample Natal Subject | quincunx ⚻       | Zeus                  | 1980 Transit | 0.17° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | trine △          | Kronos                | 1980 Transit | 5.34° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | trine △          | Kronos                | 1980 Transit | 5.33° | Separating ← |
 | Imum Coeli            | Sample Natal Subject | trine △          | Poseidon              | 1980 Transit | 5.33° | Separating ← |
 | Mean Lilith           | Sample Natal Subject | semi-square ∠    | Mars                  | 1980 Transit | 0.93° | Applying →   |
 | Mean Lilith           | Sample Natal Subject | conjunction ☌    | Uranus                | 1980 Transit | 1.84° | Applying →   |
@@ -805,7 +805,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Mean Lilith           | Sample Natal Subject | trine △          | Orcus                 | 1980 Transit | 2.99° | Applying →   |
 | Mean Lilith           | Sample Natal Subject | sextile ⚹        | Pars Spiritus         | 1980 Transit | 3.70° | Static =     |
 | Mean Lilith           | Sample Natal Subject | quincunx ⚻       | Mean Priapus          | 1980 Transit | 1.33° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | opposition ☍     | Hades                 | 1980 Transit | 0.00° | Applying →   |
+| Mean Lilith           | Sample Natal Subject | opposition ☍     | Hades                 | 1980 Transit | 0.01° | Applying →   |
 | Mean South Lunar Node | Sample Natal Subject | trine △          | Mercury               | 1980 Transit | 2.70° | Applying →   |
 | Mean South Lunar Node | Sample Natal Subject | sextile ⚹        | Jupiter               | 1980 Transit | 0.63° | Applying →   |
 | Mean South Lunar Node | Sample Natal Subject | sextile ⚹        | Saturn                | 1980 Transit | 0.56° | Separating ← |
@@ -847,9 +847,9 @@ Sample Natal Subject — Transit 1980-12-08
 | True South Lunar Node | Sample Natal Subject | opposition ☍     | Vertex                | 1980 Transit | 1.42° | Static =     |
 | True South Lunar Node | Sample Natal Subject | conjunction ☌    | Anti Vertex           | 1980 Transit | 1.42° | Static =     |
 | True South Lunar Node | Sample Natal Subject | biquintile bQ    | White Moon            | 1980 Transit | 1.29° | Applying →   |
-| True South Lunar Node | Sample Natal Subject | square □         | Cupido                | 1980 Transit | 0.22° | Separating ← |
+| True South Lunar Node | Sample Natal Subject | square □         | Cupido                | 1980 Transit | 0.21° | Separating ← |
 | True South Lunar Node | Sample Natal Subject | sextile ⚹        | Apollon               | 1980 Transit | 2.09° | Separating ← |
-| True South Lunar Node | Sample Natal Subject | square □         | Admetos               | 1980 Transit | 0.83° | Applying →   |
+| True South Lunar Node | Sample Natal Subject | square □         | Admetos               | 1980 Transit | 0.84° | Applying →   |
 | True Lilith           | Sample Natal Subject | conjunction ☌    | Sun                   | 1980 Transit | 0.78° | Applying →   |
 | True Lilith           | Sample Natal Subject | semi-sextile ⚺   | Venus                 | 1980 Transit | 0.66° | Separating ← |
 | True Lilith           | Sample Natal Subject | quintile Q       | Jupiter               | 1980 Transit | 1.15° | Separating ← |
@@ -866,7 +866,7 @@ Sample Natal Subject — Transit 1980-12-08
 | True Lilith           | Sample Natal Subject | sesquiquadrate ⚼ | True Priapus          | 1980 Transit | 1.84° | Applying →   |
 | True Lilith           | Sample Natal Subject | quincunx ⚻       | Interpolated Perigee  | 1980 Transit | 1.63° | Separating ← |
 | True Lilith           | Sample Natal Subject | square □         | Zeus                  | 1980 Transit | 2.07° | Separating ← |
-| True Lilith           | Sample Natal Subject | opposition ☍     | Kronos                | 1980 Transit | 3.44° | Separating ← |
+| True Lilith           | Sample Natal Subject | opposition ☍     | Kronos                | 1980 Transit | 3.43° | Separating ← |
 | Pholus                | Sample Natal Subject | opposition ☍     | Moon                  | 1980 Transit | 2.93° | Applying →   |
 | Pholus                | Sample Natal Subject | opposition ☍     | Mars                  | 1980 Transit | 5.07° | Separating ← |
 | Pholus                | Sample Natal Subject | square □         | Jupiter               | 1980 Transit | 0.83° | Applying →   |
@@ -885,7 +885,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Pholus                | Sample Natal Subject | trine △          | White Moon            | 1980 Transit | 3.98° | Separating ← |
 | Pholus                | Sample Natal Subject | trine △          | Cupido                | 1980 Transit | 0.51° | Applying →   |
 | Pholus                | Sample Natal Subject | quintile Q       | Zeus                  | 1980 Transit | 0.10° | Separating ← |
-| Pholus                | Sample Natal Subject | square □         | Apollon               | 1980 Transit | 1.37° | Separating ← |
+| Pholus                | Sample Natal Subject | square □         | Apollon               | 1980 Transit | 1.36° | Separating ← |
 | Pholus                | Sample Natal Subject | sextile ⚹        | Admetos               | 1980 Transit | 0.11° | Applying →   |
 | Pholus                | Sample Natal Subject | conjunction ☌    | Vulkanus              | 1980 Transit | 2.23° | Applying →   |
 | Ceres                 | Sample Natal Subject | trine △          | Sun                   | 1980 Transit | 3.52° | Separating ← |
@@ -908,9 +908,9 @@ Sample Natal Subject — Transit 1980-12-08
 | Ceres                 | Sample Natal Subject | conjunction ☌    | Pars Amoris           | 1980 Transit | 4.80° | Static =     |
 | Ceres                 | Sample Natal Subject | square □         | Interpolated Perigee  | 1980 Transit | 5.93° | Separating ← |
 | Ceres                 | Sample Natal Subject | quincunx ⚻       | White Moon            | 1980 Transit | 1.74° | Applying →   |
-| Ceres                 | Sample Natal Subject | sextile ⚹        | Kronos                | 1980 Transit | 0.86° | Applying →   |
+| Ceres                 | Sample Natal Subject | sextile ⚹        | Kronos                | 1980 Transit | 0.87° | Applying →   |
 | Ceres                 | Sample Natal Subject | sextile ⚹        | Apollon               | 1980 Transit | 4.36° | Applying →   |
-| Ceres                 | Sample Natal Subject | square □         | Admetos               | 1980 Transit | 5.62° | Separating ← |
+| Ceres                 | Sample Natal Subject | square □         | Admetos               | 1980 Transit | 5.61° | Separating ← |
 | Ceres                 | Sample Natal Subject | quintile Q       | Poseidon              | 1980 Transit | 0.47° | Applying →   |
 | Pallas                | Sample Natal Subject | opposition ☍     | Moon                  | 1980 Transit | 2.19° | Applying →   |
 | Pallas                | Sample Natal Subject | opposition ☍     | Mars                  | 1980 Transit | 5.81° | Separating ← |
@@ -932,7 +932,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Pallas                | Sample Natal Subject | quintile Q       | Zeus                  | 1980 Transit | 0.84° | Separating ← |
 | Pallas                | Sample Natal Subject | square □         | Apollon               | 1980 Transit | 2.11° | Separating ← |
 | Pallas                | Sample Natal Subject | sextile ⚹        | Admetos               | 1980 Transit | 0.85° | Applying →   |
-| Pallas                | Sample Natal Subject | conjunction ☌    | Vulkanus              | 1980 Transit | 2.97° | Applying →   |
+| Pallas                | Sample Natal Subject | conjunction ☌    | Vulkanus              | 1980 Transit | 2.98° | Applying →   |
 | Juno                  | Sample Natal Subject | sextile ⚹        | Mars                  | 1980 Transit | 2.96° | Separating ← |
 | Juno                  | Sample Natal Subject | semi-sextile ⚺   | Saturn                | 1980 Transit | 1.75° | Applying →   |
 | Juno                  | Sample Natal Subject | square □         | Mean North Lunar Node | 1980 Transit | 3.63° | Applying →   |
@@ -953,11 +953,11 @@ Sample Natal Subject — Transit 1980-12-08
 | Juno                  | Sample Natal Subject | square □         | Vertex                | 1980 Transit | 4.25° | Static =     |
 | Juno                  | Sample Natal Subject | square □         | Anti Vertex           | 1980 Transit | 4.25° | Static =     |
 | Juno                  | Sample Natal Subject | trine △          | White Moon            | 1980 Transit | 1.88° | Separating ← |
-| Juno                  | Sample Natal Subject | conjunction ☌    | Cupido                | 1980 Transit | 2.61° | Applying →   |
-| Juno                  | Sample Natal Subject | biquintile bQ    | Kronos                | 1980 Transit | 1.52° | Separating ← |
+| Juno                  | Sample Natal Subject | conjunction ☌    | Cupido                | 1980 Transit | 2.62° | Applying →   |
+| Juno                  | Sample Natal Subject | biquintile bQ    | Kronos                | 1980 Transit | 1.51° | Separating ← |
 | Juno                  | Sample Natal Subject | semi-sextile ⚺   | Apollon               | 1980 Transit | 0.74° | Applying →   |
-| Juno                  | Sample Natal Subject | opposition ☍     | Admetos               | 1980 Transit | 2.00° | Separating ← |
-| Juno                  | Sample Natal Subject | trine △          | Vulkanus              | 1980 Transit | 0.12° | Applying →   |
+| Juno                  | Sample Natal Subject | opposition ☍     | Admetos               | 1980 Transit | 1.99° | Separating ← |
+| Juno                  | Sample Natal Subject | trine △          | Vulkanus              | 1980 Transit | 0.13° | Applying →   |
 | Vesta                 | Sample Natal Subject | quincunx ⚻       | Sun                   | 1980 Transit | 0.91° | Applying →   |
 | Vesta                 | Sample Natal Subject | sesquiquadrate ⚼ | Moon                  | 1980 Transit | 1.91° | Separating ← |
 | Vesta                 | Sample Natal Subject | opposition ☍     | Venus                 | 1980 Transit | 0.53° | Separating ← |
@@ -991,7 +991,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Eris                  | Sample Natal Subject | trine △          | Pars Fortunae         | 1980 Transit | 2.05° | Static =     |
 | Eris                  | Sample Natal Subject | quintile Q       | Vertex                | 1980 Transit | 0.25° | Static =     |
 | Eris                  | Sample Natal Subject | opposition ☍     | Interpolated Lilith   | 1980 Transit | 5.68° | Separating ← |
-| Eris                  | Sample Natal Subject | sextile ⚹        | Kronos                | 1980 Transit | 3.02° | Separating ← |
+| Eris                  | Sample Natal Subject | sextile ⚹        | Kronos                | 1980 Transit | 3.01° | Separating ← |
 | Sedna                 | Sample Natal Subject | biquintile bQ    | Sun                   | 1980 Transit | 0.31° | Applying →   |
 | Sedna                 | Sample Natal Subject | trine △          | Mars                  | 1980 Transit | 1.51° | Separating ← |
 | Sedna                 | Sample Natal Subject | biquintile bQ    | Jupiter               | 1980 Transit | 1.61° | Separating ← |
@@ -1015,7 +1015,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Sedna                 | Sample Natal Subject | sextile ⚹        | White Moon            | 1980 Transit | 0.42° | Separating ← |
 | Sedna                 | Sample Natal Subject | opposition ☍     | Cupido                | 1980 Transit | 4.07° | Applying →   |
 | Sedna                 | Sample Natal Subject | conjunction ☌    | Admetos               | 1980 Transit | 3.45° | Separating ← |
-| Sedna                 | Sample Natal Subject | sextile ⚹        | Vulkanus              | 1980 Transit | 1.33° | Separating ← |
+| Sedna                 | Sample Natal Subject | sextile ⚹        | Vulkanus              | 1980 Transit | 1.32° | Separating ← |
 | Haumea                | Sample Natal Subject | sextile ⚹        | Uranus                | 1980 Transit | 0.83° | Separating ← |
 | Haumea                | Sample Natal Subject | square □         | Neptune               | 1980 Transit | 4.12° | Applying →   |
 | Haumea                | Sample Natal Subject | semi-square ∠    | True North Lunar Node | 1980 Transit | 0.84° | Applying →   |
@@ -1028,7 +1028,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Haumea                | Sample Natal Subject | conjunction ☌    | Pars Spiritus         | 1980 Transit | 1.03° | Static =     |
 | Haumea                | Sample Natal Subject | quincunx ⚻       | Mean Priapus          | 1980 Transit | 1.34° | Separating ← |
 | Haumea                | Sample Natal Subject | biquintile bQ    | True Priapus          | 1980 Transit | 1.15° | Applying →   |
-| Haumea                | Sample Natal Subject | trine △          | Hades                 | 1980 Transit | 2.67° | Applying →   |
+| Haumea                | Sample Natal Subject | trine △          | Hades                 | 1980 Transit | 2.68° | Applying →   |
 | Haumea                | Sample Natal Subject | semi-sextile ⚺   | Poseidon              | 1980 Transit | 1.08° | Applying →   |
 | Makemake              | Sample Natal Subject | trine △          | Moon                  | 1980 Transit | 0.56° | Separating ← |
 | Makemake              | Sample Natal Subject | square □         | Mercury               | 1980 Transit | 0.59° | Separating ← |
@@ -1094,7 +1094,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Orcus                 | Sample Natal Subject | sextile ⚹        | Kronos                | 1980 Transit | 3.74° | Applying →   |
 | Orcus                 | Sample Natal Subject | sextile ⚹        | Apollon               | 1980 Transit | 1.48° | Applying →   |
 | Orcus                 | Sample Natal Subject | square □         | Admetos               | 1980 Transit | 2.74° | Separating ← |
-| Orcus                 | Sample Natal Subject | semi-sextile ⚺   | Vulkanus              | 1980 Transit | 0.62° | Separating ← |
+| Orcus                 | Sample Natal Subject | semi-sextile ⚺   | Vulkanus              | 1980 Transit | 0.61° | Separating ← |
 | Quaoar                | Sample Natal Subject | conjunction ☌    | Venus                 | 1980 Transit | 5.40° | Applying →   |
 | Quaoar                | Sample Natal Subject | semi-square ∠    | Jupiter               | 1980 Transit | 1.91° | Applying →   |
 | Quaoar                | Sample Natal Subject | semi-square ∠    | Saturn                | 1980 Transit | 0.73° | Applying →   |
@@ -1115,7 +1115,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Quaoar                | Sample Natal Subject | opposition ☍     | Hades                 | 1980 Transit | 4.92° | Applying →   |
 | Quaoar                | Sample Natal Subject | sextile ⚹        | Zeus                  | 1980 Transit | 3.99° | Applying →   |
 | Quaoar                | Sample Natal Subject | semi-square ∠    | Apollon               | 1980 Transit | 0.28° | Separating ← |
-| Quaoar                | Sample Natal Subject | sesquiquadrate ⚼ | Vulkanus              | 1980 Transit | 1.14° | Applying →   |
+| Quaoar                | Sample Natal Subject | sesquiquadrate ⚼ | Vulkanus              | 1980 Transit | 1.15° | Applying →   |
 | Quaoar                | Sample Natal Subject | semi-sextile ⚺   | Poseidon              | 1980 Transit | 1.17° | Separating ← |
 | Pars Fortunae         | Sample Natal Subject | semi-sextile ⚺   | Uranus                | 1980 Transit | 1.34° | Applying →   |
 | Pars Fortunae         | Sample Natal Subject | conjunction ☌    | Pluto                 | 1980 Transit | 4.83° | Applying →   |
@@ -1130,10 +1130,10 @@ Sample Natal Subject — Transit 1980-12-08
 | Pars Fortunae         | Sample Natal Subject | conjunction ☌    | Interpolated Lilith   | 1980 Transit | 5.21° | Applying →   |
 | Pars Fortunae         | Sample Natal Subject | opposition ☍     | Mean Priapus          | 1980 Transit | 0.83° | Applying →   |
 | Pars Fortunae         | Sample Natal Subject | opposition ☍     | True Priapus          | 1980 Transit | 2.68° | Separating ← |
-| Pars Fortunae         | Sample Natal Subject | sesquiquadrate ⚼ | White Moon            | 1980 Transit | 1.51° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | sesquiquadrate ⚼ | White Moon            | 1980 Transit | 1.52° | Applying →   |
 | Pars Fortunae         | Sample Natal Subject | quincunx ⚻       | Hades                 | 1980 Transit | 0.51° | Applying →   |
 | Pars Fortunae         | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | 1980 Transit | 1.09° | Applying →   |
-| Pars Fortunae         | Sample Natal Subject | conjunction ☌    | Poseidon              | 1980 Transit | 3.24° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | conjunction ☌    | Poseidon              | 1980 Transit | 3.25° | Applying →   |
 | Pars Spiritus         | Sample Natal Subject | conjunction ☌    | Venus                 | 1980 Transit | 5.52° | Separating ← |
 | Pars Spiritus         | Sample Natal Subject | sextile ⚹        | Mars                  | 1980 Transit | 0.10° | Applying →   |
 | Pars Spiritus         | Sample Natal Subject | square □         | Mean North Lunar Node | 1980 Transit | 0.57° | Applying →   |
@@ -1148,10 +1148,10 @@ Sample Natal Subject — Transit 1980-12-08
 | Pars Spiritus         | Sample Natal Subject | conjunction ☌    | Quaoar                | 1980 Transit | 0.92° | Separating ← |
 | Pars Spiritus         | Sample Natal Subject | square □         | Pars Amoris           | 1980 Transit | 4.25° | Static =     |
 | Pars Spiritus         | Sample Natal Subject | trine △          | White Moon            | 1980 Transit | 1.18° | Applying →   |
-| Pars Spiritus         | Sample Natal Subject | conjunction ☌    | Cupido                | 1980 Transit | 5.67° | Applying →   |
-| Pars Spiritus         | Sample Natal Subject | quincunx ⚻       | Kronos                | 1980 Transit | 1.42° | Applying →   |
-| Pars Spiritus         | Sample Natal Subject | opposition ☍     | Admetos               | 1980 Transit | 5.06° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | trine △          | Vulkanus              | 1980 Transit | 2.94° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | conjunction ☌    | Cupido                | 1980 Transit | 5.68° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | quincunx ⚻       | Kronos                | 1980 Transit | 1.43° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | opposition ☍     | Admetos               | 1980 Transit | 5.05° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | trine △          | Vulkanus              | 1980 Transit | 2.93° | Separating ← |
 | Pars Amoris           | Sample Natal Subject | square □         | Moon                  | 1980 Transit | 3.93° | Applying →   |
 | Pars Amoris           | Sample Natal Subject | sextile ⚹        | Mercury               | 1980 Transit | 3.90° | Applying →   |
 | Pars Amoris           | Sample Natal Subject | square □         | Mars                  | 1980 Transit | 4.07° | Separating ← |
@@ -1175,8 +1175,8 @@ Sample Natal Subject — Transit 1980-12-08
 | Pars Amoris           | Sample Natal Subject | semi-sextile ⚺   | Cupido                | 1980 Transit | 1.51° | Applying →   |
 | Pars Amoris           | Sample Natal Subject | trine △          | Kronos                | 1980 Transit | 5.59° | Applying →   |
 | Pars Amoris           | Sample Natal Subject | conjunction ☌    | Apollon               | 1980 Transit | 0.37° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | quincunx ⚻       | Admetos               | 1980 Transit | 0.89° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | square □         | Vulkanus              | 1980 Transit | 1.23° | Applying →   |
+| Pars Amoris           | Sample Natal Subject | quincunx ⚻       | Admetos               | 1980 Transit | 0.88° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | square □         | Vulkanus              | 1980 Transit | 1.24° | Applying →   |
 | Pars Fidei            | Sample Natal Subject | trine △          | Moon                  | 1980 Transit | 3.16° | Applying →   |
 | Pars Fidei            | Sample Natal Subject | trine △          | Mars                  | 1980 Transit | 4.84° | Separating ← |
 | Pars Fidei            | Sample Natal Subject | quincunx ⚻       | Jupiter               | 1980 Transit | 1.06° | Applying →   |
@@ -1199,7 +1199,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Pars Fidei            | Sample Natal Subject | opposition ☍     | Cupido                | 1980 Transit | 0.74° | Applying →   |
 | Pars Fidei            | Sample Natal Subject | quincunx ⚻       | Apollon               | 1980 Transit | 1.14° | Separating ← |
 | Pars Fidei            | Sample Natal Subject | conjunction ☌    | Admetos               | 1980 Transit | 0.12° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | sextile ⚹        | Vulkanus              | 1980 Transit | 2.00° | Applying →   |
+| Pars Fidei            | Sample Natal Subject | sextile ⚹        | Vulkanus              | 1980 Transit | 2.01° | Applying →   |
 | Vertex                | Sample Natal Subject | opposition ☍     | Sun                   | 1980 Transit | 5.77° | Separating ← |
 | Vertex                | Sample Natal Subject | quincunx ⚻       | Mars                  | 1980 Transit | 1.59° | Separating ← |
 | Vertex                | Sample Natal Subject | trine △          | Jupiter               | 1980 Transit | 4.30° | Applying →   |
@@ -1220,9 +1220,9 @@ Sample Natal Subject — Transit 1980-12-08
 | Vertex                | Sample Natal Subject | trine △          | Vertex                | 1980 Transit | 5.62° | Static =     |
 | Vertex                | Sample Natal Subject | semi-square ∠    | Mean Priapus          | 1980 Transit | 1.19° | Separating ← |
 | Vertex                | Sample Natal Subject | square □         | White Moon            | 1980 Transit | 0.51° | Separating ← |
-| Vertex                | Sample Natal Subject | conjunction ☌    | Kronos                | 1980 Transit | 3.11° | Applying →   |
+| Vertex                | Sample Natal Subject | conjunction ☌    | Kronos                | 1980 Transit | 3.12° | Applying →   |
 | Vertex                | Sample Natal Subject | trine △          | Apollon               | 1980 Transit | 2.11° | Applying →   |
-| Vertex                | Sample Natal Subject | semi-sextile ⚺   | Vulkanus              | 1980 Transit | 1.25° | Separating ← |
+| Vertex                | Sample Natal Subject | semi-sextile ⚺   | Vulkanus              | 1980 Transit | 1.24° | Separating ← |
 | Vertex                | Sample Natal Subject | sesquiquadrate ⚼ | Poseidon              | 1980 Transit | 1.22° | Applying →   |
 | Anti Vertex           | Sample Natal Subject | conjunction ☌    | Sun                   | 1980 Transit | 5.77° | Separating ← |
 | Anti Vertex           | Sample Natal Subject | semi-sextile ⚺   | Mars                  | 1980 Transit | 1.59° | Separating ← |
@@ -1245,9 +1245,9 @@ Sample Natal Subject — Transit 1980-12-08
 | Anti Vertex           | Sample Natal Subject | trine △          | Anti Vertex           | 1980 Transit | 5.62° | Static =     |
 | Anti Vertex           | Sample Natal Subject | sesquiquadrate ⚼ | Mean Priapus          | 1980 Transit | 1.19° | Separating ← |
 | Anti Vertex           | Sample Natal Subject | square □         | White Moon            | 1980 Transit | 0.51° | Separating ← |
-| Anti Vertex           | Sample Natal Subject | opposition ☍     | Kronos                | 1980 Transit | 3.11° | Applying →   |
+| Anti Vertex           | Sample Natal Subject | opposition ☍     | Kronos                | 1980 Transit | 3.12° | Applying →   |
 | Anti Vertex           | Sample Natal Subject | sextile ⚹        | Apollon               | 1980 Transit | 2.11° | Applying →   |
-| Anti Vertex           | Sample Natal Subject | quincunx ⚻       | Vulkanus              | 1980 Transit | 1.25° | Separating ← |
+| Anti Vertex           | Sample Natal Subject | quincunx ⚻       | Vulkanus              | 1980 Transit | 1.24° | Separating ← |
 | Anti Vertex           | Sample Natal Subject | semi-square ∠    | Poseidon              | 1980 Transit | 1.22° | Applying →   |
 | Interpolated Lilith   | Sample Natal Subject | conjunction ☌    | Uranus                | 1980 Transit | 1.68° | Separating ← |
 | Interpolated Lilith   | Sample Natal Subject | semi-sextile ⚺   | Pluto                 | 1980 Transit | 1.81° | Applying →   |
@@ -1261,7 +1261,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Interpolated Lilith   | Sample Natal Subject | opposition ☍     | Interpolated Perigee  | 1980 Transit | 5.83° | Applying →   |
 | Interpolated Lilith   | Sample Natal Subject | opposition ☍     | Hades                 | 1980 Transit | 3.52° | Applying →   |
 | Interpolated Lilith   | Sample Natal Subject | semi-square ∠    | Apollon               | 1980 Transit | 1.12° | Applying →   |
-| Interpolated Lilith   | Sample Natal Subject | sesquiquadrate ⚼ | Vulkanus              | 1980 Transit | 0.26° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | sesquiquadrate ⚼ | Vulkanus              | 1980 Transit | 0.25° | Separating ← |
 | Interpolated Lilith   | Sample Natal Subject | semi-sextile ⚺   | Poseidon              | 1980 Transit | 0.23° | Applying →   |
 | Mean Priapus          | Sample Natal Subject | biquintile bQ    | Moon                  | 1980 Transit | 0.07° | Separating ← |
 | Mean Priapus          | Sample Natal Subject | sesquiquadrate ⚼ | Mars                  | 1980 Transit | 0.93° | Applying →   |
@@ -1280,7 +1280,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Mean Priapus          | Sample Natal Subject | trine △          | Pars Spiritus         | 1980 Transit | 3.70° | Static =     |
 | Mean Priapus          | Sample Natal Subject | biquintile bQ    | Interpolated Lilith   | 1980 Transit | 0.29° | Separating ← |
 | Mean Priapus          | Sample Natal Subject | semi-sextile ⚺   | Mean Priapus          | 1980 Transit | 1.33° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | conjunction ☌    | Hades                 | 1980 Transit | 0.00° | Applying →   |
+| Mean Priapus          | Sample Natal Subject | conjunction ☌    | Hades                 | 1980 Transit | 0.01° | Applying →   |
 | True Priapus          | Sample Natal Subject | opposition ☍     | Sun                   | 1980 Transit | 0.78° | Applying →   |
 | True Priapus          | Sample Natal Subject | quincunx ⚻       | Venus                 | 1980 Transit | 0.66° | Separating ← |
 | True Priapus          | Sample Natal Subject | opposition ☍     | Neptune               | 1980 Transit | 4.18° | Separating ← |
@@ -1298,7 +1298,7 @@ Sample Natal Subject — Transit 1980-12-08
 | True Priapus          | Sample Natal Subject | semi-square ∠    | True Priapus          | 1980 Transit | 1.84° | Applying →   |
 | True Priapus          | Sample Natal Subject | semi-sextile ⚺   | Interpolated Perigee  | 1980 Transit | 1.63° | Separating ← |
 | True Priapus          | Sample Natal Subject | square □         | Zeus                  | 1980 Transit | 2.07° | Separating ← |
-| True Priapus          | Sample Natal Subject | conjunction ☌    | Kronos                | 1980 Transit | 3.44° | Separating ← |
+| True Priapus          | Sample Natal Subject | conjunction ☌    | Kronos                | 1980 Transit | 3.43° | Separating ← |
 | Interpolated Perigee  | Sample Natal Subject | opposition ☍     | Sun                   | 1980 Transit | 3.75° | Applying →   |
 | Interpolated Perigee  | Sample Natal Subject | opposition ☍     | Neptune               | 1980 Transit | 1.21° | Separating ← |
 | Interpolated Perigee  | Sample Natal Subject | trine △          | Pluto                 | 1980 Transit | 2.68° | Separating ← |
@@ -1314,49 +1314,49 @@ Sample Natal Subject — Transit 1980-12-08
 | Interpolated Perigee  | Sample Natal Subject | semi-square ∠    | Anti Vertex           | 1980 Transit | 0.13° | Static =     |
 | Interpolated Perigee  | Sample Natal Subject | trine △          | Interpolated Lilith   | 1980 Transit | 2.30° | Separating ← |
 | Interpolated Perigee  | Sample Natal Subject | semi-sextile ⚺   | Interpolated Perigee  | 1980 Transit | 1.34° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | sesquiquadrate ⚼ | Cupido                | 1980 Transit | 1.50° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | sesquiquadrate ⚼ | Cupido                | 1980 Transit | 1.49° | Separating ← |
 | Interpolated Perigee  | Sample Natal Subject | square □         | Zeus                  | 1980 Transit | 0.90° | Applying →   |
 | Interpolated Perigee  | Sample Natal Subject | trine △          | Poseidon              | 1980 Transit | 4.26° | Separating ← |
 | White Moon            | Sample Natal Subject | quintile Q       | Jupiter               | 1980 Transit | 1.27° | Applying →   |
-| White Moon            | Sample Natal Subject | quintile Q       | Saturn                | 1980 Transit | 0.09° | Applying →   |
-| White Moon            | Sample Natal Subject | trine △          | Uranus                | 1980 Transit | 0.71° | Separating ← |
-| White Moon            | Sample Natal Subject | biquintile bQ    | Neptune               | 1980 Transit | 1.76° | Separating ← |
+| White Moon            | Sample Natal Subject | quintile Q       | Saturn                | 1980 Transit | 0.08° | Applying →   |
+| White Moon            | Sample Natal Subject | trine △          | Uranus                | 1980 Transit | 0.72° | Separating ← |
+| White Moon            | Sample Natal Subject | biquintile bQ    | Neptune               | 1980 Transit | 1.77° | Separating ← |
 | White Moon            | Sample Natal Subject | square □         | Pluto                 | 1980 Transit | 2.77° | Applying →   |
 | White Moon            | Sample Natal Subject | quintile Q       | Chiron                | 1980 Transit | 0.07° | Separating ← |
-| White Moon            | Sample Natal Subject | square □         | Mean Lilith           | 1980 Transit | 1.22° | Separating ← |
-| White Moon            | Sample Natal Subject | square □         | True Lilith           | 1980 Transit | 4.73° | Separating ← |
-| White Moon            | Sample Natal Subject | trine △          | Pholus                | 1980 Transit | 0.94° | Separating ← |
+| White Moon            | Sample Natal Subject | square □         | Mean Lilith           | 1980 Transit | 1.23° | Separating ← |
+| White Moon            | Sample Natal Subject | square □         | True Lilith           | 1980 Transit | 4.74° | Separating ← |
+| White Moon            | Sample Natal Subject | trine △          | Pholus                | 1980 Transit | 0.95° | Separating ← |
 | White Moon            | Sample Natal Subject | conjunction ☌    | Ceres                 | 1980 Transit | 0.24° | Applying →   |
 | White Moon            | Sample Natal Subject | square □         | Juno                  | 1980 Transit | 2.11° | Applying →   |
-| White Moon            | Sample Natal Subject | semi-sextile ⚺   | Makemake              | 1980 Transit | 0.30° | Separating ← |
-| White Moon            | Sample Natal Subject | conjunction ☌    | Orcus                 | 1980 Transit | 5.54° | Applying →   |
+| White Moon            | Sample Natal Subject | semi-sextile ⚺   | Makemake              | 1980 Transit | 0.29° | Separating ← |
+| White Moon            | Sample Natal Subject | conjunction ☌    | Orcus                 | 1980 Transit | 5.55° | Applying →   |
 | White Moon            | Sample Natal Subject | sextile ⚹        | Pars Spiritus         | 1980 Transit | 1.14° | Static =     |
-| White Moon            | Sample Natal Subject | square □         | Interpolated Lilith   | 1980 Transit | 3.16° | Applying →   |
-| White Moon            | Sample Natal Subject | square □         | Mean Priapus          | 1980 Transit | 1.22° | Separating ← |
-| White Moon            | Sample Natal Subject | square □         | True Priapus          | 1980 Transit | 4.73° | Separating ← |
+| White Moon            | Sample Natal Subject | square □         | Interpolated Lilith   | 1980 Transit | 3.15° | Applying →   |
+| White Moon            | Sample Natal Subject | square □         | Mean Priapus          | 1980 Transit | 1.23° | Separating ← |
+| White Moon            | Sample Natal Subject | square □         | True Priapus          | 1980 Transit | 4.74° | Separating ← |
 | White Moon            | Sample Natal Subject | sesquiquadrate ⚼ | White Moon            | 1980 Transit | 0.54° | Separating ← |
-| White Moon            | Sample Natal Subject | sextile ⚹        | Hades                 | 1980 Transit | 2.56° | Applying →   |
+| White Moon            | Sample Natal Subject | sextile ⚹        | Hades                 | 1980 Transit | 2.57° | Applying →   |
 | White Moon            | Sample Natal Subject | quintile Q       | Apollon               | 1980 Transit | 0.92° | Separating ← |
 | White Moon            | Sample Natal Subject | square □         | Poseidon              | 1980 Transit | 1.19° | Applying →   |
 | Cupido                | Sample Natal Subject | semi-sextile ⚺   | Sun                   | 1980 Transit | 1.38° | Applying →   |
 | Cupido                | Sample Natal Subject | semi-square ∠    | Moon                  | 1980 Transit | 1.44° | Separating ← |
 | Cupido                | Sample Natal Subject | conjunction ☌    | Venus                 | 1980 Transit | 0.06° | Separating ← |
 | Cupido                | Sample Natal Subject | square □         | Mean North Lunar Node | 1980 Transit | 4.89° | Separating ← |
-| Cupido                | Sample Natal Subject | opposition ☍     | Chiron                | 1980 Transit | 4.25° | Separating ← |
-| Cupido                | Sample Natal Subject | quintile Q       | Ascendant             | 1980 Transit | 0.86° | Separating ← |
+| Cupido                | Sample Natal Subject | opposition ☍     | Chiron                | 1980 Transit | 4.26° | Separating ← |
+| Cupido                | Sample Natal Subject | quintile Q       | Ascendant             | 1980 Transit | 0.85° | Separating ← |
 | Cupido                | Sample Natal Subject | square □         | Mean South Lunar Node | 1980 Transit | 4.89° | Separating ← |
 | Cupido                | Sample Natal Subject | quintile Q       | Vesta                 | 1980 Transit | 0.68° | Separating ← |
 | Cupido                | Sample Natal Subject | biquintile bQ    | Eris                  | 1980 Transit | 1.53° | Applying →   |
 | Cupido                | Sample Natal Subject | sextile ⚹        | Haumea                | 1980 Transit | 1.07° | Separating ← |
-| Cupido                | Sample Natal Subject | conjunction ☌    | Ixion                 | 1980 Transit | 3.75° | Applying →   |
+| Cupido                | Sample Natal Subject | conjunction ☌    | Ixion                 | 1980 Transit | 3.76° | Applying →   |
 | Cupido                | Sample Natal Subject | conjunction ☌    | Quaoar                | 1980 Transit | 4.54° | Applying →   |
 | Cupido                | Sample Natal Subject | square □         | Pars Fortunae         | 1980 Transit | 1.03° | Static =     |
 | Cupido                | Sample Natal Subject | quintile Q       | Pars Fidei            | 1980 Transit | 0.33° | Static =     |
 | Cupido                | Sample Natal Subject | opposition ☍     | Interpolated Perigee  | 1980 Transit | 1.03° | Separating ← |
 | Cupido                | Sample Natal Subject | sextile ⚹        | Zeus                  | 1980 Transit | 1.47° | Separating ← |
-| Hades                 | Sample Natal Subject | opposition ☍     | Mercury               | 1980 Transit | 4.84° | Applying →   |
+| Hades                 | Sample Natal Subject | opposition ☍     | Mercury               | 1980 Transit | 4.83° | Applying →   |
 | Hades                 | Sample Natal Subject | trine △          | Jupiter               | 1980 Transit | 2.76° | Applying →   |
-| Hades                 | Sample Natal Subject | trine △          | Saturn                | 1980 Transit | 1.58° | Applying →   |
+| Hades                 | Sample Natal Subject | trine △          | Saturn                | 1980 Transit | 1.57° | Applying →   |
 | Hades                 | Sample Natal Subject | sesquiquadrate ⚼ | Pluto                 | 1980 Transit | 1.26° | Applying →   |
 | Hades                 | Sample Natal Subject | sextile ⚹        | Mean North Lunar Node | 1980 Transit | 3.80° | Applying →   |
 | Hades                 | Sample Natal Subject | sextile ⚹        | True North Lunar Node | 1980 Transit | 2.24° | Applying →   |
@@ -1364,80 +1364,80 @@ Sample Natal Subject — Transit 1980-12-08
 | Hades                 | Sample Natal Subject | square □         | Descendant            | 1980 Transit | 2.45° | Applying →   |
 | Hades                 | Sample Natal Subject | trine △          | Mean South Lunar Node | 1980 Transit | 3.80° | Applying →   |
 | Hades                 | Sample Natal Subject | trine △          | True South Lunar Node | 1980 Transit | 2.24° | Applying →   |
-| Hades                 | Sample Natal Subject | quintile Q       | Pholus                | 1980 Transit | 0.55° | Applying →   |
+| Hades                 | Sample Natal Subject | quintile Q       | Pholus                | 1980 Transit | 0.54° | Applying →   |
 | Hades                 | Sample Natal Subject | semi-square ∠    | Ceres                 | 1980 Transit | 1.75° | Applying →   |
 | Hades                 | Sample Natal Subject | sesquiquadrate ⚼ | Juno                  | 1980 Transit | 0.60° | Applying →   |
-| Hades                 | Sample Natal Subject | square □         | Vesta                 | 1980 Transit | 2.63° | Applying →   |
+| Hades                 | Sample Natal Subject | square □         | Vesta                 | 1980 Transit | 2.62° | Applying →   |
 | Hades                 | Sample Natal Subject | sextile ⚹        | Eris                  | 1980 Transit | 4.22° | Applying →   |
-| Hades                 | Sample Natal Subject | sextile ⚹        | Pars Amoris           | 1980 Transit | 1.02° | Static =     |
-| Hades                 | Sample Natal Subject | square □         | Pars Fidei            | 1980 Transit | 3.64° | Static =     |
-| Hades                 | Sample Natal Subject | trine △          | Vertex                | 1980 Transit | 4.08° | Static =     |
-| Hades                 | Sample Natal Subject | sextile ⚹        | Anti Vertex           | 1980 Transit | 4.08° | Static =     |
-| Hades                 | Sample Natal Subject | sesquiquadrate ⚼ | Interpolated Lilith   | 1980 Transit | 1.65° | Applying →   |
+| Hades                 | Sample Natal Subject | sextile ⚹        | Pars Amoris           | 1980 Transit | 1.01° | Static =     |
+| Hades                 | Sample Natal Subject | square □         | Pars Fidei            | 1980 Transit | 3.63° | Static =     |
+| Hades                 | Sample Natal Subject | trine △          | Vertex                | 1980 Transit | 4.07° | Static =     |
+| Hades                 | Sample Natal Subject | sextile ⚹        | Anti Vertex           | 1980 Transit | 4.07° | Static =     |
+| Hades                 | Sample Natal Subject | sesquiquadrate ⚼ | Interpolated Lilith   | 1980 Transit | 1.64° | Applying →   |
 | Hades                 | Sample Natal Subject | square □         | White Moon            | 1980 Transit | 2.05° | Separating ← |
-| Hades                 | Sample Natal Subject | conjunction ☌    | Kronos                | 1980 Transit | 4.65° | Applying →   |
+| Hades                 | Sample Natal Subject | conjunction ☌    | Kronos                | 1980 Transit | 4.66° | Applying →   |
 | Hades                 | Sample Natal Subject | trine △          | Apollon               | 1980 Transit | 0.57° | Applying →   |
-| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Admetos               | 1980 Transit | 1.83° | Separating ← |
-| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Vulkanus              | 1980 Transit | 0.29° | Applying →   |
+| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Admetos               | 1980 Transit | 1.82° | Separating ← |
+| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Vulkanus              | 1980 Transit | 0.30° | Applying →   |
 | Hades                 | Sample Natal Subject | sesquiquadrate ⚼ | Poseidon              | 1980 Transit | 0.32° | Separating ← |
 | Zeus                  | Sample Natal Subject | sextile ⚹        | Uranus                | 1980 Transit | 1.12° | Separating ← |
-| Zeus                  | Sample Natal Subject | square □         | Neptune               | 1980 Transit | 3.84° | Applying →   |
+| Zeus                  | Sample Natal Subject | square □         | Neptune               | 1980 Transit | 3.83° | Applying →   |
 | Zeus                  | Sample Natal Subject | semi-square ∠    | True North Lunar Node | 1980 Transit | 1.13° | Applying →   |
 | Zeus                  | Sample Natal Subject | semi-sextile ⚺   | Mean Lilith           | 1980 Transit | 1.63° | Separating ← |
 | Zeus                  | Sample Natal Subject | sesquiquadrate ⚼ | True South Lunar Node | 1980 Transit | 1.13° | Applying →   |
 | Zeus                  | Sample Natal Subject | opposition ☍     | Pholus                | 1980 Transit | 1.35° | Separating ← |
-| Zeus                  | Sample Natal Subject | sextile ⚹        | Ceres                 | 1980 Transit | 0.64° | Applying →   |
+| Zeus                  | Sample Natal Subject | sextile ⚹        | Ceres                 | 1980 Transit | 0.65° | Applying →   |
 | Zeus                  | Sample Natal Subject | semi-sextile ⚺   | Juno                  | 1980 Transit | 1.71° | Applying →   |
-| Zeus                  | Sample Natal Subject | semi-sextile ⚺   | Makemake              | 1980 Transit | 0.10° | Applying →   |
+| Zeus                  | Sample Natal Subject | semi-sextile ⚺   | Makemake              | 1980 Transit | 0.11° | Applying →   |
 | Zeus                  | Sample Natal Subject | conjunction ☌    | Pars Spiritus         | 1980 Transit | 0.74° | Static =     |
 | Zeus                  | Sample Natal Subject | quincunx ⚻       | Mean Priapus          | 1980 Transit | 1.63° | Separating ← |
 | Zeus                  | Sample Natal Subject | biquintile bQ    | True Priapus          | 1980 Transit | 0.86° | Applying →   |
-| Zeus                  | Sample Natal Subject | trine △          | Hades                 | 1980 Transit | 2.96° | Applying →   |
-| Zeus                  | Sample Natal Subject | conjunction ☌    | Zeus                  | 1980 Transit | 5.95° | Applying →   |
+| Zeus                  | Sample Natal Subject | trine △          | Hades                 | 1980 Transit | 2.97° | Applying →   |
+| Zeus                  | Sample Natal Subject | conjunction ☌    | Zeus                  | 1980 Transit | 5.94° | Applying →   |
 | Zeus                  | Sample Natal Subject | semi-sextile ⚺   | Poseidon              | 1980 Transit | 0.79° | Applying →   |
 | Kronos                | Sample Natal Subject | opposition ☍     | Sun                   | 1980 Transit | 4.66° | Applying →   |
 | Kronos                | Sample Natal Subject | opposition ☍     | Neptune               | 1980 Transit | 0.30° | Separating ← |
-| Kronos                | Sample Natal Subject | trine △          | Pluto                 | 1980 Transit | 1.76° | Separating ← |
+| Kronos                | Sample Natal Subject | trine △          | Pluto                 | 1980 Transit | 1.77° | Separating ← |
 | Kronos                | Sample Natal Subject | trine △          | Mean Lilith           | 1980 Transit | 5.76° | Separating ← |
-| Kronos                | Sample Natal Subject | square □         | Pholus                | 1980 Transit | 5.48° | Separating ← |
-| Kronos                | Sample Natal Subject | trine △          | Juno                  | 1980 Transit | 2.42° | Separating ← |
+| Kronos                | Sample Natal Subject | square □         | Pholus                | 1980 Transit | 5.49° | Separating ← |
+| Kronos                | Sample Natal Subject | trine △          | Juno                  | 1980 Transit | 2.43° | Separating ← |
 | Kronos                | Sample Natal Subject | semi-square ∠    | Sedna                 | 1980 Transit | 1.03° | Separating ← |
-| Kronos                | Sample Natal Subject | square □         | Haumea                | 1980 Transit | 2.21° | Applying →   |
+| Kronos                | Sample Natal Subject | square □         | Haumea                | 1980 Transit | 2.20° | Applying →   |
 | Kronos                | Sample Natal Subject | sextile ⚹        | Makemake              | 1980 Transit | 4.24° | Applying →   |
-| Kronos                | Sample Natal Subject | biquintile bQ    | Ixion                 | 1980 Transit | 1.04° | Applying →   |
+| Kronos                | Sample Natal Subject | biquintile bQ    | Ixion                 | 1980 Transit | 1.03° | Applying →   |
 | Kronos                | Sample Natal Subject | biquintile bQ    | Quaoar                | 1980 Transit | 1.82° | Applying →   |
-| Kronos                | Sample Natal Subject | sextile ⚹        | Pars Fortunae         | 1980 Transit | 2.25° | Static =     |
-| Kronos                | Sample Natal Subject | square □         | Pars Spiritus         | 1980 Transit | 3.39° | Static =     |
-| Kronos                | Sample Natal Subject | sesquiquadrate ⚼ | Vertex                | 1980 Transit | 1.05° | Static =     |
-| Kronos                | Sample Natal Subject | semi-square ∠    | Anti Vertex           | 1980 Transit | 1.05° | Static =     |
-| Kronos                | Sample Natal Subject | trine △          | Interpolated Lilith   | 1980 Transit | 1.38° | Separating ← |
+| Kronos                | Sample Natal Subject | sextile ⚹        | Pars Fortunae         | 1980 Transit | 2.24° | Static =     |
+| Kronos                | Sample Natal Subject | square □         | Pars Spiritus         | 1980 Transit | 3.40° | Static =     |
+| Kronos                | Sample Natal Subject | sesquiquadrate ⚼ | Vertex                | 1980 Transit | 1.04° | Static =     |
+| Kronos                | Sample Natal Subject | semi-square ∠    | Anti Vertex           | 1980 Transit | 1.04° | Static =     |
+| Kronos                | Sample Natal Subject | trine △          | Interpolated Lilith   | 1980 Transit | 1.39° | Separating ← |
 | Kronos                | Sample Natal Subject | sesquiquadrate ⚼ | Cupido                | 1980 Transit | 0.58° | Separating ← |
 | Kronos                | Sample Natal Subject | square □         | Zeus                  | 1980 Transit | 1.81° | Applying →   |
-| Kronos                | Sample Natal Subject | semi-square ∠    | Admetos               | 1980 Transit | 1.20° | Applying →   |
+| Kronos                | Sample Natal Subject | semi-square ∠    | Admetos               | 1980 Transit | 1.21° | Applying →   |
 | Kronos                | Sample Natal Subject | trine △          | Poseidon              | 1980 Transit | 3.35° | Separating ← |
 | Apollon               | Sample Natal Subject | sextile ⚹        | Sun                   | 1980 Transit | 3.41° | Separating ← |
 | Apollon               | Sample Natal Subject | square □         | Mars                  | 1980 Transit | 0.77° | Applying →   |
 | Apollon               | Sample Natal Subject | conjunction ☌    | Saturn                | 1980 Transit | 5.48° | Applying →   |
 | Apollon               | Sample Natal Subject | semi-square ∠    | Uranus                | 1980 Transit | 1.67° | Applying →   |
 | Apollon               | Sample Natal Subject | sextile ⚹        | Mean North Lunar Node | 1980 Transit | 0.10° | Separating ← |
-| Apollon               | Sample Natal Subject | sextile ⚹        | True North Lunar Node | 1980 Transit | 1.67° | Separating ← |
+| Apollon               | Sample Natal Subject | sextile ⚹        | True North Lunar Node | 1980 Transit | 1.66° | Separating ← |
 | Apollon               | Sample Natal Subject | quincunx ⚻       | Chiron                | 1980 Transit | 0.54° | Applying →   |
 | Apollon               | Sample Natal Subject | biquintile bQ    | Descendant            | 1980 Transit | 0.35° | Applying →   |
 | Apollon               | Sample Natal Subject | trine △          | Mean South Lunar Node | 1980 Transit | 0.10° | Separating ← |
-| Apollon               | Sample Natal Subject | trine △          | True South Lunar Node | 1980 Transit | 1.67° | Separating ← |
+| Apollon               | Sample Natal Subject | trine △          | True South Lunar Node | 1980 Transit | 1.66° | Separating ← |
 | Apollon               | Sample Natal Subject | opposition ☍     | Pallas                | 1980 Transit | 2.42° | Applying →   |
 | Apollon               | Sample Natal Subject | opposition ☍     | Eris                  | 1980 Transit | 0.32° | Applying →   |
 | Apollon               | Sample Natal Subject | semi-sextile ⚺   | Ixion                 | 1980 Transit | 1.04° | Separating ← |
 | Apollon               | Sample Natal Subject | quintile Q       | Orcus                 | 1980 Transit | 0.15° | Applying →   |
 | Apollon               | Sample Natal Subject | semi-sextile ⚺   | Quaoar                | 1980 Transit | 0.25° | Separating ← |
-| Apollon               | Sample Natal Subject | sextile ⚹        | Pars Amoris           | 1980 Transit | 4.92° | Static =     |
+| Apollon               | Sample Natal Subject | sextile ⚹        | Pars Amoris           | 1980 Transit | 4.91° | Static =     |
 | Apollon               | Sample Natal Subject | biquintile bQ    | Interpolated Perigee  | 1980 Transit | 0.18° | Applying →   |
 | Apollon               | Sample Natal Subject | quincunx ⚻       | White Moon            | 1980 Transit | 1.85° | Applying →   |
-| Apollon               | Sample Natal Subject | sesquiquadrate ⚼ | Hades                 | 1980 Transit | 0.17° | Applying →   |
-| Apollon               | Sample Natal Subject | trine △          | Kronos                | 1980 Transit | 0.75° | Applying →   |
+| Apollon               | Sample Natal Subject | sesquiquadrate ⚼ | Hades                 | 1980 Transit | 0.18° | Applying →   |
+| Apollon               | Sample Natal Subject | trine △          | Kronos                | 1980 Transit | 0.76° | Applying →   |
 | Apollon               | Sample Natal Subject | conjunction ☌    | Apollon               | 1980 Transit | 4.47° | Applying →   |
-| Apollon               | Sample Natal Subject | square □         | Vulkanus              | 1980 Transit | 3.61° | Separating ← |
-| Admetos               | Sample Natal Subject | opposition ☍     | Venus                 | 1980 Transit | 3.71° | Separating ← |
+| Apollon               | Sample Natal Subject | square □         | Vulkanus              | 1980 Transit | 3.60° | Separating ← |
+| Admetos               | Sample Natal Subject | opposition ☍     | Venus                 | 1980 Transit | 3.72° | Separating ← |
 | Admetos               | Sample Natal Subject | trine △          | Mars                  | 1980 Transit | 1.90° | Applying →   |
 | Admetos               | Sample Natal Subject | biquintile bQ    | Jupiter               | 1980 Transit | 1.80° | Applying →   |
 | Admetos               | Sample Natal Subject | biquintile bQ    | Saturn                | 1980 Transit | 0.61° | Applying →   |
@@ -1459,25 +1459,25 @@ Sample Natal Subject — Transit 1980-12-08
 | Admetos               | Sample Natal Subject | trine △          | Zeus                  | 1980 Transit | 5.13° | Separating ← |
 | Admetos               | Sample Natal Subject | semi-sextile ⚺   | Kronos                | 1980 Transit | 0.38° | Separating ← |
 | Admetos               | Sample Natal Subject | biquintile bQ    | Apollon               | 1980 Transit | 0.40° | Separating ← |
-| Admetos               | Sample Natal Subject | sextile ⚹        | Vulkanus              | 1980 Transit | 4.74° | Separating ← |
-| Vulkanus              | Sample Natal Subject | quincunx ⚻       | Sun                   | 1980 Transit | 1.89° | Separating ← |
-| Vulkanus              | Sample Natal Subject | trine △          | Venus                 | 1980 Transit | 3.33° | Separating ← |
-| Vulkanus              | Sample Natal Subject | opposition ☍     | Mars                  | 1980 Transit | 2.29° | Applying →   |
+| Admetos               | Sample Natal Subject | sextile ⚹        | Vulkanus              | 1980 Transit | 4.73° | Separating ← |
+| Vulkanus              | Sample Natal Subject | quincunx ⚻       | Sun                   | 1980 Transit | 1.90° | Separating ← |
+| Vulkanus              | Sample Natal Subject | trine △          | Venus                 | 1980 Transit | 3.34° | Separating ← |
+| Vulkanus              | Sample Natal Subject | opposition ☍     | Mars                  | 1980 Transit | 2.28° | Applying →   |
 | Vulkanus              | Sample Natal Subject | semi-sextile ⚺   | Mean North Lunar Node | 1980 Transit | 1.62° | Separating ← |
 | Vulkanus              | Sample Natal Subject | sextile ⚹        | Chiron                | 1980 Transit | 0.98° | Separating ← |
 | Vulkanus              | Sample Natal Subject | quincunx ⚻       | Mean South Lunar Node | 1980 Transit | 1.62° | Separating ← |
-| Vulkanus              | Sample Natal Subject | square □         | Pallas                | 1980 Transit | 0.90° | Applying →   |
-| Vulkanus              | Sample Natal Subject | square □         | Eris                  | 1980 Transit | 1.20° | Separating ← |
-| Vulkanus              | Sample Natal Subject | sextile ⚹        | Haumea                | 1980 Transit | 4.34° | Separating ← |
+| Vulkanus              | Sample Natal Subject | square □         | Pallas                | 1980 Transit | 0.91° | Applying →   |
+| Vulkanus              | Sample Natal Subject | square □         | Eris                  | 1980 Transit | 1.19° | Separating ← |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | Haumea                | 1980 Transit | 4.35° | Separating ← |
 | Vulkanus              | Sample Natal Subject | trine △          | Ixion                 | 1980 Transit | 0.48° | Applying →   |
-| Vulkanus              | Sample Natal Subject | trine △          | Quaoar                | 1980 Transit | 1.27° | Applying →   |
-| Vulkanus              | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | 1980 Transit | 4.30° | Separating ← |
+| Vulkanus              | Sample Natal Subject | trine △          | Quaoar                | 1980 Transit | 1.26° | Applying →   |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | 1980 Transit | 4.31° | Separating ← |
 | Vulkanus              | Sample Natal Subject | trine △          | White Moon            | 1980 Transit | 3.37° | Applying →   |
-| Vulkanus              | Sample Natal Subject | semi-square ∠    | Hades                 | 1980 Transit | 1.35° | Separating ← |
-| Vulkanus              | Sample Natal Subject | sextile ⚹        | Zeus                  | 1980 Transit | 4.74° | Separating ← |
-| Vulkanus              | Sample Natal Subject | semi-sextile ⚺   | Kronos                | 1980 Transit | 0.77° | Separating ← |
-| Vulkanus              | Sample Natal Subject | square □         | Apollon               | 1980 Transit | 5.99° | Applying →   |
-| Vulkanus              | Sample Natal Subject | conjunction ☌    | Vulkanus              | 1980 Transit | 5.13° | Separating ← |
+| Vulkanus              | Sample Natal Subject | semi-square ∠    | Hades                 | 1980 Transit | 1.34° | Separating ← |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | Zeus                  | 1980 Transit | 4.75° | Separating ← |
+| Vulkanus              | Sample Natal Subject | semi-sextile ⚺   | Kronos                | 1980 Transit | 0.76° | Separating ← |
+| Vulkanus              | Sample Natal Subject | square □         | Apollon               | 1980 Transit | 5.98° | Applying →   |
+| Vulkanus              | Sample Natal Subject | conjunction ☌    | Vulkanus              | 1980 Transit | 5.11° | Separating ← |
 | Poseidon              | Sample Natal Subject | semi-sextile ⚺   | Uranus                | 1980 Transit | 1.53° | Applying →   |
 | Poseidon              | Sample Natal Subject | conjunction ☌    | Pluto                 | 1980 Transit | 5.02° | Applying →   |
 | Poseidon              | Sample Natal Subject | biquintile bQ    | Medium Coeli          | 1980 Transit | 1.13° | Applying →   |
@@ -1492,7 +1492,7 @@ Sample Natal Subject — Transit 1980-12-08
 | Poseidon              | Sample Natal Subject | opposition ☍     | Mean Priapus          | 1980 Transit | 1.02° | Applying →   |
 | Poseidon              | Sample Natal Subject | opposition ☍     | True Priapus          | 1980 Transit | 2.49° | Separating ← |
 | Poseidon              | Sample Natal Subject | sesquiquadrate ⚼ | White Moon            | 1980 Transit | 1.71° | Applying →   |
-| Poseidon              | Sample Natal Subject | quincunx ⚻       | Hades                 | 1980 Transit | 0.31° | Applying →   |
-| Poseidon              | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | 1980 Transit | 0.89° | Applying →   |
+| Poseidon              | Sample Natal Subject | quincunx ⚻       | Hades                 | 1980 Transit | 0.32° | Applying →   |
+| Poseidon              | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | 1980 Transit | 0.90° | Applying →   |
 | Poseidon              | Sample Natal Subject | conjunction ☌    | Poseidon              | 1980 Transit | 3.44° | Applying →   |
 +-----------------------+----------------------+------------------+-----------------------+--------------+-------+--------------+

--- a/tests/fixtures/transit_johnny_depp_report.txt
+++ b/tests/fixtures/transit_johnny_depp_report.txt
@@ -57,8 +57,8 @@ Johnny Depp — Transit 1940-10-09
 +Natal Subject Celestial Points--+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Aqu ♒ | 20.70°   | +507.7850°/d | N/A     | -    | First House    |
-| Medium Coeli          | Sag ♐ | 6.59°    | +341.0190°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Aqu ♒ | 20.70°   | +507.7877°/d | N/A     | -    | First House    |
+| Medium Coeli          | Sag ♐ | 6.59°    | +341.0208°/d | N/A     | -    | Tenth House    |
 | Sun                   | Gem ♊ | 17.66°   | +0.9560°/d   | +22.87° | -    | Fourth House   |
 | Moon                  | Cap ♑ | 8.74°    | +12.4796°/d  | -22.08° | -    | Eleventh House |
 | Mercury               | Tau ♉ | 25.00°   | +0.6817°/d   | +15.27° | -    | Third House    |
@@ -76,8 +76,8 @@ Johnny Depp — Transit 1940-10-09
 +Transit Subject Celestial Points+----------+--------------+---------+------+----------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House          |
 +-----------------------+--------+----------+--------------+---------+------+----------------+
-| Ascendant             | Ari ♈ | 19.71°   | +886.9396°/d | N/A     | -    | First House    |
-| Medium Coeli          | Cap ♑ | 7.06°    | +332.1233°/d | N/A     | -    | Tenth House    |
+| Ascendant             | Ari ♈ | 19.71°   | +886.9442°/d | N/A     | -    | First House    |
+| Medium Coeli          | Cap ♑ | 7.06°    | +332.1251°/d | N/A     | -    | Tenth House    |
 | Sun                   | Lib ♎ | 16.27°   | +0.9885°/d   | -6.40°  | -    | Sixth House    |
 | Moon                  | Aqu ♒ | 3.55°    | +12.5291°/d  | -14.60° | -    | Eleventh House |
 | Mercury               | Sco ♏ | 8.56°    | +1.3195°/d   | -16.23° | -    | Seventh House  |

--- a/tests/fixtures/transit_report.txt
+++ b/tests/fixtures/transit_report.txt
@@ -57,8 +57,8 @@ Sample Natal Subject — Transit 1980-12-08
 +Natal Subject Celestial Points--+----------+--------------+---------+------+---------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House         |
 +-----------------------+--------+----------+--------------+---------+------+---------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7237°/d | N/A     | -    | First House   |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6390°/d | N/A     | -    | Tenth House   |
+| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | N/A     | -    | First House   |
+| Medium Coeli          | Leo ♌ | 19.91°   | +367.6410°/d | N/A     | -    | Tenth House   |
 | Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | +20.45° | -    | Ninth House   |
 | Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | +23.21° | -    | Ninth House   |
 | Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | +16.88° | -    | Ninth House   |
@@ -76,8 +76,8 @@ Sample Natal Subject — Transit 1980-12-08
 +Transit Subject Celestial Points+----------+--------------+---------+------+---------------+
 | Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House         |
 +-----------------------+--------+----------+--------------+---------+------+---------------+
-| Ascendant             | Vir ♍ | 7.47°    | +284.2957°/d | N/A     | -    | First House   |
-| Medium Coeli          | Gem ♊ | 3.56°    | +343.5404°/d | N/A     | -    | Tenth House   |
+| Ascendant             | Vir ♍ | 7.47°    | +284.2972°/d | N/A     | -    | First House   |
+| Medium Coeli          | Gem ♊ | 3.56°    | +343.5423°/d | N/A     | -    | Tenth House   |
 | Sun                   | Sag ♐ | 17.24°   | +1.0165°/d   | -22.83° | -    | Fourth House  |
 | Moon                  | Cap ♑ | 5.06°    | +12.6292°/d  | -20.27° | -    | Fourth House  |
 | Mercury               | Sag ♐ | 5.09°    | +1.5319°/d   | -20.71° | -    | Fourth House  |

--- a/uv.lock
+++ b/uv.lock
@@ -337,7 +337,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "libephemeris", specifier = "==3.0.0" },
+    { name = "libephemeris", specifier = ">=3.0.0,<4" },
     { name = "pydantic", specifier = ">=2.5" },
     { name = "pyswisseph", marker = "extra == 'all'", specifier = ">=2.10.3.1" },
     { name = "pyswisseph", marker = "extra == 'swiss'", specifier = ">=2.10.3.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -297,7 +297,7 @@ wheels = [
 
 [[package]]
 name = "kerykeion"
-version = "6.0.0a78"
+version = "6.0.0a79"
 source = { editable = "." }
 dependencies = [
     { name = "libephemeris" },

--- a/uv.lock
+++ b/uv.lock
@@ -337,7 +337,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "libephemeris", specifier = "==3.0.0rc15" },
+    { name = "libephemeris", specifier = "==3.0.0" },
     { name = "pydantic", specifier = ">=2.5" },
     { name = "pyswisseph", marker = "extra == 'all'", specifier = ">=2.10.3.1" },
     { name = "pyswisseph", marker = "extra == 'swiss'", specifier = ">=2.10.3.1" },
@@ -369,7 +369,7 @@ dev = [
 
 [[package]]
 name = "libephemeris"
-version = "3.0.0rc15"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -379,9 +379,9 @@ dependencies = [
     { name = "skyfield-data" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/da/9b79c54db53b1adce549dd626e5f9a2e4d22e2af128fc633d62f98238656/libephemeris-3.0.0rc15.tar.gz", hash = "sha256:b4cb096135b43ce501b6728089e5c0df6aee295c9f9dd88da0df4937f6b3782c", size = 12289900, upload-time = "2026-07-20T23:03:19.116Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/fc/cbee4148c3678562894845b684a50057100b159d05e34ef43857eb0c5874/libephemeris-3.0.0.tar.gz", hash = "sha256:9e4681d9486f0a7562464b252e7f5ea672efc70524fdc3e351728eb301c59b97", size = 12398126, upload-time = "2026-08-04T18:49:09.689Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/dc/c9d64a4d413263df816eadc23e5a9a7aba9424222696b3eaef47ca5f4d2c/libephemeris-3.0.0rc15-py3-none-any.whl", hash = "sha256:e6b1bee2607c1d19db6c4c9f9b02fe11c4570ae3d944109544e6e1ee309016f2", size = 12337574, upload-time = "2026-07-20T23:03:15.254Z" },
+    { url = "https://files.pythonhosted.org/packages/92/85/9e0ec8a77b3f0b045a4ce2e2b71139f4629e722d5cbfcce202ef50a051d1/libephemeris-3.0.0-py3-none-any.whl", hash = "sha256:9128a4765a3fa1386602e28cc05b4cdf4a48244bd2f6970a8b52aee3602bf7a5", size = 12446980, upload-time = "2026-08-04T18:49:06.024Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## The defect

`solar_noon` was the midpoint between sunrise and sunset. That equals the meridian **only while the Sun's declination is stationary** — so the old value was exactly right at the solstices and on the equator, where anyone spot-checking it would look, and wrong everywhere else.

Measured against two national observatories:

| | midpoint error |
|---|--:|
| Rome, equinox | +21.5 s |
| Ushuaia, equinox | +33.5 s |
| Reykjavík, April | **+62.4 s** |
| Rome, solstice | −0.1 s |
| Quito, equinox | −0.1 s |

And when the rise/set pair straddles local midnight the midpoint lands on the **wrong civil day** entirely — Singapore did.

Nothing in the library computes on this field (it is printed in the report, serialised into the AI context, and returned to callers), so the correction is visible rather than structural.

**New**: solar noon is now reported on **polar days and nights** too. A transit is a meridian crossing, not a horizon crossing — the Sun culminates on a day it never rises. `day_length` stays `None` there.

## Why it survived

Nothing tested it against anything outside this repository. Golden snapshots prove *constancy*, which a wrong number satisfies perfectly. So the fix ships with the two guards that were missing.

### Anchors — `tests/core/test_sun_times_anchors.py`

Values transcribed by hand from the **US Naval Observatory** and **IMCCE (Observatoire de Paris)**, same UTC civil day, capture date recorded, **no script can rewrite them**.

The tolerances are shaped by what the sources actually do, not by what would be convenient:

- they **agree** on sunrise and transit → held to 45 s of USNO
- they **disagree by ~2 min on sunset** (a horizon convention; and at Wellington it is USNO that is the outlier while IMCCE agrees with us) → every event must additionally lie inside the span the two of them bracket
- **above 60° latitude, no time-domain claim at all.** The Sun grazes the horizon, `dh/dt` collapses, and clock time stops being a well-conditioned way to state an error. That cut-off is *asserted*, not assumed: the same two services that agree to a minute at mid-latitudes differ by **10 and 11 minutes at Tromsø**, and `test_the_cut_off_latitude_is_earned` says so.

17 anchored sites, both hemispheres, four seasons, single-timezone extremes (Ürümqi), date-line side (Wellington), UTC-day straddles (Singapore, Tokyo).

### Altitude invariant — `tests/core/test_sun_times_altitude_invariant.py`

Never compares times. Takes the instant we return and asks **Skyfield** where the Sun was. (Honesty note from review round 3: the backend is itself built on Skyfield's machinery, so this is a second *use*, not a second implementation — what the suite isolates is everything kerykeion adds on top: bookkeeping, search, pairing, transit-vs-midpoint. Common-mode truth is the anchors' job.)

- true **upper limb at −33.59′**, spread **2.5″** across ten sites and four seasons
- **solar noon's hour angle under 0.1 s** of time
- **`is_diurnal` flips within a second** of the geometric centre crossing zero

Reverting solar noon to the midpoint kills **10** of these and **3** anchors, so neither file is decorative.

The documented gap between sunrise and diurnality (3.3 min at the equator, 4.4 at Rome, 8.2 at Reykjavík) is pinned there too, because the README now quotes it and prose drifts.

## Dependency: libephemeris 3.0.0rc15 → 3.0.0

Validated rather than assumed — see the second commit. Full cross-engine parity against a **file-backed** reference: identical verdicts, identical counts, 5213 quantities. Direct value-by-value diff: **16337 compared, 16267 bit-identical**. House cusps and angles did not move at all.

The 70 that moved are sidereal ayanamsas at 0.0014″ and the apsis family at 0.064″ — plus the eight Uranian points, which go from a disordered ±20″ scatter against the reference to a uniform +2..3″ bias (8 of 9 improve, Kronos by 20″). The 29 regenerated report fixtures are that and nothing else: **exactly eleven points changed position, all analytically-modelled bodies, none a planet, an angle or a cusp.**

⚠️ Worth recording: the parity grid does **not** cover the Uranian family, so a 36″ change passed 5213 comparisons unseen and only the report snapshots caught it.

## Documentation

The horizon convention is now stated where callers meet it — apparent upper limb, semidiameter from the real distance rather than a fixed 16′, standard-atmosphere refraction, level sea horizon at any elevation. Both the README and the model docstrings say plainly that sunrise and `is_diurnal` answer different questions and must never be derived from one another.

## Verification

- `poe test:extended` — **10684 passed**, 1390 skipped (10611 before, +73 new)
- `poe lint` — All checks passed
- `poe typecheck` — 0 errors, 1 pre-existing warning
- `poe analyze` — no issues in 108 source files
- mutation: midpoint reverted → 10 invariant tests + 3 anchors go red

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FVi6KXwFmp564FrQFbYRQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Solar noon now reflects the Sun’s actual meridian transit rather than a sunrise/sunset midpoint.
  - Solar-noon times remain available during polar day and night, while day length correctly remains unavailable when sunrise or sunset is absent.
  - Sunrise and sunset calculations now consistently apply upper-limb and atmospheric-refraction conventions.

- **Documentation**
  - Clarified solar-noon semantics, polar-day behavior, sunrise/sunset calculations, and the distinction between sunrise and diurnal status.

- **Tests**
  - Added broad validation against astronomical reference observations and independent solar-geometry checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Round 3 (blind adversarial review, all findings fixed in `2ca86c6b`)

- The rewritten `_polar_state` docstring still carried a name this project never uses, in a line this branch itself added — rewritten to point at the constant whose note owns the 0.006° gap.
- The altitude suite's "shares no code" independence claim was **false** (see note above); its module docstring now states exactly what it does and does not isolate.
- **A transit on the wrong civil day was invisible to the whole suite**: every comparison unwraps to the nearest day. Proven by reverting solar noon to the midpoint — Singapore answered 2026-08-06 for a 2026-08-05 request and stayed green. A new date-pinning test covers all 19 grid cases; the same mutant now fails 5 of them.
- The module-level transit blindfold in the mocked suite also covered the two **real-ephemeris** classes, silently zeroing their transit coverage — the round-2 commit message's "three tests still call the backend for all six helpers" was wrong (five real, one fake). Both classes now shadow the fixture with a no-op.
- The declination count is **19, not 17**: the dual-return fixture carries Mean Lilith and Mean Priapus in both its tables — the exact duplicate-cell trap the CHANGELOG paragraph warns about caught its own correction.
- The factory docstring recovered the transition-day qualifier ("day_length can exceed 24 h") it had dropped.
