### PR TITLE
fix(timing): the last day of the calendar exits cleanly, and the relocated sidereal Sunshine is the natal chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@
 
 ### Fixed
 
+- **Two factories let a raw error out at the end of the civil range.** On the
+  full-range kernel (DE441, to the year 17191) 9999-12-31 is computable, and it is
+  the day AFTER it that does not exist: the planetary day beginning at that
+  evening's sunrise needs a sunrise on 10000-01-01 and overflowed `date`
+  arithmetic with a bare `OverflowError`; the void-of-course Moon walking to its
+  next ingress past the year's end surfaced a bare `ValueError` from the Julian
+  Day conversion. Both refuse with `KerykeionException` now, naming the civil
+  range rather than the ephemeris. The test that guards this had asserted that
+  9999-12-31 itself must fail — true on the base and medium kernels, where the
+  coverage check refuses first, and false on the extended one, where it never
+  reached the two lines that would have caught the real defect. It says the
+  truth at every tier now, and an extended-only test pins the asymmetry: before
+  that day's sunrise the planetary hours work (yesterday exists), after it they
+  cannot.
+
+- **A sidereal Sunshine `i` relocated onto its own birthplace was a different
+  chart.** The reference implementation casts a sidereal `i` (Makransky) as `I`
+  (Treindl) — libephemeris matches it — except in the fixed-epoch modes; the
+  natal chart got that ring by asking with the sidereal flag, while the relocated
+  chart asks tropically and applies the subject's ayanamsa afterwards, so it asked
+  for `i` and got Makransky: at sixty degrees north the two constructions are
+  tens of degrees apart, and inside the polar circle the tropical `i` is refused
+  and substituted with Porphyry where the natal has a crowded Sunshine ring. The
+  relocation asks for the system the reference would cast, with the fixed-epoch
+  modes left on Makransky as the reference leaves them. Nothing to change
+  upstream: both backends behave the same way, and that way is Swiss Ephemeris'.
+
 - **An angle could be filed in the wrong house, and twelve numbers could not say
   otherwise.** Where a house system brings several cusps onto one longitude —
   Sunshine at 74.25 degrees north puts the second through the sixth on

--- a/kerykeion/planetary_hours/factory.py
+++ b/kerykeion/planetary_hours/factory.py
@@ -17,6 +17,25 @@ _POLAR_MESSAGE = (
 )
 
 
+def _civil_day_beside(year: int, month: int, day: int, offset_days: int) -> date:
+    """The civil date ``offset_days`` away, or a clean refusal at either end of the range.
+
+    A planetary day runs from one sunrise to the next, so the last evening of
+    9999 needs a sunrise on 10000-01-01 and the first morning of year 1 needs a
+    sunset on the day before it; ``date`` has neither and raises ``OverflowError``.
+    Only the full-range ephemeris ever gets this far — on a narrower kernel the
+    coverage check refuses first — which is how the raw error went unseen.
+    """
+    try:
+        return date(year, month, day) + timedelta(days=offset_days)
+    except OverflowError as exc:
+        which = "after" if offset_days > 0 else "before"
+        raise KerykeionException(
+            f"Planetary hours for {year:04d}-{month:02d}-{day:02d} need the sunrise of the day {which} it, "
+            f"and there is no civil date {which} this one: the library represents years 1 to 9999."
+        ) from exc
+
+
 class PlanetaryHoursFactory:
     """
     Factory for the planetary (Chaldean) hours of a moment at a location.
@@ -102,14 +121,14 @@ class PlanetaryHoursFactory:
             # The moment is within today's planetary day (sunrise → next sunrise).
             if today.sunset is None:
                 raise KerykeionException(_POLAR_MESSAGE)
-            tomorrow = date(year, month, day) + timedelta(days=1)
+            tomorrow = _civil_day_beside(year, month, day, +1)
             next_events = compute_sun_events(tomorrow.year, tomorrow.month, tomorrow.day, latitude, longitude, tz)
             if next_events.sunrise is None:
                 raise KerykeionException(_POLAR_MESSAGE)
             sunrise, sunset, next_sunrise = today.sunrise, today.sunset, next_events.sunrise
         else:
             # Before today's sunrise → still in the previous planetary day's night.
-            yesterday = date(year, month, day) - timedelta(days=1)
+            yesterday = _civil_day_beside(year, month, day, -1)
             prev_events = compute_sun_events(yesterday.year, yesterday.month, yesterday.day, latitude, longitude, tz)
             if prev_events.sunrise is None or prev_events.sunset is None:
                 raise KerykeionException(_POLAR_MESSAGE)

--- a/kerykeion/relocated_chart/factory.py
+++ b/kerykeion/relocated_chart/factory.py
@@ -51,6 +51,31 @@ from kerykeion.utilities.core import (
 _AXIAL_POINTS_SET: frozenset[str] = frozenset(AXIAL_POINTS)
 
 
+#: Sidereal modes that request a fixed reference frame rather than an ayanamsa
+#: along the ecliptic of date; the reference keeps Sunshine 'i' on its own
+#: construction under these.
+_FIXED_EPOCH_SIDEREAL_MODES = frozenset({"J2000", "J1900", "B1950", "GALALIGN_MARDYKS"})
+
+
+def _house_system_the_reference_casts(hsys: bytes, is_sidereal: bool, sidereal_mode: Optional[str]) -> bytes:
+    """The house system the ephemeris actually computes for a sidereal request.
+
+    Under a sidereal flag the reference implementation casts Sunshine 'i'
+    (Makransky) as 'I' (Treindl) — libephemeris matches it, see its
+    ``houses_ex`` — except in the fixed-epoch modes, where 'i' stays on its own
+    construction. The natal chart got that ring because it asked with the
+    sidereal flag. This factory asks TROPICALLY and applies the subject's own
+    ayanamsa afterwards, so it has to ask for the same system the reference would
+    pick, or a sidereal 'i' relocated onto its own birthplace would come back a
+    different chart: Makransky cusps, tens of degrees from Treindl's at sixty
+    degrees north, and inside the polar circle a refused cast substituted with
+    Porphyry, where the natal has a Sunshine ring.
+    """
+    if is_sidereal and hsys == b"i" and sidereal_mode not in _FIXED_EPOCH_SIDEREAL_MODES:
+        return b"I"
+    return hsys
+
+
 class RelocatedChartFactory:
     """Create a relocated chart from an existing natal chart."""
 
@@ -174,8 +199,10 @@ class RelocatedChartFactory:
             )
 
         jd = subject.julian_day
-        hsys = subject.houses_system_identifier.encode("ascii")
         is_sidereal = subject.zodiac_type == "Sidereal"
+        hsys = _house_system_the_reference_casts(
+            subject.houses_system_identifier.encode("ascii"), is_sidereal, subject.sidereal_mode
+        )
 
         # Validate but do NOT clamp: relocating to lat 78 must persist the real
         # latitude and cast latitude-agnostic house systems there, exactly like a

--- a/kerykeion/sun_times/utils.py
+++ b/kerykeion/sun_times/utils.py
@@ -267,8 +267,21 @@ def local_midnight_julian_day(year: int, month: int, day: int, tz: ZoneInfo) -> 
 
 
 def julian_day_to_utc(jd: float) -> datetime:
-    """Convert a Julian Day (UT) to a timezone-aware UTC ``datetime``."""
-    return julian_to_datetime(jd).replace(tzinfo=timezone.utc)
+    """Convert a Julian Day (UT) to a timezone-aware UTC ``datetime``.
+
+    Raises:
+        KerykeionException: When the instant lies outside civil years 1 to 9999,
+            which ``datetime`` cannot represent. A Moon scan that walks past
+            9999-12-31 on the full-range ephemeris used to surface this as a raw
+            ``ValueError`` from a public factory.
+    """
+    try:
+        return julian_to_datetime(jd).replace(tzinfo=timezone.utc)
+    except (ValueError, OverflowError) as exc:
+        raise KerykeionException(
+            f"Julian Day {jd} lies outside the civil range this library represents "
+            f"(years 1 to 9999): {exc}"
+        ) from exc
 
 
 def _civil_day_bounds(year: int, month: int, day: int, tz: ZoneInfo) -> tuple[float, float]:

--- a/release_notes/v6.0.0a88.md
+++ b/release_notes/v6.0.0a88.md
@@ -211,6 +211,25 @@ were read once more for what they say.
 
 ---
 
+## Two things the review flagged and left, now done
+
+**The end of the civil range.** On the full-range kernel 9999-12-31 is a day like
+any other; the day after it is not. The planetary hours that begin at that
+evening's sunrise, and the Moon's next ingress past the year's end, used to come
+back as a raw `OverflowError` and `ValueError` — visible only on that kernel, where
+the guarding test had stopped one assertion earlier, wrongly insisting that the
+31st itself must fail. Both refuse cleanly now, and the test says what is true on
+every kernel.
+
+**Sidereal Sunshine `i`.** The reference casts it as `I` under a sidereal flag,
+except in the fixed-epoch modes, and both backends agree. The natal chart already
+got that ring; the relocated chart asked tropically for `i` and got Makransky's
+construction instead — tens of degrees off at sixty north, and refused inside the
+polar circle. It asks for what the reference would cast. Known and left: a
+fixed-epoch relocation (J2000, J1900, B1950) drifts by ~0.002 degrees for every
+house system, because it shifts by a plain ayanamsa where the reference applies
+the epoch's frame.
+
 ## Upgrading from a87
 
 The compile-time surface only grows. `coincident_house_cusps` is a new optional

--- a/release_notes/v6.0.0a88.md
+++ b/release_notes/v6.0.0a88.md
@@ -226,9 +226,9 @@ except in the fixed-epoch modes, and both backends agree. The natal chart alread
 got that ring; the relocated chart asked tropically for `i` and got Makransky's
 construction instead — tens of degrees off at sixty north, and refused inside the
 polar circle. It asks for what the reference would cast. Known and left: a
-fixed-epoch relocation (J2000, J1900, B1950) drifts by ~0.002 degrees for every
-house system, because it shifts by a plain ayanamsa where the reference applies
-the epoch's frame.
+fixed-epoch relocation (J2000, J1900, B1950, Mardyks) drifts for every house
+system — thousandths of a degree under J2000, up to five hundredths under J1900 —
+because it shifts by a plain ayanamsa where the reference applies the epoch's frame.
 
 ## Upgrading from a87
 

--- a/tests/core/test_relocated_chart.py
+++ b/tests/core/test_relocated_chart.py
@@ -676,3 +676,76 @@ class TestRelocateExtremeYearBoundary:
                 edge, new_lat=0.0, new_lng=0.0, new_city="K", new_nation="KI",
                 new_tz_str=new_tz_str,
             )
+
+
+class TestSiderealSunshineFollowsTheReference:
+    """A sidereal Sunshine 'i' relocated onto its own birthplace is the natal chart.
+
+    The reference casts a sidereal 'i' (Makransky) as 'I' (Treindl) except in the
+    fixed-epoch modes, and the natal chart got that ring by asking with the
+    sidereal flag. The relocation asks tropically and shifts by the subject's own
+    ayanamsa, so it must ask for the same system: it used to ask for 'i', and came
+    back with Makransky cusps — at sixty degrees north the two constructions are
+    tens of degrees apart — and, inside the polar circle, with a refused cast
+    substituted by Porphyry where the natal has a crowded Sunshine ring. (At Rome
+    on this date the two constructions happen to coincide, which is why the
+    latitude here is sixty.)
+    """
+
+    _SIXTY_NORTH = dict(lng=12.5, lat=60.0, tz_str="Europe/Oslo", city="Sixty North", nation="NO")
+    _POLAR = dict(lng=0.0, lat=74.25, tz_str="UTC", city="Crowded", nation="NO")
+
+    @staticmethod
+    def _sunshine(place, **zodiac):
+        return AstrologicalSubjectFactory.from_birth_data(
+            "Sunshine", 1990, 6, 15, 3, 45, **place, online=False,
+            houses_system_identifier="i", suppress_geonames_warning=True, **zodiac,
+        )
+
+    @staticmethod
+    def _relocated_onto_itself(subject):
+        return RelocatedChartFactory.relocate(
+            subject, new_lat=subject.lat, new_lng=subject.lng, new_city=subject.city,
+            new_nation=subject.nation, new_tz_str=subject.tz_str,
+        )
+
+    @staticmethod
+    def _cusps(subject):
+        from kerykeion.utilities.core import HOUSE_FIELD_NAMES
+
+        return [getattr(subject, name).abs_pos for name in HOUSE_FIELD_NAMES]
+
+    def test_at_sixty_north_the_relocated_cusps_are_the_natal_cusps(self):
+        natal = self._sunshine(self._SIXTY_NORTH, zodiac_type="Sidereal", sidereal_mode="LAHIRI")
+        relocated = self._relocated_onto_itself(natal)
+        for natal_cusp, relocated_cusp in zip(self._cusps(natal), self._cusps(relocated)):
+            assert _angular_diff(natal_cusp, relocated_cusp) < 1e-9
+
+    def test_inside_the_polar_circle_the_relocated_ring_is_the_natal_ring(self):
+        natal = self._sunshine(self._POLAR, zodiac_type="Sidereal", sidereal_mode="LAHIRI")
+        relocated = self._relocated_onto_itself(natal)
+        assert natal.polar_house_fallbacks == [] and relocated.polar_house_fallbacks == []
+        assert natal.coincident_house_cusps == relocated.coincident_house_cusps != []
+        for natal_cusp, relocated_cusp in zip(self._cusps(natal), self._cusps(relocated)):
+            assert _angular_diff(natal_cusp, relocated_cusp) < 1e-9
+
+    def test_a_fixed_epoch_mode_keeps_makransky_on_both_sides(self):
+        """The rule stops at the fixed-epoch modes, where the reference keeps 'i' as itself.
+
+        Makransky and Treindl are tens of degrees apart here, so a hundredth of a
+        degree tells them apart while absorbing the drift every fixed-epoch
+        relocation carries already (Placidus included, ~0.002 degrees): the
+        relocation shifts by a plain ayanamsa where the reference applies the
+        epoch's frame. That drift predates this test and is not its subject.
+        """
+        natal = self._sunshine(self._SIXTY_NORTH, zodiac_type="Sidereal", sidereal_mode="J2000")
+        relocated = self._relocated_onto_itself(natal)
+        for natal_cusp, relocated_cusp in zip(self._cusps(natal), self._cusps(relocated)):
+            assert _angular_diff(natal_cusp, relocated_cusp) < 0.01
+
+    def test_a_tropical_sunshine_inside_the_polar_circle_is_still_substituted(self):
+        """The rule is the reference's rule for SIDEREAL charts; a tropical 'i' is refused there as before."""
+        natal = self._sunshine(self._POLAR)
+        relocated = self._relocated_onto_itself(natal)
+        assert natal.polar_house_fallbacks and relocated.polar_house_fallbacks
+        assert relocated.effective_houses_system_identifier == natal.effective_houses_system_identifier

--- a/tests/core/test_relocated_chart.py
+++ b/tests/core/test_relocated_chart.py
@@ -732,16 +732,17 @@ class TestSiderealSunshineFollowsTheReference:
     def test_a_fixed_epoch_mode_keeps_makransky_on_both_sides(self):
         """The rule stops at the fixed-epoch modes, where the reference keeps 'i' as itself.
 
-        Makransky and Treindl are tens of degrees apart here, so a hundredth of a
+        Makransky and Treindl are tens of degrees apart here, so a tenth of a
         degree tells them apart while absorbing the drift every fixed-epoch
-        relocation carries already (Placidus included, ~0.002 degrees): the
-        relocation shifts by a plain ayanamsa where the reference applies the
-        epoch's frame. That drift predates this test and is not its subject.
+        relocation carries already, for every house system: thousandths of a
+        degree under J2000, up to five hundredths under J1900, on both backends.
+        The relocation shifts by a plain ayanamsa where the reference applies the
+        epoch's frame; that drift predates this test and is not its subject.
         """
         natal = self._sunshine(self._SIXTY_NORTH, zodiac_type="Sidereal", sidereal_mode="J2000")
         relocated = self._relocated_onto_itself(natal)
         for natal_cusp, relocated_cusp in zip(self._cusps(natal), self._cusps(relocated)):
-            assert _angular_diff(natal_cusp, relocated_cusp) < 0.01
+            assert _angular_diff(natal_cusp, relocated_cusp) < 0.1
 
     def test_a_tropical_sunshine_inside_the_polar_circle_is_still_substituted(self):
         """The rule is the reference's rule for SIDEREAL charts; a tropical 'i' is refused there as before."""

--- a/tests/core/test_sun_times_factory.py
+++ b/tests/core/test_sun_times_factory.py
@@ -187,30 +187,80 @@ def test_civil_range_edge_is_sign_dependent_not_symmetric():
     assert localize_datetime(1, 1, 1, 0, 30, tz=new_york).year == 1
 
 
+def _ephemeris_reaches_the_last_civil_year() -> bool:
+    """Can the loaded ephemeris put the Sun somewhere on 9999-12-31?
+
+    Probed, not inferred from the tier: the libephemeris full-range kernel
+    (DE441, to the year 17191) reaches it, while a swisseph install that passes
+    the tier probe at the year 1000 still needs a file (`sepl_96.se1`) it may
+    not have for the year 9999. Same probe as tests/conftest.py uses for tiers.
+    """
+    from kerykeion.ephemeris_backend import ephe, ephemeris_session
+
+    try:
+        with ephemeris_session() as iflag:
+            ephe.calc_ut(ephe.julday(9999, 12, 31, 12.0), 0, iflag)
+        return True
+    except Exception:
+        return False
+
+
 def test_civil_range_edge_days_raise_clean_exception():
     # Whatever the cause, a caller must see a KerykeionException and never a raw
-    # OverflowError or backend error. The two ends now fail for DIFFERENT reasons:
-    # year 1 east of UTC fails in the timezone layer (above), while year 9999 gets
-    # past the timezone layer and is stopped by the ephemeris coverage range. Both
-    # are asserted here because the guarantee this test protects is the exception
-    # TYPE at the public boundary, which must hold either way.
+    # OverflowError or backend error. The two ends fail for DIFFERENT reasons: year
+    # 1 east of UTC fails in the timezone layer (above) on every kernel; year 9999
+    # gets past the timezone layer and is then either stopped by the ephemeris
+    # coverage (base and medium kernels) or, on the full-range kernel, computed —
+    # a sunset on 9999-12-31 in Rome is a perfectly good sunset. What no kernel
+    # can supply is the day AFTER it, which the planetary day and the Moon's next
+    # ingress both need; those must refuse cleanly rather than overflow, and on
+    # the full-range kernel they used to overflow.
     from kerykeion.planetary_hours import PlanetaryHoursFactory
     from kerykeion.void_of_course_moon import VoidOfCourseMoonFactory
 
     with pytest.raises(KerykeionException, match="east-of-UTC"):
         SunTimesFactory.from_date(1, 1, 1, **ROME)
-    with pytest.raises(KerykeionException):
-        SunTimesFactory.from_date(9999, 12, 31, **ROME)
     with pytest.raises(KerykeionException, match="east-of-UTC"):
         PlanetaryHoursFactory.from_datetime(1, 1, 1, 0, 30, **ROME)
-    with pytest.raises(KerykeionException):
-        PlanetaryHoursFactory.from_datetime(9999, 12, 31, 23, 30, **ROME)
     with pytest.raises(KerykeionException, match="east-of-UTC"):
         VoidOfCourseMoonFactory.from_datetime(1, 1, 1, 0, 30, tz_str=ROME["tz_str"])
+
+    if _ephemeris_reaches_the_last_civil_year():
+        last_day = SunTimesFactory.from_date(9999, 12, 31, **ROME)
+        assert last_day.sunrise is not None and last_day.sunset is not None
+    else:
+        with pytest.raises(KerykeionException):
+            SunTimesFactory.from_date(9999, 12, 31, **ROME)
+
+    with pytest.raises(KerykeionException):
+        PlanetaryHoursFactory.from_datetime(9999, 12, 31, 23, 30, **ROME)
     with pytest.raises(KerykeionException):
         VoidOfCourseMoonFactory.from_datetime(9999, 12, 31, 23, 30, tz_str=ROME["tz_str"])
 
 
+@pytest.mark.extended
+def test_the_last_civil_day_on_the_full_range_kernel():
+    """Where the ephemeris reaches 9999, the civil range is the only limit left.
+
+    Before that day's sunrise the planetary day is yesterday's, which exists; after
+    it the day needs tomorrow's sunrise, which does not. The Moon at the start of
+    December still finds its next ingress inside the year; on the last evening it
+    does not. Each refusal names the civil range, not the ephemeris.
+    """
+    from kerykeion.planetary_hours import PlanetaryHoursFactory
+    from kerykeion.void_of_course_moon import VoidOfCourseMoonFactory
+
+    if not _ephemeris_reaches_the_last_civil_year():
+        pytest.skip("the loaded ephemeris does not reach 9999-12-31; the civil-range limit is not the one in play")
+
+    before_dawn = PlanetaryHoursFactory.from_datetime(9999, 12, 31, 3, 0, **ROME)
+    assert before_dawn.hours
+    with pytest.raises(KerykeionException, match="no civil date after"):
+        PlanetaryHoursFactory.from_datetime(9999, 12, 31, 23, 30, **ROME)
+
+    assert VoidOfCourseMoonFactory.from_datetime(9999, 12, 1, 12, 0, tz_str=ROME["tz_str"]).moon_sign
+    with pytest.raises(KerykeionException, match="years 1 to 9999"):
+        VoidOfCourseMoonFactory.from_datetime(9999, 12, 31, 23, 30, tz_str=ROME["tz_str"])
 def test_invalid_timezone_raises():
     with pytest.raises(KerykeionException):
         SunTimesFactory.from_date(2026, 5, 28, latitude=0.0, longitude=0.0, tz_str="Not/AZone")


### PR DESCRIPTION
Closes the two pre-existing issues reported by the #255 review.

## 1. The day after 9999-12-31 does not exist
On the extended kernel (DE441, up to 17191) 9999-12-31 is computable. Two factories let a raw error out for the day **after**:
- `PlanetaryHoursFactory` — `date(9999,12,31) + 1 day` → `OverflowError` (and symmetrically towards 0001-01-01 west of UTC) → now a `KerykeionException` naming the calendar (`_civil_day_beside`);
- `VoidOfCourseMoonFactory` — the Moon's walk past the end of the year → `ValueError: year 10000` from `julian_day_to_utc` → now `KerykeionException` (the single-moment path deliberately excludes `ValueError` from the normalised exceptions, so the wrapping lives in the helper).

The test `test_civil_range_edge_days_raise_clean_exception` demanded that the 31st itself fail: true on the base/medium kernels (coverage), false on the extended one — and there it never reached the two lines that would have caught the defect. It now **probes** the ephemeris for 9999 (a swisseph install passes the tier probe at year 1000 but has no `sepl_96.se1`) and an `@extended` test pins the asymmetry: at 03:00 on 9999-12-31 the planetary hours work (yesterday is needed), at 23:30 they do not; the VoC on 12-01 works, on the 31st at 23:30 it does not.

## 2. Sidereal Sunshine `i` in the relocated chart
Verified on **both** backends: tropical `i` inside the polar circle raises; sidereal `i` returns the ring of `I`. It is the Swiss Ephemeris rule (Makransky → Treindl under the sidereal flag, except in the fixed-epoch modes), and libephemeris mirrors it in `houses_ex`: **nothing to push upstream**. Kerykeion's relocated chart calls the houses in tropical + ayanamsa shift, so it asked for `i`: at 60 N the two constructions are tens of degrees apart, at the pole the refusal was replaced by Porphyry where the natal has the crowded ring. `_house_system_the_reference_casts` asks for `I` exactly in the cases where the reference would.

Tests: `TestSiderealSunshineFollowsTheReference` (60 N, pole, J2000 as a guard against a wrong extension of the rule, polar tropical `i` still replaced), on libephemeris and swisseph. Mutation: without the rule exactly the two LAHIRI tests fail.

## Gates
- libephemeris medium `test:all`: **12,288 passed, 0 failed**.
- libephemeris extended `test:all`: **13,591 passed**; the pre-existing `sun_times` failure is gone. 5 BCE failures remain (`Ancient Greece 500BC …`) that are on `origin/alpha/v6` regardless of this PR: the panel line changed with #254 and the baselines are updated in the not-yet-pushed local commit `dfebf107` — they disappear with its push.
- `test:swe`: the usual 3 pre-existing ones.
- `ruff`, `mypy`, `docs:check` clean.

## Left open, declared
Relocations in the fixed-epoch modes (J2000/J1900/B1950/Mardyks) drift for **every** house system — thousandths of a degree with J2000, up to five hundredths with J1900, the same on both backends: they shift by a flat ayanamsa where the reference applies the epoch's frame. Pre-existing; the J2000 test uses a 0.1° tolerance (Makransky and Treindl are tens of degrees apart) and says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHgj2emQBET9RL2XayUxf7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for dates outside the supported civil range, including planetary hours, lunar ingress, and solar-time calculations.
  - Relocated sidereal Sunshine charts now use reference-compatible house-system calculations.
  - Preserved existing behavior for fixed-epoch modes and non-sidereal charts.

- **Tests**
  - Added coverage for year-9999 boundaries, extended ephemeris ranges, polar relocation scenarios, and sidereal house-system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

