### PR TITLE
feat: make the silent half of the v5 upgrade visible

### DIFF
--- a/kerykeion/__init__.py
+++ b/kerykeion/__init__.py
@@ -341,6 +341,22 @@ __all__ = [
 # =============================================================================
 _MIGRATION_GUIDE_URL = "https://www.kerykeion.net/content/docs/migration"
 
+# Appended to every removed-name message below. Rewriting the call is only half
+# the upgrade: v6 also changed defaults that alter the numbers, and those change
+# silently for code that already used the v5 factories correctly. This error is
+# the one moment we know the reader is looking, so it says both things.
+_BEHAVIOUR_CHANGES_NOTE = (
+    "\n\n"
+    "Note: v6 also changed defaults that affect RESULTS, not just imports:\n"
+    "  - active points: 18 -> 14 (Descendant, Imum_Coeli, True_South_Lunar_Node,\n"
+    "    Mean_Lilith are no longer active unless requested)\n"
+    "  - Sun/Moon aspect orbs: +1.5 degrees by default (new in v6)\n"
+    "  - chart style: 'classic' -> 'modern'\n"
+    "Porting the call above does not restore v5 output. See 'What changes in the\n"
+    "results' in the guide; kerykeion.settings.V5_DEFAULT_ACTIVE_POINTS restores\n"
+    "the old point set."
+)
+
 _V5_REMOVED_NAMES = {
     "AstrologicalSubject": (
         "'AstrologicalSubject' was removed in v6. Use the factory instead:\n"
@@ -372,5 +388,8 @@ def __getattr__(name: str):
     # Trade-off: hasattr()/getattr(..., default) also raise for these names —
     # feature-detect with try/except ImportError instead.
     if name in _V5_REMOVED_NAMES:
-        raise ImportError(f"{_V5_REMOVED_NAMES[name]}\nMigration guide: {_MIGRATION_GUIDE_URL}")
+        raise ImportError(
+            f"{_V5_REMOVED_NAMES[name]}{_BEHAVIOUR_CHANGES_NOTE}"
+            f"\nMigration guide: {_MIGRATION_GUIDE_URL}"
+        )
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/kerykeion/settings/__init__.py
+++ b/kerykeion/settings/__init__.py
@@ -6,6 +6,12 @@ from .chart_defaults import (
     DEFAULT_CELESTIAL_POINTS_SETTINGS,
     DEFAULT_CHART_ASPECTS_SETTINGS,
 )
+from .config_constants import (
+    ALL_ACTIVE_POINTS,
+    DEFAULT_ACTIVE_ASPECTS,
+    DEFAULT_ACTIVE_POINTS,
+    V5_DEFAULT_ACTIVE_POINTS,
+)
 # load_settings_mapping stays importable for compatibility but is NOT part of
 # __all__: it was born deprecated ("removed in 7.0.0") and a new major must
 # not freeze dead API in its public surface.
@@ -17,6 +23,10 @@ __all__ = [
     "DEFAULT_CHART_COLORS",
     "DEFAULT_CELESTIAL_POINTS_SETTINGS",
     "DEFAULT_CHART_ASPECTS_SETTINGS",
+    "DEFAULT_ACTIVE_POINTS",
+    "DEFAULT_ACTIVE_ASPECTS",
+    "ALL_ACTIVE_POINTS",
+    "V5_DEFAULT_ACTIVE_POINTS",
     "LANGUAGE_SETTINGS",
     "load_language_pair",
     "load_language_settings",

--- a/kerykeion/settings/config_constants.py
+++ b/kerykeion/settings/config_constants.py
@@ -397,6 +397,49 @@ Default list of active points in the charts or aspects calculations.
 The full list of points is available in the `schemas.literals.AstrologicalPoint` literal.
 """
 
+V5_DEFAULT_ACTIVE_POINTS: list[AstrologicalPoint] = [
+    "Sun",
+    "Moon",
+    "Mercury",
+    "Venus",
+    "Mars",
+    "Jupiter",
+    "Saturn",
+    "Uranus",
+    "Neptune",
+    "Pluto",
+    "True_North_Lunar_Node",
+    "True_South_Lunar_Node",
+    "Chiron",
+    "Mean_Lilith",
+    "Ascendant",
+    "Medium_Coeli",
+    "Descendant",
+    "Imum_Coeli",
+]
+"""
+The 18 points that ``DEFAULT_ACTIVE_POINTS`` held in v5, kept for result continuity.
+
+v6 trimmed the default set to 14: ``True_South_Lunar_Node``, ``Mean_Lilith``,
+``Descendant`` and ``Imum_Coeli`` are no longer active unless asked for. Code that
+relied on the defaults therefore gets fewer points after upgrading, silently --
+nothing raises, the results are simply narrower.
+
+Pass this list to reproduce v5 output verbatim::
+
+    from kerykeion import AstrologicalSubjectFactory
+    from kerykeion.settings import V5_DEFAULT_ACTIVE_POINTS
+
+    subject = AstrologicalSubjectFactory.from_birth_data(
+        ..., active_points=V5_DEFAULT_ACTIVE_POINTS,
+    )
+
+This is a frozen historical record, not a maintained preset: it will not follow
+future changes to the default set. See the migration guide for the other two
+behavioural changes (Sun/Moon orb adjustments and the chart style default),
+which this constant does not address.
+"""
+
 ALL_ACTIVE_POINTS: list[AstrologicalPoint] = [
     # Planets
     "Sun",

--- a/site/docs/migration.md
+++ b/site/docs/migration.md
@@ -182,6 +182,79 @@ The v5 model aliases `NatalAspectsModel` and `SynastryAspectsModel` were also re
 | `disable_chiron_and_lilith` | Removed | Use `active_points` to exclude |
 | `new_settings_file` | Removed | Use `language_pack` parameter |
 
+## What Changes in the Results
+
+Everything above is about code that stops working: you get an `ImportError`, you fix the call, you move on. This section is about the opposite — code that keeps working and quietly returns **different numbers**.
+
+It applies even if you were already using the v5 factory API correctly. Nothing raises, nothing warns; the output is simply not the same as before.
+
+| What | v5 | v6 | What you see |
+|:-----|:---|:---|:-------------|
+| Default active points | 18 | 14 | Fewer points in charts and aspects |
+| Sun/Moon aspect orbs | no adjustment | `+1.5°` | Aspects appear or disappear near the orb boundary |
+| Chart style | `"classic"` | `"modern"` | A different drawing, and a different filename |
+
+These are deliberate v6 choices, not oversights. What follows is how to opt back into the old behaviour where you need continuity.
+
+### Active points: 18 → 14
+
+Four points left the default set: `Descendant`, `Imum_Coeli`, `True_South_Lunar_Node` and `Mean_Lilith`. They still exist — they are simply no longer computed unless you ask for them.
+
+```python
+from kerykeion import AstrologicalSubjectFactory
+from kerykeion.settings import V5_DEFAULT_ACTIVE_POINTS
+
+# v6 defaults: 14 points
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "John", 1990, 1, 1, 12, 0,
+    lng=-0.1276, lat=51.5074, tz_str="Europe/London", online=False,
+)
+
+# The v5 set, restored explicitly
+subject_v5 = AstrologicalSubjectFactory.from_birth_data(
+    "John", 1990, 1, 1, 12, 0,
+    lng=-0.1276, lat=51.5074, tz_str="Europe/London", online=False,
+    active_points=V5_DEFAULT_ACTIVE_POINTS,
+)
+
+print(len(subject.active_points), len(subject_v5.active_points))
+```
+
+`V5_DEFAULT_ACTIVE_POINTS` is a frozen historical record: it will not track future changes to the default set. If you want the current defaults plus one point, build the list from `DEFAULT_ACTIVE_POINTS` instead.
+
+### Sun and Moon orbs
+
+v6 widens the orb for aspects involving the Sun or the Moon by 1.5°, which v4 and v5 never did. Near the boundary this changes which aspects are reported.
+
+The adjustment applies to the chart-data factories. `AspectsFactory` does not apply it by default, so the two can disagree on the same subject — pass `point_orb_adjustments={}` to compute without it:
+
+```python
+from kerykeion import AspectsFactory, ChartDataFactory
+
+# v6 default for chart data: Sun/Moon orbs widened by 1.5°
+chart_data = ChartDataFactory.create_natal_chart_data(subject)
+
+# v5-equivalent orbs
+chart_data_v5 = ChartDataFactory.create_natal_chart_data(
+    subject, point_orb_adjustments={},
+)
+
+print(len(chart_data.aspects), len(chart_data_v5.aspects))
+```
+
+### Chart style
+
+`ChartDrawer` now defaults to `style="modern"`. The v5 drawing is still available, and the saved filename reflects the style (`"... - Classic.svg"` vs `"... - Modern.svg"`), so scripts that look for a fixed filename need updating either way.
+
+```python
+from kerykeion import ChartDrawer
+
+drawer = ChartDrawer(chart_data, style="classic")  # the v5 look
+svg = drawer.generate_svg_string()
+```
+
+Note that `external_view` only takes effect in the classic style.
+
 ## Backward Compatibility Layer (Removed in v6)
 
 v5 included a compatibility layer in `kerykeion.backword` that allowed gradual migration. **This layer has been removed in v6.0.**

--- a/tests/core/test_v5_migration_errors.py
+++ b/tests/core/test_v5_migration_errors.py
@@ -9,11 +9,15 @@ replacement and the migration guide, instead of a bare ImportError or a
 pydantic AttributeError.
 """
 
+from typing import get_args
+
 import pytest
 
 import kerykeion
 from kerykeion import AstrologicalSubjectFactory, ChartDrawer
 from kerykeion.schemas import KerykeionException
+from kerykeion.schemas.literals import AstrologicalPoint
+from kerykeion.settings import DEFAULT_ACTIVE_POINTS, V5_DEFAULT_ACTIVE_POINTS
 
 REMOVED_NAME_TO_REPLACEMENT = {
     "AstrologicalSubject": "AstrologicalSubjectFactory",
@@ -82,3 +86,69 @@ def test_chart_drawer_rejects_arbitrary_objects():
     with pytest.raises(KerykeionException) as excinfo:
         ChartDrawer({"not": "chart data"})
     assert "ChartDataFactory" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Behavioural changes: the half of the upgrade that raises nothing
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("name", sorted(REMOVED_NAME_TO_REPLACEMENT))
+def test_removed_name_error_also_warns_about_changed_defaults(name):
+    """The ImportError is the one moment we know the reader is looking.
+
+    Porting the call is only half the upgrade: v6 also changed defaults that
+    alter results without raising anything, so the message names them too.
+    """
+    with pytest.raises(ImportError) as excinfo:
+        getattr(kerykeion, name)
+    message = str(excinfo.value)
+    assert "active points" in message
+    assert "orb" in message
+    assert "V5_DEFAULT_ACTIVE_POINTS" in message
+
+
+def test_v5_default_active_points_is_the_v5_set():
+    """Frozen historical record of the 18 points v5 activated by default."""
+    assert len(V5_DEFAULT_ACTIVE_POINTS) == 18
+    assert len(set(V5_DEFAULT_ACTIVE_POINTS)) == 18, "no duplicates"
+
+
+def test_v5_default_active_points_is_a_superset_of_the_v6_default():
+    """v6 only ever dropped points from the default set; it added none.
+
+    If this ever fails, the constant is no longer a faithful record and the
+    migration guide's claim ("18 -> 14, nothing added") is wrong.
+    """
+    dropped = set(V5_DEFAULT_ACTIVE_POINTS) - set(DEFAULT_ACTIVE_POINTS)
+    added = set(DEFAULT_ACTIVE_POINTS) - set(V5_DEFAULT_ACTIVE_POINTS)
+    assert added == set()
+    assert dropped == {"Descendant", "Imum_Coeli", "True_South_Lunar_Node", "Mean_Lilith"}
+
+
+def test_v5_default_active_points_are_all_valid_today():
+    """Every v5 point must still be a computable point in v6, or the constant
+    would hand users a list the factory rejects."""
+    valid = set(get_args(AstrologicalPoint))
+    assert set(V5_DEFAULT_ACTIVE_POINTS) <= valid
+
+
+def test_v5_default_active_points_actually_restores_the_v5_output(subject):
+    """The constant is only useful if passing it brings the dropped points back."""
+    v5_subject = AstrologicalSubjectFactory.from_birth_data(
+        name="Migration Test",
+        year=1990,
+        month=6,
+        day=15,
+        hour=12,
+        minute=30,
+        city="Rome",
+        nation="IT",
+        lat=41.9028,
+        lng=12.4964,
+        tz_str="Europe/Rome",
+        online=False,
+        active_points=V5_DEFAULT_ACTIVE_POINTS,
+    )
+    assert len(subject.active_points) == 14
+    assert len(v5_subject.active_points) == 18
+    for point in ("Descendant", "Imum_Coeli", "True_South_Lunar_Node", "Mean_Lilith"):
+        assert point in v5_subject.active_points


### PR DESCRIPTION
> Stacked on #247 — base is `refactor/package-layout`. GitHub will retarget this to `alpha/v6` once that merges.

## Why

Upgrading from v5 breaks in two ways, and only one of them is loud.

The loud one is the removed API: `AstrologicalSubject`, `KerykeionChartSVG`, `NatalAspects`, `SynastryAspects` raise an `ImportError` naming their replacement. That case takes care of itself — the user reads the error and fixes the call.

The quiet one hits the users who **had already migrated correctly**. v6 changed defaults that alter results, so code written against the v5 factory API keeps running and returns different numbers:

| What | v5 | v6 | Effect on unchanged v5 code |
|:-----|:---|:---|:----------------------------|
| Default active points | 18 | 14 | `Descendant`, `Imum_Coeli`, `True_South_Lunar_Node`, `Mean_Lilith` are no longer computed |
| Sun/Moon aspect orbs | no adjustment | `+1.5°` | Aspects appear or disappear near the orb boundary |
| `ChartDrawer` style | `"classic"` | `"modern"` | A different drawing, and a different saved filename |

Nothing raises, nothing warns. The user finds out weeks later, looking at a chart that does not match, with nothing connecting it to the upgrade.

All three are verified against `git show v5:…`, not inferred.

## What this does

**1. The `ImportError` now names the changed defaults too.** It is the one moment we know the reader is looking, so it reports both halves of the upgrade rather than only the one they asked about:

```
'AstrologicalSubject' was removed in v6. Use the factory instead:
    from kerykeion import AstrologicalSubjectFactory
    subject = AstrologicalSubjectFactory.from_birth_data(...)

Note: v6 also changed defaults that affect RESULTS, not just imports:
  - active points: 18 -> 14 (Descendant, Imum_Coeli, True_South_Lunar_Node,
    Mean_Lilith are no longer active unless requested)
  - Sun/Moon aspect orbs: +1.5 degrees by default (new in v6)
  - chart style: 'classic' -> 'modern'
Porting the call above does not restore v5 output. See 'What changes in the
results' in the guide; kerykeion.settings.V5_DEFAULT_ACTIVE_POINTS restores
the old point set.
Migration guide: https://www.kerykeion.net/content/docs/migration
```

**2. `kerykeion.settings.V5_DEFAULT_ACTIVE_POINTS`** restores the old point set explicitly, for anyone who needs numerical continuity. Deliberately a **frozen historical record, not a maintained preset**: it will not follow future changes to the defaults, and the docstring says so. `DEFAULT_ACTIVE_POINTS`, `DEFAULT_ACTIVE_ASPECTS` and `ALL_ACTIVE_POINTS` are re-exported from `kerykeion.settings` alongside it, so callers can depend on the package facade rather than on `config_constants`' filename.

**3. A "What changes in the results" section in the migration guide**, with runnable examples for all three — including `point_orb_adjustments={}` for v5-equivalent orbs and `style="classic"` for the v5 drawing. The guide previously covered renamed APIs only and said nothing about behaviour, which is the part that bites people who did everything right.

## What this deliberately does not do

**No v5 compatibility wrapper.** `kerykeion/backword.py` still exists in `git show v5:` and could be restored cheaply, along with its 1205-line test suite. I recommend against it, and the reasoning is worth recording:

With the defaults staying breaking, a wrapper removes the *signal* without removing the *change*. The code would run and the results would still differ. The `DeprecationWarning` meant to compensate is hidden by default in Python unless the call happens in `__main__` — so in any non-trivial application it is invisible.

The `ImportError` is doing useful work: it is what sends people to the guide, where they also learn the defaults moved. The quiet break is the one that needed the effort.

Worth noting too: those classes were *already* deprecated wrappers in v5, emitting `DeprecationWarning`, and the layer was removed deliberately in `2309807c`. Restoring it means signing up to maintain it again, and to have the same discussion at v7.

## Verification

| Gate | Result |
|---|---|
| `poe test:core` | 5662 passed, 144 skipped (8 new tests) |
| `poe docs:snippets` | 400/400 — the three new guide examples actually run |
| `poe docs:check` | 120/120 exports documented |
| `poe lint` / `poe analyze` / `poe imports` | clean |

The new tests pin the claims rather than the implementation: that the constant holds exactly the 18 v5 points, that v6 only ever *dropped* points from the set (so the guide's "18 → 14, nothing added" cannot silently become false), that every one of those points is still computable today, and that passing the constant genuinely brings the four missing points back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQy5QpvBWe1Vk9LyHbBRnK
