### PR TITLE
feat(aspects): aspect-keyed per-point orb adjustments (orb matrix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
   Supported end to end: `AspectsFactory` (single and dual charts),
   `ChartDataFactory`, `SecondaryProgressionFactory.compute_full` and
   `SolarArcFactory.compute` (whose self-conjunction guard now sizes itself to
-  the conjunction's own delta). The combination strategies
+  the conjunction's own delta — resolved independently of the aspect filter,
+  with the whole sum clamped at zero exactly like detection). Both predictive
+  entry points now validate the full adjustment table up front, like the
+  `AspectsFactory` entry points always did. The combination strategies
   (`max_explicit`/`min_explicit`/`sum`/`none`) operate on the per-aspect
   resolved values. New helpers in `kerykeion.aspects.orb_utils`:
   `lookup_point_adjustment`, `has_aspect_keyed_adjustments`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Aspect-keyed per-point orb adjustments.** A `point_orb_adjustments` entry
+  can now vary by aspect: instead of a single number, a point may carry a
+  mapping of aspect name → additive delta, with `"*"` as the default for
+  aspects not listed (`{"Sun": {"*": 1.5, "conjunction": 3.0}}` applies 3.0°
+  to Sun conjunctions and 1.5° to every other Sun aspect). `number` and
+  `{"*": number}` are equivalent, so every existing table is valid unchanged
+  and resolves identically. The explicit-only rule carries over per aspect:
+  without `"*"`, a point is *unconfigured* (not `0.0`) for the aspects it does
+  not list, so negative adjustments on the other endpoint keep tightening.
+  Supported end to end: `AspectsFactory` (single and dual charts),
+  `ChartDataFactory`, `SecondaryProgressionFactory.compute_full` and
+  `SolarArcFactory.compute` (whose self-conjunction guard now sizes itself to
+  the conjunction's own delta). The combination strategies
+  (`max_explicit`/`min_explicit`/`sum`/`none`) operate on the per-aspect
+  resolved values. New helpers in `kerykeion.aspects.orb_utils`:
+  `lookup_point_adjustment`, `has_aspect_keyed_adjustments`,
+  `resolve_pair_orb_adjustments_for_aspects`; `resolve_pair_orb_adjustment`
+  gains a keyword-only `aspect_name` parameter (default `None` = legacy
+  behavior, `"*"` only). `get_aspect_from_two_points` accepts a per-aspect
+  `extra_orb` mapping; the scalar path is byte-identical to before. Unknown
+  aspect names in a mapping log a warning (never an error), mirroring
+  `active_aspects`; non-finite leaves are rejected up front.
+
 ## 6.0.0a80 - 2026-08-07
 
 ### Changed

--- a/kerykeion/aspects/aspects_factory.py
+++ b/kerykeion/aspects/aspects_factory.py
@@ -15,7 +15,10 @@ from kerykeion.aspects.aspects_utils import (
 )
 from kerykeion.aspects.orb_utils import (
     OrbAdjustmentStrategy,
+    PointOrbAdjustment,
+    has_aspect_keyed_adjustments,
     resolve_pair_orb_adjustment,
+    resolve_pair_orb_adjustments_for_aspects,
     validate_point_orb_adjustments,
 )
 from kerykeion.schemas.kr_models import (
@@ -117,7 +120,7 @@ class AspectsFactory:
         active_points: Optional[List[AstrologicalPoint]] = None,
         active_aspects: Optional[List[ActiveAspect]] = None,
         axis_orb_limit: Optional[float] = None,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
     ) -> SingleChartAspectsModel:
         """
@@ -139,7 +142,11 @@ class AspectsFactory:
             axis_orb_limit: Optional orb threshold applied to chart axes; when None, no special axis filter
             point_orb_adjustments: Optional per-point orb adjustment table (e.g.
                 ``{"Sun": 1.5, "Moon": 1.5}``); widens/tightens the base orb when
-                a configured point is involved in the aspect
+                a configured point is involved in the aspect. An entry can also
+                vary by aspect: ``{"Sun": {"*": 1.5, "conjunction": 3.0}}``
+                applies 3.0° to Sun conjunctions and 1.5° to every other Sun
+                aspect (``"*"`` is the default for unlisted aspects; without it
+                the point is unconfigured for those aspects).
             point_orb_adjustment_strategy: How to combine the two points'
                 adjustments (default ``"max_explicit"``)
 
@@ -231,7 +238,7 @@ class AspectsFactory:
         axis_orb_limit: Optional[float] = None,
         first_subject_is_fixed: bool = False,
         second_subject_is_fixed: bool = False,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
     ) -> DualChartAspectsModel:
         """
@@ -259,7 +266,9 @@ class AspectsFactory:
                 are time-sensitive points, so the tighter orb is applied uniformly
                 to both single-chart and dual-chart (synastry/transit) aspects.
                 When ``None`` (default) no axis-specific filtering is performed.
-            point_orb_adjustments: Optional per-point orb adjustment table
+            point_orb_adjustments: Optional per-point orb adjustment table; a
+                point's entry is a number or an aspect-keyed mapping with a
+                ``"*"`` default (see ``single_chart_aspects``)
             point_orb_adjustment_strategy: How to combine the two points'
                 adjustments (default ``"max_explicit"``)
 
@@ -375,7 +384,7 @@ class AspectsFactory:
         aspects_settings: Sequence[Mapping[str, Any]],
         axis_orb_limit: Optional[float],
         celestial_points: List[_CelestialPointSetting],
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         star_names: frozenset = frozenset(),
     ) -> SingleChartAspectsModel:
@@ -418,7 +427,7 @@ class AspectsFactory:
         celestial_points: List[_CelestialPointSetting],
         first_subject_is_fixed: bool,
         second_subject_is_fixed: bool,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         star_names: frozenset = frozenset(),
     ) -> DualChartAspectsModel:
@@ -486,7 +495,7 @@ class AspectsFactory:
         active_aspects: List[ActiveAspect],
         aspects_settings: Sequence[Mapping[str, Any]],
         celestial_points: List[_CelestialPointSetting],
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         star_names: frozenset = frozenset(),
     ) -> List[AspectModel]:
@@ -515,6 +524,12 @@ class AspectsFactory:
         all_aspects_list = []
         n_points = len(active_points_list)
 
+        # Aspect-keyed table entries need the resolver to run once per aspect
+        # for the pair. Decided once per call: tables of plain numbers (the
+        # overwhelmingly common case) keep the single-resolve scalar path.
+        aspect_keyed = has_aspect_keyed_adjustments(point_orb_adjustments)
+        aspect_names = [setting["name"] for setting in filtered_settings] if aspect_keyed else []
+
         for first_idx, first_point in enumerate(active_points_list):
             first_name = first_point["name"]
             first_abs_pos = first_point["abs_pos"]
@@ -541,12 +556,24 @@ class AspectsFactory:
                     continue
 
                 second_abs_pos = second_point["abs_pos"]
-                extra_orb = resolve_pair_orb_adjustment(
-                    first_name,
-                    second_name,
-                    point_orb_adjustments,
-                    point_orb_adjustment_strategy,
-                )
+                extra_orb: Union[float, dict]
+                if aspect_keyed:
+                    # Resolve the pair once per aspect in play; "*" wildcards
+                    # collapse here, so downstream sees plain per-aspect deltas.
+                    extra_orb = resolve_pair_orb_adjustments_for_aspects(
+                        first_name,
+                        second_name,
+                        point_orb_adjustments,
+                        point_orb_adjustment_strategy,
+                        aspect_names,
+                    )
+                else:
+                    extra_orb = resolve_pair_orb_adjustment(
+                        first_name,
+                        second_name,
+                        point_orb_adjustments,
+                        point_orb_adjustment_strategy,
+                    )
                 aspect = get_aspect_from_two_points(
                     filtered_settings, first_abs_pos, second_abs_pos, extra_orb=extra_orb
                 )
@@ -606,7 +633,7 @@ class AspectsFactory:
         celestial_points: List[_CelestialPointSetting],
         first_subject_is_fixed: bool,
         second_subject_is_fixed: bool,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         star_names: frozenset = frozenset(),
     ) -> List[AspectModel]:
@@ -641,6 +668,11 @@ class AspectsFactory:
         # Update aspects settings with active aspects orbs
         filtered_settings = AspectsFactory._update_aspect_settings(aspects_settings, active_aspects)
 
+        # See _calculate_single_chart_aspects: aspect-keyed entries switch the
+        # pair to a per-aspect resolve; plain-number tables keep the scalar path.
+        aspect_keyed = has_aspect_keyed_adjustments(point_orb_adjustments)
+        aspect_names = [setting["name"] for setting in filtered_settings] if aspect_keyed else []
+
         all_aspects_list = []
         for first in range(len(first_active_points_list)):
             # Read the point name before the inner loop so the orb resolver
@@ -658,12 +690,22 @@ class AspectsFactory:
                 if first_is_star and second_name in star_names:
                     continue
 
-                extra_orb = resolve_pair_orb_adjustment(
-                    first_name,
-                    second_name,
-                    point_orb_adjustments,
-                    point_orb_adjustment_strategy,
-                )
+                extra_orb: Union[float, dict]
+                if aspect_keyed:
+                    extra_orb = resolve_pair_orb_adjustments_for_aspects(
+                        first_name,
+                        second_name,
+                        point_orb_adjustments,
+                        point_orb_adjustment_strategy,
+                        aspect_names,
+                    )
+                else:
+                    extra_orb = resolve_pair_orb_adjustment(
+                        first_name,
+                        second_name,
+                        point_orb_adjustments,
+                        point_orb_adjustment_strategy,
+                    )
                 aspect = get_aspect_from_two_points(
                     filtered_settings,
                     first_active_points_list[first]["abs_pos"],

--- a/kerykeion/aspects/aspects_utils.py
+++ b/kerykeion/aspects/aspects_utils.py
@@ -8,7 +8,7 @@ import logging
 from kerykeion.ephemeris_backend import ephe as _ephe
 
 difdeg2n = _ephe.difdeg2n
-from typing import Optional, Union, get_args
+from typing import Mapping, Optional, Union, get_args
 from kerykeion.schemas.kr_models import AstrologicalSubjectModel, CompositeSubjectModel, PlanetReturnModel
 from kerykeion.schemas.kr_literals import AspectMovementType, AstrologicalPoint
 from kerykeion.schemas.settings_models import KerykeionSettingsCelestialPointModel
@@ -32,7 +32,7 @@ def get_aspect_from_two_points(
     aspects_settings: list[dict],
     point_one: Union[float, int],
     point_two: Union[float, int],
-    extra_orb: float = 0.0,
+    extra_orb: Union[float, Mapping[str, float]] = 0.0,
 ):
     """
     Utility function to calculate the aspects between two points.
@@ -41,9 +41,12 @@ def get_aspect_from_two_points(
         aspects_settings (list[dict]): List of aspect setting dictionaries.
         point_one (Union[float, int]): First point.
         point_two (Union[float, int]): Second point.
-        extra_orb (float): Additive orb adjustment in degrees applied to every
-            aspect's base orb (e.g. a luminary widening). Defaults to ``0.0``.
-            The effective orb is clamped to ``>= 0.0``.
+        extra_orb (Union[float, Mapping[str, float]]): Additive orb adjustment
+            in degrees. A number applies to every aspect's base orb (e.g. a
+            luminary widening); a mapping of aspect name → adjustment applies
+            per aspect, with missing names getting ``0.0`` (callers resolve
+            any ``"*"`` wildcard *before* building the mapping). Defaults to
+            ``0.0``. The effective orb is clamped to ``>= 0.0``.
 
     Returns:
         dict: Dictionary containing the aspect details. The ``orbit`` field
@@ -56,6 +59,9 @@ def get_aspect_from_two_points(
     # exported as kr:planetsdiff).
     diff = distance
 
+    # Hoisted out of the loop; the scalar path stays exactly as before.
+    extra_orb_is_map = isinstance(extra_orb, Mapping)
+
     # Pick the CLOSEST qualifying aspect, not the first: with user-supplied
     # overlapping orbs the ascending-degree order could label a separation
     # with a wider aspect whose window merely contains it. Ties keep the
@@ -65,7 +71,8 @@ def get_aspect_from_two_points(
     best_deviation: Optional[float] = None
     for aspect in aspects_settings:
         aspect_degree = aspect["degree"]  # type: ignore
-        aspect_orb = max(0.0, aspect["orb"] + extra_orb)  # type: ignore
+        extra = extra_orb.get(aspect["name"], 0.0) if extra_orb_is_map else extra_orb  # type: ignore[union-attr]
+        aspect_orb = max(0.0, aspect["orb"] + extra)  # type: ignore
 
         deviation = abs(distance - aspect_degree)
         if deviation <= aspect_orb and (best_deviation is None or deviation < best_deviation):

--- a/kerykeion/aspects/orb_utils.py
+++ b/kerykeion/aspects/orb_utils.py
@@ -199,10 +199,15 @@ def resolve_pair_orb_adjustments_for_aspects(
     fed directly to ``get_aspect_from_two_points`` as a per-aspect
     ``extra_orb``.
     """
-    # Validated even when aspect_names is empty (the comprehension would then
-    # never reach the per-pair resolver's own check) — a typo must raise here
-    # exactly as it does on the scalar path.
-    _validate_strategy(strategy)
+    names = list(aspect_names)
+    if not names:
+        # No aspects in play, but the call must keep the scalar path's whole
+        # contract — strategy validation AND the pair's wildcard-value checks.
+        # ``number ≡ {"*": number}`` extends to the error behavior: a sum
+        # overflow raises identically on both forms instead of the wildcard
+        # one silently returning an empty result. Resolve once, discard.
+        resolve_pair_orb_adjustment(first_name, second_name, point_orb_adjustments, strategy)
+        return {}
     return {
         aspect_name: resolve_pair_orb_adjustment(
             first_name,
@@ -211,7 +216,7 @@ def resolve_pair_orb_adjustments_for_aspects(
             strategy,
             aspect_name=aspect_name,
         )
-        for aspect_name in aspect_names
+        for aspect_name in names
     }
 
 

--- a/kerykeion/aspects/orb_utils.py
+++ b/kerykeion/aspects/orb_utils.py
@@ -174,6 +174,17 @@ def has_aspect_keyed_adjustments(
     )
 
 
+def _validate_strategy(strategy: OrbAdjustmentStrategy) -> None:
+    """Fail fast on a misspelled strategy rather than silently returning 0.0,
+    which would quietly disable the orb adjustment and yield wrong aspects.
+    """
+    if strategy not in ("max_explicit", "min_explicit", "sum", "none"):
+        raise ValueError(
+            f"Unknown orb adjustment strategy: {strategy!r}. "
+            "Expected one of: 'max_explicit', 'min_explicit', 'sum', 'none'."
+        )
+
+
 def resolve_pair_orb_adjustments_for_aspects(
     first_name: str,
     second_name: str,
@@ -188,6 +199,10 @@ def resolve_pair_orb_adjustments_for_aspects(
     fed directly to ``get_aspect_from_two_points`` as a per-aspect
     ``extra_orb``.
     """
+    # Validated even when aspect_names is empty (the comprehension would then
+    # never reach the per-pair resolver's own check) — a typo must raise here
+    # exactly as it does on the scalar path.
+    _validate_strategy(strategy)
     return {
         aspect_name: resolve_pair_orb_adjustment(
             first_name,
@@ -231,15 +246,9 @@ def resolve_pair_orb_adjustment(
         ValueError: If ``strategy`` is not a recognised
             :data:`OrbAdjustmentStrategy` value.
     """
-    # Fail fast on a misspelled strategy rather than silently returning 0.0,
-    # which would quietly disable the orb adjustment and yield wrong aspects.
     # Validated *before* any early return so the error surfaces even when the
     # table is empty or the pair is unconfigured.
-    if strategy not in ("max_explicit", "min_explicit", "sum", "none"):
-        raise ValueError(
-            f"Unknown orb adjustment strategy: {strategy!r}. "
-            "Expected one of: 'max_explicit', 'min_explicit', 'sum', 'none'."
-        )
+    _validate_strategy(strategy)
 
     if not point_orb_adjustments or strategy == "none":
         return 0.0

--- a/kerykeion/aspects/orb_utils.py
+++ b/kerykeion/aspects/orb_utils.py
@@ -15,14 +15,34 @@ example, with ``{"Pluto": -2.0}`` and the pair ``(Pluto, Saturn)``, the
 the effective orb is tightened. A naive ``max(adj_a, adj_b)`` over defaulted
 values would yield ``max(-2.0, 0.0) == 0.0`` and silently drop the tightening.
 
+A table entry can also vary by aspect. Instead of a single number, a point may
+carry a mapping of aspect name → adjustment, with ``"*"`` as the default for
+aspects not listed::
+
+    {
+        "Sun": 1.5,                              # every aspect
+        "Moon": {"*": 1.5, "conjunction": 3.0},  # 3.0 for conjunctions, 1.5 otherwise
+        "Ascendant": {"conjunction": -3.0},      # configured ONLY for conjunctions
+    }
+
+The explicit-only philosophy carries over per aspect: without a ``"*"`` key, a
+point is *unconfigured* for the aspects it does not list (not ``0.0``), so a
+trine to the Ascendant above resolves exactly as if the Ascendant were absent
+from the table.
+
 This is part of Kerykeion (C) 2025 Giacomo Battaglia
 """
 
 from __future__ import annotations
 
+import logging
 import math
 from numbers import Real
-from typing import Literal, Mapping, Optional
+from typing import Iterable, Literal, Mapping, Optional, Union, get_args
+
+from kerykeion.schemas.kr_literals import AspectName
+
+logger = logging.getLogger(__name__)
 
 OrbAdjustmentStrategy = Literal["max_explicit", "min_explicit", "sum", "none"]
 """How to combine the orb adjustments of the two points in a pair.
@@ -33,6 +53,24 @@ OrbAdjustmentStrategy = Literal["max_explicit", "min_explicit", "sum", "none"]
 - ``sum``: adjustments of both configured points are added together.
 - ``none``: adjustments are disabled (always resolves to ``0.0``).
 """
+
+PointOrbAdjustment = Union[float, Mapping[str, float]]
+"""A point's entry in an orb adjustment table.
+
+Either a single number (an additive delta applied to every aspect's base orb)
+or a mapping of aspect name → delta with the optional ``"*"`` key acting as
+the default for aspects not listed. ``number`` and ``{"*": number}`` are
+equivalent.
+"""
+
+ASPECT_ORB_WILDCARD = "*"
+"""The aspect-map key that supplies the default delta for unlisted aspects."""
+
+# Known aspect names, used to flag probable typos in aspect-keyed adjustment
+# maps. A warning, not an error — mirroring how active_aspects treats unknown
+# names — so a table can be shared across configurations that enable
+# different aspect sets.
+_KNOWN_ASPECT_NAMES: frozenset = frozenset(get_args(AspectName))
 
 
 def _is_finite_real(value: object) -> bool:
@@ -50,25 +88,125 @@ def _is_finite_real(value: object) -> bool:
 
 
 def validate_point_orb_adjustments(
-    point_orb_adjustments: Optional[Mapping[str, float]],
+    point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]],
 ) -> None:
-    """Validate every configured per-point orb adjustment once, up front."""
+    """Validate every configured per-point orb adjustment once, up front.
+
+    Accepts both entry forms: a plain number, or an aspect-keyed mapping
+    (``{"conjunction": 3.0, "*": 1.5}``). Unknown aspect names in a mapping
+    log a warning rather than raising — consistent with how unknown
+    ``active_aspects`` names are treated — since the key may belong to an
+    aspect set this configuration simply does not enable.
+    """
     if point_orb_adjustments is None:
         return
     for point_name, adjustment in point_orb_adjustments.items():
         if not isinstance(point_name, str):
             raise ValueError(f"point_orb_adjustments keys must be point names, got {point_name!r}.")
-        if not _is_finite_real(adjustment):
+        if isinstance(adjustment, Mapping):
+            for aspect_key, leaf in adjustment.items():
+                if not isinstance(aspect_key, str):
+                    raise ValueError(
+                        f"point_orb_adjustments[{point_name!r}] keys must be aspect names "
+                        f"or '{ASPECT_ORB_WILDCARD}', got {aspect_key!r}."
+                    )
+                if aspect_key != ASPECT_ORB_WILDCARD and aspect_key not in _KNOWN_ASPECT_NAMES:
+                    logger.warning(
+                        "point_orb_adjustments[%r] has an unrecognized aspect name %r; "
+                        "it will never match a computed aspect. Check for a typo.",
+                        point_name,
+                        aspect_key,
+                    )
+                if not _is_finite_real(leaf):
+                    raise ValueError(
+                        f"point_orb_adjustments[{point_name!r}][{aspect_key!r}] must be "
+                        f"a finite number, got {leaf!r}."
+                    )
+        elif not _is_finite_real(adjustment):
             raise ValueError(
                 f"point_orb_adjustments[{point_name!r}] must be a finite number, got {adjustment!r}."
             )
 
 
+def lookup_point_adjustment(
+    adjustment: Optional[PointOrbAdjustment],
+    aspect_name: Optional[str] = None,
+) -> Optional[float]:
+    """Resolve one point's table entry for a specific aspect.
+
+    Args:
+        adjustment: The point's entry — a number, an aspect-keyed mapping, or
+            ``None`` when the point is not in the table.
+        aspect_name: The aspect being evaluated. ``None`` means "no aspect
+            context": aspect-keyed mappings then fall back to their ``"*"``
+            entry only, so legacy callers see per-aspect overrides as if they
+            were not there.
+
+    Returns:
+        The resolved delta, or ``None`` when the point is unconfigured for
+        this aspect (a missing point, an aspect absent from a mapping without
+        ``"*"``, or an empty mapping). ``None`` is deliberately distinct from
+        ``0.0`` — see the module docstring.
+
+    Note:
+        No finiteness validation happens here; callers validate the resolved
+        value (``resolve_pair_orb_adjustment``) or the whole table up front
+        (``validate_point_orb_adjustments``).
+    """
+    if adjustment is None or not isinstance(adjustment, Mapping):
+        return adjustment
+    if aspect_name is not None and aspect_name in adjustment:
+        return adjustment[aspect_name]
+    return adjustment.get(ASPECT_ORB_WILDCARD)
+
+
+def has_aspect_keyed_adjustments(
+    point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]],
+) -> bool:
+    """Return whether any table entry varies by aspect (is a mapping).
+
+    Callers use this once per calculation to decide between the scalar
+    fast path (one resolve per pair) and the per-aspect path (one resolve
+    per pair per aspect in play).
+    """
+    return bool(point_orb_adjustments) and any(
+        isinstance(value, Mapping) for value in point_orb_adjustments.values()  # type: ignore[union-attr]
+    )
+
+
+def resolve_pair_orb_adjustments_for_aspects(
+    first_name: str,
+    second_name: str,
+    point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]],
+    strategy: OrbAdjustmentStrategy,
+    aspect_names: Iterable[str],
+) -> dict:
+    """Resolve a pair's adjustment for each named aspect.
+
+    Returns a plain ``{aspect_name: delta}`` dict — the ``"*"`` wildcard and
+    the combination strategy are fully collapsed here, so the result can be
+    fed directly to ``get_aspect_from_two_points`` as a per-aspect
+    ``extra_orb``.
+    """
+    return {
+        aspect_name: resolve_pair_orb_adjustment(
+            first_name,
+            second_name,
+            point_orb_adjustments,
+            strategy,
+            aspect_name=aspect_name,
+        )
+        for aspect_name in aspect_names
+    }
+
+
 def resolve_pair_orb_adjustment(
     first_name: str,
     second_name: str,
-    point_orb_adjustments: Optional[Mapping[str, float]],
+    point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]],
     strategy: OrbAdjustmentStrategy = "max_explicit",
+    *,
+    aspect_name: Optional[str] = None,
 ) -> float:
     """Resolve the additive orb adjustment for a pair of points.
 
@@ -76,13 +214,18 @@ def resolve_pair_orb_adjustment(
         first_name: Name of the first point (e.g. ``"Sun"``).
         second_name: Name of the second point.
         point_orb_adjustments: Mapping of point name → orb adjustment in
-            degrees. ``None`` or empty disables adjustments.
+            degrees. Each entry is either a number or an aspect-keyed mapping
+            (see :data:`PointOrbAdjustment`). ``None`` or empty disables
+            adjustments.
         strategy: How to combine the two points' adjustments. See
             :data:`OrbAdjustmentStrategy`.
+        aspect_name: The aspect the pair is being evaluated for. When ``None``
+            (the default, and the behavior of every pre-existing caller),
+            aspect-keyed entries resolve through their ``"*"`` key only.
 
     Returns:
         The orb adjustment in degrees to add to the aspect's base orb.
-        ``0.0`` when no point in the pair is configured.
+        ``0.0`` when no point in the pair is configured (for this aspect).
 
     Raises:
         ValueError: If ``strategy`` is not a recognised
@@ -101,8 +244,8 @@ def resolve_pair_orb_adjustment(
     if not point_orb_adjustments or strategy == "none":
         return 0.0
 
-    v1 = point_orb_adjustments.get(first_name)
-    v2 = point_orb_adjustments.get(second_name)
+    v1 = lookup_point_adjustment(point_orb_adjustments.get(first_name), aspect_name)
+    v2 = lookup_point_adjustment(point_orb_adjustments.get(second_name), aspect_name)
 
     # Direct callers of this resolver still get a safe boundary even when they
     # bypass the factory-level whole-mapping validation.

--- a/kerykeion/chart_data_factory.py
+++ b/kerykeion/chart_data_factory.py
@@ -59,7 +59,7 @@ from kerykeion.settings.config_constants import (
     DEFAULT_NATAL_POINT_ORB_ADJUSTMENTS,
     NO_POINT_ORB_ADJUSTMENTS,
 )
-from kerykeion.aspects.orb_utils import OrbAdjustmentStrategy
+from kerykeion.aspects.orb_utils import OrbAdjustmentStrategy, PointOrbAdjustment
 from kerykeion.settings.chart_defaults import DEFAULT_CELESTIAL_POINTS_SETTINGS
 from kerykeion.charts.charts_utils import (
     DOUBLE_CHART_TYPES,
@@ -116,7 +116,7 @@ class ChartDataFactory:
         include_relationship_score: bool = False,
         *,
         axis_orb_limit: Optional[float] = None,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
         custom_distribution_weights: Optional[Mapping[str, float]] = None,
@@ -144,6 +144,11 @@ class ChartDataFactory:
                 ``{"Sun": 1.5, "Moon": 1.5}``). When ``None``, the per-chart-type
                 default applies — natal/synastry/composite use
                 ``DEFAULT_NATAL_POINT_ORB_ADJUSTMENTS``, every other type uses none.
+                An entry can also vary by aspect:
+                ``{"Sun": {"*": 1.5, "conjunction": 3.0}}`` applies 3.0° to Sun
+                conjunctions and 1.5° to every other Sun aspect (``"*"`` is the
+                default for unlisted aspects; without it the point is
+                unconfigured for those aspects).
             point_orb_adjustment_strategy: How to combine the two points'
                 adjustments (default ``"max_explicit"``)
             distribution_method: Strategy for element/modality weighting ("pure_count" or "weighted")
@@ -473,7 +478,7 @@ class ChartDataFactory:
         active_aspects: Optional[list[ActiveAspect]] = None,
         *,
         axis_orb_limit: Optional[float] = None,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
         custom_distribution_weights: Optional[Mapping[str, float]] = None,
@@ -519,7 +524,7 @@ class ChartDataFactory:
         include_relationship_score: bool = True,
         *,
         axis_orb_limit: Optional[float] = None,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
         custom_distribution_weights: Optional[Mapping[str, float]] = None,
@@ -570,7 +575,7 @@ class ChartDataFactory:
         include_house_comparison: bool = True,
         *,
         axis_orb_limit: Optional[float] = None,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
         custom_distribution_weights: Optional[Mapping[str, float]] = None,
@@ -616,7 +621,7 @@ class ChartDataFactory:
         active_aspects: Optional[list[ActiveAspect]] = None,
         *,
         axis_orb_limit: Optional[float] = None,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
         custom_distribution_weights: Optional[Mapping[str, float]] = None,
@@ -660,7 +665,7 @@ class ChartDataFactory:
         include_house_comparison: bool = True,
         *,
         axis_orb_limit: Optional[float] = None,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
         custom_distribution_weights: Optional[Mapping[str, float]] = None,
@@ -707,7 +712,7 @@ class ChartDataFactory:
         active_aspects: Optional[list[ActiveAspect]] = None,
         *,
         axis_orb_limit: Optional[float] = None,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
         custom_distribution_weights: Optional[Mapping[str, float]] = None,
@@ -752,7 +757,7 @@ class ChartDataFactory:
         include_house_comparison: bool = True,
         *,
         axis_orb_limit: Optional[float] = None,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
         distribution_method: ElementQualityDistributionMethod = "weighted",
         custom_distribution_weights: Optional[Mapping[str, float]] = None,

--- a/kerykeion/secondary_progressions/secondary_progression_factory.py
+++ b/kerykeion/secondary_progressions/secondary_progression_factory.py
@@ -36,6 +36,7 @@ from kerykeion.aspects.orb_utils import (
     has_aspect_keyed_adjustments,
     resolve_pair_orb_adjustment,
     resolve_pair_orb_adjustments_for_aspects,
+    validate_point_orb_adjustments,
 )
 from kerykeion.ephemeris_backend import ephe
 from kerykeion.schemas.kr_models import AstrologicalSubjectModel
@@ -488,6 +489,12 @@ class SecondaryProgressionFactory:
             A :class:`SecondaryProgressionsResultModel` with the progressed subject
             and (optionally) the cross-aspect contacts.
         """
+        # Validate the WHOLE table up front, like the AspectsFactory entry
+        # points do: the per-pair resolver only ever validates the leaves it
+        # resolves, so a typo'd aspect key or a non-finite leaf outside the
+        # selected aspects would otherwise be silently ignored.
+        validate_point_orb_adjustments(point_orb_adjustments)
+
         progressed = SecondaryProgressionFactory.compute(
             natal_subject,
             target_iso_utc_datetime=target_iso_utc_datetime,

--- a/kerykeion/secondary_progressions/secondary_progression_factory.py
+++ b/kerykeion/secondary_progressions/secondary_progression_factory.py
@@ -30,7 +30,13 @@ from kerykeion.schemas.kr_models import SubscriptableBaseModel
 
 from kerykeion.astrological_subject_factory import AstrologicalSubjectFactory
 from kerykeion.aspects.aspects_utils import get_aspect_from_two_points
-from kerykeion.aspects.orb_utils import OrbAdjustmentStrategy, resolve_pair_orb_adjustment
+from kerykeion.aspects.orb_utils import (
+    OrbAdjustmentStrategy,
+    PointOrbAdjustment,
+    has_aspect_keyed_adjustments,
+    resolve_pair_orb_adjustment,
+    resolve_pair_orb_adjustments_for_aspects,
+)
 from kerykeion.ephemeris_backend import ephe
 from kerykeion.schemas.kr_models import AstrologicalSubjectModel
 from kerykeion.schemas import KerykeionException
@@ -448,7 +454,7 @@ class SecondaryProgressionFactory:
         compute_aspects: bool = True,
         aspect_orb: float = 3.0,
         aspects: Optional[Sequence[str]] = None,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
     ) -> SecondaryProgressionsResultModel:
         """Build the progressed chart with optional progressed-to-natal aspects.
@@ -504,15 +510,29 @@ class SecondaryProgressionFactory:
             natal_targets = gather_active_points(natal_subject, natal_subject.active_points)
             effective_aspects = aspects if aspects is not None else PTOLEMAIC_ASPECTS
             aspect_settings = build_aspect_settings(aspect_orb, effective_aspects)
+            # Aspect-keyed table entries resolve once per aspect for the pair;
+            # plain-number tables keep the single-resolve scalar path.
+            aspect_keyed = has_aspect_keyed_adjustments(point_orb_adjustments)
+            aspect_names = [setting["name"] for setting in aspect_settings] if aspect_keyed else []
 
             for prog_name, prog_pos in progressed_points:
                 for natal_name, natal_pos in natal_targets:
-                    extra_orb = resolve_pair_orb_adjustment(
-                        prog_name,
-                        natal_name,
-                        point_orb_adjustments,
-                        point_orb_adjustment_strategy,
-                    )
+                    extra_orb: float | dict
+                    if aspect_keyed:
+                        extra_orb = resolve_pair_orb_adjustments_for_aspects(
+                            prog_name,
+                            natal_name,
+                            point_orb_adjustments,
+                            point_orb_adjustment_strategy,
+                            aspect_names,
+                        )
+                    else:
+                        extra_orb = resolve_pair_orb_adjustment(
+                            prog_name,
+                            natal_name,
+                            point_orb_adjustments,
+                            point_orb_adjustment_strategy,
+                        )
                     outcome = get_aspect_from_two_points(
                         aspects_settings=aspect_settings,
                         point_one=prog_pos,

--- a/kerykeion/secondary_progressions/solar_arc_factory.py
+++ b/kerykeion/secondary_progressions/solar_arc_factory.py
@@ -227,6 +227,7 @@ class SolarArcFactory:
             for d in directed_points:
                 for natal_name, natal_pos in natal_targets:
                     extra_orb: float | dict
+                    scalar_extra: Optional[float]
                     if aspect_keyed:
                         extra_orb = resolve_pair_orb_adjustments_for_aspects(
                             d.name,
@@ -235,27 +236,15 @@ class SolarArcFactory:
                             point_orb_adjustment_strategy,
                             aspect_names,
                         )
-                        # The tautological hit below IS a conjunction, so the
-                        # guard is sized to the conjunction's own extra —
-                        # resolved directly, NOT read from the per-aspect map:
-                        # that map only covers the aspects the caller enabled,
-                        # and a filtered-out conjunction would silently read as
-                        # 0.0, breaking the number ≡ {"*": number} equivalence.
-                        conjunction_extra = resolve_pair_orb_adjustment(
-                            d.name,
-                            natal_name,
-                            point_orb_adjustments,
-                            point_orb_adjustment_strategy,
-                            aspect_name="conjunction",
-                        )
+                        scalar_extra = None
                     else:
-                        extra_orb = resolve_pair_orb_adjustment(
+                        scalar_extra = resolve_pair_orb_adjustment(
                             d.name,
                             natal_name,
                             point_orb_adjustments,
                             point_orb_adjustment_strategy,
                         )
-                        conjunction_extra = extra_orb
+                        extra_orb = scalar_extra
                     # Skip the tautological self-conjunction (a directed point
                     # with its own natal position) using the SAME effective orb
                     # the detection below uses — otherwise a per-pair widening
@@ -265,10 +254,31 @@ class SolarArcFactory:
                     # base orb when a negative conjunction delta has already
                     # closed the conjunction window, discarding same-name
                     # contacts another aspect could still legitimately make.
-                    if natal_name == d.name and _is_near_zero_arc(
-                        solar_arc, max(0.0, aspect_orb + conjunction_extra)
-                    ):
-                        continue
+                    if natal_name == d.name:
+                        if scalar_extra is None:
+                            # The tautological hit IS a conjunction, so the
+                            # guard is sized to the conjunction's own extra —
+                            # resolved directly, NOT read from the per-aspect
+                            # map (that map only covers the aspects the caller
+                            # enabled, and a filtered-out conjunction would
+                            # silently read as 0.0, breaking the number ≡
+                            # {"*": number} equivalence). Resolved HERE, only
+                            # for same-name pairs: no other pair consumes this
+                            # value, and resolving it for every pair would
+                            # evaluate — and possibly reject, e.g. a 'sum'
+                            # overflow — an adjustment that is irrelevant to
+                            # the pair being examined.
+                            conjunction_extra = resolve_pair_orb_adjustment(
+                                d.name,
+                                natal_name,
+                                point_orb_adjustments,
+                                point_orb_adjustment_strategy,
+                                aspect_name="conjunction",
+                            )
+                        else:
+                            conjunction_extra = scalar_extra
+                        if _is_near_zero_arc(solar_arc, max(0.0, aspect_orb + conjunction_extra)):
+                            continue
                     outcome = get_aspect_from_two_points(
                         aspects_settings=aspect_settings,
                         point_one=d.directed_abs_pos,

--- a/kerykeion/secondary_progressions/solar_arc_factory.py
+++ b/kerykeion/secondary_progressions/solar_arc_factory.py
@@ -29,7 +29,13 @@ from pydantic import BaseModel, Field  # noqa: F401  (BaseModel kept for back-co
 from kerykeion.schemas.kr_models import SubscriptableBaseModel
 
 from kerykeion.aspects.aspects_utils import get_aspect_from_two_points
-from kerykeion.aspects.orb_utils import OrbAdjustmentStrategy, resolve_pair_orb_adjustment
+from kerykeion.aspects.orb_utils import (
+    OrbAdjustmentStrategy,
+    PointOrbAdjustment,
+    has_aspect_keyed_adjustments,
+    resolve_pair_orb_adjustment,
+    resolve_pair_orb_adjustments_for_aspects,
+)
 from kerykeion.schemas import KerykeionException
 from kerykeion.schemas.kr_literals import SIGN_CODES
 from kerykeion.schemas.kr_models import AstrologicalSubjectModel
@@ -133,7 +139,7 @@ class SolarArcFactory:
         compute_aspects: bool = True,
         aspect_orb: float = 3.0,
         aspects: Optional[Sequence[str]] = None,
-        point_orb_adjustments: Optional[Mapping[str, float]] = None,
+        point_orb_adjustments: Optional[Mapping[str, PointOrbAdjustment]] = None,
         point_orb_adjustment_strategy: OrbAdjustmentStrategy = "max_explicit",
     ) -> SolarArcSubjectModel:
         """Compute the solar arc and directed-to-natal aspect picture.
@@ -207,21 +213,39 @@ class SolarArcFactory:
         if compute_aspects:
             effective_aspects = aspects if aspects is not None else PTOLEMAIC_ASPECTS
             aspect_settings = build_aspect_settings(aspect_orb, effective_aspects)
+            # Aspect-keyed table entries resolve once per aspect for the pair;
+            # plain-number tables keep the single-resolve scalar path.
+            aspect_keyed = has_aspect_keyed_adjustments(point_orb_adjustments)
+            aspect_names = [setting["name"] for setting in aspect_settings] if aspect_keyed else []
             for d in directed_points:
                 for natal_name, natal_pos in natal_targets:
-                    extra_orb = resolve_pair_orb_adjustment(
-                        d.name,
-                        natal_name,
-                        point_orb_adjustments,
-                        point_orb_adjustment_strategy,
-                    )
+                    extra_orb: float | dict
+                    if aspect_keyed:
+                        extra_orb = resolve_pair_orb_adjustments_for_aspects(
+                            d.name,
+                            natal_name,
+                            point_orb_adjustments,
+                            point_orb_adjustment_strategy,
+                            aspect_names,
+                        )
+                        # The tautological hit below IS a conjunction, so the
+                        # guard is sized to the conjunction's own extra.
+                        conjunction_extra = extra_orb.get("conjunction", 0.0)
+                    else:
+                        extra_orb = resolve_pair_orb_adjustment(
+                            d.name,
+                            natal_name,
+                            point_orb_adjustments,
+                            point_orb_adjustment_strategy,
+                        )
+                        conjunction_extra = extra_orb
                     # Skip the tautological self-conjunction (a directed point
                     # with its own natal position) using the SAME effective orb
                     # the detection below uses — otherwise a per-pair widening
                     # (extra_orb) lets the self-conjunction slip past a guard
                     # sized only to the base orb.
                     if natal_name == d.name and _is_near_zero_arc(
-                        solar_arc, aspect_orb + max(0.0, extra_orb)
+                        solar_arc, aspect_orb + max(0.0, conjunction_extra)
                     ):
                         continue
                     outcome = get_aspect_from_two_points(

--- a/kerykeion/secondary_progressions/solar_arc_factory.py
+++ b/kerykeion/secondary_progressions/solar_arc_factory.py
@@ -35,6 +35,7 @@ from kerykeion.aspects.orb_utils import (
     has_aspect_keyed_adjustments,
     resolve_pair_orb_adjustment,
     resolve_pair_orb_adjustments_for_aspects,
+    validate_point_orb_adjustments,
 )
 from kerykeion.schemas import KerykeionException
 from kerykeion.schemas.kr_literals import SIGN_CODES
@@ -168,6 +169,12 @@ class SolarArcFactory:
             A :class:`SolarArcSubjectModel` describing the arc and every
             directed point + directed-to-natal aspect found.
         """
+        # Validate the WHOLE table up front, like the AspectsFactory entry
+        # points do: the per-pair resolver only ever validates the leaves it
+        # resolves, so a typo'd aspect key or a non-finite leaf outside the
+        # selected aspects would otherwise be silently ignored.
+        validate_point_orb_adjustments(point_orb_adjustments)
+
         if natal_subject.sun is None:
             raise KerykeionException("Natal subject is missing the Sun — cannot compute solar arc.")
         if (target_iso_utc_datetime is None) == (target_year is None):
@@ -229,8 +236,18 @@ class SolarArcFactory:
                             aspect_names,
                         )
                         # The tautological hit below IS a conjunction, so the
-                        # guard is sized to the conjunction's own extra.
-                        conjunction_extra = extra_orb.get("conjunction", 0.0)
+                        # guard is sized to the conjunction's own extra —
+                        # resolved directly, NOT read from the per-aspect map:
+                        # that map only covers the aspects the caller enabled,
+                        # and a filtered-out conjunction would silently read as
+                        # 0.0, breaking the number ≡ {"*": number} equivalence.
+                        conjunction_extra = resolve_pair_orb_adjustment(
+                            d.name,
+                            natal_name,
+                            point_orb_adjustments,
+                            point_orb_adjustment_strategy,
+                            aspect_name="conjunction",
+                        )
                     else:
                         extra_orb = resolve_pair_orb_adjustment(
                             d.name,
@@ -243,9 +260,13 @@ class SolarArcFactory:
                     # with its own natal position) using the SAME effective orb
                     # the detection below uses — otherwise a per-pair widening
                     # (extra_orb) lets the self-conjunction slip past a guard
-                    # sized only to the base orb.
+                    # sized only to the base orb. Clamp the SUM, like detection
+                    # does: clamping only the delta would keep the guard at the
+                    # base orb when a negative conjunction delta has already
+                    # closed the conjunction window, discarding same-name
+                    # contacts another aspect could still legitimately make.
                     if natal_name == d.name and _is_near_zero_arc(
-                        solar_arc, aspect_orb + max(0.0, conjunction_extra)
+                        solar_arc, max(0.0, aspect_orb + conjunction_extra)
                     ):
                         continue
                     outcome = get_aspect_from_two_points(

--- a/site/docs/aspects.md
+++ b/site/docs/aspects.md
@@ -171,6 +171,29 @@ aspects = AspectsFactory.single_chart_aspects(
 A built-in preset, `DEFAULT_NATAL_POINT_ORB_ADJUSTMENTS` (luminary widening), is
 available in `kerykeion.settings.config_constants`.
 
+##### Aspect-keyed adjustments
+
+A point's entry can also vary **by aspect**: instead of a single number, pass a
+mapping of aspect name → adjustment, with `"*"` as the default for aspects not
+listed. `number` and `{"*": number}` are equivalent.
+
+```python
+aspects = AspectsFactory.single_chart_aspects(
+    subject,
+    point_orb_adjustments={
+        "Sun": {"*": 1.5, "conjunction": 3.0},  # 3.0° for Sun conjunctions, 1.5° otherwise
+        "Ascendant": {"conjunction": -3.0},     # configured ONLY for conjunctions
+    },
+)
+```
+
+Without a `"*"` key, the point is **unconfigured** for the aspects it does not
+list — not treated as `0.0`. That preserves the explicit-only rule per aspect:
+in the example above, a Mars–Ascendant trine resolves exactly as if the
+Ascendant were absent from the table, so another point's negative adjustment
+still tightens the pair. Unknown aspect names log a warning (they can never
+match) but do not raise, mirroring how `active_aspects` treats unknown names.
+
 ## Return Data Structure
 
 The factory returns a `SingleChartAspectsModel` (for single charts) or `DualChartAspectsModel` (for dual charts) containing a list of `AspectModel` objects.

--- a/site/docs/chart_data_factory.md
+++ b/site/docs/chart_data_factory.md
@@ -44,7 +44,7 @@ print(f"Qualities: {natal_data.quality_distribution.cardinal_percentage}% Cardin
 | `active_points`              | `List[str]`                | `None`       | Custom points list. If `None`, uses the first subject's own `active_points`.  |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to natal defaults. Each item: `{"name": "conjunction", "orb": 10}`. |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only. |
-| `point_orb_adjustments`      | `Mapping[str, float]`      | `None`       | Finite additive per-point orb adjustments; `None` resolves to the natal Sun/Moon preset. Keyword-only. |
+| `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; `None` resolves to the natal Sun/Moon preset. Keyword-only. |
 | `point_orb_adjustment_strategy` | `str`                   | `"max_explicit"` | `"max_explicit"`, `"min_explicit"`, `"sum"`, or `"none"`. Keyword-only. |
 | `distribution_method`        | `str`                      | `"weighted"` | Element/quality calculation method: `"weighted"` or `"pure_count"`. Keyword-only. |
 | `custom_distribution_weights`| `Mapping[str, float]`      | `None`       | Override individual point weights. Use `"__default__"` for fallback. Keyword-only. |
@@ -82,7 +82,7 @@ if synastry_data.relationship_score:
 | `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to natal defaults.             |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
-| `point_orb_adjustments`      | `Mapping[str, float]`      | `None`       | Finite additive per-point orb adjustments; `None` resolves to the natal Sun/Moon preset. Keyword-only. |
+| `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; `None` resolves to the natal Sun/Moon preset. Keyword-only. |
 | `point_orb_adjustment_strategy` | `str`                   | `"max_explicit"` | Orb adjustment combination strategy. Keyword-only.                         |
 | `include_house_comparison`   | `bool`                     | `True`       | Calculate house overlays.                                                     |
 | `include_relationship_score` | `bool`                     | `True`       | Calculate Ciro Discepolo compatibility score.                                 |
@@ -107,7 +107,7 @@ transit_data = ChartDataFactory.create_transit_chart_data(subject, now)
 | `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list; `None` resolves to predictive defaults.                  |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
-| `point_orb_adjustments`      | `Mapping[str, float]`      | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
+| `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
 | `point_orb_adjustment_strategy` | `str`                   | `"max_explicit"` | Orb adjustment combination strategy. Keyword-only.                         |
 | `include_house_comparison`   | `bool`                     | `True`       | Calculate natal points in transit houses.                                     |
 | `distribution_method`        | `str`                      | `"weighted"` | Element/quality calculation method. Keyword-only.                             |
@@ -132,7 +132,7 @@ composite_data = ChartDataFactory.create_composite_chart_data(composite_subject)
 | `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to natal defaults.             |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
-| `point_orb_adjustments`      | `Mapping[str, float]`      | `None`       | Finite additive per-point orb adjustments; `None` resolves to the natal Sun/Moon preset. Keyword-only. |
+| `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; `None` resolves to the natal Sun/Moon preset. Keyword-only. |
 | `point_orb_adjustment_strategy` | `str`                   | `"max_explicit"` | Orb adjustment combination strategy. Keyword-only.                         |
 | `distribution_method`        | `str`                      | `"weighted"` | Element/quality calculation method. Keyword-only.                             |
 | `custom_distribution_weights`| `Mapping[str, float]`      | `None`       | Override point weights. Keyword-only.                                         |
@@ -159,7 +159,7 @@ return_data = ChartDataFactory.create_return_chart_data(subject, solar_return)
 | `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to predictive defaults.        |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
-| `point_orb_adjustments`      | `Mapping[str, float]`      | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
+| `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
 | `point_orb_adjustment_strategy` | `str`                   | `"max_explicit"` | Orb adjustment combination strategy. Keyword-only.                         |
 | `include_house_comparison`   | `bool`                     | `True`       | Calculate house overlays between natal and return.                            |
 | `distribution_method`        | `str`                      | `"weighted"` | Element/quality calculation method. Keyword-only.                             |
@@ -181,7 +181,7 @@ single_return_data = ChartDataFactory.create_single_wheel_return_chart_data(sola
 | `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to predictive defaults.        |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
-| `point_orb_adjustments`      | `Mapping[str, float]`      | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
+| `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
 | `point_orb_adjustment_strategy` | `str`                   | `"max_explicit"` | Orb adjustment combination strategy. Keyword-only.                         |
 | `distribution_method`        | `str`                      | `"weighted"` | Element/quality calculation method. Keyword-only.                             |
 | `custom_distribution_weights`| `Mapping[str, float]`      | `None`       | Override point weights. Keyword-only.                                         |
@@ -206,7 +206,7 @@ progression_data = ChartDataFactory.create_progression_chart_data(subject, progr
 | `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to predictive defaults.        |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
-| `point_orb_adjustments`      | `Mapping[str, float]`      | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
+| `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
 | `point_orb_adjustment_strategy` | `str`                   | `"max_explicit"` | Orb adjustment combination strategy. Keyword-only.                         |
 | `include_house_comparison`   | `bool`                     | `True`       | Calculate house overlays between natal and progressed.                        |
 | `distribution_method`        | `str`                      | `"weighted"` | Element/quality calculation method. Keyword-only.                             |
@@ -234,7 +234,7 @@ chart_data = ChartDataFactory.create_chart_data(
 | `include_house_comparison`   | `bool`                     | `True`       | Calculate house overlays (dual charts only).                                  |
 | `include_relationship_score` | `bool`                     | `False`      | Calculate compatibility score (synastry only).                                |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite, positive stricter orb for angles. Keyword-only.                        |
-| `point_orb_adjustments`      | `Mapping[str, float]`      | `None`       | Finite additive per-point orb adjustments; chart-type defaults are resolved internally. Keyword-only. |
+| `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; chart-type defaults are resolved internally. Keyword-only. |
 | `point_orb_adjustment_strategy` | `str`                   | `"max_explicit"` | `"max_explicit"`, `"min_explicit"`, `"sum"`, or `"none"`. Keyword-only. |
 | `distribution_method`        | `str`                      | `"weighted"` | `"weighted"` or `"pure_count"`. Keyword-only.                                 |
 | `custom_distribution_weights`| `Mapping[str, float]`      | `None`       | Override point weights. Keyword-only.                                         |

--- a/site/docs/secondary_progressions_factory.md
+++ b/site/docs/secondary_progressions_factory.md
@@ -61,7 +61,7 @@ Returns a `SecondaryProgressionsResultModel` with the progressed subject **plus*
 | `compute_aspects`              | bool              | True            | Whether to compute progressed-to-natal aspects     |
 | `aspect_orb`                   | float             | 3.0             | Orb in degrees for aspect detection                |
 | `aspects`                      | Sequence[str] or None | None        | Whitelist of aspect names (defaults to the 5 Ptolemaic majors: conjunction, opposition, trine, square, sextile) |
-| `point_orb_adjustments`         | Mapping[str, float] or None | None   | Finite additive per-point orb adjustments          |
+| `point_orb_adjustments`         | Mapping[str, float or Mapping[str, float]] or None | None   | Finite additive per-point orb adjustments; entries may be aspect-keyed with a `"*"` default |
 | `point_orb_adjustment_strategy`| str               | "max_explicit" | `max_explicit`, `min_explicit`, `sum`, or `none`   |
 
 ```python

--- a/site/docs/solar_arc_factory.md
+++ b/site/docs/solar_arc_factory.md
@@ -51,7 +51,7 @@ Returns a `SolarArcSubjectModel` with the solar arc, directed points, and direct
 | `compute_aspects`          | bool              | True            | Whether to compute directed-to-natal aspects   |
 | `aspect_orb`               | float             | 3.0             | Orb in degrees for aspect detection            |
 | `aspects`                  | Sequence[str] or None | None        | Whitelist of aspect names                      |
-| `point_orb_adjustments`    | Mapping[str, float] or None | None   | Finite additive per-point orb adjustments      |
+| `point_orb_adjustments`    | Mapping[str, float or Mapping[str, float]] or None | None   | Finite additive per-point orb adjustments; entries may be aspect-keyed with a `"*"` default |
 | `point_orb_adjustment_strategy` | str          | "max_explicit" | `max_explicit`, `min_explicit`, `sum`, or `none` |
 
 ### `compute_directed_subject(natal_subject, *, target_iso_utc_datetime=None, target_year=None)`

--- a/tests/core/test_aspects.py
+++ b/tests/core/test_aspects.py
@@ -1412,6 +1412,24 @@ class TestAspectKeyedOrbAdjustmentsIntegration:
                 "Sun", "Mars", {"Sun": {"conjunction": 1.0}}, "bogus", []  # type: ignore[arg-type]
             )
 
+    def test_empty_aspect_names_keeps_scalar_wildcard_error_parity(self):
+        """number ≡ {"*": number} extends to the error contract: with no
+        aspects in play, a sum overflow must raise on BOTH forms — not only
+        when the table happens to be scalar."""
+        from kerykeion.aspects.orb_utils import resolve_pair_orb_adjustments_for_aspects
+
+        with pytest.raises(ValueError, match="must be finite"):
+            resolve_pair_orb_adjustments_for_aspects(
+                "Sun", "Moon", {"Sun": 1e308, "Moon": {"*": 1e308}}, "sum", []
+            )
+        # A well-formed table still just returns the empty mapping.
+        assert (
+            resolve_pair_orb_adjustments_for_aspects(
+                "Sun", "Moon", {"Sun": {"*": 1.5}, "Moon": 1.5}, "sum", []
+            )
+            == {}
+        )
+
     def test_predictive_factories_validate_table_up_front(self, _subject):
         """A non-finite leaf must raise even when its aspect is not selected."""
         from kerykeion.secondary_progressions import SecondaryProgressionFactory, SolarArcFactory
@@ -1462,6 +1480,26 @@ class TestAspectKeyedOrbAdjustmentsIntegration:
             point_orb_adjustments={"Sun": {"*": 27.0}},
         ).directed_to_natal_aspects
         assert mapped == scalar
+
+    def test_solar_arc_guard_delta_resolved_only_for_self_pairs(self, _subject):
+        """The guard's conjunction delta must not be resolved for cross-name
+        pairs: with 'sum' and huge-but-finite conjunction-only deltas on two
+        points that only ever meet cross-pair (Moon is a natal target but not
+        directed), an eager resolve would overflow and raise for a value no
+        pair consumes."""
+        from kerykeion.secondary_progressions import SolarArcFactory
+
+        result = SolarArcFactory.compute(
+            _subject,
+            target_year=2020,
+            active_points=["Sun"],  # Moon never directed → Moon–Moon never guarded
+            aspects=["trine"],
+            point_orb_adjustments={"Sun": {"conjunction": 8e307}, "Moon": {"conjunction": 1.1e308}},
+            point_orb_adjustment_strategy="sum",
+        )
+        # The call completing IS the assertion; the guard still ran for Sun–Sun
+        # (8e307 + 8e307 is finite) without touching the poisonous cross-sum.
+        assert result.directed_points
 
     def test_solar_arc_guard_tightens_with_negative_conjunction_delta(self, _subject):
         """The guard clamps the SUM like detection: with the conjunction window

--- a/tests/core/test_aspects.py
+++ b/tests/core/test_aspects.py
@@ -1154,6 +1154,255 @@ class TestPointOrbAdjustmentsIntegration:
         assert len(with_bonus.aspects) >= len(without.aspects)
 
 
+class TestAspectKeyedOrbAdjustmentResolver:
+    """Unit tests for aspect-keyed table entries ({"Sun": {"*": 1.5, "conjunction": 3.0}})."""
+
+    def test_wildcard_map_equals_scalar(self):
+        from kerykeion.aspects.orb_utils import resolve_pair_orb_adjustment
+
+        scalar = {"Sun": 1.5}
+        mapped = {"Sun": {"*": 1.5}}
+        for aspect_name in ("conjunction", "trine", None):
+            assert resolve_pair_orb_adjustment(
+                "Sun", "Mars", mapped, aspect_name=aspect_name
+            ) == resolve_pair_orb_adjustment("Sun", "Mars", scalar, aspect_name=aspect_name)
+
+    def test_aspect_override_beats_wildcard(self):
+        from kerykeion.aspects.orb_utils import resolve_pair_orb_adjustment
+
+        table = {"Sun": {"*": 1.5, "conjunction": 3.0}}
+        assert resolve_pair_orb_adjustment("Sun", "Mars", table, aspect_name="conjunction") == 3.0
+        assert resolve_pair_orb_adjustment("Sun", "Mars", table, aspect_name="trine") == 1.5
+
+    def test_no_wildcard_means_unconfigured_for_other_aspects(self):
+        """Explicit-only carries over per aspect: no "*" → absent, not 0.0."""
+        from kerykeion.aspects.orb_utils import resolve_pair_orb_adjustment
+
+        table = {"Ascendant": {"conjunction": -3.0}}
+        assert resolve_pair_orb_adjustment("Mars", "Ascendant", table, aspect_name="conjunction") == -3.0
+        # A trine treats the Ascendant as NOT configured (0.0), not as explicit 0.
+        assert resolve_pair_orb_adjustment("Mars", "Ascendant", table, aspect_name="trine") == 0.0
+
+    def test_absence_preserves_other_points_tightening(self):
+        """The reason absent ≠ 0: an unrelated explicit 0 would neutralize a negative."""
+        from kerykeion.aspects.orb_utils import resolve_pair_orb_adjustment
+
+        table = {"Sun": {"conjunction": 1.5}, "Ascendant": -3.0}
+        # conjunction: both explicit → widest of (1.5, -3.0) = 1.5
+        assert resolve_pair_orb_adjustment("Sun", "Ascendant", table, aspect_name="conjunction") == 1.5
+        # trine: Sun unconfigured → only the Ascendant's -3.0 is explicit
+        assert resolve_pair_orb_adjustment("Sun", "Ascendant", table, aspect_name="trine") == -3.0
+
+    def test_legacy_call_without_aspect_name_uses_wildcard_only(self):
+        """Pre-existing callers (no aspect_name) must see overrides as absent."""
+        from kerykeion.aspects.orb_utils import resolve_pair_orb_adjustment
+
+        assert resolve_pair_orb_adjustment("Sun", "Mars", {"Sun": {"*": 1.0, "conjunction": 5.0}}) == 1.0
+        assert resolve_pair_orb_adjustment("Sun", "Mars", {"Sun": {"conjunction": 5.0}}) == 0.0
+
+    def test_empty_inner_map_is_absent(self):
+        from kerykeion.aspects.orb_utils import resolve_pair_orb_adjustment
+
+        assert resolve_pair_orb_adjustment("Sun", "Mars", {"Sun": {}}, aspect_name="conjunction") == 0.0
+
+    def test_strategies_apply_to_per_aspect_resolved_values(self):
+        from kerykeion.aspects.orb_utils import resolve_pair_orb_adjustment
+
+        table = {"Sun": {"conjunction": 1.5}, "Moon": 1.0}
+        assert resolve_pair_orb_adjustment("Sun", "Moon", table, "sum", aspect_name="conjunction") == 2.5
+        assert resolve_pair_orb_adjustment("Sun", "Moon", table, "sum", aspect_name="trine") == 1.0
+        assert resolve_pair_orb_adjustment("Sun", "Moon", table, "min_explicit", aspect_name="conjunction") == 1.0
+        assert resolve_pair_orb_adjustment("Sun", "Moon", table, "none", aspect_name="conjunction") == 0.0
+
+    def test_lookup_point_adjustment_contract(self):
+        from kerykeion.aspects.orb_utils import lookup_point_adjustment
+
+        assert lookup_point_adjustment(None) is None
+        assert lookup_point_adjustment(1.5) == 1.5
+        assert lookup_point_adjustment({"*": 1.5}, "trine") == 1.5
+        assert lookup_point_adjustment({"conjunction": 3.0}, "conjunction") == 3.0
+        assert lookup_point_adjustment({"conjunction": 3.0}, "trine") is None
+        assert lookup_point_adjustment({"conjunction": 3.0}, None) is None
+        assert lookup_point_adjustment({}, "conjunction") is None
+
+    def test_non_finite_resolved_leaf_rejected(self):
+        from kerykeion.aspects.orb_utils import resolve_pair_orb_adjustment
+
+        with pytest.raises(ValueError, match="finite"):
+            resolve_pair_orb_adjustment(
+                "Sun", "Mars", {"Sun": {"conjunction": float("nan")}}, aspect_name="conjunction"
+            )
+
+    def test_validate_accepts_map_form(self):
+        from kerykeion.aspects.orb_utils import validate_point_orb_adjustments
+
+        validate_point_orb_adjustments({"Sun": {"*": 1.5, "conjunction": 3.0}, "Moon": 1.5})
+
+    @pytest.mark.parametrize("leaf", [float("nan"), float("inf"), True, 10**309])
+    def test_validate_rejects_bad_inner_leaf(self, leaf):
+        from kerykeion.aspects.orb_utils import validate_point_orb_adjustments
+
+        with pytest.raises(ValueError, match="finite"):
+            validate_point_orb_adjustments({"Sun": {"conjunction": leaf}})
+
+    def test_validate_rejects_non_string_inner_key(self):
+        from kerykeion.aspects.orb_utils import validate_point_orb_adjustments
+
+        with pytest.raises(ValueError, match="aspect names"):
+            validate_point_orb_adjustments({"Sun": {1: 2.0}})
+
+    def test_validate_warns_on_unknown_aspect_name(self, caplog):
+        """Permissive like active_aspects: a probable typo warns, never raises."""
+        from kerykeion.aspects.orb_utils import validate_point_orb_adjustments
+
+        with caplog.at_level(logging.WARNING, logger="kerykeion.aspects.orb_utils"):
+            validate_point_orb_adjustments({"Sun": {"conjuction": 1.0}})
+        assert any("unrecognized aspect name" in record.getMessage() for record in caplog.records)
+
+    def test_validate_accepts_wildcard_without_warning(self, caplog):
+        from kerykeion.aspects.orb_utils import validate_point_orb_adjustments
+
+        with caplog.at_level(logging.WARNING, logger="kerykeion.aspects.orb_utils"):
+            validate_point_orb_adjustments({"Sun": {"*": 1.5}})
+        assert not caplog.records
+
+    def test_has_aspect_keyed_adjustments(self):
+        from kerykeion.aspects.orb_utils import has_aspect_keyed_adjustments
+
+        assert has_aspect_keyed_adjustments({"Sun": {"conjunction": 1.0}})
+        assert has_aspect_keyed_adjustments({"Sun": 1.5, "Moon": {"*": 1.0}})
+        assert not has_aspect_keyed_adjustments({"Sun": 1.5})
+        assert not has_aspect_keyed_adjustments({})
+        assert not has_aspect_keyed_adjustments(None)
+
+
+class TestAspectKeyedExtraOrbInAspectDetection:
+    """get_aspect_from_two_points with a per-aspect extra_orb mapping."""
+
+    SETTINGS = [
+        {"name": "conjunction", "degree": 0, "orb": 6.0},
+        {"name": "trine", "degree": 120, "orb": 6.0},
+    ]
+
+    def test_map_extra_widens_only_named_aspect(self):
+        from kerykeion.aspects.aspects_utils import get_aspect_from_two_points
+
+        # 7° separation: outside the 6° base orb, inside 6+1.5.
+        hit = get_aspect_from_two_points(self.SETTINGS, 10.0, 17.0, extra_orb={"conjunction": 1.5})
+        assert hit["verdict"] is True and hit["name"] == "conjunction"
+        miss = get_aspect_from_two_points(self.SETTINGS, 10.0, 17.0, extra_orb={"trine": 1.5})
+        assert miss["verdict"] is False
+
+    def test_missing_name_in_map_defaults_to_zero(self):
+        from kerykeion.aspects.aspects_utils import get_aspect_from_two_points
+
+        # 127° separation: a trine at 7° deviation needs the extra; an empty
+        # map must behave exactly like extra_orb=0.0.
+        assert get_aspect_from_two_points(self.SETTINGS, 0.0, 127.0, extra_orb={})["verdict"] is False
+        assert get_aspect_from_two_points(self.SETTINGS, 0.0, 127.0, extra_orb={"trine": 1.5})["verdict"] is True
+
+    def test_scalar_path_unchanged(self):
+        from kerykeion.aspects.aspects_utils import get_aspect_from_two_points
+
+        scalar = get_aspect_from_two_points(self.SETTINGS, 10.0, 17.0, extra_orb=1.5)
+        mapped = get_aspect_from_two_points(
+            self.SETTINGS, 10.0, 17.0, extra_orb={"conjunction": 1.5, "trine": 1.5}
+        )
+        assert scalar == mapped
+
+
+class TestAspectKeyedOrbAdjustmentsIntegration:
+    """Aspect-keyed adjustments threaded through the factories end to end."""
+
+    @pytest.fixture()
+    def _subject(self):
+        return AstrologicalSubjectFactory.from_birth_data(
+            "Orb Matrix Test", 1990, 6, 15, 12, 0,
+            lat=41.9, lng=12.5, tz_str="Europe/Rome",
+            online=False, suppress_geonames_warning=True,
+        )
+
+    @pytest.fixture()
+    def _subject2(self):
+        return AstrologicalSubjectFactory.from_birth_data(
+            "Orb Matrix Other", 1985, 2, 3, 6, 30,
+            lat=48.85, lng=2.35, tz_str="Europe/Paris",
+            online=False, suppress_geonames_warning=True,
+        )
+
+    @staticmethod
+    def _is_sun_conjunction(aspect):
+        return aspect.aspect == "conjunction" and "Sun" in (aspect.p1_name, aspect.p2_name)
+
+    def test_wildcard_map_table_matches_scalar_table(self, _subject):
+        """{"Sun": 1.5} and {"Sun": {"*": 1.5}} must produce identical aspects."""
+        scalar = AspectsFactory.single_chart_aspects(
+            _subject, point_orb_adjustments={"Sun": 1.5, "Moon": 1.5}
+        ).aspects
+        mapped = AspectsFactory.single_chart_aspects(
+            _subject, point_orb_adjustments={"Sun": {"*": 1.5}, "Moon": {"*": 1.5}}
+        ).aspects
+        assert mapped == scalar
+
+    def test_tightening_one_aspect_leaves_every_other_aspect_untouched(self, _subject):
+        base = AspectsFactory.single_chart_aspects(_subject).aspects
+        result = AspectsFactory.single_chart_aspects(
+            _subject, point_orb_adjustments={"Sun": {"conjunction": -100.0}}
+        ).aspects
+        assert not any(self._is_sun_conjunction(a) for a in result)
+        expected = [a for a in base if not self._is_sun_conjunction(a)]
+        assert result == expected
+
+    def test_widening_one_aspect_leaves_every_other_aspect_untouched(self, _subject):
+        base = AspectsFactory.single_chart_aspects(_subject).aspects
+        result = AspectsFactory.single_chart_aspects(
+            _subject, point_orb_adjustments={"Sun": {"conjunction": 3.0}}
+        ).aspects
+        assert [a for a in result if not self._is_sun_conjunction(a)] == [
+            a for a in base if not self._is_sun_conjunction(a)
+        ]
+        assert sum(self._is_sun_conjunction(a) for a in result) >= sum(
+            self._is_sun_conjunction(a) for a in base
+        )
+
+    def test_dual_chart_tightening_one_aspect(self, _subject, _subject2):
+        base = AspectsFactory.dual_chart_aspects(_subject, _subject2).aspects
+        result = AspectsFactory.dual_chart_aspects(
+            _subject, _subject2, point_orb_adjustments={"Sun": {"conjunction": -100.0}}
+        ).aspects
+        assert not any(self._is_sun_conjunction(a) for a in result)
+        expected = [a for a in base if not self._is_sun_conjunction(a)]
+        assert result == expected
+
+    def test_factory_validates_map_leaves_up_front(self, _subject):
+        with pytest.raises(ValueError, match="finite"):
+            AspectsFactory.single_chart_aspects(
+                _subject, point_orb_adjustments={"Sun": {"conjunction": float("nan")}}
+            )
+
+    def test_secondary_progressions_accept_map_form(self, _subject):
+        from kerykeion.secondary_progressions import SecondaryProgressionFactory
+
+        scalar = SecondaryProgressionFactory.compute_full(
+            _subject, target_year=2020, point_orb_adjustments={"Sun": 1.0}
+        ).progressed_to_natal_aspects
+        mapped = SecondaryProgressionFactory.compute_full(
+            _subject, target_year=2020, point_orb_adjustments={"Sun": {"*": 1.0}}
+        ).progressed_to_natal_aspects
+        assert mapped == scalar
+
+    def test_solar_arc_accepts_map_form(self, _subject):
+        from kerykeion.secondary_progressions import SolarArcFactory
+
+        scalar = SolarArcFactory.compute(
+            _subject, target_year=2020, point_orb_adjustments={"Sun": 1.0}
+        ).directed_to_natal_aspects
+        mapped = SolarArcFactory.compute(
+            _subject, target_year=2020, point_orb_adjustments={"Sun": {"*": 1.0}}
+        ).directed_to_natal_aspects
+        assert mapped == scalar
+
+
 # =============================================================================
 # Regression tests — geometric opposite pairs, fixed stars, unknown aspects
 # =============================================================================

--- a/tests/core/test_aspects.py
+++ b/tests/core/test_aspects.py
@@ -11,6 +11,7 @@ Uses session-scoped conftest fixtures: johnny_depp, john_lennon, yoko_ono, paul_
 """
 
 import logging
+from typing import ClassVar
 
 import pytest
 from pytest import approx
@@ -1279,7 +1280,7 @@ class TestAspectKeyedOrbAdjustmentResolver:
 class TestAspectKeyedExtraOrbInAspectDetection:
     """get_aspect_from_two_points with a per-aspect extra_orb mapping."""
 
-    SETTINGS = [
+    SETTINGS: ClassVar[list[dict]] = [
         {"name": "conjunction", "degree": 0, "orb": 6.0},
         {"name": "trine", "degree": 120, "orb": 6.0},
     ]
@@ -1401,6 +1402,84 @@ class TestAspectKeyedOrbAdjustmentsIntegration:
             _subject, target_year=2020, point_orb_adjustments={"Sun": {"*": 1.0}}
         ).directed_to_natal_aspects
         assert mapped == scalar
+
+    def test_strategy_validated_even_with_no_aspects_in_play(self):
+        """An empty aspect_names must not swallow a misspelled strategy."""
+        from kerykeion.aspects.orb_utils import resolve_pair_orb_adjustments_for_aspects
+
+        with pytest.raises(ValueError, match="Unknown orb adjustment strategy"):
+            resolve_pair_orb_adjustments_for_aspects(
+                "Sun", "Mars", {"Sun": {"conjunction": 1.0}}, "bogus", []  # type: ignore[arg-type]
+            )
+
+    def test_predictive_factories_validate_table_up_front(self, _subject):
+        """A non-finite leaf must raise even when its aspect is not selected."""
+        from kerykeion.secondary_progressions import SecondaryProgressionFactory, SolarArcFactory
+
+        bad_table = {"Sun": {"conjunction": float("nan")}}
+        with pytest.raises(ValueError, match="finite"):
+            SecondaryProgressionFactory.compute_full(
+                _subject, target_year=2020, aspects=["trine"], point_orb_adjustments=bad_table
+            )
+        with pytest.raises(ValueError, match="finite"):
+            SolarArcFactory.compute(
+                _subject, target_year=2020, aspects=["trine"], point_orb_adjustments=bad_table
+            )
+
+    def test_predictive_factories_warn_on_typo_aspect_key(self, _subject, caplog):
+        """The unknown-aspect-name warning must fire from the predictive entry points too."""
+        from kerykeion.secondary_progressions import SecondaryProgressionFactory, SolarArcFactory
+
+        typo_table = {"Sun": {"conjuction": 1.0}}
+        for factory_call in (
+            lambda: SecondaryProgressionFactory.compute_full(
+                _subject, target_year=2020, point_orb_adjustments=typo_table
+            ),
+            lambda: SolarArcFactory.compute(
+                _subject, target_year=2020, point_orb_adjustments=typo_table
+            ),
+        ):
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="kerykeion.aspects.orb_utils"):
+                factory_call()
+            assert any("unrecognized aspect name" in record.getMessage() for record in caplog.records)
+
+    def test_solar_arc_guard_equivalence_when_conjunction_not_selected(self, _subject):
+        """number ≡ {"*": number} must hold in the self-conjunction guard even
+        when the aspect filter excludes the conjunction (the guard's delta is
+        resolved directly, not read from the filtered per-aspect map)."""
+        from kerykeion.secondary_progressions import SolarArcFactory
+
+        # ~5 years after birth → solar arc ≈ 5°: inside the scalar guard
+        # (3 + 27), outside the base orb alone. The huge widening makes the
+        # semi-sextile window (3 + 27 = 30) reach the same-name pair.
+        scalar = SolarArcFactory.compute(
+            _subject, target_year=1995, aspects=["semi-sextile"],
+            point_orb_adjustments={"Sun": 27.0},
+        ).directed_to_natal_aspects
+        mapped = SolarArcFactory.compute(
+            _subject, target_year=1995, aspects=["semi-sextile"],
+            point_orb_adjustments={"Sun": {"*": 27.0}},
+        ).directed_to_natal_aspects
+        assert mapped == scalar
+
+    def test_solar_arc_guard_tightens_with_negative_conjunction_delta(self, _subject):
+        """The guard clamps the SUM like detection: with the conjunction window
+        closed by a negative delta, a same-name contact another aspect can
+        still make must survive the guard."""
+        from kerykeion.secondary_progressions import SolarArcFactory
+
+        # Target ~6 months after birth → solar arc ≈ 0.5°. The conjunction
+        # window is max(0, 3 - 100) = 0, so the guard must not skip; the
+        # widened semi-sextile (3 + 27 = 30) then reaches |0.5 - 30| ≈ 29.5.
+        result = SolarArcFactory.compute(
+            _subject, target_year=1991, aspects=["conjunction", "semi-sextile"],
+            point_orb_adjustments={"Sun": {"conjunction": -100.0, "semi-sextile": 27.0}},
+        ).directed_to_natal_aspects
+        assert any(
+            a.directed_point == "Sun" and a.natal_point == "Sun" and a.aspect == "semi-sextile"
+            for a in result
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
## What

`point_orb_adjustments` entries can now vary **by aspect**. A point's entry is either the existing plain number, or a mapping of aspect name → additive delta with `"*"` as the default for aspects not listed:

```python
point_orb_adjustments={
    "Sun": 1.5,                              # current form: every aspect
    "Moon": {"*": 1.5, "conjunction": 3.0},  # 3.0° for Moon conjunctions, 1.5° otherwise
    "Ascendant": {"conjunction": -3.0},      # configured ONLY for conjunctions
}
```

Lookup per (point, aspect) is `map[aspect] ?? map["*"] ?? absent`. `number` and `{"*": number}` are strictly equivalent.

## Why

The per-point table can widen or tighten every aspect of a point, but professional practice often wants aspect-specific rules ("Sun conjunctions at 9°, Sun trines at 7.5°"). Aspect × point matrices have professional precedent; the per-*pair* variant was evaluated and rejected (no tradition prescribes it beyond what moieties derive, and it invites astronomically impossible rules).

## Design decisions

- **Explicit-only carries over per aspect.** Without `"*"`, a point is *unconfigured* (not `0.0`) for aspects it does not list — so a negative delta on the other endpoint keeps tightening, exactly like the existing scalar semantics. This is the property that makes negative adjustments work at all.
- **Deltas, not absolute orbs.** The combination strategies (`max_explicit` / `min_explicit` / `sum` / `none`) stay the only pair mechanism, now applied to the two per-aspect resolved values.
- **100% backward compatible.** Every existing table is valid unchanged and resolves identically. `resolve_pair_orb_adjustment` gains a keyword-only `aspect_name=None`; with `None` (every pre-existing caller) aspect-keyed entries resolve through `"*"` only. The scalar fast path in `get_aspect_from_two_points` and the factories is untouched — per-aspect resolution only activates when the table actually contains a mapping entry.
- **Permissive validation.** Unknown aspect names in a mapping log a warning (never an error), mirroring `active_aspects`; non-finite leaves and non-string keys are rejected up front.

## Where

- `kerykeion/aspects/orb_utils.py` — `PointOrbAdjustment` type, `lookup_point_adjustment`, `has_aspect_keyed_adjustments`, `resolve_pair_orb_adjustments_for_aspects`, `aspect_name` parameter, extended validation.
- `kerykeion/aspects/aspects_utils.py` — `get_aspect_from_two_points` accepts a per-aspect `extra_orb` mapping.
- `kerykeion/aspects/aspects_factory.py` — single- and dual-chart loops resolve per aspect only when the table is aspect-keyed.
- `kerykeion/secondary_progressions/{secondary_progression_factory,solar_arc_factory}.py` — same pattern; the solar-arc self-conjunction guard now sizes itself to the **conjunction's** own delta (the tautological hit is a conjunction).
- `kerykeion/chart_data_factory.py` — signature/docs widening only (delegates to the factories above).
- Docs: `site/docs/aspects.md` (new "Aspect-keyed adjustments" section), factory parameter tables, CHANGELOG under Unreleased.

## Versioning

No version bump here — this joins the next release train (a81 in preparation on #241, or a82). Nothing is published.

## Tests

- 30 new tests in `tests/core/test_aspects.py`: resolver unit coverage (wildcard equivalence, override precedence, no-wildcard absence, legacy `aspect_name=None` behavior, strategies on per-aspect values, validation incl. the typo warning), `get_aspect_from_two_points` with map `extra_orb`, and factory integration (scalar ≡ `{"*": x}` parity, tightening/widening one aspect leaves every other aspect byte-identical, dual chart, progressions, solar arc).
- Full suite green; mypy and ruff clean on all touched modules.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FVi6KXwFmp564FrQFbYRQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-aspect point orb adjustments, including wildcard defaults.
  * Supports aspect-specific adjustments across natal, dual-chart, progression, and solar-arc calculations.
  * Preserves compatibility with existing numeric adjustments.
  * Added validation, warnings for unknown aspects, and rejection of invalid values.

* **Documentation**
  * Updated aspect, chart, progression, and solar-arc documentation with configuration examples and behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->