### PR TITLE
docs: document studio-calc migration features

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ It is [open source](https://github.com/g-battaglia/Astrologer-API) and directly 
   - [Astro-Cartography (ACG)](#astro-cartography-acg)
   - [Chart Dominants](#chart-dominants)
   - [Zodiacal Releasing (Aphesis)](#zodiacal-releasing-aphesis)
+  - [Profections (Annual)](#profections-annual)
+  - [Firdaria (Planetary Periods)](#firdaria-planetary-periods)
+  - [Mutual Receptions](#mutual-receptions)
+  - [Horary Indicators](#horary-indicators)
 - [Documentation](#documentation)
 - [Projects built with Kerykeion](#projects-built-with-kerykeion)
 - [Development](#development)
@@ -2343,6 +2347,55 @@ from kerykeion import AstrologicalSubjectFactory, ZodiacalReleasingFactory
 subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, "Rome", "IT")
 zr = ZodiacalReleasingFactory.from_subject(subject, lot="fortune", levels=2, target_date="2026-06-04")
 print(zr.lot_sign, len(zr.periods), "top-level periods")
+```
+
+### Profections (Annual)
+
+`ProfectionsFactory` computes annual profections — a traditional timing technique where each year of life activates one house (cycling every 12 years). The sign on the cusp determines the Lord of the Year. Respects the subject's house system and supports BCE births.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, ProfectionsFactory
+
+subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, "Rome", "IT")
+profections = ProfectionsFactory.from_subject(subject, target_date="2026-06-04")
+print(f"Age {profections.current.age}: house {profections.current.house}, lord {profections.current.lord}")
+```
+
+### Firdaria (Planetary Periods)
+
+`FirdariaFactory` computes the Persian time-lord sequence that divides life into planetary periods. Day charts begin with the Sun (10 years), night charts with the Moon (9 years). Each major period is subdivided among the seven classical planets. All date arithmetic uses Julian Days, so BCE births are supported.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, FirdariaFactory
+
+subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, "Rome", "IT")
+firdaria = FirdariaFactory.from_subject(subject, target_date="2026-06-04")
+print(f"Current lord: {firdaria.current.lord}" if firdaria.current else "No current period")
+```
+
+### Mutual Receptions
+
+`MutualReceptionsFactory` detects domicile and exaltation mutual receptions among the seven classical planets (Sun through Saturn). A reception is found when two planets each occupy a sign ruled by the other.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, MutualReceptionsFactory
+
+subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, "Rome", "IT")
+receptions = MutualReceptionsFactory.from_subject(subject)
+for r in receptions.receptions:
+    print(f"{r.first_planet} ↔ {r.second_planet} ({r.reception_type})")
+```
+
+### Horary Indicators
+
+`HoraryIndicatorsFactory` assembles horary significators (querent/quesited via classical rulership), considerations before judgment (Ascendant degree, Saturn placement, Moon void-of-course), and mutual receptions for a question chart.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, HoraryIndicatorsFactory
+
+subject = AstrologicalSubjectFactory.from_birth_data("Question", 2026, 6, 4, 15, 30, "Rome", "IT")
+indicators = HoraryIndicatorsFactory.from_subject(subject)
+print(f"Querent ruler: {indicators.querent.ruler}, Quesited ruler: {indicators.quesited.ruler}")
 ```
 
 ## Documentation

--- a/examples/firdaria_example.py
+++ b/examples/firdaria_example.py
@@ -1,0 +1,39 @@
+"""Firdaria: compute Persian planetary periods for a natal chart."""
+
+from kerykeion import AstrologicalSubjectFactory, FirdariaFactory
+
+
+def main() -> None:
+    natal = AstrologicalSubjectFactory.from_birth_data(
+        name="Grace Hopper",
+        year=1906,
+        month=12,
+        day=9,
+        hour=11,
+        minute=30,
+        lng=-73.9857,
+        lat=40.7484,
+        tz_str="America/New_York",
+        city="New York",
+        nation="US",
+        online=False,
+    )
+
+    firdaria = FirdariaFactory.from_subject(natal, target_date="2026-06-04")
+    print(f"Sect: {'Day' if firdaria.is_diurnal else 'Night'}")
+
+    if firdaria.current:
+        print(f"Current lord: {firdaria.current.lord} ({firdaria.current.years} years)")
+        print(f"  Ages {firdaria.current.age_start}–{firdaria.current.age_end}")
+        print(f"  {firdaria.current.start} to {firdaria.current.end}")
+    if firdaria.current_sub:
+        print(f"Current sub-lord: {firdaria.current_sub.lord}")
+        print(f"  {firdaria.current_sub.start} to {firdaria.current_sub.end}")
+
+    print(f"\nAll periods ({len(firdaria.periods)}):")
+    for p in firdaria.periods:
+        print(f"  {p.lord:12s}  {p.years:2d} years  ages {p.age_start:3d}–{p.age_end:3d}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/horary_example.py
+++ b/examples/horary_example.py
@@ -1,0 +1,44 @@
+"""Horary Indicators: assemble significators and considerations."""
+
+from kerykeion import AstrologicalSubjectFactory, HoraryIndicatorsFactory
+
+
+def main() -> None:
+    question = AstrologicalSubjectFactory.from_birth_data(
+        name="Question",
+        year=2026,
+        month=6,
+        day=4,
+        hour=15,
+        minute=30,
+        lng=12.4964,
+        lat=41.9028,
+        tz_str="Europe/Rome",
+        city="Rome",
+        nation="IT",
+        online=False,
+    )
+
+    indicators = HoraryIndicatorsFactory.from_subject(question, is_moon_void=False)
+
+    print("Querent (1st house):")
+    q = indicators.querent
+    print(f"  Sign: {q.sign}, Ruler: {q.ruler}, in house {q.ruler_house_number}")
+
+    print("Quesited (7th house):")
+    qs = indicators.quesited
+    print(f"  Sign: {qs.sign}, Ruler: {qs.ruler}, in house {qs.ruler_house_number}")
+
+    print(f"\nAscendant degree: {indicators.ascendant_degree:.2f}°")
+
+    print("\nConsiderations:")
+    for c in indicators.considerations:
+        print(f"  [{c.status}] {c.key}")
+
+    print(f"\nMutual receptions: {len(indicators.mutual_receptions)}")
+    for r in indicators.mutual_receptions:
+        print(f"  {r.first_planet} ↔ {r.second_planet} ({r.reception_type})")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mutual_receptions_example.py
+++ b/examples/mutual_receptions_example.py
@@ -1,0 +1,32 @@
+"""Mutual Receptions: detect domicile and exaltation receptions."""
+
+from kerykeion import AstrologicalSubjectFactory, MutualReceptionsFactory
+
+
+def main() -> None:
+    natal = AstrologicalSubjectFactory.from_birth_data(
+        name="Grace Hopper",
+        year=1906,
+        month=12,
+        day=9,
+        hour=11,
+        minute=30,
+        lng=-73.9857,
+        lat=40.7484,
+        tz_str="America/New_York",
+        city="New York",
+        nation="US",
+        online=False,
+    )
+
+    receptions = MutualReceptionsFactory.from_subject(natal)
+
+    if not receptions.receptions:
+        print("No mutual receptions found among the classical planets.")
+    else:
+        for r in receptions.receptions:
+            print(f"{r.first_planet} ↔ {r.second_planet} (by {r.reception_type})")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/profections_example.py
+++ b/examples/profections_example.py
@@ -1,0 +1,35 @@
+"""Annual Profections: compute profection years for a natal chart."""
+
+from kerykeion import AstrologicalSubjectFactory, ProfectionsFactory
+
+
+def main() -> None:
+    natal = AstrologicalSubjectFactory.from_birth_data(
+        name="Grace Hopper",
+        year=1906,
+        month=12,
+        day=9,
+        hour=11,
+        minute=30,
+        lng=-73.9857,
+        lat=40.7484,
+        tz_str="America/New_York",
+        city="New York",
+        nation="US",
+        online=False,
+    )
+
+    profections = ProfectionsFactory.from_subject(natal, target_date="2026-06-04")
+    current = profections.current
+    print(f"Age {current.age}: {current.house}th house ({current.sign})")
+    print(f"Lord of the Year: {current.lord}")
+    print(f"Year: {current.year_start} to {current.year_end}")
+
+    print(f"\nFull table ({len(profections.years)} years):")
+    for year in profections.years:
+        marker = " ★" if year.age == current.age else ""
+        print(f"  Age {year.age:3d}  House {year.house:2d}  {year.sign:3s}  {year.lord}{marker}")
+
+
+if __name__ == "__main__":
+    main()

--- a/kerykeion/llms.txt
+++ b/kerykeion/llms.txt
@@ -341,6 +341,44 @@ windows intersecting a UTC range. `MundaneAspectFactory` defaults to Sun–Pluto
 signs but not exact aspect times. Sun/planetary-hour datetimes are timezone-aware
 UTC values anchored to the requested civil timezone.
 
+## 5B. Traditional / Hellenistic Techniques
+
+```python
+from kerykeion import (
+    AstrologicalSubjectFactory,
+    ProfectionsFactory,
+    FirdariaFactory,
+    MutualReceptionsFactory,
+    HoraryIndicatorsFactory,
+)
+
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Example", 1990, 6, 15, 14, 30,
+    lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False
+)
+
+profections = ProfectionsFactory.from_subject(subject, target_date="2026-06-04")
+print(profections.current.age, profections.current.sign, profections.current.lord)
+
+firdaria = FirdariaFactory.from_subject(subject, target_date="2026-06-04")
+print(firdaria.is_diurnal, firdaria.current.lord if firdaria.current else None)
+
+receptions = MutualReceptionsFactory.from_subject(subject)
+print(len(receptions.receptions), "mutual receptions found")
+
+indicators = HoraryIndicatorsFactory.from_subject(subject)
+print(indicators.querent.ruler, indicators.quesited.ruler)
+```
+
+`ProfectionsFactory` computes annual profections from the subject's houses — age,
+activated house/sign, and the Lord of the Year via classical rulership. BCE births
+supported. `FirdariaFactory` builds the Persian time-lord sequence (diurnal or
+nocturnal) with seven-planet sub-periods; all arithmetic on Julian Days.
+`MutualReceptionsFactory` finds domicile and exaltation receptions among the
+classical planets. `HoraryIndicatorsFactory` assembles horary significators (1st/7th
+house), classical considerations (Ascendant degree, Saturn, Moon void), and
+receptions. All require terrestrial perspective.
+
 ## 6. AI Context Serialization
 
 Convert any Kerykeion model to AI-readable XML:
@@ -614,6 +652,10 @@ export KERYKEION_GEONAMES_USERNAME="your_username"  # For online mode
 | Void-of-Course   | `VoidOfCourseMoonFactory`      | Moment/range     |
 | Sun Times        | `SunTimesFactory`              | Date + location  |
 | Planetary Hours  | `PlanetaryHoursFactory`        | Moment + location|
+| Profections      | `ProfectionsFactory`           | Subject          |
+| Firdaria         | `FirdariaFactory`              | Subject          |
+| Receptions       | `MutualReceptionsFactory`      | Subject          |
+| Horary           | `HoraryIndicatorsFactory`      | Subject          |
 
 ---
 

--- a/site/docs/astrological_subject_factory.md
+++ b/site/docs/astrological_subject_factory.md
@@ -245,6 +245,10 @@ Adds `subject.nutation` with `true_obliquity`, `mean_obliquity`, `nutation_in_lo
 
 Adds `azimuth` and `altitude_above_horizon` fields for each point. Useful for astro-locality work.
 
+### Motion State
+
+Always computed for the ten planets (Sun through Pluto) in Earth-centred perspectives. Access via `subject.sun.motion_state`. Returns a `MotionState` literal: `"retrograde"`, `"stationary"` (< 5% of mean motion), `"slow"` (< 80%), `"average"` (80-120%), or `"fast"` (> 120%). `None` for nodes, asteroids, fixed stars, and non-geocentric perspectives.
+
 ### Declination & Out-of-Bounds
 
 Always computed. Access via `subject.sun.declination` and `subject.sun.is_out_of_bounds`. A planet is out-of-bounds when its declination exceeds the Sun's maximum (~23.44°).

--- a/site/docs/chart_data_factory.md
+++ b/site/docs/chart_data_factory.md
@@ -249,6 +249,8 @@ Used for Natal, Composite, and Single Return charts.
 - `aspects`: List of internal aspects.
 - `element_distribution`: Fire/Earth/Air/Water breakdown.
 - `quality_distribution`: Cardinal/Fixed/Mutable breakdown.
+- `angularities`: List of `AngularityModel` — classical planets conjunct the four angles (Ascendant, Medium Coeli, Descendant, Imum Coeli) within the orb (default 8°). Each entry carries `point`, `angle`, and `distance`.
+- `stelliums`: List of `StelliumModel` — houses with three or more classical planets. Each entry carries `house` (1-12) and `points` (list of planet names).
 
 ### `DualChartDataModel`
 
@@ -258,6 +260,8 @@ Used for Synastry, Transit, and Dual Return charts.
 - `aspects`: Inter-chart aspects.
 - `relationship_score`: Compatibility score (if requested).
 - `house_comparison`: Planet overlays in houses (if requested).
+- `first_subject_angularities`, `first_subject_stelliums`: Angularities and stelliums for the first (natal) subject.
+- `second_subject_angularities`, `second_subject_stelliums`: Angularities and stelliums for the second (transit/partner/return) subject.
 
 ## Analysis Example
 

--- a/site/docs/firdaria_factory.md
+++ b/site/docs/firdaria_factory.md
@@ -1,0 +1,91 @@
+---
+title: 'Firdaria (Planetary Periods)'
+description: 'Compute the firdaria — Persian planetary time-lord periods based on the chart sect.'
+category: 'Forecasting'
+tags: ['docs', 'firdaria', 'time-lord', 'persian', 'traditional', 'kerykeion']
+order: 61
+---
+
+# Firdaria (Planetary Periods)
+
+**`FirdariaFactory`** computes the **firdaria**, a Persian time-lord technique that divides life into a fixed sequence of planetary periods. The sequence depends on the chart's sect: diurnal charts begin with the Sun (10 years), nocturnal charts begin with the Moon (9 years). The full 75-year cycle runs through the seven classical planets and the two lunar nodes.
+
+Each major period (except the nodes) is subdivided into seven sub-periods, one per classical planet, beginning from the major lord itself and cycling through the Chaldean order.
+
+All date arithmetic runs on Julian Days over the subject's local wall-clock anchor, so deep-BCE births are fully supported. A firdaria "year" is the Julian year of 365.25 days.
+
+## Basic Usage
+
+```python
+from kerykeion import AstrologicalSubjectFactory, FirdariaFactory
+
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Jane", 1990, 6, 15, 12, 0,
+    lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False
+)
+
+firdaria = FirdariaFactory.from_subject(subject, target_date="2026-06-04")
+print(f"Sect: {'Day' if firdaria.is_diurnal else 'Night'}")
+if firdaria.current:
+    print(f"Current lord: {firdaria.current.lord} ({firdaria.current.years} years)")
+if firdaria.current_sub:
+    print(f"Current sub-lord: {firdaria.current_sub.lord}")
+```
+
+## Methods
+
+### `from_subject(subject, *, target_date=None, life_cap_years=120)`
+
+Build the firdaria timeline for a subject.
+
+| Parameter        | Type                       | Default | Description                                                                                     |
+| :--------------- | :------------------------- | :------ | :---------------------------------------------------------------------------------------------- |
+| `subject`        | `AstrologicalSubjectModel` | --      | The natal chart. Requires a real sect (`is_diurnal` must be a boolean). Midpoint composites are rejected. |
+| `target_date`    | str (ISO date/datetime) or None | None | Date the current period is resolved against. Astronomical year numbering accepted. When omitted, now in the subject's timezone. |
+| `life_cap_years` | int                        | 120     | How far the timeline extends, in years of life.                                                 |
+
+**Returns:** `FirdariaModel`
+
+**Raises:** `KerykeionException` when the sect is unresolvable, the birth moment is missing, or `target_date` is unparseable.
+
+## Data Models
+
+### `FirdariaModel`
+
+| Field         | Type                             | Description                                                      |
+| :------------ | :------------------------------- | :--------------------------------------------------------------- |
+| `is_diurnal`  | `bool`                           | Sect the sequence was chosen from.                               |
+| `periods`     | `list[FirdariaPeriodModel]`      | Major periods from birth up to the life cap, in order.           |
+| `current`     | `FirdariaPeriodModel \| None`    | The major period containing the target date, if any.             |
+| `current_sub` | `FirdariaSubPeriodModel \| None` | The sub-period containing the target date, if any.               |
+
+### `FirdariaPeriodModel`
+
+| Field         | Type                              | Description                                                                  |
+| :------------ | :-------------------------------- | :--------------------------------------------------------------------------- |
+| `lord`        | `str`                             | Ruler of the period (classical planet or `North_Node` / `South_Node`).       |
+| `years`       | `int`                             | Length of the period in firdaria years.                                       |
+| `age_start`   | `int`                             | Age at which the period begins.                                              |
+| `age_end`     | `int`                             | Age at which the period ends.                                                |
+| `start`       | `str`                             | Local ISO datetime (`YYYY-MM-DDTHH:MM:SS`) the period begins.               |
+| `end`         | `str`                             | Local ISO datetime the period ends.                                          |
+| `sub_periods` | `list[FirdariaSubPeriodModel]`    | Seven sub-lord periods (empty for the nodes, which are not subdivided).      |
+
+### `FirdariaSubPeriodModel`
+
+| Field   | Type              | Description                                              |
+| :------ | :---------------- | :------------------------------------------------------- |
+| `lord`  | `ClassicalPlanet` | Planet ruling the sub-period.                            |
+| `start` | `str`             | Local ISO datetime the sub-period begins.                |
+| `end`   | `str`             | Local ISO datetime the sub-period ends.                  |
+
+### Period Sequences
+
+| Sect     | Sequence (lord, years)                                                                    |
+| :------- | :---------------------------------------------------------------------------------------- |
+| Diurnal  | Sun 10 → Venus 8 → Mercury 13 → Moon 9 → Saturn 11 → Jupiter 12 → Mars 7 → NN 3 → SN 2 |
+| Nocturnal| Moon 9 → Saturn 11 → Jupiter 12 → Mars 7 → Sun 10 → Venus 8 → Mercury 13 → NN 3 → SN 2 |
+
+---
+
+> **Need this in production?** Use the [Astrologer API](https://www.kerykeion.net/astrologer-api/subscribe) for hosted calculations, charts, and AI interpretations - no server setup required. [Learn more →](/content/docs/astrologer-api)

--- a/site/docs/fixed_star_discovery_factory.md
+++ b/site/docs/fixed_star_discovery_factory.md
@@ -62,9 +62,11 @@ Each returned `KerykeionPointModel` is enriched with discovery metadata:
 The catalog is sourced from **libephemeris** (the default backend). On the swisseph backend, the factory requires `sefstars.txt` to be present in the ephemeris data path (see [Swiss Ephemeris Configuration](/content/docs/swisseph_configuration) for details).
 
 Catalog enumeration uses immutable `FixedStarMetadataModel` entries containing
-`name`, canonical `slug`, optional Hipparcos number, nomenclature, and visual
-magnitude. Discovery results remain enriched `KerykeionPointModel` objects as
-described above.
+`name`, canonical `slug`, optional Hipparcos number, nomenclature, visual
+magnitude, and `constellation` (the IAU three-letter abbreviation of the star's
+constellation, e.g. `"Ori"` for Orion, derived from the nomenclature; `None` when
+the star has no standard constellation assignment). Discovery results remain
+enriched `KerykeionPointModel` objects as described above.
 
 ## Wider Orb Example
 

--- a/site/docs/horary_factory.md
+++ b/site/docs/horary_factory.md
@@ -1,0 +1,97 @@
+---
+title: 'Horary Indicators'
+description: 'Assemble horary significators, classical considerations before judgment, and mutual receptions for a question chart.'
+category: 'Analysis'
+tags: ['docs', 'horary', 'significators', 'considerations', 'traditional', 'kerykeion']
+order: 63
+---
+
+# Horary Indicators
+
+**`HoraryIndicatorsFactory`** assembles the core components an astrologer evaluates when reading a horary chart: the **significators** of the querent (1st house) and quesited (7th house), the **classical considerations before judgment**, and the **mutual receptions** among classical planets.
+
+The Ascendant degree is read from the true Ascendant point (not the first-house cusp), so Whole Sign charts — where the cusp sits at 0° of the rising sign — are correctly handled.
+
+Only terrestrial (geocentric/topocentric) perspectives are accepted.
+
+## Basic Usage
+
+```python
+from kerykeion import AstrologicalSubjectFactory, HoraryIndicatorsFactory
+
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Question", 2026, 6, 4, 15, 30,
+    lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False
+)
+
+indicators = HoraryIndicatorsFactory.from_subject(subject, is_moon_void=False)
+print(f"Querent ruler: {indicators.querent.ruler}")
+print(f"Quesited ruler: {indicators.quesited.ruler}")
+for c in indicators.considerations:
+    print(f"  [{c.status}] {c.key}")
+```
+
+## Methods
+
+### `from_subject(subject, *, is_moon_void=None)`
+
+Build the indicators for a question chart.
+
+| Parameter     | Type                       | Default | Description                                                                                                     |
+| :------------ | :------------------------- | :------ | :-------------------------------------------------------------------------------------------------------------- |
+| `subject`     | `AstrologicalSubjectModel` | --      | The chart cast for the moment of the question.                                                                  |
+| `is_moon_void`| `bool \| None`             | None    | Whether the Moon is void of course (from a separate void-of-course calculation). `None` omits the Moon void considerations. |
+
+**Returns:** `HoraryIndicatorsModel`
+
+**Raises:** `KerykeionException` when the chart's perspective is not terrestrial.
+
+## Data Models
+
+### `HoraryIndicatorsModel`
+
+| Field               | Type                              | Description                                                    |
+| :------------------ | :-------------------------------- | :------------------------------------------------------------- |
+| `querent`           | `HorarySignificatorModel`         | Significator of the 1st house.                                 |
+| `quesited`          | `HorarySignificatorModel`         | Significator of the 7th house.                                 |
+| `ascendant_degree`  | `float \| None`                   | Ascendant degree within its sign (0-30), from the true Ascendant point. |
+| `considerations`    | `list[HoraryConsiderationModel]`  | Classical considerations before judgment.                      |
+| `mutual_receptions` | `list[MutualReceptionModel]`      | Mutual receptions among the classical planets.                 |
+
+### `HorarySignificatorModel`
+
+| Field              | Type                  | Description                                                   |
+| :----------------- | :-------------------- | :------------------------------------------------------------ |
+| `house`            | `int`                 | House the significator describes (1 = querent, 7 = quesited). |
+| `sign`             | `Sign \| None`        | Sign on that house cusp.                                      |
+| `ruler`            | `ClassicalPlanet \| None` | Traditional ruler of that sign — the significator planet.  |
+| `ruler_sign`       | `Sign \| None`        | Sign the ruler occupies in the chart.                         |
+| `ruler_house`      | `Houses \| None`      | House the ruler occupies.                                     |
+| `ruler_house_number` | `int \| None`       | Same house as a number (1-12).                                |
+| `ruler_retrograde` | `bool \| None`        | Whether the ruler is retrograde.                              |
+| `essential_dignity` | `str \| None`        | The ruler's essential dignity (requires `calculate_dignities=True`). |
+
+### `HoraryConsiderationModel`
+
+The model carries a stable key, not display prose: wording belongs to the consuming product (and its active school), the engine states the fact.
+
+| Field    | Type     | Description                                    |
+| :------- | :------- | :--------------------------------------------- |
+| `key`    | Literal  | Which consideration fired (see table below).   |
+| `status` | Literal  | Classical reading: `"favorable"`, `"caution"`, or `"neutral"`. |
+
+**Consideration keys:**
+
+| Key                  | Status      | Meaning                                              |
+| :------------------- | :---------- | :--------------------------------------------------- |
+| `asc_early_degree`   | `caution`   | Ascendant < 3° — the matter may be too early to judge. |
+| `asc_late_degree`    | `caution`   | Ascendant ≥ 27° — the matter may already be decided. |
+| `asc_judgeable`      | `favorable` | Ascendant at a judgeable degree.                     |
+| `moon_void`          | `caution`   | Moon is void of course.                              |
+| `moon_not_void`      | `favorable` | Moon is not void of course.                          |
+| `saturn_in_first`    | `caution`   | Saturn in the 1st house.                             |
+| `saturn_in_seventh`  | `caution`   | Saturn in the 7th house.                             |
+
+---
+
+> **Need this in production?** Use the [Astrologer API](https://www.kerykeion.net/astrologer-api/subscribe) for hosted calculations, charts, and AI interpretations - no server setup required. [Learn more →](/content/docs/astrologer-api)

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -92,6 +92,8 @@ For more examples, see the [Examples Gallery](/content/examples/).
 -   **[House Comparison](/content/docs/house_comparison)**: Bidirectional synastry house overlay analysis.
 -   **[Element & Quality Distribution](/content/docs/element_quality_distribution)**: Analyzing element (Fire/Earth/Air/Water) and quality (Cardinal/Fixed/Mutable) balance.
 -   **[Chart Dominants](/content/docs/dominants_factory)**: Dominant planet/sign/element/quality via modern, Almuten Figuris, or elemental schools.
+-   **[Mutual Receptions](/content/docs/receptions_factory)**: Mutual reception detection via `MutualReceptionsFactory`.
+-   **[Horary Indicators](/content/docs/horary_factory)**: Horary chart significators and considerations via `HoraryIndicatorsFactory`.
 
 ## Forecasting
 
@@ -103,6 +105,8 @@ For more examples, see the [Examples Gallery](/content/examples/).
 -   **[Solar Arc Directions](/content/docs/solar_arc_factory)**: Solar arc directed charts via `SolarArcFactory`.
 -   **[Primary Directions](/content/docs/primary_directions_factory)**: Placidus semi-arc method via `PrimaryDirectionsFactory`.
 -   **[Zodiacal Releasing](/content/docs/zodiacal_releasing_factory)**: Hellenistic aphesis time-lord periods from the Lot of Fortune or Spirit.
+-   **[Profections](/content/docs/profections_factory)**: Annual profection timeline via `ProfectionsFactory`.
+-   **[Firdaria](/content/docs/firdaria_factory)**: Persian planetary time-lord periods via `FirdariaFactory`.
 -   **[Lunation Finder](/content/docs/lunation_factory)**: New/First-Quarter/Full/Last-Quarter Moons over a date range.
 -   **[Retrograde Stations](/content/docs/retrograde_station_factory)**: Planetary retrograde/direct stations over a date range.
 -   **[Sign Ingresses](/content/docs/sign_ingress_factory)**: Planet sign-change moments over a date range.

--- a/site/docs/moon_phase_details_factory.md
+++ b/site/docs/moon_phase_details_factory.md
@@ -14,7 +14,7 @@ The `MoonPhaseDetailsFactory` builds a complete `MoonPhaseOverviewModel` from an
 
 | Section | Data |
 | :--- | :--- |
-| **Moon Summary** | Phase name, emoji, major phase label, waxing/waning stage, illumination percentage, age in days, lunar cycle progress, Sun and Moon zodiac signs |
+| **Moon Summary** | Phase name, emoji, major phase label, waxing/waning stage, illumination percentage, age in days, precise age in days (`age_days_precise`), lunar cycle progress, Sun and Moon zodiac signs |
 | **Illumination Details** | Numeric percentage, visible fraction (0-1), phase angle in degrees |
 | **Upcoming Phases** | Last and next occurrence of New Moon, First Quarter, Full Moon, Last Quarter (precise ephemeris timing) |
 | **Next Lunar Eclipse** | Date, timestamp, eclipse type (Total, Partial, Penumbral) |

--- a/site/docs/profections_factory.md
+++ b/site/docs/profections_factory.md
@@ -1,0 +1,71 @@
+---
+title: 'Profections (Annual)'
+description: 'Compute annual profections — a traditional timing technique that activates one house per year of life.'
+category: 'Forecasting'
+tags: ['docs', 'profections', 'annual profections', 'time-lord', 'traditional', 'kerykeion']
+order: 60
+---
+
+# Profections (Annual)
+
+**`ProfectionsFactory`** computes annual profections, a traditional timing technique that activates one house per year of life. Starting from the 1st house at birth, the profected house advances one house each birthday, cycling every 12 years. The sign on the activated cusp determines the **Lord of the Year** — the traditional domicile ruler of that sign.
+
+The profection timeline follows the subject's own house system: a whole-sign chart profects through whole signs by construction, while a Placidus chart profects through Placidus cusps.
+
+BCE births are fully supported (astronomical year numbering), and birthday anniversaries on February 29 correctly roll to March 1 in common years.
+
+## Basic Usage
+
+```python
+from kerykeion import AstrologicalSubjectFactory, ProfectionsFactory
+
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Jane", 1990, 6, 15, 12, 0,
+    lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False
+)
+
+profections = ProfectionsFactory.from_subject(subject, target_date="2026-06-04")
+print(f"Age {profections.current.age}: {profections.current.house}th house")
+print(f"Sign: {profections.current.sign}, Lord: {profections.current.lord}")
+```
+
+## Methods
+
+### `from_subject(subject, *, target_date=None, years_before=3, years_after=4)`
+
+Build the profection years around a target date.
+
+| Parameter      | Type                       | Default  | Description                                                                                       |
+| :------------- | :------------------------- | :------- | :------------------------------------------------------------------------------------------------ |
+| `subject`      | `AstrologicalSubjectModel` | --       | The natal chart. Requires the twelve house cusps. BCE births are supported.                        |
+| `target_date`  | str (ISO `YYYY-MM-DD`) or None | None | Date the "current" year is resolved against. Astronomical year numbering accepted (e.g. `'-0550-10-07'`). When omitted, today in the subject's timezone. |
+| `years_before` | int                        | 3        | Past years to include in the table.                                                               |
+| `years_after`  | int                        | 4        | Future years to include in the table.                                                             |
+
+**Returns:** `ProfectionsModel`
+
+**Raises:** `KerykeionException` when cusps are missing, the target date is unparseable, or the target date precedes the birth date.
+
+## Data Models
+
+### `ProfectionsModel`
+
+| Field     | Type                         | Description                                                          |
+| :-------- | :--------------------------- | :------------------------------------------------------------------- |
+| `current` | `ProfectionYearModel`        | The profection year containing the target date.                      |
+| `years`   | `list[ProfectionYearModel]`  | Window of profection years (past and future around the current one). |
+
+### `ProfectionYearModel`
+
+| Field        | Type              | Description                                                                   |
+| :----------- | :---------------- | :---------------------------------------------------------------------------- |
+| `age`        | `int`             | Completed age the profection year begins at (0 = birth).                      |
+| `house`      | `int`             | Profected house number (1-12), cycling every 12 years.                        |
+| `sign`       | `Sign`            | Sign on the cusp of the profected house, in the subject's house system.       |
+| `lord`       | `ClassicalPlanet` | Traditional (domicile) ruler of that sign — the Lord of the Year.             |
+| `year_start` | `str`             | ISO date (`YYYY-MM-DD`) the profection year begins (the birthday anniversary).|
+| `year_end`   | `str`             | ISO date the profection year ends (the next anniversary).                     |
+
+---
+
+> **Need this in production?** Use the [Astrologer API](https://www.kerykeion.net/astrologer-api/subscribe) for hosted calculations, charts, and AI interpretations - no server setup required. [Learn more →](/content/docs/astrologer-api)

--- a/site/docs/receptions_factory.md
+++ b/site/docs/receptions_factory.md
@@ -1,0 +1,67 @@
+---
+title: 'Mutual Receptions'
+description: 'Detect mutual receptions (domicile and exaltation) among the seven classical planets.'
+category: 'Analysis'
+tags: ['docs', 'mutual receptions', 'dignities', 'traditional', 'kerykeion']
+order: 62
+---
+
+# Mutual Receptions
+
+**`MutualReceptionsFactory`** detects **mutual receptions** among the seven classical planets (Sun through Saturn). A mutual reception occurs when two planets each occupy a sign ruled by the other:
+
+- **Domicile reception**: planet A sits in a sign that planet B rules, and planet B sits in a sign that planet A rules.
+- **Exaltation reception**: planet A sits in the sign of planet B's exaltation, and vice versa.
+
+Receptions are deduplicated per pair (A↔B counted once) and listed separately by type.
+
+Only terrestrial (geocentric/topocentric) perspectives are accepted — receptions are a dignity technique defined on sign placements as seen from Earth.
+
+## Basic Usage
+
+```python
+from kerykeion import AstrologicalSubjectFactory, MutualReceptionsFactory
+
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Jane", 1990, 6, 15, 12, 0,
+    lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False
+)
+
+receptions = MutualReceptionsFactory.from_subject(subject)
+for r in receptions.receptions:
+    print(f"{r.first_planet} ↔ {r.second_planet} (by {r.reception_type})")
+```
+
+## Methods
+
+### `from_subject(subject)`
+
+Collect domicile and exaltation mutual receptions.
+
+| Parameter | Type                       | Default | Description                                                         |
+| :-------- | :------------------------- | :------ | :------------------------------------------------------------------ |
+| `subject` | `AstrologicalSubjectModel` | --      | Any chart carrying the classical planets. Absent planets are skipped.|
+
+**Returns:** `MutualReceptionsModel`
+
+**Raises:** `KerykeionException` when the chart's perspective is not terrestrial (heliocentric, barycentric, selenocentric or planetocentric).
+
+## Data Models
+
+### `MutualReceptionsModel`
+
+| Field       | Type                          | Description                                                   |
+| :---------- | :---------------------------- | :------------------------------------------------------------ |
+| `receptions`| `list[MutualReceptionModel]`  | One entry per deduplicated pair and reception type.            |
+
+### `MutualReceptionModel`
+
+| Field           | Type                                | Description                                   |
+| :-------------- | :---------------------------------- | :-------------------------------------------- |
+| `first_planet`  | `ClassicalPlanet`                   | One planet of the pair.                       |
+| `second_planet` | `ClassicalPlanet`                   | The other planet.                             |
+| `reception_type`| `"domicile"` \| `"exaltation"`      | Which dignity table produces the reception.   |
+
+---
+
+> **Need this in production?** Use the [Astrologer API](https://www.kerykeion.net/astrologer-api/subscribe) for hosted calculations, charts, and AI interpretations - no server setup required. [Learn more →](/content/docs/astrologer-api)

--- a/site/docs/schemas.md
+++ b/site/docs/schemas.md
@@ -84,6 +84,7 @@ Detailed information about a celestial body or house cusp.
 | `nakshatra_pada` | `int \| None`                 | Nakshatra pada/quarter (1-4). Requires `calculate_nakshatra=True` |
 | `nakshatra_lord` | `str \| None`                 | Vimsottari Dasha lord planet. Requires `calculate_nakshatra=True` |
 | `gauquelin_sector` | `float \| None`             | Gauquelin 36-sector position. Requires `calculate_gauquelin=True` |
+| `motion_state` | `MotionState \| None`           | Speed classification (`retrograde`/`stationary`/`slow`/`average`/`fast`). Populated for the ten planets in Earth-centred perspectives. |
 | `azimuth`    | `float \| None`                   | Azimuth angle in degrees. Requires `calculate_local_space=True` |
 | `altitude_above_horizon` | `float \| None`       | Altitude above horizon. Requires `calculate_local_space=True` |
 
@@ -98,6 +99,8 @@ The complete data structure for a calculated single chart (Natal, Return, etc.).
 | `aspects`              | `List[AspectModel]`        | List of internal aspects                    |
 | `element_distribution` | `ElementDistributionModel` | Points/Percentage for each element          |
 | `quality_distribution` | `QualityDistributionModel` | Points/Percentage for each quality          |
+| `angularities`         | `List[AngularityModel]`    | Classical planets conjunct the four angles (within orb) |
+| `stelliums`            | `List[StelliumModel]`      | Houses with three or more classical planets |
 | `active_points`        | `List[AstrologicalPoint]`  | Points used in calculation                  |
 | `active_aspects`       | `List[ActiveAspect]`       | Aspect configuration used                   |
 
@@ -115,8 +118,31 @@ Data structure for comparing two charts (Synastry, Transits).
 | `relationship_score`   | `RelationshipScoreModel \| None` | Compatibility scoring (optional, synastry only) |
 | `element_distribution` | `ElementDistributionModel` | Points/Percentage for each element      |
 | `quality_distribution` | `QualityDistributionModel` | Points/Percentage for each quality      |
+| `first_subject_angularities` | `List[AngularityModel]` | Angularities for the first subject    |
+| `first_subject_stelliums` | `List[StelliumModel]`     | Stelliums for the first subject       |
+| `second_subject_angularities` | `List[AngularityModel]` | Angularities for the second subject  |
+| `second_subject_stelliums` | `List[StelliumModel]`    | Stelliums for the second subject      |
 | `active_points`        | `List[AstrologicalPoint]`  | Points used in calculation              |
 | `active_aspects`       | `List[ActiveAspect]`       | Aspect configuration used               |
+
+### AngularityModel
+
+A classical planet conjunct one of the four chart angles.
+
+| Field      | Type    | Description                                                        |
+| :--------- | :------ | :----------------------------------------------------------------- |
+| `point`    | `str`   | The planet's name.                                                 |
+| `angle`    | `str`   | Which angle (`Ascendant`, `Medium_Coeli`, `Descendant`, `Imum_Coeli`). |
+| `distance` | `float` | Shortest ecliptic arc between planet and angle, in degrees.        |
+
+### StelliumModel
+
+A concentration of classical planets in one house.
+
+| Field    | Type         | Description                                  |
+| :------- | :----------- | :------------------------------------------- |
+| `house`  | `int`        | House number (1-12).                         |
+| `points` | `list[str]`  | Names of the planets gathered there.         |
 
 ### AspectModel
 
@@ -438,6 +464,29 @@ These models are returned by the v6 advanced calculation factories. Each factory
 | `ACGLineModel` | [`AstroCartographyFactory`](/content/docs/astro_cartography_factory) | A planetary line on the ACG map |
 | `ACGLinePointModel` | `AstroCartographyFactory` | A geographic coordinate on an ACG line |
 
+### Traditional / Hellenistic Models
+
+| Model | Factory | Description |
+| :---- | :------ | :---------- |
+| `ProfectionsModel` | [`ProfectionsFactory`](/content/docs/profections_factory) | Annual profection timeline with activated houses |
+| `ProfectionYearModel` | `ProfectionsFactory` | A single profection year |
+| `FirdariaModel` | [`FirdariaFactory`](/content/docs/firdaria_factory) | Firdaria planetary period timeline |
+| `FirdariaPeriodModel` | `FirdariaFactory` | A major firdaria period |
+| `FirdariaSubPeriodModel` | `FirdariaFactory` | A sub-period within a major firdaria |
+| `MutualReceptionModel` | [`MutualReceptionsFactory`](/content/docs/receptions_factory) | A single mutual reception pair |
+| `MutualReceptionsModel` | `MutualReceptionsFactory` | Collection of mutual receptions in a chart |
+| `HoraryIndicatorsModel` | [`HoraryIndicatorsFactory`](/content/docs/horary_factory) | Horary chart analysis with significators and considerations |
+| `HorarySignificatorModel` | `HoraryIndicatorsFactory` | A horary significator planet |
+| `HoraryConsiderationModel` | `HoraryIndicatorsFactory` | A horary consideration before judgment |
+
+### Chart Analysis Models
+
+| Model | Factory | Description |
+| :---- | :------ | :---------- |
+| `AngularityModel` | [`ChartDataFactory`](/content/docs/chart_data_factory) | A planet conjunct a chart angle (within orb) |
+| `StelliumModel` | `ChartDataFactory` | A house concentration of three or more planets |
+| `ProgressedPointModel` | [`SecondaryProgressionFactory`](/content/docs/secondary_progressions_factory) | Per-point natal-vs-progressed comparison with sign-change flag |
+
 ---
 
 ## Literals & Constants (`kr_literals`)
@@ -445,6 +494,20 @@ These models are returned by the v6 advanced calculation factories. Each factory
 Import from: `kerykeion.schemas.kr_literals`
 
 These Literal types define the allowed string values for various model fields, providing strict type checking and autocompletion in your IDE.
+
+---
+
+### `MotionState`
+
+Classification of a celestial body's speed relative to its mean daily motion. Populated on `KerykeionPointModel.motion_state` for the ten planets in Earth-centred perspectives; `None` elsewhere.
+
+| Value           | Description                                           |
+| :-------------- | :---------------------------------------------------- |
+| `"retrograde"`  | Moving backward (negative speed).                     |
+| `"stationary"`  | Near-zero speed at a station (< 5% of mean motion).   |
+| `"slow"`        | Below 80% of mean daily motion.                       |
+| `"average"`     | Between 80% and 120% of mean daily motion.            |
+| `"fast"`        | Above 120% of mean daily motion.                      |
 
 ---
 

--- a/site/docs/secondary_progressions_factory.md
+++ b/site/docs/secondary_progressions_factory.md
@@ -88,6 +88,18 @@ for asp in result.progressed_to_natal_aspects:
 | `ephemeris_iso_utc_datetime`   | str                           | The actual ephemeris date looked up           |
 | `progressed_subject`           | AstrologicalSubjectModel      | The full progressed chart                    |
 | `progressed_to_natal_aspects`  | List[ProgressedToNatalAspectModel] | Cross-chart aspects                          |
+| `progressed_points`            | List[ProgressedPointModel]        | Per-point natal-vs-progressed comparison     |
+
+### `ProgressedPointModel`
+
+| Field              | Type   | Description                                           |
+| :----------------- | :----- | :---------------------------------------------------- |
+| `name`             | str    | Planet name.                                          |
+| `natal_abs_pos`    | float  | Natal absolute longitude.                             |
+| `progressed_abs_pos` | float | Progressed absolute longitude.                       |
+| `natal_sign`       | str    | Sign of the natal placement.                          |
+| `progressed_sign`  | str    | Sign of the progressed placement.                     |
+| `sign_changed`     | bool   | Whether the planet changed signs from natal to progressed. |
 
 ### `ProgressedToNatalAspectModel`
 


### PR DESCRIPTION
## Summary

Documents all 17 new public exports added by #243 (profections, firdaria, receptions, horary, motion_state, angularities/stelliums, progressed_points, age_days_precise, constellation, MotionState). Restores the `poe docs:check` gate to **100% coverage** (was 85.8% / exit 1 on #243).

**Stacked on #243** — merge #243 first (the code this documents), then this PR.

## Review guide — file order

1. **`site/docs/profections_factory.md`** — New page: annual profections factory, models, usage. Pattern follows `zodiacal_releasing_factory.md`.
2. **`site/docs/firdaria_factory.md`** — New page: firdaria factory, period sequences table, BCE support noted.
3. **`site/docs/receptions_factory.md`** — New page: mutual receptions factory, domicile + exaltation, terrestrial-only.
4. **`site/docs/horary_factory.md`** — New page: horary indicators, significators table, consideration keys table, Whole-Sign ASC note.
5. **`site/docs/index.md`** — 4 new entries: 2 under Forecasting (Profections, Firdaria), 2 under Analysis (Mutual Receptions, Horary).
6. **`site/docs/schemas.md`** — `motion_state` on KerykeionPointModel; `MotionState` literal; `angularities`/`stelliums` on chart data models; Traditional/Hellenistic + Chart Analysis model tables.
7. **`site/docs/chart_data_factory.md`** — Angularities/stelliums bullet points in Data Models section (single + dual).
8. **`site/docs/astrological_subject_factory.md`** — Motion State section under V6 Optional Enrichments.
9. **`site/docs/moon_phase_details_factory.md`** — `age_days_precise` added to Moon Summary description.
10. **`site/docs/secondary_progressions_factory.md`** — `progressed_points` field + `ProgressedPointModel` table.
11. **`site/docs/fixed_star_discovery_factory.md`** — `constellation` field on catalog metadata.
12. **`README.md`** — 4 ToC entries + 4 content sections with code examples after Zodiacal Releasing.
13. **`kerykeion/llms.txt`** — 4 rows in quick-reference table + section 5B narrative with runnable code.
14-17. **`examples/{profections,firdaria,mutual_receptions,horary}_example.py`** — Standalone offline scripts.

## Verification

- `poe docs:check`: 120/120 exports documented (100.0%)
- `poe docs:snippets`: all 4 new snippets pass (4 pre-existing GeoNames-rate-limit failures unrelated)
- Core test suite: 10,861 passed, 0 failed
- `ruff check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CXv9wr5mmkAkzWiZDRKX9