### PR TITLE
docs: correct v6.0.0a83 compatibility notes

### DIFF
--- a/release_notes/v6.0.0a83.md
+++ b/release_notes/v6.0.0a83.md
@@ -2,10 +2,10 @@
 
 This alpha lands the traditional time-lord techniques as first-class
 factories, and the point- and chart-level fields a consumer needs to *read*
-them. Five new factories share one rule: a chart that cannot answer the
-question honestly is refused with a clear error, never guessed. No existing
-computation changes — every chart that does not call the new entry points is
-byte-identical to a82.
+them. Four new factories share one rule: a chart that cannot answer the
+question honestly is refused with a clear error, never guessed. Existing API
+entry points remain available, but standard factory outputs gain additive
+fields in this release, so serialized a83 output is not byte-identical to a82.
 
 ## The time-lords
 
@@ -71,11 +71,14 @@ The techniques above sit on fields the model gained alongside them:
 
 ## The engine under them: a BCE-safe civil-date kit
 
-Profections and firdaria do their date arithmetic on **Julian Days**, so a
+Profections and firdaria use different BCE-safe date strategies, so a
 deep-antiquity birth (astronomical year ≤ 0) builds a timeline instead of
-hitting Python's `datetime` year-1 floor. The kit lives in
-`kerykeion.utilities`: `resolve_subject_local_moment`, `civil_jd`,
-`jd_to_iso_date`, `format_astronomical_iso_date`,
+hitting Python's `datetime` year-1 floor. Profections computes ages and
+birthday anniversaries directly from civil components with `_anniversary` and
+`civil_leap_year`; firdaria converts birth and target instants to Julian Days
+and advances its period boundaries there. The supporting kit lives in
+`kerykeion.utilities`: `resolve_subject_local_moment`, `civil_leap_year`,
+`civil_jd`, `jd_to_iso_datetime`, `format_astronomical_iso_date`,
 `parse_astronomical_iso_moment`, plus the shared `resolve_subject_birth_datetime`
 (now also used by zodiacal releasing) and `resolve_subject_local_now`.
 
@@ -100,7 +103,17 @@ literal.
 
 ## Compatibility
 
-Purely additive. Every new field is optional on its model, every new factory
-is a new entry point, and no existing computation path is touched. Charts that
-do not call the new factories render and serialize exactly as they did in a82;
-no golden fixture was regenerated for this release.
+This release makes additive schema and serialized-output changes. The four new
+factories are new entry points, but existing factories now populate additional
+output: subject points include `motion_state`; moon-phase details include
+`age_days_precise`; `SecondaryProgressionFactory.compute_full` includes
+`progressed_points`; fixed-star metadata can include `constellation`; and chart
+data includes the new angularity and stellium lists.
+
+There is also a behavior change to the existing moon-phase `age_days` value.
+When the last-new-moon record has no timestamp, `MoonPhaseDetailsFactory` now
+uses the phase-based synodic-month estimate instead of falling back to zero.
+
+Callers that serialize these models should accept unknown additive fields and
+refresh byte-for-byte snapshots or strict output schemas when upgrading from
+a82.


### PR DESCRIPTION
## Summary

- replace the false byte-identical compatibility guarantee with explicit additive schema/output guidance
- identify the existing factory outputs that gain fields or values and warn strict consumers to refresh snapshots and schemas
- correct adjacent release-note details about the factory count, BCE-safe date strategies, and moon-phase fallback behavior

## Why

Existing serialization paths populate `motion_state`, `age_days_precise`, `progressed_points`, fixed-star `constellation`, and chart-data angularity/stellium lists. Normal a83 model dumps can therefore differ from a82 even when callers do not invoke a newly introduced factory. The previous release notes overstated compatibility.

## Impact

Documentation only. Runtime behavior and schemas are unchanged by this PR; consumers get accurate upgrade guidance for additive output changes and the `age_days` fallback correction already present in a83.

## Validation

- `git diff --check`
- `uv run python scripts/test_markdown_snippets.py release_notes/v6.0.0a83.md` (no runnable snippets; passed)
- compared the documented behavior with the `v6.0.0a82..v6.0.0a83` source diff
