### PR TITLE
deps+docs: libephemeris 3.1.0 floor; sealed-mode logging FAQ (issue #240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **libephemeris floor raised to 3.1.0** (closes the warning flood in
+  issue #240). Sealed `leb` mode no longer logs a WARNING for every
+  Uranian/fictitious-body calculation — routing those bodies to their
+  runtime analytical models is by-design source selection, now signalled
+  with a typed dispatch and logged at DEBUG. Upstream also retired the
+  `uranians` LEB companion: the Hamburg bodies (Cupido–Poseidon) and the
+  White Moon are always computed from their analytical models, so their
+  provenance is the invariant `source="Analytical"` /
+  `precision_class="analytical"` instead of flipping to `"LEB"` when a
+  companion file happened to be on disk. Positions move by at most the
+  retired file's fit residual (~1e-9°): every golden fixture — reports,
+  SVG baselines, gallery — passes unchanged, so none were regenerated.
+
+### Documentation
+
+- New FAQ entry: why libephemeris log lines appear, why sealed mode is
+  the normal state, and how to quiet the logger
+  (`logging.getLogger("libephemeris")`). The backend guide no longer
+  tells users to install a uranians companion group; Uranian points and
+  the White Moon need no data files at any tier.
+
 ## 6.0.0a80 - 2026-08-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 6.0.0a81 - 2026-08-11
+
 ### Changed
 
 - **libephemeris floor raised to 3.1.0** (closes the warning flood in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kerykeion"
-version = "6.0.0a80"
+version = "6.0.0a81"
 authors = [
     { name = "Giacomo Battaglia", email = "kerykeion.astrology@gmail.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,22 +45,19 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    # A FLOOR, not a pin — and the precedent is mixed, so here is the whole of it.
-    # The rc1 pin was relaxed once, in 6.0.0a62, "so the stable release does not
-    # conflict with other constraints"; every release after that re-pinned
-    # exactly (a67, a68, a72, a73, a78), and a78's own note reasons FROM the pin
-    # being exact. So this is a change of policy, not a return to one.
-    # The argument for it: an exact pin on a library that is itself pre-release
-    # makes kerykeion unco-installable with anything else that depends on
-    # libephemeris, which is what a62 was about, and 3.0.0 is the first stable
-    # release where that stops being hypothetical.
-    # The argument against, which is real: this project's verification model is
-    # version-locked — the golden fixtures were regenerated for rc15 -> 3.0.0,
-    # and `test_sun_times_altitude_invariant.py` hardcodes an invariant that a
-    # 3.1 with a different refraction or rise/set convention would silently
-    # invalidate. Nothing asserts the installed version. The lockfile protects
-    # this repository; it does not protect `pip install kerykeion`.
-    "libephemeris>=3.0.0,<4",
+    # A FLOOR, not a pin (policy set at 3.0.0; see a62 vs a67-a78 history for
+    # the precedent debate). An exact pin would make kerykeion
+    # unco-installable with anything else depending on libephemeris.
+    # The floor is 3.1.0 because kerykeion's UX depends on its two changes:
+    # sealed leb mode no longer warns on fictitious-body dispatch (the
+    # kerykeion#240 flood), and Uranian points always report
+    # source="Analytical" (the retired uranians companion no longer flips
+    # provenance by environment). The standing caveat remains: this
+    # project's verification model is version-locked — golden fixtures track
+    # the release the lockfile holds, and nothing asserts the installed
+    # version at runtime. The lockfile protects this repository; it does not
+    # protect `pip install kerykeion`.
+    "libephemeris>=3.1.0,<4",
     "pydantic>=2.5",
     "svg-polish>=1.0.0",
     "requests-cache>=1.2.1",

--- a/release_notes/v6.0.0a81.md
+++ b/release_notes/v6.0.0a81.md
@@ -1,0 +1,47 @@
+# v6.0.0a81 — The sealed-mode warning flood is gone
+
+This alpha closes [issue #240](https://github.com/g-battaglia/kerykeion/issues/240)
+by raising the libephemeris floor to 3.1.0. No kerykeion calculation changes:
+what changes is what the backend logs and how Uranian provenance reads.
+
+## The warning flood, fixed at the source
+
+Requesting Uranian points (Cupido…Poseidon) or the White Moon used to print a
+`[libephemeris] WARNING: LEB body=NN … unavailable in sealed mode` line per
+body, per date, per chart — twice per body, since declination needs a second
+equatorial evaluation. Those bodies are *fictitious*: they are defined by
+analytical models, and routing them to those models is the by-design source
+selection, not a sealed-mode degradation. libephemeris 3.1.0 types that
+dispatch signal and logs it at DEBUG; genuine sealed-mode problems (a body
+missing from a file, an out-of-range date, corrupted data) keep their WARNING
+severity. Re-running the exact scenario from the issue report — every active
+point over four birth dates — now produces zero backend warnings.
+
+## Uranian provenance is now invariant
+
+Upstream also retired the `uranians` LEB companion files: fictitious bodies
+are always computed from their runtime models, so their provenance reads
+`source="Analytical"` / `precision_class="analytical"` everywhere, instead of
+flipping to `"LEB"` when a companion file happened to sit on disk. Leftover
+`{tier}_uranians.leb2` files from older installs are recognized and ignored;
+they can be deleted freely. Positions move by at most the retired file's fit
+residual (~1e-9°): every golden fixture — reports, SVG baselines, gallery —
+passes unchanged, so none were regenerated in this release.
+
+Code that asserted `source == "LEB"` for Uranian bodies (an
+environment-dependent label) must accept the new invariant answer.
+
+## Docs
+
+The FAQ gains an entry on backend logging: why sealed `leb` mode is the
+normal state, how to quiet the `libephemeris` logger, and what the
+informational Earth-exclusion warning means. The backend guide no longer
+tells you to install a uranians companion group — Uranian points and the
+White Moon need no data files at any tier, for any date.
+
+## Compatibility
+
+- `libephemeris>=3.1.0,<4` (floor, not a pin).
+- `KERYKEION_LEB_MODE` still defaults to `"leb"`: the sealed contract remains
+  kerykeion's default.
+- No API changes.

--- a/site/docs/ephemeris_backend.md
+++ b/site/docs/ephemeris_backend.md
@@ -101,10 +101,13 @@ download_leb_for_tier("extended")  # full range (incl. BCE dates), ~1154 MB
 ```
 
 Asteroids (Chiron, Ceres, Pallas, Juno, Vesta), other curated minor
-bodies and exotics (centaurs, trans-Neptunians), lunar apsides, and the
-Hamburg/Uranian points are **separate companion groups**, available at
-every tier — they are not folded into the core by tier. Install them
-alongside the core with `download_leb2_for_tier(tier, groups=[...])`.
+bodies and exotics (centaurs, trans-Neptunians), and lunar apsides are
+**separate companion groups**, available at every tier — they are not
+folded into the core by tier. Install them alongside the core with
+`download_leb2_for_tier(tier, groups=[...])`. The Hamburg/Uranian points
+and the White Moon need **no files at all**: they are fictitious bodies,
+always computed from their runtime analytical models (provenance
+`source="Analytical"`), at every tier and for every date.
 
 ## Architecture
 

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -416,6 +416,30 @@ subject = AstrologicalSubjectFactory.from_birth_data(
 )
 ```
 
+### Why do I see libephemeris log lines, and how do I quiet them?
+
+Kerykeion pins libephemeris to its sealed `leb` mode by default: positions
+come only from local, verified ephemeris files or from declared analytical
+models — no network, no silent source substitution. That is the normal,
+intended state, not a misconfiguration. The backend logs through its own
+`libephemeris` logger, so standard logging configuration controls it:
+
+```python
+import logging
+
+logging.getLogger("libephemeris").setLevel(logging.ERROR)
+```
+
+Two messages people ask about:
+
+- `Excluding ['Earth'] from active_points` — informational and correct: you
+  passed the perspective's center body in `active_points`, and it has no
+  position as seen from itself. Remove it from your list or ignore the line.
+- `LEB body=NN ... unavailable in sealed mode` for bodies 40–47/56 (Uranian
+  points, White Moon) — a logging bug fixed in libephemeris 3.1.0: those
+  bodies are always computed from their analytical models by design, and the
+  routing is no longer reported as a warning. Upgrade rather than filter.
+
 ### How do I cache GeoNames results?
 
 Results are cached for 30 days by default. Customize with:


### PR DESCRIPTION
Kerykeion side of [issue #240](https://github.com/g-battaglia/kerykeion/issues/240). Depends on [libephemeris#54](https://github.com/g-battaglia/libephemeris/pull/54) being merged **and published to PyPI** — draft until then.

## What

- **`libephemeris>=3.1.0,<4`**: the floor that closes the warning flood at the source (typed fictitious dispatch → DEBUG in sealed mode) and makes Uranian/White Moon provenance invariantly `source="Analytical"` (upstream retired the uranians LEB companion; those bodies never need data files).
- **FAQ** (`site/docs/faq.md`): why libephemeris log lines appear, why sealed `leb` mode is the *normal* state, how to quiet the logger, and what the Earth-exclusion warning means.
- **Backend guide** (`site/docs/ephemeris_backend.md`): stops telling users to install a uranians companion group.
- `KERYKEION_LEB_MODE` default stays `"leb"` — deliberate decision, the sealed contract remains kerykeion's default.

## Verified against libephemeris 3.1.0 (from source, editable install)

- Full non-online suite: **10 756 passed, 0 failed** — including all 13 report fixtures, all 20 Cupido-bearing SVG goldens, provenance and uranian test files. **Zero baselines regenerated**: the position delta is bounded by the retired file's ~1e-9° fit residual, below every fixture tolerance.
- End-to-end issue repro (all points incl. Earth/Uranians/White_Moon over multiple dates, sealed mode): zero libephemeris warnings; only the intentional, informational Earth-exclusion line remains.

## Before releasing a81

1. Merge + publish libephemeris 3.1.0 to PyPI.
2. `uv lock` here (uv.lock intentionally still holds 3.0.0 — it cannot resolve 3.1.0 before publication), commit as part of the release.
3. `poe quality` + `poe build:smoke`, then `chore(release): 6.0.0a81`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNGUpecRa27hFdZw58HRbA