### PR TITLE
fix(returns): the instant of a reported return is a valid seed for the next one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
   entry points. The backend's solvers do not reach that resolution on their
   own — their at-crossing dead band is ~90 ms for the Sun, and their 0.001″
   tolerance is six seconds of Pluto's motion, so a seed one second past a
-  slow body's crossing came back as its own answer — so every ISO search is
+  slow body's crossing came back as its own answer — so every supported ISO search is
   held to the contract (`_settled`): heliocentric crossings are settled to a
   millisecond by bisection around the solver's answer, a crossing inside the
   second before a backward seed is looked for explicitly, and a result that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,15 +33,16 @@
   instant for instant, `previous` from the second after a reported instant
   finds it (twenty consecutive solar returns, dead band included), and a walk
   of steps lands on each return exactly once. One limit is the ephemeris'
-  own: a crossing within some tens of microseconds of a whole second cannot
+  own: a crossing within a tenth of a millisecond of a whole second cannot
   be told from a crossing at that second, and is treated as one — the natal
   instant, a crossing by construction, being the case that matters: seeded
   with it, `previous` finds the cycle before birth, never a return a second
-  before the birth itself. The lunar nodes and Liliths are
-  not heliocentric bodies and stay outside, as before. Solar, lunar and node
-  instants are reported as they were; heliocentric instants settle onto the
-  crossing itself, which for the slow bodies can move the reported second by
-  up to ~1.5 s from the solver's (about one in eight Uranus–Pluto crossings).
+  before the birth itself. Outside the contract, as before: the heliocentric
+  search for the lunar nodes and the Liliths, which are not heliocentric
+  bodies. Solar, lunar and node instants are reported as they were;
+  heliocentric instants settle onto the crossing itself, which moves the
+  reported second of about half the Uranus–Pluto crossings, by up to the
+  solver's tolerance — some 2 s for Uranus, 4 s for Neptune, 9 s for Pluto.
   The date and year wrappers keep their inclusive
   midnight seed, so a return in the first second of a date is still that
   date's return. The one visible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,17 @@
   instants it was given never advanced — for solar, lunar, heliocentric and node
   crossing alike. Ordering between a seed and a return is now decided at the
   resolution the factory reports at: a forward search starts from the whole
-  second after the seed's, a backward one from the whole second before it, in
-  one helper (`_search_start_jd`) behind all three `*_from_iso_formatted_time`
-  entry points. The contract is pinned for every kind: `next(reported(N))` is
-  `N + 1`, `previous(reported(N))` is `N − 1`, `previous(next(r))` is `r`
-  instant for instant, and a walk of steps lands on each return exactly once.
+  second after the seed's, a backward one from the seed's own whole second
+  (the backend's backward searches are strictly past, so a crossing inside
+  that second is excluded and one in the second before is found), in one
+  helper (`_search_start_jd`) behind all three `*_from_iso_formatted_time`
+  entry points. The contract is pinned for the Sun, the Moon, the lunar nodes
+  and the heliocentric planets the backend solves (Mercury to Saturn in the
+  tests): `next(reported(N))` is `N + 1`, `previous(reported(N))` is `N − 1`,
+  `previous(next(r))` is `r` instant for instant, and a walk of steps lands on
+  each return exactly once. Bodies the backend has no heliocentric crossing
+  for (Chiron, Pholus, the Uranian points, the nodes and Liliths themselves)
+  stay outside it — their search returned its seed before and does still.
   Nothing reported changes; the date and year wrappers keep their inclusive
   midnight seed, so a return in the first second of a date is still that
   date's return. The one visible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [6.0.0a89] - Unreleased
+
+### Fixed
+
+- **A return instant this library reported could not seed the search for the
+  next one.** Return instants are reported truncated to the whole second (the
+  chart is rebuilt from an integer `seconds` field), so the exact crossing of a
+  return reported at `T` lies in `[T, T + 1s)` — a fraction of a second AFTER the
+  value the caller holds. A forward search seeded with that value asked the
+  ephemeris for the first crossing at or after it and got the same return back;
+  a backward search happened to work, because the truncated seed lands before
+  the crossing. A client stepping through the sequence of returns with the
+  instants it was given never advanced — for solar, lunar, heliocentric and node
+  crossing alike. Ordering between a seed and a return is now decided at the
+  resolution the factory reports at: a forward search starts from the whole
+  second after the seed's, a backward one from the whole second before it, in
+  one helper (`_search_start_jd`) behind all three `*_from_iso_formatted_time`
+  entry points. The contract is pinned for every kind: `next(reported(N))` is
+  `N + 1`, `previous(reported(N))` is `N − 1`, `previous(next(r))` is `r`
+  instant for instant, and a walk of steps lands on each return exactly once.
+  Nothing reported changes; the date and year wrappers are untouched in effect
+  (their midnight seeds never share a second with a return). The one visible
+  consequence: a seed inside the same second as a crossing now selects the
+  following return — so a search seeded from the natal instant itself yields the
+  first return rather than the birth moment (four report fixtures that pinned
+  that degenerate chart are regenerated). Seeds at the edge of
+  the civil range — forward from 9999-12-31T23:59:59, backward from
+  0001-01-01T00:00:00 — used to overflow `datetime` and now refuse with
+  `KerykeionException`. Two calendar facts are pinned alongside, as the reason a
+  return is identified by its instant and never by a period: a leap year can
+  hold two solar returns (born 1 January: 1 January and 31 December 2024), and a
+  month can hold two lunar returns (2 and 29 August 2026).
+  See [release_notes/v6.0.0a89.md](release_notes/v6.0.0a89.md).
+
 ## [6.0.0a88] - 2026-08-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,17 @@
   is `N + 1`, `previous(reported(N))` is `N − 1`, `previous(next(r))` is `r`
   instant for instant, `previous` from the second after a reported instant
   finds it (twenty consecutive solar returns, dead band included), and a walk
-  of steps lands on each return exactly once. The lunar nodes and Liliths
-  have no heliocentric longitude in the backend and stay outside, as before.
-  Nothing reported changes; the date and year wrappers keep their inclusive
+  of steps lands on each return exactly once. One limit is the ephemeris'
+  own: a crossing within some tens of microseconds of a whole second cannot
+  be told from a crossing at that second, and is treated as one — the natal
+  instant, a crossing by construction, being the case that matters: seeded
+  with it, `previous` finds the cycle before birth, never a return a second
+  before the birth itself. The lunar nodes and Liliths are
+  not heliocentric bodies and stay outside, as before. Solar, lunar and node
+  instants are reported as they were; heliocentric instants settle onto the
+  crossing itself, which for the slow bodies can move the reported second by
+  up to ~1.5 s from the solver's (about one in eight Uranus–Pluto crossings).
+  The date and year wrappers keep their inclusive
   midnight seed, so a return in the first second of a date is still that
   date's return. The one visible
   consequence: a seed inside the same second as a crossing now selects the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@
   entry points. The contract is pinned for every kind: `next(reported(N))` is
   `N + 1`, `previous(reported(N))` is `N − 1`, `previous(next(r))` is `r`
   instant for instant, and a walk of steps lands on each return exactly once.
-  Nothing reported changes; the date and year wrappers are untouched in effect
-  (their midnight seeds never share a second with a return). The one visible
+  Nothing reported changes; the date and year wrappers keep their inclusive
+  midnight seed, so a return in the first second of a date is still that
+  date's return. The one visible
   consequence: a seed inside the same second as a crossing now selects the
   following return — so a search seeded from the natal instant itself yields the
   first return rather than the birth moment (four report fixtures that pinned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,21 @@
   (the backend's backward searches are strictly past, so a crossing inside
   that second is excluded and one in the second before is found), in one
   helper (`_search_start_jd`) behind all three `*_from_iso_formatted_time`
-  entry points. The contract is pinned for the Sun, the Moon, the lunar nodes
-  and the heliocentric planets the backend solves (Mercury to Saturn in the
-  tests): `next(reported(N))` is `N + 1`, `previous(reported(N))` is `N − 1`,
-  `previous(next(r))` is `r` instant for instant, and a walk of steps lands on
-  each return exactly once. Bodies the backend has no heliocentric crossing
-  for (Chiron, Pholus, the Uranian points, the nodes and Liliths themselves)
-  stay outside it — their search returned its seed before and does still.
+  entry points. The backend's solvers do not reach that resolution on their
+  own — their at-crossing dead band is ~90 ms for the Sun, and their 0.001″
+  tolerance is six seconds of Pluto's motion, so a seed one second past a
+  slow body's crossing came back as its own answer — so every ISO search is
+  held to the contract (`_settled`): heliocentric crossings are settled to a
+  millisecond by bisection around the solver's answer, a crossing inside the
+  second before a backward seed is looked for explicitly, and a result that
+  has not moved past the seed's second restarts from outside the solver's
+  basin. The contract is pinned for the Sun, the Moon, the lunar nodes and the
+  heliocentric bodies from Mercury to Pluto plus Chiron: `next(reported(N))`
+  is `N + 1`, `previous(reported(N))` is `N − 1`, `previous(next(r))` is `r`
+  instant for instant, `previous` from the second after a reported instant
+  finds it (twenty consecutive solar returns, dead band included), and a walk
+  of steps lands on each return exactly once. The lunar nodes and Liliths
+  have no heliocentric longitude in the backend and stay outside, as before.
   Nothing reported changes; the date and year wrappers keep their inclusive
   midnight seed, so a return in the first second of a date is still that
   date's return. The one visible

--- a/kerykeion/planetary_returns/factory.py
+++ b/kerykeion/planetary_returns/factory.py
@@ -74,7 +74,7 @@ import logging
 
 from kerykeion.ephemeris_backend.backend import ephe, ephemeris_session
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import List, Literal, Union, cast
 
 from kerykeion.schemas import KerykeionException
@@ -246,6 +246,47 @@ class PlanetaryReturnFactory:
             raise KerykeionException(
                 f"Invalid ISO timestamp {iso_formatted_time!r}: {exc}. "
                 "Expected an ISO 8601 datetime such as '2023-06-15T14:30:00Z'."
+            ) from exc
+
+    @classmethod
+    def _search_start_jd(cls, iso_formatted_time: str, backwards: bool) -> float:
+        """Julian Day a return search starts from: the seed's own second excluded.
+
+        Return instants are reported truncated to the whole second (the chart
+        is rebuilt from an integer ``seconds`` field), so the exact crossing of
+        a return reported at ``T`` lies in ``[T, T + 1s)`` — at or a fraction
+        of a second AFTER the value the caller holds. Seeding a forward search
+        with that value found the same crossing again, sitting just ahead of
+        the seed, so a caller stepping through the sequence of returns with the
+        instants this factory reports never advanced; backward searches only
+        worked because the truncation happens to land the seed on the right
+        side.
+
+        Ordering between a seed and a return is therefore defined at the
+        library's reporting resolution: a forward search starts from the whole
+        second after the seed's, a backward one from the whole second before
+        it. Reported instants become re-usable as seeds — ``next`` from the
+        instant of return N is N+1, ``previous`` is N−1, exactly — and nothing
+        can be skipped, since consecutive returns of every supported kind are
+        at least ~13 days apart (half a draconic month, the node crossing).
+
+        Naive timestamps are read as UTC, like every ``*_from_iso`` entry.
+        """
+        dt = cls._parse_iso(iso_formatted_time)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        whole_second = dt.replace(microsecond=0)
+        step = timedelta(seconds=-1 if backwards else 1)
+        try:
+            return datetime_to_julian(whole_second + step)
+        except OverflowError as exc:
+            # 9999-12-31T23:59:59 forward / 0001-01-01T00:00:00 backward: the
+            # next second is outside datetime's civil range. Refuse with the
+            # library's own exception, naming the range, not the ephemeris.
+            raise KerykeionException(
+                f"Cannot search {'backward' if backwards else 'forward'} from "
+                f"{iso_formatted_time!r}: the search would start outside the "
+                "supported civil range (years 1 to 9999)."
             ) from exc
 
     def __init__(
@@ -528,7 +569,10 @@ class PlanetaryReturnFactory:
             iso_formatted_time (str): Starting datetime in ISO format for the search.
                 Must be a valid ISO 8601 datetime string (e.g., "2024-01-15T10:30:00"
                 or "2024-01-15T10:30:00+00:00"). The method will find the next return
-                occurring after this moment.
+                occurring after this moment, "after" being decided at the whole
+                second — the resolution return instants are reported at — so the
+                instant of a return this factory reported is a valid seed for the
+                following (or, with ``backwards``, the preceding) return.
             return_type (SolarLunarReturnType): Type of planetary return to calculate.
                 Must be either "Solar" for Sun returns or "Lunar" for Moon returns.
                 This determines which planet's return cycle to compute.
@@ -602,8 +646,7 @@ class PlanetaryReturnFactory:
             next_return_from_date(): Date-based calculation interface
         """
 
-        date = self._parse_iso(iso_formatted_time)
-        julian_day = datetime_to_julian(date)
+        julian_day = self._search_start_jd(iso_formatted_time, backwards)
 
         # The natal abs_pos values are expressed in the subject's zodiac
         # (tropical OR sidereal) AND perspective (apparent/true geocentric,
@@ -1133,12 +1176,9 @@ class PlanetaryReturnFactory:
         Returns:
             PlanetReturnModel for the heliocentric return chart.
         """
-        dt = self._parse_iso(iso_formatted_time)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
         return self.next_heliocentric_return(
             planet_name=planet_name,
-            start_jd=datetime_to_julian(dt),
+            start_jd=self._search_start_jd(iso_formatted_time, backwards),
             backwards=backwards,
         )
 
@@ -1216,11 +1256,8 @@ class PlanetaryReturnFactory:
         Returns:
             PlanetReturnModel for the node crossing chart.
         """
-        dt = self._parse_iso(iso_formatted_time)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
         return self.next_lunar_node_crossing(
-            start_jd=datetime_to_julian(dt),
+            start_jd=self._search_start_jd(iso_formatted_time, backwards),
             backwards=backwards,
         )
 

--- a/kerykeion/planetary_returns/factory.py
+++ b/kerykeion/planetary_returns/factory.py
@@ -281,8 +281,8 @@ class PlanetaryReturnFactory:
         crossings are settled to a millisecond by bisection, a crossing inside
         the second before a backward seed is looked for explicitly, and a
         result that has not moved past the seed's second restarts from outside
-        the solver's basin. The lunar nodes and Liliths have no heliocentric
-        longitude in the backend and are outside this contract, as they were.
+        the solver's basin. The lunar nodes and Liliths are not heliocentric
+        bodies and are outside this contract, as they were.
 
         Naive timestamps are read as UTC, like every ``*_from_iso`` entry.
         """
@@ -329,37 +329,61 @@ class PlanetaryReturnFactory:
 
     @staticmethod
     def _signed_arc(longitude: float, target: float) -> float:
-        """Signed arc from ``target`` to ``longitude``, in (-180, 180]."""
+        """Signed arc from ``target`` to ``longitude``, in [-180, 180)."""
         return ((longitude - target + 180.0) % 360.0) - 180.0
 
-    @staticmethod
-    def _crossing_between(offset: Callable[[float], float], lo: float, hi: float) -> Optional[float]:
-        """The root of a monotone signed ``offset`` inside ``[lo, hi)``, to a millisecond — or None.
+    # A sign change of a signed arc is a crossing only when the arc is small
+    # on both sides: the arc also flips sign at the antipode of the target,
+    # where it jumps from +180 to -180, and that is an opposition, not a
+    # return. Over any window used here (a second; a minute around a solver's
+    # answer) a body moves a few arcseconds at most, so a genuine crossing
+    # keeps the arc within a fraction of a degree of zero.
+    _CROSSING_ARC_LIMIT = 90.0
+    # Resolution of the bisection, in days (one millisecond).
+    _CROSSING_RESOLUTION = 1e-3 / 86400.0
+
+    @classmethod
+    def _crossing_between(cls, offset: Callable[[float], float], lo: float, hi: float) -> Optional[float]:
+        """The root of a monotone signed ``offset`` strictly inside ``[lo, hi)``, to a millisecond — or None.
 
         ``offset`` is negative on one side of the crossing and positive on the
         other; a sign change across the window is the crossing, found by
         bisection. This reaches the resolution the backend's solvers do not:
-        inside one second (their at-crossing dead band spans ~90 ms for the
-        Sun) and inside the convergence basin of a slow heliocentric body
-        (their 0.001″ tolerance is six seconds of Pluto's motion).
+        inside one second (their at-crossing dead band is ~90 ms either side
+        of the target for the Sun) and inside the convergence basin of a slow
+        heliocentric body (their 0.001″ tolerance is six seconds of Pluto's
+        motion).
+
+        A root at ``hi`` itself — a seed that IS a crossing, the natal instant
+        being one by construction — is not inside the window and yields None:
+        a crossing at the seed is inside the seed's own second, which the
+        ordering contract excludes. Roots within a millisecond of ``hi`` are
+        treated the same, below the resolution of the bisection.
         """
         f_lo, f_hi = offset(lo), offset(hi)
+        if max(abs(f_lo), abs(f_hi)) > cls._CROSSING_ARC_LIMIT:
+            return None  # the window straddles the antipode, not the target
         if f_lo == 0.0:
             return lo
-        if (f_lo < 0.0) == (f_hi < 0.0):
+        if f_hi == 0.0 or (f_lo < 0.0) == (f_hi < 0.0):
             return None
+        top = hi
         for _ in range(64):
-            if (hi - lo) * 86400.0 < 1e-3:
+            if hi - lo < cls._CROSSING_RESOLUTION:
                 break
             mid = 0.5 * (lo + hi)
             f_mid = offset(mid)
             if f_mid == 0.0:
-                return mid
+                lo = hi = mid
+                break
             if (f_mid < 0.0) == (f_lo < 0.0):
                 lo, f_lo = mid, f_mid
             else:
                 hi, f_hi = mid, f_mid
-        return 0.5 * (lo + hi)
+        root = 0.5 * (lo + hi)
+        if top - root < cls._CROSSING_RESOLUTION:
+            return None  # at the seed, within the resolution
+        return root
 
     def _settled(
         self,
@@ -379,7 +403,8 @@ class PlanetaryReturnFactory:
         seed_second = round(datetime_to_julian(self._seed_whole_second(iso_formatted_time)) * 86400.0)
         model = search(self._search_start_jd(iso_formatted_time, backwards))
         for _ in range(2):
-            assert model.julian_day is not None
+            if model.julian_day is None:
+                raise KerykeionException("The return chart carries no Julian Day; cannot order it against the seed.")
             reported_second = round(model.julian_day * 86400.0)
             if (reported_second < seed_second) if backwards else (reported_second > seed_second):
                 return model
@@ -1320,7 +1345,7 @@ class PlanetaryReturnFactory:
             if backwards:
                 # The Moon crosses its node where its latitude changes sign. A
                 # crossing inside the second before the seed is before it at
-                # reporting resolution; the solver's dead band (~20 ms) may
+                # reporting resolution; the solver's dead band (up to ~90 ms) may
                 # skip it — look for it explicitly.
                 def moon_latitude(jd: float) -> float:
                     return ephe.calc_ut(jd, ephe.MOON, iflag)[0][1]

--- a/kerykeion/planetary_returns/factory.py
+++ b/kerykeion/planetary_returns/factory.py
@@ -281,8 +281,9 @@ class PlanetaryReturnFactory:
         crossings are settled to a millisecond by bisection, a crossing inside
         the second before a backward seed is looked for explicitly, and a
         result that has not moved past the seed's second restarts from outside
-        the solver's basin. The lunar nodes and Liliths are not heliocentric
-        bodies and are outside this contract, as they were.
+        the solver's basin. Outside it, as before: the heliocentric search for
+        the lunar nodes and the Liliths, which are not heliocentric bodies
+        (the Moon's own node crossings are inside it).
 
         Naive timestamps are read as UTC, like every ``*_from_iso`` entry.
         """
@@ -336,15 +337,16 @@ class PlanetaryReturnFactory:
     # on both sides: the arc also flips sign at the antipode of the target,
     # where it jumps from +180 to -180, and that is an opposition, not a
     # return. Over any window used here (a second; a minute around a solver's
-    # answer) a body moves a few arcseconds at most, so a genuine crossing
-    # keeps the arc within a fraction of a degree of zero.
+    # answer) a body moves a few tens of arcseconds at most, so a genuine
+    # crossing keeps the arc within a fraction of a degree of zero.
     _CROSSING_ARC_LIMIT = 90.0
-    # Resolution of the bisection, in days (one millisecond).
-    _CROSSING_RESOLUTION = 1e-3 / 86400.0
+    # Resolution of the bisection, in days: a tenth of a millisecond, just
+    # above the granularity of a Julian Day in double precision (~46 µs).
+    _CROSSING_RESOLUTION = 1e-4 / 86400.0
 
     @classmethod
     def _crossing_between(cls, offset: Callable[[float], float], lo: float, hi: float) -> Optional[float]:
-        """The root of a monotone signed ``offset`` strictly inside ``[lo, hi)``, to a millisecond — or None.
+        """The root of a monotone signed ``offset`` strictly inside ``[lo, hi)``, to a tenth of a millisecond — or None.
 
         ``offset`` is negative on one side of the crossing and positive on the
         other; a sign change across the window is the crossing, found by
@@ -357,8 +359,8 @@ class PlanetaryReturnFactory:
         A root at ``hi`` itself — a seed that IS a crossing, the natal instant
         being one by construction — is not inside the window and yields None:
         a crossing at the seed is inside the seed's own second, which the
-        ordering contract excludes. Roots within a millisecond of ``hi`` are
-        treated the same, below the resolution of the bisection.
+        ordering contract excludes. Roots within a tenth of a millisecond of
+        ``hi`` are treated the same, below the resolution of the bisection.
         """
         f_lo, f_hi = offset(lo), offset(hi)
         if max(abs(f_lo), abs(f_hi)) > cls._CROSSING_ARC_LIMIT:
@@ -1345,7 +1347,7 @@ class PlanetaryReturnFactory:
             if backwards:
                 # The Moon crosses its node where its latitude changes sign. A
                 # crossing inside the second before the seed is before it at
-                # reporting resolution; the solver's dead band (up to ~90 ms) may
+                # reporting resolution; the solver's dead band (~22 ms) may
                 # skip it — look for it explicitly.
                 def moon_latitude(jd: float) -> float:
                     return ephe.calc_ut(jd, ephe.MOON, iflag)[0][1]

--- a/kerykeion/planetary_returns/factory.py
+++ b/kerykeion/planetary_returns/factory.py
@@ -263,27 +263,36 @@ class PlanetaryReturnFactory:
         side.
 
         Ordering between a seed and a return is therefore defined at the
-        library's reporting resolution: a forward search starts from the whole
-        second after the seed's, a backward one from the whole second before
-        it. Reported instants become re-usable as seeds — ``next`` from the
-        instant of return N is N+1, ``previous`` is N−1, exactly — and nothing
-        can be skipped, since consecutive returns of every supported kind are
-        at least ~13 days apart (half a draconic month, the node crossing).
+        library's reporting resolution. A forward search starts from the whole
+        second AFTER the seed's: every crossing inside the seed's own second
+        is reported at that second, hence not "after" it. A backward search
+        starts from the seed's own whole second: the ephemeris backend's
+        backward searches are strictly past (a crossing at the start epoch is
+        never the answer), so a crossing inside the seed's second — reported
+        at that second, hence not "before" it — is excluded, while one in the
+        second before is found. Reported instants become re-usable as seeds —
+        ``next`` from the instant of return N is N+1, ``previous`` is N−1,
+        exactly — and nothing can be skipped: consecutive crossings of the
+        Sun, the Moon, the lunar nodes and the heliocentric planets the backend
+        solves (Mercury to Pluto, Ceres to Vesta) are at least ~12.4 days
+        apart (the node crossing, every half draconic month). Bodies the
+        backend has no heliocentric crossing for (Chiron, Pholus, the Uranian
+        points, the nodes and Liliths themselves) are outside this contract:
+        their search returns its seed, before and after this change alike.
 
         Naive timestamps are read as UTC, like every ``*_from_iso`` entry.
         """
         dt = cls._parse_iso(iso_formatted_time)
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
-        step = timedelta(seconds=-1 if backwards else 1)
+        step = timedelta(seconds=0 if backwards else 1)
         try:
             # Normalize to UTC BEFORE truncating and stepping: the civil range
             # is a range of instants, and a local wall time at its edge
             # (9999-12-31T23:59:59+14:00 is a mid-morning UTC instant) must not
             # trip on the local representation. What overflows here is a seed
             # genuinely outside the range — 9999-12-31T23:59:59 UTC forward,
-            # 0001-01-01T00:00:00 UTC backward, or an aware timestamp whose
-            # UTC instant is already past the edge.
+            # or an aware timestamp whose UTC instant is already past an edge.
             whole_second = dt.astimezone(timezone.utc).replace(microsecond=0)
             return datetime_to_julian(whole_second + step)
         except OverflowError as exc:
@@ -597,8 +606,10 @@ class PlanetaryReturnFactory:
 
         Raises:
             KerykeionException: If ``return_type`` is not "Solar" or "Lunar", if
-                ``iso_formatted_time`` is not a valid ISO datetime, or if the return
-                search steps outside the available ephemeris date range.
+                ``iso_formatted_time`` is not a valid ISO datetime, if the seed's
+                UTC instant sits at the edge of the civil range (years 1 to 9999)
+                so the search cannot start inside it, or if the return search
+                steps outside the available ephemeris date range.
 
         Examples:
             Calculate next Solar Return after a specific date:
@@ -856,8 +867,10 @@ class PlanetaryReturnFactory:
         within that year. For Lunar Returns, it finds the first lunar return occurring
         in January of the specified year.
 
-        The method internally uses next_return_from_iso_formatted_time() with a starting
-        point of January 1st at midnight UTC for the specified year.
+        The method delegates to next_return_from_date() with January 1st of the
+        specified year: an inclusive midnight seed, so a return in the year's
+        first second is that year's return (unlike the ISO entry point, whose
+        seed's own second is excluded so a reported instant steps).
 
         Args:
             year (int): The calendar year to search for the return. Must be a valid
@@ -1193,7 +1206,10 @@ class PlanetaryReturnFactory:
 
         Args:
             planet_name: Planet name (e.g. "Mars", "Jupiter", "Saturn").
-            iso_formatted_time: ISO 8601 datetime string to start from.
+            iso_formatted_time: ISO 8601 datetime string to start from. Ordered
+                at the whole second, so the instant of a crossing this factory
+                reported is a valid seed for the following (or, with
+                ``backwards``, the preceding) one.
             backwards: Search backward instead of forward.
 
         Returns:
@@ -1273,7 +1289,10 @@ class PlanetaryReturnFactory:
         Mirrors :meth:`next_return_from_iso_formatted_time` (Solar/Lunar).
 
         Args:
-            iso_formatted_time: ISO 8601 datetime string to start from.
+            iso_formatted_time: ISO 8601 datetime string to start from. Ordered
+                at the whole second, so the instant of a crossing this factory
+                reported is a valid seed for the following (or, with
+                ``backwards``, the preceding) one.
             backwards: Search backward instead of forward.
 
         Returns:

--- a/kerykeion/planetary_returns/factory.py
+++ b/kerykeion/planetary_returns/factory.py
@@ -275,14 +275,20 @@ class PlanetaryReturnFactory:
         dt = cls._parse_iso(iso_formatted_time)
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
-        whole_second = dt.replace(microsecond=0)
         step = timedelta(seconds=-1 if backwards else 1)
         try:
+            # Normalize to UTC BEFORE truncating and stepping: the civil range
+            # is a range of instants, and a local wall time at its edge
+            # (9999-12-31T23:59:59+14:00 is a mid-morning UTC instant) must not
+            # trip on the local representation. What overflows here is a seed
+            # genuinely outside the range — 9999-12-31T23:59:59 UTC forward,
+            # 0001-01-01T00:00:00 UTC backward, or an aware timestamp whose
+            # UTC instant is already past the edge.
+            whole_second = dt.astimezone(timezone.utc).replace(microsecond=0)
             return datetime_to_julian(whole_second + step)
         except OverflowError as exc:
-            # 9999-12-31T23:59:59 forward / 0001-01-01T00:00:00 backward: the
-            # next second is outside datetime's civil range. Refuse with the
-            # library's own exception, naming the range, not the ephemeris.
+            # Refuse with the library's own exception, naming the range, not
+            # the ephemeris.
             raise KerykeionException(
                 f"Cannot search {'backward' if backwards else 'forward'} from "
                 f"{iso_formatted_time!r}: the search would start outside the "

--- a/kerykeion/planetary_returns/factory.py
+++ b/kerykeion/planetary_returns/factory.py
@@ -75,7 +75,7 @@ import logging
 from kerykeion.ephemeris_backend.backend import ephe, ephemeris_session
 
 from datetime import datetime, timedelta, timezone
-from typing import List, Literal, Union, cast
+from typing import Callable, List, Literal, Optional, Union, cast
 
 from kerykeion.schemas import KerykeionException
 from kerykeion.geonames.fetcher import FetchGeonames
@@ -271,38 +271,124 @@ class PlanetaryReturnFactory:
         never the answer), so a crossing inside the seed's second — reported
         at that second, hence not "before" it — is excluded, while one in the
         second before is found. Reported instants become re-usable as seeds —
-        ``next`` from the instant of return N is N+1, ``previous`` is N−1,
-        exactly — and nothing can be skipped: consecutive crossings of the
-        Sun, the Moon, the lunar nodes and the heliocentric planets the backend
-        solves (Mercury to Pluto, Ceres to Vesta) are at least ~12.4 days
-        apart (the node crossing, every half draconic month). Bodies the
-        backend has no heliocentric crossing for (Chiron, Pholus, the Uranian
-        points, the nodes and Liliths themselves) are outside this contract:
-        their search returns its seed, before and after this change alike.
+        ``next`` from the instant of return N is N+1, ``previous`` is N-1,
+        exactly — and nothing can be skipped: consecutive crossings of any
+        one kind are at least ~12.4 days apart (the node crossing, every half
+        draconic month). The backend's solvers do not reach this resolution
+        on their own — their at-crossing dead band spans ~90 ms for the Sun,
+        their 0.001″ tolerance is seconds of a slow heliocentric body's motion
+        — so ``_settled`` holds every ISO search to the contract: heliocentric
+        crossings are settled to a millisecond by bisection, a crossing inside
+        the second before a backward seed is looked for explicitly, and a
+        result that has not moved past the seed's second restarts from outside
+        the solver's basin. The lunar nodes and Liliths have no heliocentric
+        longitude in the backend and are outside this contract, as they were.
 
         Naive timestamps are read as UTC, like every ``*_from_iso`` entry.
         """
-        dt = cls._parse_iso(iso_formatted_time)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
+        whole_second = cls._seed_whole_second(iso_formatted_time)
         step = timedelta(seconds=0 if backwards else 1)
         try:
-            # Normalize to UTC BEFORE truncating and stepping: the civil range
-            # is a range of instants, and a local wall time at its edge
-            # (9999-12-31T23:59:59+14:00 is a mid-morning UTC instant) must not
-            # trip on the local representation. What overflows here is a seed
-            # genuinely outside the range — 9999-12-31T23:59:59 UTC forward,
-            # or an aware timestamp whose UTC instant is already past an edge.
-            whole_second = dt.astimezone(timezone.utc).replace(microsecond=0)
             return datetime_to_julian(whole_second + step)
         except OverflowError as exc:
-            # Refuse with the library's own exception, naming the range, not
-            # the ephemeris.
+            # 9999-12-31T23:59:59 UTC forward: the next second is outside the
+            # civil range. Refuse with the library's own exception, naming the
+            # range, not the ephemeris.
             raise KerykeionException(
                 f"Cannot search {'backward' if backwards else 'forward'} from "
                 f"{iso_formatted_time!r}: the search would start outside the "
                 "supported civil range (years 1 to 9999)."
             ) from exc
+
+    @classmethod
+    def _seed_whole_second(cls, iso_formatted_time: str) -> datetime:
+        """The seed's whole second, in UTC — the instant ordering is decided against."""
+        dt = cls._parse_iso(iso_formatted_time)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        try:
+            # Normalize to UTC BEFORE truncating: the civil range is a range of
+            # instants, and a local wall time at its edge
+            # (9999-12-31T23:59:59+14:00 is a mid-morning UTC instant) must not
+            # trip on the local representation. What overflows here is an
+            # aware timestamp whose UTC instant is already past an edge.
+            return dt.astimezone(timezone.utc).replace(microsecond=0)
+        except OverflowError as exc:
+            raise KerykeionException(
+                f"Cannot search from {iso_formatted_time!r}: its UTC instant is outside "
+                "the supported civil range (years 1 to 9999)."
+            ) from exc
+
+    # One second, in days.
+    _SECOND = 1.0 / 86400.0
+    # Where a search restarts when the solver handed back the crossing its seed
+    # came from: well outside every solver's convergence basin (a minute, for
+    # the slowest heliocentric body) and well inside every cycle (twelve days,
+    # for a node crossing).
+    _ESCAPE_DAYS = 1.0 / 24.0
+
+    @staticmethod
+    def _signed_arc(longitude: float, target: float) -> float:
+        """Signed arc from ``target`` to ``longitude``, in (-180, 180]."""
+        return ((longitude - target + 180.0) % 360.0) - 180.0
+
+    @staticmethod
+    def _crossing_between(offset: Callable[[float], float], lo: float, hi: float) -> Optional[float]:
+        """The root of a monotone signed ``offset`` inside ``[lo, hi)``, to a millisecond — or None.
+
+        ``offset`` is negative on one side of the crossing and positive on the
+        other; a sign change across the window is the crossing, found by
+        bisection. This reaches the resolution the backend's solvers do not:
+        inside one second (their at-crossing dead band spans ~90 ms for the
+        Sun) and inside the convergence basin of a slow heliocentric body
+        (their 0.001″ tolerance is six seconds of Pluto's motion).
+        """
+        f_lo, f_hi = offset(lo), offset(hi)
+        if f_lo == 0.0:
+            return lo
+        if (f_lo < 0.0) == (f_hi < 0.0):
+            return None
+        for _ in range(64):
+            if (hi - lo) * 86400.0 < 1e-3:
+                break
+            mid = 0.5 * (lo + hi)
+            f_mid = offset(mid)
+            if f_mid == 0.0:
+                return mid
+            if (f_mid < 0.0) == (f_lo < 0.0):
+                lo, f_lo = mid, f_mid
+            else:
+                hi, f_hi = mid, f_mid
+        return 0.5 * (lo + hi)
+
+    def _settled(
+        self,
+        iso_formatted_time: str,
+        backwards: bool,
+        search: Callable[[float], PlanetReturnModel],
+    ) -> PlanetReturnModel:
+        """Run ``search`` from the ISO seed and hold it to the ordering contract.
+
+        A result is accepted only when its reported second lies strictly after
+        (forward) or before (backward) the seed's whole second. When it does
+        not, the solver has handed back the crossing the seed came from — its
+        convergence basin, up to a minute for the slowest heliocentric bodies,
+        is wider than the second the seed stepped — and the search restarts
+        from well outside that basin.
+        """
+        seed_second = round(datetime_to_julian(self._seed_whole_second(iso_formatted_time)) * 86400.0)
+        model = search(self._search_start_jd(iso_formatted_time, backwards))
+        for _ in range(2):
+            assert model.julian_day is not None
+            reported_second = round(model.julian_day * 86400.0)
+            if (reported_second < seed_second) if backwards else (reported_second > seed_second):
+                return model
+            escape = model.julian_day + (-self._ESCAPE_DAYS if backwards else self._ESCAPE_DAYS)
+            model = search(escape)
+        raise KerykeionException(
+            f"The return search could not move past its seed {iso_formatted_time!r}: "
+            "the backend keeps answering with the crossing the seed came from."
+        )
 
     def __init__(
         self,
@@ -663,8 +749,10 @@ class PlanetaryReturnFactory:
             next_return_from_date(): Date-based calculation interface
         """
 
-        return self._next_return_from_jd(
-            self._search_start_jd(iso_formatted_time, backwards), return_type, backwards=backwards
+        return self._settled(
+            iso_formatted_time,
+            backwards,
+            lambda start_jd: self._next_return_from_jd(start_jd, return_type, backwards=backwards),
         )
 
     def _next_return_from_jd(
@@ -790,6 +878,24 @@ class PlanetaryReturnFactory:
                         ) from exc
             else:
                 raise KerykeionException(f"Invalid return type {return_type}. Use 'Solar' or 'Lunar'.")
+
+            if backwards and return_julian_date is not None:
+                # The backend treats a body within ~1e-6° of its target as "at
+                # the crossing" and jumps a full cycle back: a dead band of
+                # ~90 ms for the Sun, ~7 ms for the Moon. A crossing inside the
+                # second before the seed is still before it at reporting
+                # resolution — look for it explicitly.
+                body = self.subject.sun if return_type == "Solar" else self.subject.moon
+                assert body is not None
+                body_id = ephe.SUN if return_type == "Solar" else ephe.MOON
+                target = body.abs_pos
+
+                def geocentric_offset(jd: float) -> float:
+                    return self._signed_arc(ephe.calc_ut(jd, body_id, iflag)[0][0], target)
+
+                inside = self._crossing_between(geocentric_offset, julian_day - self._SECOND, julian_day)
+                if inside is not None:
+                    return_julian_date = inside
 
         try:
             return_date_utc = julian_to_datetime(return_julian_date)
@@ -1141,6 +1247,28 @@ class PlanetaryReturnFactory:
                         f"ephemeris date range; narrow the search window. ({exc})"
                     ) from exc
 
+            def heliocentric_offset(jd: float) -> float:
+                return self._signed_arc(ephe.calc_ut(jd, planet_id, helio_iflag)[0][0], natal_lon)
+
+            # The solver converges to 0.001″ — six seconds of Pluto's motion,
+            # two of Uranus', one of Chiron's — so its answer can sit seconds
+            # from the crossing, and a seed one second on may be handed back as
+            # its own answer. Settle the crossing to a millisecond by bisection
+            # around the solver's result (no other crossing lies within a
+            # minute: the shortest heliocentric period is Mercury's 88 days),
+            # so the instant reported is the crossing's own, whatever the seed.
+            refined = self._crossing_between(
+                heliocentric_offset, return_jd - 60.0 * self._SECOND, return_jd + 60.0 * self._SECOND
+            )
+            if refined is not None:
+                return_jd = refined
+            if backwards:
+                # A crossing inside the second before the seed is before it at
+                # reporting resolution; the solver's past-exclusion may skip it.
+                inside = self._crossing_between(heliocentric_offset, start_jd - self._SECOND, start_jd)
+                if inside is not None:
+                    return_jd = inside
+
         # Build return chart at that moment (outside the session: subject
         # construction manages its own ephemeris state).
         return_model = self._build_return_chart(return_jd, "Heliocentric")
@@ -1189,6 +1317,18 @@ class PlanetaryReturnFactory:
                     ) from exc
             crossing_jd = result[0]
 
+            if backwards:
+                # The Moon crosses its node where its latitude changes sign. A
+                # crossing inside the second before the seed is before it at
+                # reporting resolution; the solver's dead band (~20 ms) may
+                # skip it — look for it explicitly.
+                def moon_latitude(jd: float) -> float:
+                    return ephe.calc_ut(jd, ephe.MOON, iflag)[0][1]
+
+                inside = self._crossing_between(moon_latitude, start_jd - self._SECOND, start_jd)
+                if inside is not None:
+                    crossing_jd = inside
+
         return_model = self._build_return_chart(crossing_jd, "Lunar_Node_Crossing")
         return return_model
 
@@ -1215,10 +1355,12 @@ class PlanetaryReturnFactory:
         Returns:
             PlanetReturnModel for the heliocentric return chart.
         """
-        return self.next_heliocentric_return(
-            planet_name=planet_name,
-            start_jd=self._search_start_jd(iso_formatted_time, backwards),
-            backwards=backwards,
+        return self._settled(
+            iso_formatted_time,
+            backwards,
+            lambda start_jd: self.next_heliocentric_return(
+                planet_name=planet_name, start_jd=start_jd, backwards=backwards
+            ),
         )
 
     def next_heliocentric_return_from_year(
@@ -1298,9 +1440,10 @@ class PlanetaryReturnFactory:
         Returns:
             PlanetReturnModel for the node crossing chart.
         """
-        return self.next_lunar_node_crossing(
-            start_jd=self._search_start_jd(iso_formatted_time, backwards),
-            backwards=backwards,
+        return self._settled(
+            iso_formatted_time,
+            backwards,
+            lambda start_jd: self.next_lunar_node_crossing(start_jd=start_jd, backwards=backwards),
         )
 
     def next_lunar_node_crossing_from_year(

--- a/kerykeion/planetary_returns/factory.py
+++ b/kerykeion/planetary_returns/factory.py
@@ -646,7 +646,21 @@ class PlanetaryReturnFactory:
             next_return_from_date(): Date-based calculation interface
         """
 
-        julian_day = self._search_start_jd(iso_formatted_time, backwards)
+        return self._next_return_from_jd(
+            self._search_start_jd(iso_formatted_time, backwards), return_type, backwards=backwards
+        )
+
+    def _next_return_from_jd(
+        self, julian_day: float, return_type: SolarLunarReturnType, backwards: bool = False
+    ) -> PlanetReturnModel:
+        """Solar/Lunar return search from a Julian Day seed, taken as given.
+
+        The ISO entry point snaps its seed to the reporting resolution before
+        arriving here (``_search_start_jd``), so a reported instant steps to
+        the next return. The date wrapper passes its midnight seed straight
+        through, inclusive: a return in the first second of a date is that
+        date's return, as ``next_return_from_date`` has always promised.
+        """
 
         # The natal abs_pos values are expressed in the subject's zodiac
         # (tropical OR sidereal) AND perspective (apparent/true geocentric,
@@ -983,8 +997,11 @@ class PlanetaryReturnFactory:
         # Create datetime for the specified date (UTC)
         start_date = datetime(year, month, day, 0, 0, tzinfo=timezone.utc)
 
-        # Get the return using the existing method
-        return self.next_return_from_iso_formatted_time(start_date.isoformat(), return_type, backwards=backwards)
+        # Midnight is the seed, inclusive — NOT the ISO entry point, whose seed
+        # is snapped past its own second so that a reported return instant
+        # steps to the next return. "The first return of this date" must keep
+        # a return that falls in the date's first second.
+        return self._next_return_from_jd(datetime_to_julian(start_date), return_type, backwards=backwards)
 
     def next_return_from_month_and_year(self, year: int, month: int, return_type: SolarLunarReturnType) -> PlanetReturnModel:
         """

--- a/kerykeion/planetary_returns/factory.py
+++ b/kerykeion/planetary_returns/factory.py
@@ -279,7 +279,7 @@ class PlanetaryReturnFactory:
         own — their at-crossing dead band spans ~90 ms for the Sun, their
         0.001″ tolerance is seconds of a slow heliocentric body's motion — so
         ``_settled`` holds every supported ISO search to the contract: heliocentric
-        crossings are settled to a millisecond by bisection, a crossing inside
+        crossings are settled to a tenth of a millisecond by bisection, a crossing inside
         the second before a backward seed is looked for explicitly, and a
         result that has not moved past the seed's second restarts from outside
         the solver's basin. Outside it, as before: the heliocentric search for
@@ -1281,7 +1281,7 @@ class PlanetaryReturnFactory:
             # The solver converges to 0.001″ — six seconds of Pluto's motion,
             # two of Uranus', one of Chiron's — so its answer can sit seconds
             # from the crossing, and a seed one second on may be handed back as
-            # its own answer. Settle the crossing to a millisecond by bisection
+            # its own answer. Settle the crossing to a tenth of a millisecond by bisection
             # around the solver's result (no other crossing lies within a
             # minute: the shortest heliocentric period is Mercury's 88 days),
             # so the instant reported is the crossing's own, whatever the seed.

--- a/kerykeion/planetary_returns/factory.py
+++ b/kerykeion/planetary_returns/factory.py
@@ -273,11 +273,12 @@ class PlanetaryReturnFactory:
         second before is found. Reported instants become re-usable as seeds —
         ``next`` from the instant of return N is N+1, ``previous`` is N-1,
         exactly — and nothing can be skipped: consecutive crossings of any
-        one kind are at least ~12.4 days apart (the node crossing, every half
-        draconic month). The backend's solvers do not reach this resolution
-        on their own — their at-crossing dead band spans ~90 ms for the Sun,
-        their 0.001″ tolerance is seconds of a slow heliocentric body's motion
-        — so ``_settled`` holds every ISO search to the contract: heliocentric
+        one kind are at least ~12.4 days apart (the shortest interval between
+        the Moon's node crossings; half a draconic month is 13.6 days on
+        average). The backend's solvers do not reach this resolution on their
+        own — their at-crossing dead band spans ~90 ms for the Sun, their
+        0.001″ tolerance is seconds of a slow heliocentric body's motion — so
+        ``_settled`` holds every supported ISO search to the contract: heliocentric
         crossings are settled to a millisecond by bisection, a crossing inside
         the second before a backward seed is looked for explicitly, and a
         result that has not moved past the seed's second restarts from outside
@@ -403,15 +404,15 @@ class PlanetaryReturnFactory:
         from well outside that basin.
         """
         seed_second = round(datetime_to_julian(self._seed_whole_second(iso_formatted_time)) * 86400.0)
-        model = search(self._search_start_jd(iso_formatted_time, backwards))
+        start_jd = self._search_start_jd(iso_formatted_time, backwards)
         for _ in range(2):
+            model = search(start_jd)
             if model.julian_day is None:
                 raise KerykeionException("The return chart carries no Julian Day; cannot order it against the seed.")
             reported_second = round(model.julian_day * 86400.0)
             if (reported_second < seed_second) if backwards else (reported_second > seed_second):
                 return model
-            escape = model.julian_day + (-self._ESCAPE_DAYS if backwards else self._ESCAPE_DAYS)
-            model = search(escape)
+            start_jd = model.julian_day + (-self._ESCAPE_DAYS if backwards else self._ESCAPE_DAYS)
         raise KerykeionException(
             f"The return search could not move past its seed {iso_formatted_time!r}: "
             "the backend keeps answering with the crossing the seed came from."

--- a/kerykeion/planetary_returns/factory.py
+++ b/kerykeion/planetary_returns/factory.py
@@ -363,26 +363,34 @@ class PlanetaryReturnFactory:
         ordering contract excludes. Roots within a tenth of a millisecond of
         ``hi`` are treated the same, below the resolution of the bisection.
         """
-        f_lo, f_hi = offset(lo), offset(hi)
-        if max(abs(f_lo), abs(f_hi)) > cls._CROSSING_ARC_LIMIT:
-            return None  # the window straddles the antipode, not the target
-        if f_lo == 0.0:
-            return lo
-        if f_hi == 0.0 or (f_lo < 0.0) == (f_hi < 0.0):
-            return None
-        top = hi
-        for _ in range(64):
-            if hi - lo < cls._CROSSING_RESOLUTION:
-                break
-            mid = 0.5 * (lo + hi)
-            f_mid = offset(mid)
-            if f_mid == 0.0:
-                lo = hi = mid
-                break
-            if (f_mid < 0.0) == (f_lo < 0.0):
-                lo, f_lo = mid, f_mid
-            else:
-                hi, f_hi = mid, f_mid
+        try:
+            f_lo, f_hi = offset(lo), offset(hi)
+            if max(abs(f_lo), abs(f_hi)) > cls._CROSSING_ARC_LIMIT:
+                return None  # the window straddles the antipode, not the target
+            if f_lo == 0.0:
+                return lo
+            if f_hi == 0.0 or (f_lo < 0.0) == (f_hi < 0.0):
+                return None
+            top = hi
+            for _ in range(64):
+                if hi - lo < cls._CROSSING_RESOLUTION:
+                    break
+                mid = 0.5 * (lo + hi)
+                f_mid = offset(mid)
+                if f_mid == 0.0:
+                    lo = hi = mid
+                    break
+                if (f_mid < 0.0) == (f_lo < 0.0):
+                    lo, f_lo = mid, f_mid
+                else:
+                    hi, f_hi = mid, f_mid
+        except _BACKEND_ERRORS as exc:
+            # A probe at the edge of the ephemeris range fails like the solver
+            # calls do: with the library's own exception, not a raw backend one.
+            raise KerykeionException(
+                "The crossing refinement stepped outside the available ephemeris date range; "
+                f"narrow the search window. ({exc})"
+            ) from exc
         root = 0.5 * (lo + hi)
         if top - root < cls._CROSSING_RESOLUTION:
             return None  # at the seed, within the resolution

--- a/release_notes/v6.0.0a89.md
+++ b/release_notes/v6.0.0a89.md
@@ -29,8 +29,10 @@ factory's: it chose to report at one second and then compared at full precision.
 
 Ordering between a seed and a return is now decided **at the resolution the factory
 reports at**. A forward search starts from the whole second after the seed's; a
-backward search from the whole second before it. One helper, `_search_start_jd`,
-behind all three `*_from_iso_formatted_time` entry points.
+backward search from the seed's own whole second — the backend's backward searches
+are strictly past, so a crossing inside that second (reported at it, hence not
+"before" it) is excluded, and one in the second before is found. One helper,
+`_search_start_jd`, behind all three `*_from_iso_formatted_time` entry points.
 
 The contract this establishes, and the tests that pin it for every kind:
 
@@ -41,8 +43,12 @@ previous(next(r))      == r          exactly, instant for instant
 ```
 
 A walk of five steps forward and five back lands on each return exactly once and
-comes home to the same instant. Nothing can be skipped: consecutive returns of every
-supported kind are at least ~13 days apart, half a draconic month.
+comes home to the same instant. Nothing can be skipped: consecutive crossings of the
+Sun, the Moon, the lunar nodes and the heliocentric planets the backend solves are at
+least ~12.4 days apart, half a draconic month. Bodies the backend has no heliocentric
+crossing for — Chiron, Pholus, the Uranian points, the nodes and Liliths themselves —
+are outside this contract: their search returned its seed before this change and
+does still.
 
 Nothing reported changes. The instants, the charts, the Julian Days are what they
 were; only which return a seed *selects* moves — by one second's worth of ordering,

--- a/release_notes/v6.0.0a89.md
+++ b/release_notes/v6.0.0a89.md
@@ -43,12 +43,30 @@ previous(next(r))      == r          exactly, instant for instant
 ```
 
 A walk of five steps forward and five back lands on each return exactly once and
-comes home to the same instant. Nothing can be skipped: consecutive crossings of the
-Sun, the Moon, the lunar nodes and the heliocentric planets the backend solves are at
-least ~12.4 days apart, half a draconic month. Bodies the backend has no heliocentric
-crossing for — Chiron, Pholus, the Uranian points, the nodes and Liliths themselves —
-are outside this contract: their search returned its seed before this change and
-does still.
+comes home to the same instant. Nothing can be skipped: consecutive crossings of any
+one kind are at least ~12.4 days apart, half a draconic month.
+
+## What the solvers could not do alone
+
+The backend's crossing solvers are built for a different question — *when does the
+body reach this longitude?* — and answer it to 0.001″. That is a fine answer and a
+coarse instant: six seconds of Pluto's motion, two of Uranus', one of Chiron's. Seed
+such a solver one second past a crossing and it hands the seed back as its own
+answer: the same crossing, reported a second later, visited twice by a walk. And
+backward, the Sun's solver treats a body within a millionth of a degree of its target
+as already there — a dead band of ~90 ms — and jumps a whole year from a seed that
+sits inside it.
+
+So the factory holds every ISO search to the contract itself. A heliocentric
+crossing is settled to a millisecond by bisection around the solver's answer (no
+other crossing lies within a minute; Mercury's period is 88 days). A crossing inside
+the second before a backward seed is looked for explicitly, by the same bisection.
+And a result that has not moved past the seed's second restarts from an hour out —
+outside every solver's basin, inside every cycle. The contract is pinned for the Sun,
+the Moon, the lunar nodes and the heliocentric bodies from Mercury to Pluto plus
+Chiron; twenty consecutive solar returns are found from the second after each, dead
+band included. The lunar nodes and Liliths have no heliocentric longitude in the
+backend and stay outside the contract, as they were.
 
 Nothing reported changes. The instants, the charts, the Julian Days are what they
 were; only which return a seed *selects* moves — by one second's worth of ordering,

--- a/release_notes/v6.0.0a89.md
+++ b/release_notes/v6.0.0a89.md
@@ -65,12 +65,19 @@ And a result that has not moved past the seed's second restarts from an hour out
 outside every solver's basin, inside every cycle. The contract is pinned for the Sun,
 the Moon, the lunar nodes and the heliocentric bodies from Mercury to Pluto plus
 Chiron; twenty consecutive solar returns are found from the second after each, dead
-band included. The lunar nodes and Liliths have no heliocentric longitude in the
-backend and stay outside the contract, as they were.
+band included. One limit is the ephemeris' own: a crossing within some tens of
+microseconds of a whole second cannot be told from a crossing at that second, and is
+treated as one. The case that matters is the natal instant — a crossing by
+construction — and it is handled: seeded with it, `previous` finds the cycle before
+birth, never a "return" a second before the birth itself. The lunar nodes and Liliths are not heliocentric bodies and stay
+outside the contract, as they were.
 
-Nothing reported changes. The instants, the charts, the Julian Days are what they
-were; only which return a seed *selects* moves — by one second's worth of ordering,
-and only when the seed falls inside the same second as a crossing. `next_return_from_date`
+Solar, lunar and node instants are reported as they were; only which return a seed
+*selects* moves — by one second's worth of ordering, and only when the seed falls
+inside the same second as a crossing. Heliocentric instants now settle onto the
+crossing itself: for the slow bodies that can move the reported second by up to
+~1.5 s from the solver's answer (about one in eight Uranus–Pluto crossings), toward
+the truth. `next_return_from_date`
 and the `*_from_year` wrappers keep their inclusive midnight seed: "the first return
 of this date" still includes a return in the date's first second. Only the ISO entry
 points snap their seed — they are the ones a reported instant comes back through.

--- a/release_notes/v6.0.0a89.md
+++ b/release_notes/v6.0.0a89.md
@@ -47,8 +47,9 @@ supported kind are at least ~13 days apart, half a draconic month.
 Nothing reported changes. The instants, the charts, the Julian Days are what they
 were; only which return a seed *selects* moves — by one second's worth of ordering,
 and only when the seed falls inside the same second as a crossing. `next_return_from_date`
-and the `*_from_year` wrappers are untouched in effect: their midnight seeds never
-share a second with a return.
+and the `*_from_year` wrappers keep their inclusive midnight seed: "the first return
+of this date" still includes a return in the date's first second. Only the ISO entry
+points snap their seed — they are the ones a reported instant comes back through.
 
 The one consequence a caller can see: a seed inside the same second as a crossing
 now selects the following return. Seeding a solar return search from the natal

--- a/release_notes/v6.0.0a89.md
+++ b/release_notes/v6.0.0a89.md
@@ -1,0 +1,70 @@
+# v6.0.0a89 — The return that would not step forward
+
+One defect, small in code and large in effect: **a return instant this library
+reported could not be handed back to it as the seed of the next search.** Ask for
+the solar return after 2022-06-10T08:46:33Z — the instant it had just given you for
+2022 — and it gave you 2022 again. Ask for the one before, and it correctly went to
+2021. A client walking the sequence of returns with a *next* button stood still;
+its *previous* button worked. Every kind of return had it: solar, lunar, heliocentric,
+lunar node crossing.
+
+---
+
+## Why
+
+Return instants are reported truncated to the whole second: the chart is rebuilt
+from an integer `seconds` field, and the class docstring has always said so. The
+exact crossing therefore lies in `[T, T + 1s)` — a fraction of a second **after**
+the value the caller holds. A forward search seeded with that value asked the
+ephemeris for the first crossing at or after it, and the ephemeris answered,
+correctly, with the same crossing, sitting just ahead. The backward search worked
+for the mirror reason: the truncated seed lands before the crossing, so stepping
+back skips it.
+
+The ephemeris primitive is not at fault — a body immediately before its target
+*should* have its first crossing at the current instant. The fault was the
+factory's: it chose to report at one second and then compared at full precision.
+
+## What changed
+
+Ordering between a seed and a return is now decided **at the resolution the factory
+reports at**. A forward search starts from the whole second after the seed's; a
+backward search from the whole second before it. One helper, `_search_start_jd`,
+behind all three `*_from_iso_formatted_time` entry points.
+
+The contract this establishes, and the tests that pin it for every kind:
+
+```
+next(reported(N))      == N + 1
+previous(reported(N))  == N − 1
+previous(next(r))      == r          exactly, instant for instant
+```
+
+A walk of five steps forward and five back lands on each return exactly once and
+comes home to the same instant. Nothing can be skipped: consecutive returns of every
+supported kind are at least ~13 days apart, half a draconic month.
+
+Nothing reported changes. The instants, the charts, the Julian Days are what they
+were; only which return a seed *selects* moves — by one second's worth of ordering,
+and only when the seed falls inside the same second as a crossing. `next_return_from_date`
+and the `*_from_year` wrappers are untouched in effect: their midnight seeds never
+share a second with a return.
+
+The one consequence a caller can see: a seed inside the same second as a crossing
+now selects the following return. Seeding a solar return search from the natal
+instant itself — as four report fixtures did — used to return the birth moment,
+a "return" that was the natal chart under another title; it returns the first
+birthday now. Those fixtures are regenerated.
+
+Two seeds at the very edge of the civil range — forward from 9999-12-31T23:59:59,
+backward from 0001-01-01T00:00:00 — used to overflow `datetime`; they now refuse
+with `KerykeionException`, naming the range.
+
+## Two calendar facts, pinned alongside
+
+They are why a client must identify a return by its instant and never by a period:
+
+- Born on 1 January, the 2024 solar return falls on 1 January and the next on
+  31 December **of the same year**. "The return of 2024" names two charts.
+- A lunar return on 2 August 2026 and the next on 29 August: "August's lunar
+  return" names two as well.

--- a/release_notes/v6.0.0a89.md
+++ b/release_notes/v6.0.0a89.md
@@ -65,19 +65,20 @@ And a result that has not moved past the seed's second restarts from an hour out
 outside every solver's basin, inside every cycle. The contract is pinned for the Sun,
 the Moon, the lunar nodes and the heliocentric bodies from Mercury to Pluto plus
 Chiron; twenty consecutive solar returns are found from the second after each, dead
-band included. One limit is the ephemeris' own: a crossing within some tens of
-microseconds of a whole second cannot be told from a crossing at that second, and is
+band included. One limit is the ephemeris' own: a crossing within a tenth of a
+millisecond of a whole second cannot be told from a crossing at that second, and is
 treated as one. The case that matters is the natal instant — a crossing by
 construction — and it is handled: seeded with it, `previous` finds the cycle before
-birth, never a "return" a second before the birth itself. The lunar nodes and Liliths are not heliocentric bodies and stay
-outside the contract, as they were.
+birth, never a "return" a second before the birth itself. Outside the contract, as
+before: the heliocentric search for the lunar nodes and the Liliths, which are not
+heliocentric bodies (the Moon's own node crossings are inside it).
 
 Solar, lunar and node instants are reported as they were; only which return a seed
 *selects* moves — by one second's worth of ordering, and only when the seed falls
 inside the same second as a crossing. Heliocentric instants now settle onto the
-crossing itself: for the slow bodies that can move the reported second by up to
-~1.5 s from the solver's answer (about one in eight Uranus–Pluto crossings), toward
-the truth. `next_return_from_date`
+crossing itself: for the slow bodies that moves the reported second of about half
+the Uranus–Pluto crossings, by up to the solver's tolerance — some 2 s for Uranus,
+4 s for Neptune, 9 s for Pluto — toward the truth. `next_return_from_date`
 and the `*_from_year` wrappers keep their inclusive midnight seed: "the first return
 of this date" still includes a return in the date's first second. Only the ISO entry
 points snap their seed — they are the ones a reported instant comes back through.

--- a/release_notes/v6.0.0a89.md
+++ b/release_notes/v6.0.0a89.md
@@ -44,7 +44,7 @@ previous(next(r))      == r          exactly, instant for instant
 
 A walk of five steps forward and five back lands on each return exactly once and
 comes home to the same instant. Nothing can be skipped: consecutive crossings of any
-one kind are at least ~12.4 days apart, half a draconic month.
+one kind are at least ~12.4 days apart — the shortest interval between two of the Moon's node crossings (half a draconic month is 13.6 days on average).
 
 ## What the solvers could not do alone
 
@@ -57,8 +57,8 @@ backward, the Sun's solver treats a body within a millionth of a degree of its t
 as already there — a dead band of ~90 ms — and jumps a whole year from a seed that
 sits inside it.
 
-So the factory holds every ISO search to the contract itself. A heliocentric
-crossing is settled to a millisecond by bisection around the solver's answer (no
+So the factory holds every supported ISO search to the contract itself. A heliocentric
+crossing is settled to a tenth of a millisecond by bisection around the solver's answer (no
 other crossing lies within a minute; Mercury's period is 88 days). A crossing inside
 the second before a backward seed is looked for explicitly, by the same bisection.
 And a result that has not moved past the seed's second restarts from an hour out —
@@ -89,9 +89,11 @@ instant itself — as four report fixtures did — used to return the birth mome
 a "return" that was the natal chart under another title; it returns the first
 birthday now. Those fixtures are regenerated.
 
-Two seeds at the very edge of the civil range — forward from 9999-12-31T23:59:59,
-backward from 0001-01-01T00:00:00 — used to overflow `datetime`; they now refuse
-with `KerykeionException`, naming the range.
+A seed at the very edge of the civil range — forward from 9999-12-31T23:59:59 UTC,
+or any timestamp whose UTC instant already lies past an edge — used to overflow
+`datetime`; it now refuses with `KerykeionException`, naming the range. Seeds are
+normalized to UTC first, so 9999-12-31T23:59:59+14:00, a mid-morning UTC instant,
+seeds normally.
 
 ## Two calendar facts, pinned alongside
 

--- a/site/docs/planetary_return_factory.md
+++ b/site/docs/planetary_return_factory.md
@@ -189,9 +189,24 @@ result = return_factory.next_return_from_iso_formatted_time("2024-06-15T12:00:00
 
 | Parameter            | Type         | Default      | Description                              |
 | :------------------- | :----------- | :----------- | :--------------------------------------- |
-| `iso_formatted_time` | `str`        | **Required** | ISO 8601 timestamp at which to start the search. |
+| `iso_formatted_time` | `str`        | **Required** | ISO 8601 timestamp at which to start the search (naive values are read as UTC). |
 | `return_type`        | `ReturnType` | **Required** | `"Solar"` or `"Lunar"`.                  |
 | `backwards`          | `bool`       | `False`      | If `True`, search for the most recent return before the timestamp. |
+
+Return instants are reported truncated to the whole second, and the search is
+ordered at that resolution: the instant of a return this factory reported is a
+valid seed for the following one (or, with `backwards=True`, the preceding one),
+so a walk of `next_return_from_iso_formatted_time` calls seeded with each result's
+`iso_formatted_utc_datetime` visits every return exactly once. A seed inside the
+same second as a crossing selects the return after it (forward) or before it
+(backward). The date and year wrappers above keep an inclusive midnight seed: "the
+first return of this date" includes a return in the date's first second.
+
+```python
+first = return_factory.next_return_from_iso_formatted_time("2024-03-01T00:00:00+00:00", "Solar")
+second = return_factory.next_return_from_iso_formatted_time(first.iso_formatted_utc_datetime, "Solar")
+assert second.julian_day > first.julian_day  # the following return, not the same one again
+```
 
 Backward Solar/Lunar return search requires the default libephemeris backend;
 the optional pyswisseph backend does not expose backward crossing searches and

--- a/tests/core/test_planetary_return_roundtrip.py
+++ b/tests/core/test_planetary_return_roundtrip.py
@@ -48,8 +48,20 @@ pytestmark = pytest.mark.skipif(
 MAX_GAP_DAYS = {
     "Solar": 367.0,
     "Lunar": 28.0,
-    "Node": 15.0,  # the Moon meets either node every half draconic month
+    "Node": 16.0,  # the Moon meets either node every ~12.4–14.7 days (half a draconic month)
     "Mars": 800.0,  # heliocentric Mars, ~687 days
+}
+
+# The heliocentric bodies the backend solves crossings for, with their
+# sidereal periods rounded up, in days. Chiron, Pholus, the Uranian points,
+# the nodes and Liliths have no heliocentric crossing in the backend (their
+# search returns its seed) and are outside the contract.
+HELIOCENTRIC_MAX_GAP_DAYS = {
+    "Mercury": 100.0,
+    "Venus": 240.0,
+    "Mars": 800.0,
+    "Jupiter": 4500.0,
+    "Saturn": 11000.0,
 }
 
 
@@ -106,6 +118,17 @@ def test_next_from_reported_instant_is_the_following_return(factory, kind):
     assert gap < MAX_GAP_DAYS[kind], f"{kind}: a return was skipped ({gap:.2f} days)"
 
 
+@pytest.mark.parametrize("planet", sorted(HELIOCENTRIC_MAX_GAP_DAYS))
+def test_every_solved_heliocentric_planet_steps_from_its_reported_instant(factory, planet):
+    first = _step(factory, planet, START)
+    second = _step(factory, planet, first.iso_formatted_utc_datetime)
+    back = _step(factory, planet, second.iso_formatted_utc_datetime, backwards=True)
+
+    gap = second.julian_day - first.julian_day
+    assert 0 < gap < HELIOCENTRIC_MAX_GAP_DAYS[planet], f"{planet}: {gap:.2f} days"
+    assert back.iso_formatted_utc_datetime == first.iso_formatted_utc_datetime
+
+
 @pytest.mark.parametrize("kind", KINDS)
 def test_previous_from_reported_instant_is_the_preceding_return(factory, kind):
     first = _step(factory, kind, START)
@@ -150,9 +173,12 @@ def test_a_walk_visits_each_return_once_and_comes_back(factory, kind):
 def test_sub_second_seeds_are_ordered_at_reporting_resolution(factory):
     """A seed inside the same whole second as a reported instant means that instant.
 
-    ``T + 0.5s`` and ``T`` are the same second, so both step to the following
-    return; ``T - 0.5s`` belongs to the second before, so the return reported
-    at ``T`` is still ahead of it.
+    Forward: ``T + 0.5s`` and ``T`` are the same second, so both step to the
+    following return; ``T - 0.5s`` belongs to the second before, so the return
+    reported at ``T`` is still ahead of it. Backward, mirrored: from ``T`` and
+    from ``T + 0.5s`` the return reported at ``T`` is not before the seed, so
+    the preceding return is found; from ``T + 1s`` it is, and it is found — a
+    crossing a fraction of a second before the seed is not skipped.
     """
     first = factory.next_return_from_iso_formatted_time(START, "Solar")
     reported = first.iso_formatted_utc_datetime
@@ -163,6 +189,23 @@ def test_sub_second_seeds_are_ordered_at_reporting_resolution(factory):
 
     assert from_half_after.iso_formatted_utc_datetime == from_reported.iso_formatted_utc_datetime
     assert from_half_before.iso_formatted_utc_datetime == reported
+
+    back_from_reported = factory.next_return_from_iso_formatted_time(reported, "Solar", backwards=True)
+    back_from_half_after = factory.next_return_from_iso_formatted_time(_shift(reported, 0.5), "Solar", backwards=True)
+    back_from_next_second = factory.next_return_from_iso_formatted_time(_shift(reported, 1), "Solar", backwards=True)
+
+    assert back_from_reported.julian_day < first.julian_day
+    assert back_from_half_after.iso_formatted_utc_datetime == back_from_reported.iso_formatted_utc_datetime
+    assert back_from_next_second.iso_formatted_utc_datetime == reported
+
+
+@pytest.mark.parametrize("kind", ["Lunar", "Node", "Mars"])
+def test_a_crossing_a_fraction_before_the_seed_is_found_backward(factory, kind):
+    """Every kind: ``previous`` from the second after a reported instant finds
+    that very return, not the one a whole cycle earlier."""
+    first = _step(factory, kind, START)
+    back = _step(factory, kind, _shift(first.iso_formatted_utc_datetime, 1), backwards=True)
+    assert back.iso_formatted_utc_datetime == first.iso_formatted_utc_datetime
 
 
 def test_date_and_iso_entry_points_agree_away_from_the_boundary(factory):
@@ -229,7 +272,7 @@ def test_seed_is_normalized_to_utc_before_it_is_stepped():
     assert forward_edge == datetime_to_julian(datetime(9999, 12, 31, 10, 0, 0, tzinfo=timezone.utc))
 
     backward_edge = seed("0001-01-01T00:00:00-14:00", backwards=True)
-    assert backward_edge == datetime_to_julian(datetime(1, 1, 1, 13, 59, 59, tzinfo=timezone.utc))
+    assert backward_edge == datetime_to_julian(datetime(1, 1, 1, 14, 0, 0, tzinfo=timezone.utc))
 
     with pytest.raises(KerykeionException, match="civil range"):
         seed("9999-12-31T23:59:59-14:00", backwards=False)  # already year 10000 in UTC
@@ -240,7 +283,9 @@ def test_seed_is_normalized_to_utc_before_it_is_stepped():
 def test_search_refuses_to_start_outside_the_civil_range(factory):
     with pytest.raises(KerykeionException, match="civil range"):
         factory.next_return_from_iso_formatted_time("9999-12-31T23:59:59+00:00", "Solar")
-    with pytest.raises(KerykeionException, match="civil range"):
+    # The first second of 1 CE is a valid backward seed; the search itself then
+    # runs out of the civil range and refuses through the library's exception.
+    with pytest.raises(KerykeionException, match="1 CE|civil range|range"):
         factory.next_return_from_iso_formatted_time("0001-01-01T00:00:00+00:00", "Solar", backwards=True)
 
 

--- a/tests/core/test_planetary_return_roundtrip.py
+++ b/tests/core/test_planetary_return_roundtrip.py
@@ -297,6 +297,17 @@ def test_crossing_between_finds_a_sign_change_to_a_millisecond():
     assert PlanetaryReturnFactory._crossing_between(arc_through_the_antipode, root - 1.0, root + 1.0) is None
 
 
+def test_a_probe_outside_the_ephemeris_range_fails_with_the_library_exception():
+    """A probe window at the edge of the ephemeris range fails like the solver
+    calls do: with ``KerykeionException``, never a raw backend error."""
+
+    def out_of_range(_jd: float) -> float:
+        raise RuntimeError("jd outside the ephemeris range")
+
+    with pytest.raises(KerykeionException, match="ephemeris date range"):
+        PlanetaryReturnFactory._crossing_between(out_of_range, 2460000.0, 2460001.0)
+
+
 def test_previous_from_the_natal_instant_is_the_return_before_birth():
     """The natal instant is a crossing by construction (every body sits at its
     natal position). Seeded with it, ``previous`` must find the cycle before

--- a/tests/core/test_planetary_return_roundtrip.py
+++ b/tests/core/test_planetary_return_roundtrip.py
@@ -48,7 +48,7 @@ pytestmark = pytest.mark.skipif(
 MAX_GAP_DAYS = {
     "Solar": 367.0,
     "Lunar": 28.0,
-    "Node": 16.0,  # the Moon meets either node every ~12.4–14.7 days (half a draconic month)
+    "Node": 16.0,  # the Moon meets either node every ~12.4-14.7 days (half a draconic month)
     "Mars": 800.0,  # heliocentric Mars, ~687 days
 }
 
@@ -210,6 +210,70 @@ def test_a_crossing_a_fraction_before_the_seed_is_found_backward(factory, kind):
     assert back.iso_formatted_utc_datetime == first.iso_formatted_utc_datetime
 
 
+@pytest.mark.parametrize(
+    "start",
+    [
+        # Solar returns whose exact crossing falls in the last ~90 ms of its
+        # reported second — inside the backend's at-crossing dead band, where
+        # a backward search from the next second used to jump a whole year.
+        "1985-03-01T00:00:00+00:00",
+        "2021-03-01T00:00:00+00:00",
+        "2024-03-01T00:00:00+00:00",
+    ],
+)
+def test_a_solar_return_in_the_dead_band_is_still_found_backward(factory, start):
+    first = _step(factory, "Solar", start)
+    back = _step(factory, "Solar", _shift(first.iso_formatted_utc_datetime, 1), backwards=True)
+    assert back.iso_formatted_utc_datetime == first.iso_formatted_utc_datetime
+
+
+def test_twenty_consecutive_solar_returns_are_found_from_the_second_after(factory):
+    """The dead band catches ~9% of solar returns at random; a run of twenty
+    consecutive ones leaves no room for luck."""
+    current = _step(factory, "Solar", "1980-01-01T00:00:00+00:00")
+    for _ in range(20):
+        back = _step(factory, "Solar", _shift(current.iso_formatted_utc_datetime, 1), backwards=True)
+        assert back.iso_formatted_utc_datetime == current.iso_formatted_utc_datetime
+        current = _step(factory, "Solar", current.iso_formatted_utc_datetime)
+
+
+# The slow heliocentric bodies: the solver's 0.001″ tolerance is seconds of
+# their motion, so a seed one second past a crossing used to be handed back
+# as its own answer (the same crossing reported a second later). Settled to a
+# millisecond and held to the ordering contract, they step like the rest.
+SLOW_HELIOCENTRIC_MAX_GAP_DAYS = {
+    "Uranus": 31000.0,
+    "Neptune": 61000.0,
+    "Pluto": 92000.0,
+    "Chiron": 19000.0,
+}
+
+
+@pytest.mark.parametrize("planet", sorted(SLOW_HELIOCENTRIC_MAX_GAP_DAYS))
+def test_slow_heliocentric_bodies_step_and_come_back(factory, planet):
+    first = _step(factory, planet, START)
+    second = _step(factory, planet, first.iso_formatted_utc_datetime)
+    back = _step(factory, planet, second.iso_formatted_utc_datetime, backwards=True)
+    from_next_second = _step(factory, planet, _shift(first.iso_formatted_utc_datetime, 1), backwards=True)
+
+    gap = second.julian_day - first.julian_day
+    assert 1.0 < gap < SLOW_HELIOCENTRIC_MAX_GAP_DAYS[planet], f"{planet}: {gap:.2f} days"
+    assert back.iso_formatted_utc_datetime == first.iso_formatted_utc_datetime
+    assert from_next_second.iso_formatted_utc_datetime == first.iso_formatted_utc_datetime
+
+
+def test_crossing_between_finds_a_sign_change_to_a_millisecond():
+    root = 2460000.123456
+    crossing = PlanetaryReturnFactory._crossing_between(lambda jd: jd - root, root - 1.0, root + 1.0)
+    assert crossing is not None and abs(crossing - root) * 86400.0 < 1e-3
+
+    assert PlanetaryReturnFactory._crossing_between(lambda jd: jd - root, root + 1.0, root + 2.0) is None
+    assert PlanetaryReturnFactory._crossing_between(lambda jd: jd - root, root, root + 1.0) == root
+    # A decreasing offset (the Moon's latitude at a descending node) is a sign change too.
+    falling = PlanetaryReturnFactory._crossing_between(lambda jd: root - jd, root - 1.0, root + 1.0)
+    assert falling is not None and abs(falling - root) * 86400.0 < 1e-3
+
+
 def test_date_and_iso_entry_points_agree_away_from_the_boundary(factory):
     """Away from a date's first second, the date wrapper and an ISO midnight
     seed select the same return."""
@@ -287,7 +351,7 @@ def test_search_refuses_to_start_outside_the_civil_range(factory):
         factory.next_return_from_iso_formatted_time("9999-12-31T23:59:59+00:00", "Solar")
     # The first second of 1 CE is a valid backward seed; the search itself then
     # runs out of the civil range and refuses through the library's exception.
-    with pytest.raises(KerykeionException, match="1 CE|civil range|range"):
+    with pytest.raises(KerykeionException, match=r"1 CE|civil range|range"):
         factory.next_return_from_iso_formatted_time("0001-01-01T00:00:00+00:00", "Solar", backwards=True)
 
 

--- a/tests/core/test_planetary_return_roundtrip.py
+++ b/tests/core/test_planetary_return_roundtrip.py
@@ -26,14 +26,17 @@ pyswisseph, like the backwards suite.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
 
 from kerykeion import AstrologicalSubjectFactory
 from kerykeion.ephemeris_backend import BACKEND_NAME
+from kerykeion.planetary_returns import factory as factory_module
 from kerykeion.planetary_returns.factory import PlanetaryReturnFactory
 from kerykeion.schemas import KerykeionException
+from kerykeion.utilities import datetime_to_julian
 
 pytestmark = pytest.mark.skipif(
     BACKEND_NAME == "swisseph",
@@ -162,13 +165,58 @@ def test_sub_second_seeds_are_ordered_at_reporting_resolution(factory):
     assert from_half_before.iso_formatted_utc_datetime == reported
 
 
-def test_date_and_year_entry_points_are_unchanged(factory):
-    """Whole-second seeds already start the search where they did: the first
-    return after midnight of a date is never inside that midnight second."""
+def test_date_and_iso_entry_points_agree_away_from_the_boundary(factory):
+    """Away from a date's first second, the date wrapper and an ISO midnight
+    seed select the same return."""
     by_date = factory.next_return_from_date(2024, 1, 1, return_type="Solar")
     by_iso = factory.next_return_from_iso_formatted_time("2024-01-01T00:00:00+00:00", "Solar")
     assert by_date.iso_formatted_utc_datetime == by_iso.iso_formatted_utc_datetime
     assert by_date.iso_formatted_utc_datetime.startswith("2024-06-")
+
+
+def test_date_wrapper_keeps_its_midnight_seed_inclusive(factory):
+    """``next_return_from_date`` promises the first return ON OR AFTER the date:
+    its seed is midnight itself, not the second after it. Only the ISO entry
+    point snaps its seed past its own second (a reported instant must step)."""
+    midnight = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    original = factory_module.ephe.solcross_ut
+
+    with patch.object(factory_module.ephe, "solcross_ut", wraps=original) as spy:
+        factory.next_return_from_date(2024, 1, 1, return_type="Solar")
+        assert spy.call_args.args[1] == datetime_to_julian(midnight)
+
+    with patch.object(factory_module.ephe, "solcross_ut", wraps=original) as spy:
+        factory.next_return_from_iso_formatted_time(midnight.isoformat(), "Solar")
+        assert spy.call_args.args[1] == datetime_to_julian(midnight + timedelta(seconds=1))
+
+
+def test_a_return_in_the_first_second_of_a_date_belongs_to_that_date():
+    """Born at 00:00:00 UTC, the natal Sun sits exactly where the year's crossing
+    is found: a return in the first second of that date. The date wrapper keeps
+    it; the ISO entry point, seeded with that same instant, steps a year on."""
+    subject = AstrologicalSubjectFactory.from_birth_data(
+        "Midnight",
+        1990,
+        6,
+        15,
+        0,
+        0,
+        seconds=0,
+        lat=51.5,
+        lng=0.0,
+        tz_str="UTC",
+        online=False,
+        suppress_geonames_warning=True,
+    )
+    factory = PlanetaryReturnFactory(
+        subject, city="Greenwich", nation="GB", lat=51.5, lng=0.0, tz_str="UTC", online=False
+    )
+
+    by_date = factory.next_return_from_date(1990, 6, 15, return_type="Solar")
+    assert abs(by_date.julian_day - subject.julian_day) * 86400 < 1.5, by_date.iso_formatted_utc_datetime
+
+    by_iso = factory.next_return_from_iso_formatted_time("1990-06-15T00:00:00+00:00", "Solar")
+    assert by_iso.iso_formatted_utc_datetime.startswith("1991-06-")
 
 
 def test_search_refuses_to_start_outside_the_civil_range(factory):

--- a/tests/core/test_planetary_return_roundtrip.py
+++ b/tests/core/test_planetary_return_roundtrip.py
@@ -199,10 +199,12 @@ def test_sub_second_seeds_are_ordered_at_reporting_resolution(factory):
     assert back_from_next_second.iso_formatted_utc_datetime == reported
 
 
-@pytest.mark.parametrize("kind", ["Lunar", "Node", "Mars"])
+@pytest.mark.parametrize("kind", ["Lunar", "Node", *sorted(HELIOCENTRIC_MAX_GAP_DAYS)])
 def test_a_crossing_a_fraction_before_the_seed_is_found_backward(factory, kind):
-    """Every kind: ``previous`` from the second after a reported instant finds
-    that very return, not the one a whole cycle earlier."""
+    """Every kind, every solved heliocentric planet: ``previous`` from the
+    second after a reported instant finds that very return, not the one a
+    whole cycle earlier. (The old seed, one second earlier still, passed the
+    forward/backward walk yet failed exactly this.)"""
     first = _step(factory, kind, START)
     back = _step(factory, kind, _shift(first.iso_formatted_utc_datetime, 1), backwards=True)
     assert back.iso_formatted_utc_datetime == first.iso_formatted_utc_datetime

--- a/tests/core/test_planetary_return_roundtrip.py
+++ b/tests/core/test_planetary_return_roundtrip.py
@@ -48,7 +48,7 @@ pytestmark = pytest.mark.skipif(
 MAX_GAP_DAYS = {
     "Solar": 367.0,
     "Lunar": 28.0,
-    "Node": 16.0,  # the Moon meets either node every ~12.4-14.7 days (half a draconic month)
+    "Node": 16.0,  # the Moon meets either node every 12.4-14.7 days (13.6 on average)
     "Mars": 800.0,  # heliocentric Mars, ~687 days
 }
 

--- a/tests/core/test_planetary_return_roundtrip.py
+++ b/tests/core/test_planetary_return_roundtrip.py
@@ -214,10 +214,10 @@ def test_a_crossing_a_fraction_before_the_seed_is_found_backward(factory, kind):
 @pytest.mark.parametrize(
     "start",
     [
-        # The first two are solar returns whose exact crossing falls in the
+        # The first three are solar returns whose exact crossing falls in the
         # last ~90 ms of its reported second — inside the backend's at-crossing
         # dead band, where a backward search from the next second used to jump
-        # a whole year. The third is a control from outside the band.
+        # a whole year. The fourth is a control from outside the band.
         "1984-03-01T00:00:00+00:00",  # 52 ms before the next second
         "2004-03-01T00:00:00+00:00",  # 76 ms
         "2021-03-01T00:00:00+00:00",  # 6 ms
@@ -283,12 +283,16 @@ def test_crossing_between_finds_a_sign_change_to_a_millisecond():
     # crossing by construction, and a backward seed on it must not be told
     # there is a return a millisecond before itself.
     assert PlanetaryReturnFactory._crossing_between(lambda jd: jd - root, root - 1.0, root) is None
-    almost = root - 0.2e-3 / 86400.0
+    almost = root - 0.05e-3 / 86400.0  # 50 µs before the seed: below the resolution, at the seed
     assert PlanetaryReturnFactory._crossing_between(lambda jd: jd - almost, root - 1.0, root) is None
+    near = root - 0.3e-3 / 86400.0  # 300 µs before the seed: a crossing before it
+    found = PlanetaryReturnFactory._crossing_between(lambda jd: jd - near, root - 1.0, root)
+    assert found is not None and abs(found - near) * 86400.0 < 0.2e-3
 
-    # A signed arc flips sign at the antipode too; that is an opposition, not a crossing.
+    # A signed arc flips sign at the antipode too; that is an opposition, not a
+    # crossing. A slow sweep through 180°: +179.9° at one end, -179.9° at the other.
     def arc_through_the_antipode(jd: float) -> float:
-        return PlanetaryReturnFactory._signed_arc(180.0 + (jd - root) * 3600.0, 0.0)
+        return PlanetaryReturnFactory._signed_arc(180.0 + (jd - root) * 0.1, 0.0)
 
     assert PlanetaryReturnFactory._crossing_between(arc_through_the_antipode, root - 1.0, root + 1.0) is None
 

--- a/tests/core/test_planetary_return_roundtrip.py
+++ b/tests/core/test_planetary_return_roundtrip.py
@@ -52,10 +52,11 @@ MAX_GAP_DAYS = {
     "Mars": 800.0,  # heliocentric Mars, ~687 days
 }
 
-# The heliocentric bodies the backend solves crossings for, with their
-# sidereal periods rounded up, in days. Chiron, Pholus, the Uranian points,
-# the nodes and Liliths have no heliocentric crossing in the backend (their
-# search returns its seed) and are outside the contract.
+# Heliocentric planets whose solver tolerance is under a second of their own
+# motion, with their sidereal periods rounded up, in days. The slow bodies
+# (Uranus outward, Chiron) are pinned separately below: their crossings are
+# settled by the factory itself. The lunar nodes and Liliths have no
+# heliocentric longitude in the backend and are outside the contract.
 HELIOCENTRIC_MAX_GAP_DAYS = {
     "Mercury": 100.0,
     "Venus": 240.0,

--- a/tests/core/test_planetary_return_roundtrip.py
+++ b/tests/core/test_planetary_return_roundtrip.py
@@ -219,6 +219,24 @@ def test_a_return_in_the_first_second_of_a_date_belongs_to_that_date():
     assert by_iso.iso_formatted_utc_datetime.startswith("1991-06-")
 
 
+def test_seed_is_normalized_to_utc_before_it_is_stepped():
+    """The civil range is a range of instants: a local wall time at its edge
+    whose UTC instant is well inside it must seed normally, and an aware
+    timestamp whose UTC instant is already past the edge must refuse."""
+    seed = PlanetaryReturnFactory._search_start_jd
+
+    forward_edge = seed("9999-12-31T23:59:59+14:00", backwards=False)
+    assert forward_edge == datetime_to_julian(datetime(9999, 12, 31, 10, 0, 0, tzinfo=timezone.utc))
+
+    backward_edge = seed("0001-01-01T00:00:00-14:00", backwards=True)
+    assert backward_edge == datetime_to_julian(datetime(1, 1, 1, 13, 59, 59, tzinfo=timezone.utc))
+
+    with pytest.raises(KerykeionException, match="civil range"):
+        seed("9999-12-31T23:59:59-14:00", backwards=False)  # already year 10000 in UTC
+    with pytest.raises(KerykeionException, match="civil range"):
+        seed("0001-01-01T00:00:00+14:00", backwards=True)  # already year 0 in UTC
+
+
 def test_search_refuses_to_start_outside_the_civil_range(factory):
     with pytest.raises(KerykeionException, match="civil range"):
         factory.next_return_from_iso_formatted_time("9999-12-31T23:59:59+00:00", "Solar")

--- a/tests/core/test_planetary_return_roundtrip.py
+++ b/tests/core/test_planetary_return_roundtrip.py
@@ -214,12 +214,14 @@ def test_a_crossing_a_fraction_before_the_seed_is_found_backward(factory, kind):
 @pytest.mark.parametrize(
     "start",
     [
-        # Solar returns whose exact crossing falls in the last ~90 ms of its
-        # reported second — inside the backend's at-crossing dead band, where
-        # a backward search from the next second used to jump a whole year.
-        "1985-03-01T00:00:00+00:00",
-        "2021-03-01T00:00:00+00:00",
-        "2024-03-01T00:00:00+00:00",
+        # The first two are solar returns whose exact crossing falls in the
+        # last ~90 ms of its reported second — inside the backend's at-crossing
+        # dead band, where a backward search from the next second used to jump
+        # a whole year. The third is a control from outside the band.
+        "1984-03-01T00:00:00+00:00",  # 52 ms before the next second
+        "2004-03-01T00:00:00+00:00",  # 76 ms
+        "2021-03-01T00:00:00+00:00",  # 6 ms
+        "2024-03-01T00:00:00+00:00",  # a control from outside the band
     ],
 )
 def test_a_solar_return_in_the_dead_band_is_still_found_backward(factory, start):
@@ -231,7 +233,10 @@ def test_a_solar_return_in_the_dead_band_is_still_found_backward(factory, start)
 def test_twenty_consecutive_solar_returns_are_found_from_the_second_after(factory):
     """The dead band catches ~9% of solar returns at random; a run of twenty
     consecutive ones leaves no room for luck."""
-    current = _step(factory, "Solar", "1980-01-01T00:00:00+00:00")
+    # From 1986: the 1985 return's crossing sits 15 µs before a whole second,
+    # under the ephemeris' own resolution — indistinguishable from a crossing
+    # at that second, and treated as one (see _crossing_between).
+    current = _step(factory, "Solar", "1986-01-01T00:00:00+00:00")
     for _ in range(20):
         back = _step(factory, "Solar", _shift(current.iso_formatted_utc_datetime, 1), backwards=True)
         assert back.iso_formatted_utc_datetime == current.iso_formatted_utc_datetime
@@ -273,6 +278,66 @@ def test_crossing_between_finds_a_sign_change_to_a_millisecond():
     # A decreasing offset (the Moon's latitude at a descending node) is a sign change too.
     falling = PlanetaryReturnFactory._crossing_between(lambda jd: root - jd, root - 1.0, root + 1.0)
     assert falling is not None and abs(falling - root) * 86400.0 < 1e-3
+
+    # A root AT the window's end is not inside it: the natal instant is a
+    # crossing by construction, and a backward seed on it must not be told
+    # there is a return a millisecond before itself.
+    assert PlanetaryReturnFactory._crossing_between(lambda jd: jd - root, root - 1.0, root) is None
+    almost = root - 0.2e-3 / 86400.0
+    assert PlanetaryReturnFactory._crossing_between(lambda jd: jd - almost, root - 1.0, root) is None
+
+    # A signed arc flips sign at the antipode too; that is an opposition, not a crossing.
+    def arc_through_the_antipode(jd: float) -> float:
+        return PlanetaryReturnFactory._signed_arc(180.0 + (jd - root) * 3600.0, 0.0)
+
+    assert PlanetaryReturnFactory._crossing_between(arc_through_the_antipode, root - 1.0, root + 1.0) is None
+
+
+def test_previous_from_the_natal_instant_is_the_return_before_birth():
+    """The natal instant is a crossing by construction (every body sits at its
+    natal position). Seeded with it, ``previous`` must find the cycle before
+    birth — never a return a second before the birth itself."""
+    subject = AstrologicalSubjectFactory.from_birth_data(
+        "Natal Seed",
+        1985,
+        6,
+        10,
+        12,
+        23,
+        lat=45.41,
+        lng=10.39,
+        tz_str="Europe/Rome",
+        online=False,
+        suppress_geonames_warning=True,
+    )
+    factory = PlanetaryReturnFactory(
+        subject, city="Montichiari", nation="IT", lat=45.41, lng=10.39, tz_str="Europe/Rome", online=False
+    )
+    natal = subject.iso_formatted_utc_datetime
+
+    for kind, min_gap_days in (("Solar", 300.0), ("Lunar", 20.0), ("Jupiter", 4000.0)):
+        before = _step(factory, kind, natal, backwards=True)
+        gap = subject.julian_day - before.julian_day
+        assert gap > min_gap_days, (
+            f"{kind}: previous from the natal instant returned {before.iso_formatted_utc_datetime}"
+        )
+
+
+def test_a_seed_just_past_an_opposition_does_not_return_the_opposition(factory):
+    """A backward seed one second after the Sun opposed the natal Sun: the
+    signed arc flips sign in that second, at the antipode. The answer is the
+    previous solar return, not the opposition."""
+    natal_sun = factory.subject.sun.abs_pos
+    opposition_jd = factory_module.ephe.solcross_ut(
+        (natal_sun + 180.0) % 360.0, datetime_to_julian(datetime(2024, 3, 1, tzinfo=timezone.utc))
+    )
+    opposition = factory_module.julian_to_datetime(opposition_jd).replace(tzinfo=timezone.utc, microsecond=0)
+    seed = (opposition + timedelta(seconds=1)).isoformat()
+
+    before = factory.next_return_from_iso_formatted_time(seed, "Solar", backwards=True)
+    arc = PlanetaryReturnFactory._signed_arc(before.sun.abs_pos, natal_sun)
+    assert abs(arc) < 0.01, f"the 'return' sits {arc:.3f} degrees from the natal Sun"
+    assert before.julian_day < opposition_jd - 1.0
 
 
 def test_date_and_iso_entry_points_agree_away_from_the_boundary(factory):

--- a/tests/core/test_planetary_return_roundtrip.py
+++ b/tests/core/test_planetary_return_roundtrip.py
@@ -1,0 +1,225 @@
+"""
+Round-trip tests for PlanetaryReturnFactory: reported instants as seeds.
+
+Return instants are reported truncated to the whole second. A caller walking
+the sequence of returns re-feeds the instant it was given as the seed of the
+next search — the exact crossing sits a fraction of a second AFTER that seed,
+so a raw forward search found the same return again. These tests pin the
+contract that fixes it: ordering between a seed and a return is decided at the
+library's reporting resolution, so for every supported kind
+
+    next(reported(N))     == N + 1
+    previous(reported(N)) == N - 1
+    previous(next(r))     == r        (an exact involution on the walk)
+
+and a walk of steps lands on each return exactly once, in order. The mirror
+image of ``test_planetary_return_backwards.py::test_back_is_one_cycle_earlier``,
+which only ever seeded the direction the truncation happened to favour.
+
+Two calendar facts are pinned alongside, because they are why a return is
+identified by its instant and never by a year or a month: a leap year can hold
+two solar returns, and a month can hold two lunar returns.
+
+Backward search requires the libephemeris backend; the module skips on
+pyswisseph, like the backwards suite.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from kerykeion import AstrologicalSubjectFactory
+from kerykeion.ephemeris_backend import BACKEND_NAME
+from kerykeion.planetary_returns.factory import PlanetaryReturnFactory
+from kerykeion.schemas import KerykeionException
+
+pytestmark = pytest.mark.skipif(
+    BACKEND_NAME == "swisseph",
+    reason="Backward return searches require the libephemeris backend (documented contract).",
+)
+
+# Upper bounds on the gap between consecutive returns of each kind, in days.
+# Generous on purpose: the tests assert order and exactness, not cycle length.
+MAX_GAP_DAYS = {
+    "Solar": 367.0,
+    "Lunar": 28.0,
+    "Node": 15.0,  # the Moon meets either node every half draconic month
+    "Mars": 800.0,  # heliocentric Mars, ~687 days
+}
+
+
+@pytest.fixture(scope="module")
+def factory():
+    subject = AstrologicalSubjectFactory.from_birth_data(
+        "Round Trip",
+        1985,
+        6,
+        10,
+        12,
+        23,
+        lat=45.41,
+        lng=10.39,
+        tz_str="Europe/Rome",
+        online=False,
+        suppress_geonames_warning=True,
+    )
+    return PlanetaryReturnFactory(
+        subject,
+        city="Montichiari",
+        nation="IT",
+        lat=45.41,
+        lng=10.39,
+        tz_str="Europe/Rome",
+        online=False,
+    )
+
+
+def _step(factory: PlanetaryReturnFactory, kind: str, seed_iso: str, backwards: bool = False):
+    """One search of the given kind from an ISO seed — the four entry points behind one door."""
+    if kind in ("Solar", "Lunar"):
+        return factory.next_return_from_iso_formatted_time(seed_iso, kind, backwards=backwards)
+    if kind == "Node":
+        return factory.next_lunar_node_crossing_from_iso_formatted_time(seed_iso, backwards=backwards)
+    return factory.next_heliocentric_return_from_iso_formatted_time(kind, seed_iso, backwards=backwards)
+
+
+def _shift(iso: str, seconds: float) -> str:
+    return (datetime.fromisoformat(iso) + timedelta(seconds=seconds)).isoformat()
+
+
+KINDS = ["Solar", "Lunar", "Node", "Mars"]
+START = "2024-03-01T00:00:00+00:00"
+
+
+@pytest.mark.parametrize("kind", KINDS)
+def test_next_from_reported_instant_is_the_following_return(factory, kind):
+    first = _step(factory, kind, START)
+    second = _step(factory, kind, first.iso_formatted_utc_datetime)
+
+    gap = second.julian_day - first.julian_day
+    assert gap > 0, f"{kind}: seeding from the reported instant found the same return again"
+    assert gap < MAX_GAP_DAYS[kind], f"{kind}: a return was skipped ({gap:.2f} days)"
+
+
+@pytest.mark.parametrize("kind", KINDS)
+def test_previous_from_reported_instant_is_the_preceding_return(factory, kind):
+    first = _step(factory, kind, START)
+    before = _step(factory, kind, first.iso_formatted_utc_datetime, backwards=True)
+
+    gap = first.julian_day - before.julian_day
+    assert gap > 0, f"{kind}: seeding backward from the reported instant found the same return again"
+    assert gap < MAX_GAP_DAYS[kind], f"{kind}: a return was skipped ({gap:.2f} days)"
+
+
+@pytest.mark.parametrize("kind", KINDS)
+def test_previous_of_next_is_an_exact_involution(factory, kind):
+    first = _step(factory, kind, START)
+    forward = _step(factory, kind, first.iso_formatted_utc_datetime)
+    back = _step(factory, kind, forward.iso_formatted_utc_datetime, backwards=True)
+
+    assert back.iso_formatted_utc_datetime == first.iso_formatted_utc_datetime
+    assert back.julian_day == first.julian_day
+
+
+@pytest.mark.parametrize("kind", ["Solar", "Lunar", "Node"])
+def test_a_walk_visits_each_return_once_and_comes_back(factory, kind):
+    steps = 5
+    origin = _step(factory, kind, START)
+
+    outbound = [origin]
+    for _ in range(steps):
+        outbound.append(_step(factory, kind, outbound[-1].iso_formatted_utc_datetime))
+
+    instants = [r.iso_formatted_utc_datetime for r in outbound]
+    assert len(set(instants)) == len(instants), f"{kind}: a step stood still: {instants}"
+    assert [r.julian_day for r in outbound] == sorted(r.julian_day for r in outbound)
+
+    current = outbound[-1]
+    for expected in reversed(outbound[:-1]):
+        current = _step(factory, kind, current.iso_formatted_utc_datetime, backwards=True)
+        assert current.iso_formatted_utc_datetime == expected.iso_formatted_utc_datetime
+
+    assert current.iso_formatted_utc_datetime == origin.iso_formatted_utc_datetime
+
+
+def test_sub_second_seeds_are_ordered_at_reporting_resolution(factory):
+    """A seed inside the same whole second as a reported instant means that instant.
+
+    ``T + 0.5s`` and ``T`` are the same second, so both step to the following
+    return; ``T - 0.5s`` belongs to the second before, so the return reported
+    at ``T`` is still ahead of it.
+    """
+    first = factory.next_return_from_iso_formatted_time(START, "Solar")
+    reported = first.iso_formatted_utc_datetime
+
+    from_reported = factory.next_return_from_iso_formatted_time(reported, "Solar")
+    from_half_after = factory.next_return_from_iso_formatted_time(_shift(reported, 0.5), "Solar")
+    from_half_before = factory.next_return_from_iso_formatted_time(_shift(reported, -0.5), "Solar")
+
+    assert from_half_after.iso_formatted_utc_datetime == from_reported.iso_formatted_utc_datetime
+    assert from_half_before.iso_formatted_utc_datetime == reported
+
+
+def test_date_and_year_entry_points_are_unchanged(factory):
+    """Whole-second seeds already start the search where they did: the first
+    return after midnight of a date is never inside that midnight second."""
+    by_date = factory.next_return_from_date(2024, 1, 1, return_type="Solar")
+    by_iso = factory.next_return_from_iso_formatted_time("2024-01-01T00:00:00+00:00", "Solar")
+    assert by_date.iso_formatted_utc_datetime == by_iso.iso_formatted_utc_datetime
+    assert by_date.iso_formatted_utc_datetime.startswith("2024-06-")
+
+
+def test_search_refuses_to_start_outside_the_civil_range(factory):
+    with pytest.raises(KerykeionException, match="civil range"):
+        factory.next_return_from_iso_formatted_time("9999-12-31T23:59:59+00:00", "Solar")
+    with pytest.raises(KerykeionException, match="civil range"):
+        factory.next_return_from_iso_formatted_time("0001-01-01T00:00:00+00:00", "Solar", backwards=True)
+
+
+# ---------------------------------------------------------------------------
+# Why a return is identified by its instant, never by a calendar period
+# ---------------------------------------------------------------------------
+
+
+def _walk(factory: PlanetaryReturnFactory, kind: str, seed_iso: str, count: int) -> list[str]:
+    instants = [_step(factory, kind, seed_iso).iso_formatted_utc_datetime]
+    while len(instants) < count:
+        instants.append(_step(factory, kind, instants[-1]).iso_formatted_utc_datetime)
+    return instants
+
+
+def test_a_leap_year_can_hold_two_solar_returns():
+    """Born on 1 January: the 2024 return falls on 1 January and the next on
+    31 December of the same year. Stepping by "the return of year Y" would
+    never reach the second one."""
+    subject = AstrologicalSubjectFactory.from_birth_data(
+        "New Year",
+        1985,
+        1,
+        1,
+        2,
+        0,
+        lat=51.5,
+        lng=0.0,
+        tz_str="Europe/London",
+        online=False,
+        suppress_geonames_warning=True,
+    )
+    factory = PlanetaryReturnFactory(
+        subject,
+        city="London",
+        nation="GB",
+        lat=51.5,
+        lng=0.0,
+        tz_str="Europe/London",
+        online=False,
+    )
+    years = [datetime.fromisoformat(i).year for i in _walk(factory, "Solar", "2023-01-01T00:00:00+00:00", 5)]
+    assert years == [2023, 2024, 2024, 2026, 2027]
+
+
+def test_a_month_can_hold_two_lunar_returns(factory):
+    months = [i[:7] for i in _walk(factory, "Lunar", "2026-01-01T00:00:00+00:00", 10)]
+    assert months.count("2026-08") == 2, months

--- a/tests/fixtures/dual_return_all_points_all_aspects_report.txt
+++ b/tests/fixtures/dual_return_all_points_all_aspects_report.txt
@@ -1,5 +1,5 @@
 ===================================================
-Sample Natal Subject — Solar Return Comparison 1990
+Sample Natal Subject — Solar Return Comparison 1991
 ===================================================
 
 +Natal Subject — Birth Data----------------------+
@@ -38,8 +38,8 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Latitude           | 53.4084°                          |
 | Longitude          | -2.9916°                          |
 | Timezone           | Europe/London                     |
-| Day of Week        | Saturday                          |
-| ISO Local Datetime | 1990-07-21T14:44:59+01:00         |
+| Day of Week        | Sunday                            |
+| ISO Local Datetime | 1991-07-21T20:33:06+01:00         |
 | Diurnality         | Diurnal                           |
 +--------------------+-----------------------------------+
 
@@ -49,7 +49,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Zodiac Type         | Tropical            |
 | Houses System       | Placidus            |
 | Perspective Type    | Apparent Geocentric |
-| Julian Day          | 2448094.072905      |
+| Julian Day          | 2448459.314653      |
 | Active Points Count | 52                  |
 +---------------------+---------------------+
 
@@ -115,67 +115,67 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Pars Fidei    | Tau ♉ | 8.22°    | N/A   | N/A   | -    | Seventh House  |
 +---------------+--------+----------+-------+-------+------+----------------+
 
-+Return Subject Celestial Points-+----------+--------------+------------+---------+-----+------+----------------+
-| Point                 | Sign   | Position | Speed        | Motion     | Decl.   | OOB | Ret. | House          |
-+-----------------------+--------+----------+--------------+------------+---------+-----+------+----------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | -          | N/A     | -   | -    | First House    |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6364°/d | -          | N/A     | -   | -    | Tenth House    |
-| Descendant            | Tau ♉ | 5.82°    | +245.7250°/d | -          | N/A     | -   | -    | Seventh House  |
-| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6364°/d | -          | N/A     | -   | -    | Fourth House   |
-| Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | Average    | +20.45° | -   | -    | Ninth House    |
-| Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | Average    | +23.21° | -   | -    | Ninth House    |
-| Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | Fast       | +16.88° | -   | -    | Ninth House    |
-| Venus                 | Can ♋ | 1.71°    | +1.2038°/d   | Average    | +22.74° | -   | -    | Eighth House   |
-| Mars                  | Tau ♉ | 5.97°    | +0.6554°/d   | Fast       | +11.57° | -   | -    | Seventh House  |
-| Jupiter               | Can ♋ | 23.91°   | +0.2240°/d   | Fast       | +21.56° | -   | -    | Ninth House    |
-| Saturn                | Cap ♑ | 21.52°   | -0.0732°/d   | Retrograde | -21.66° | -   | R    | Third House    |
-| Uranus                | Cap ♑ | 6.74°    | -0.0366°/d   | Retrograde | -23.60° | Y   | R    | Second House   |
-| Neptune               | Cap ♑ | 12.76°   | -0.0257°/d   | Retrograde | -21.96° | -   | R    | Third House    |
-| Pluto                 | Sco ♏ | 14.97°   | -0.0025°/d   | Retrograde | -1.42°  | -   | R    | First House    |
-| Mean North Lunar Node | Aqu ♒ | 7.79°    | -0.0529°/d   | -          | -18.32° | -   | R    | Third House    |
-| True North Lunar Node | Aqu ♒ | 7.26°    | -0.0080°/d   | -          | -18.46° | -   | R    | Third House    |
-| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -          | -24.62° | Y   | -    | First House    |
-| True Lilith           | Sag ♐ | 18.01°   | -1.4330°/d   | -          | -26.88° | Y   | R    | Second House   |
-| Chiron                | Can ♋ | 19.88°   | +0.1071°/d   | -          | +15.79° | -   | -    | Ninth House    |
-| Pholus                | Can ♋ | 7.99°    | +0.1329°/d   | -          | +13.79° | -   | -    | Eighth House   |
-| Ceres                 | Leo ♌ | 13.71°   | +0.4493°/d   | -          | +23.05° | -   | -    | Ninth House    |
-| Pallas                | Can ♋ | 7.25°    | +0.5959°/d   | -          | -1.55°  | -   | -    | Eighth House   |
-| Juno                  | Sco ♏ | 10.10°   | +0.0843°/d   | -          | -2.06°  | -   | -    | First House    |
-| Vesta                 | Tau ♉ | 18.15°   | +0.3292°/d   | -          | +10.88° | -   | -    | Seventh House  |
-| Interpolated Lilith   | Sco ♏ | 25.48°   | +0.1694°/d   | -          | -23.89° | Y   | -    | First House    |
-| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1733°/d   | -          | +26.84° | Y   | -    | Eighth House   |
-| Cupido                | Sco ♏ | 18.62°   | -0.0043°/d   | -          | -16.34° | -   | R    | First House    |
-| Hades                 | Gem ♊ | 9.92°    | +0.0153°/d   | -          | +20.93° | -   | -    | Eighth House   |
-| Zeus                  | Vir ♍ | 26.03°   | +0.0109°/d   | -          | +1.58°  | -   | -    | Eleventh House |
-| Kronos                | Gem ♊ | 21.89°   | +0.0138°/d   | -          | +23.21° | -   | -    | Eighth House   |
-| Apollon               | Lib ♎ | 13.82°   | +0.0052°/d   | -          | -5.46°  | -   | -    | Eleventh House |
-| Admetos               | Tau ♉ | 14.96°   | +0.0054°/d   | -          | +16.33° | -   | -    | Seventh House  |
-| Vulkanus              | Can ♋ | 15.34°   | +0.0136°/d   | -          | +22.57° | -   | -    | Ninth House    |
-| Poseidon              | Lib ♎ | 28.68°   | +0.0013°/d   | -          | -11.01° | -   | -    | Twelfth House  |
-| Eris                  | Ari ♈ | 17.60°   | -0.0013°/d   | -          | -9.16°  | -   | R    | Sixth House    |
-| Sedna                 | Tau ♉ | 11.55°   | +0.0038°/d   | -          | +4.25°  | -   | -    | Seventh House  |
-| Haumea                | Vir ♍ | 26.32°   | +0.0134°/d   | -          | +23.02° | -   | -    | Eleventh House |
-| Makemake              | Vir ♍ | 4.50°    | +0.0202°/d   | -          | +35.44° | Y   | -    | Tenth House    |
-| Ixion                 | Sco ♏ | 22.70°   | -0.0060°/d   | -          | -12.62° | -   | R    | First House    |
-| Orcus                 | Leo ♌ | 10.84°   | +0.0234°/d   | -          | +4.04°  | -   | -    | Ninth House    |
-| Quaoar                | Sco ♏ | 24.08°   | -0.0062°/d   | -          | -13.09° | -   | R    | First House    |
-| Vertex                | Gem ♊ | 11.46°   | N/A          | -          | N/A     | -   | -    | Eighth House   |
-| White Moon            | Can ♋ | 26.43°   | +0.1409°/d   | -          | +20.87° | -   | -    | Ninth House    |
-| Anti Vertex           | Sag ♐ | 11.46°   | N/A          | -          | N/A     | -   | -    | Second House   |
-| Mean South Lunar Node | Leo ♌ | 7.79°    | -0.0529°/d   | -          | +18.32° | -   | R    | Ninth House    |
-| True South Lunar Node | Leo ♌ | 7.26°    | -0.0080°/d   | -          | +18.46° | -   | R    | Ninth House    |
-| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | -          | +24.62° | Y   | -    | Seventh House  |
-| True Priapus          | Gem ♊ | 18.01°   | -1.4330°/d   | -          | +26.88° | Y   | R    | Eighth House   |
-+-----------------------+--------+----------+--------------+------------+---------+-----+------+----------------+
++Return Subject Celestial Points-+----------+--------------+------------+---------+-----+------+---------------+
+| Point                 | Sign   | Position | Speed        | Motion     | Decl.   | OOB | Ret. | House         |
++-----------------------+--------+----------+--------------+------------+---------+-----+------+---------------+
+| Ascendant             | Cap ♑ | 13.82°   | +409.8309°/d | -          | N/A     | -   | -    | First House   |
+| Medium Coeli          | Sco ♏ | 21.77°   | +355.0355°/d | -          | N/A     | -   | -    | Tenth House   |
+| Descendant            | Can ♋ | 13.82°   | +409.8309°/d | -          | N/A     | -   | -    | Seventh House |
+| Imum Coeli            | Tau ♉ | 21.77°   | +355.0355°/d | -          | N/A     | -   | -    | Fourth House  |
+| Sun                   | Can ♋ | 28.54°   | +0.9545°/d   | Average    | +20.45° | -   | -    | Seventh House |
+| Moon                  | Sag ♐ | 4.63°    | +11.9554°/d  | Average    | -24.70° | Y   | -    | Tenth House   |
+| Mercury               | Leo ♌ | 25.32°   | +1.1015°/d   | Slow       | +12.70° | -   | -    | Seventh House |
+| Venus                 | Vir ♍ | 5.30°    | +0.3635°/d   | Slow       | +7.49°  | -   | -    | Seventh House |
+| Mars                  | Vir ♍ | 3.87°    | +0.6178°/d   | Average    | +11.07° | -   | -    | Seventh House |
+| Jupiter               | Leo ♌ | 18.64°   | +0.2120°/d   | Fast       | +15.95° | -   | -    | Seventh House |
+| Saturn                | Aqu ♒ | 3.89°    | -0.0738°/d   | Retrograde | -19.74° | -   | R    | First House   |
+| Uranus                | Cap ♑ | 11.13°   | -0.0379°/d   | Retrograde | -23.35° | -   | R    | Twelfth House |
+| Neptune               | Cap ♑ | 15.01°   | -0.0261°/d   | Retrograde | -21.79° | -   | R    | First House   |
+| Pluto                 | Sco ♏ | 17.58°   | -0.0040°/d   | Retrograde | -2.43°  | -   | R    | Ninth House   |
+| Mean North Lunar Node | Cap ♑ | 18.45°   | -0.0529°/d   | -          | -22.17° | -   | R    | First House   |
+| True North Lunar Node | Cap ♑ | 18.94°   | +0.0160°/d   | -          | -22.10° | -   | -    | First House   |
+| Mean Lilith           | Cap ♑ | 9.64°    | +0.1108°/d   | -          | -23.88° | Y   | -    | Twelfth House |
+| True Lilith           | Cap ♑ | 1.04°    | +1.6109°/d   | -          | -25.07° | Y   | -    | Twelfth House |
+| Chiron                | Leo ♌ | 0.02°    | +0.1160°/d   | -          | +13.98° | -   | -    | Seventh House |
+| Pholus                | Can ♋ | 22.39°   | +0.1390°/d   | -          | +18.51° | -   | -    | Seventh House |
+| Ceres                 | Lib ♎ | 26.79°   | +0.2408°/d   | -          | -4.75°  | -   | -    | Ninth House   |
+| Pallas                | Vir ♍ | 27.34°   | +0.3701°/d   | -          | +14.30° | -   | -    | Eighth House  |
+| Juno                  | Cap ♑ | 22.77°   | -0.2378°/d   | -          | -5.27°  | -   | R    | First House   |
+| Vesta                 | Can ♋ | 22.37°   | +0.4407°/d   | -          | +22.11° | -   | -    | Seventh House |
+| Interpolated Lilith   | Cap ♑ | 5.98°    | +0.0063°/d   | -          | -24.42° | Y   | -    | Twelfth House |
+| Interpolated Perigee  | Can ♋ | 18.48°   | +0.4813°/d   | -          | +22.16° | -   | -    | Seventh House |
+| Cupido                | Sco ♏ | 20.02°   | -0.0049°/d   | -          | -16.72° | -   | R    | Ninth House   |
+| Hades                 | Gem ♊ | 10.92°   | +0.0155°/d   | -          | +21.07° | -   | -    | Fifth House   |
+| Zeus                  | Vir ♍ | 26.83°   | +0.0107°/d   | -          | +1.26°  | -   | -    | Eighth House  |
+| Kronos                | Gem ♊ | 22.59°   | +0.0139°/d   | -          | +23.25° | -   | -    | Fifth House   |
+| Apollon               | Lib ♎ | 14.45°   | +0.0050°/d   | -          | -5.70°  | -   | -    | Eighth House  |
+| Admetos               | Tau ♉ | 15.54°   | +0.0055°/d   | -          | +16.50° | -   | -    | Third House   |
+| Vulkanus              | Can ♋ | 15.88°   | +0.0136°/d   | -          | +22.51° | -   | -    | Seventh House |
+| Poseidon              | Lib ♎ | 29.17°   | +0.0012°/d   | -          | -11.19° | -   | -    | Ninth House   |
+| Eris                  | Ari ♈ | 17.83°   | -0.0012°/d   | -          | -8.90°  | -   | R    | Second House  |
+| Sedna                 | Tau ♉ | 12.06°   | +0.0039°/d   | -          | +4.38°  | -   | -    | Third House   |
+| Haumea                | Vir ♍ | 27.25°   | +0.0132°/d   | -          | +22.86° | -   | -    | Eighth House  |
+| Makemake              | Vir ♍ | 5.55°    | +0.0199°/d   | -          | +35.13° | Y   | -    | Seventh House |
+| Ixion                 | Sco ♏ | 23.74°   | -0.0064°/d   | -          | -13.21° | -   | R    | Tenth House   |
+| Orcus                 | Leo ♌ | 11.85°   | +0.0233°/d   | -          | +3.54°  | -   | -    | Seventh House |
+| Quaoar                | Sco ♏ | 25.34°   | -0.0066°/d   | -          | -13.27° | -   | R    | Tenth House   |
+| Vertex                | Leo ♌ | 26.69°   | N/A          | -          | N/A     | -   | -    | Seventh House |
+| White Moon            | Vir ♍ | 17.86°   | +0.1408°/d   | -          | +4.80°  | -   | -    | Eighth House  |
+| Anti Vertex           | Aqu ♒ | 26.69°   | N/A          | -          | N/A     | -   | -    | First House   |
+| Mean South Lunar Node | Can ♋ | 18.45°   | -0.0529°/d   | -          | +22.17° | -   | R    | Seventh House |
+| True South Lunar Node | Can ♋ | 18.94°   | +0.0160°/d   | -          | +22.10° | -   | -    | Seventh House |
+| Mean Priapus          | Can ♋ | 9.64°    | +0.1108°/d   | -          | +23.88° | Y   | -    | Sixth House   |
+| True Priapus          | Can ♋ | 1.04°    | +1.6109°/d   | -          | +25.07° | Y   | -    | Sixth House   |
++-----------------------+--------+----------+--------------+------------+---------+-----+------+---------------+
 
-+Return Subject Arabic Parts--------+-------+-------+------+----------------+
-| Point         | Sign   | Position | Speed | Decl. | Ret. | House          |
-+---------------+--------+----------+-------+-------+------+----------------+
-| Pars Fortunae | Lib ♎ | 28.48°   | N/A   | N/A   | -    | Twelfth House  |
-| Pars Spiritus | Sco ♏ | 13.15°   | N/A   | N/A   | -    | First House    |
-| Pars Amoris   | Lib ♎ | 8.98°    | N/A   | N/A   | -    | Eleventh House |
-| Pars Fidei    | Tau ♉ | 8.21°    | N/A   | N/A   | -    | Seventh House  |
-+---------------+--------+----------+-------+-------+------+----------------+
++Return Subject Arabic Parts--------+-------+-------+------+---------------+
+| Point         | Sign   | Position | Speed | Decl. | Ret. | House         |
++---------------+--------+----------+-------+-------+------+---------------+
+| Pars Fortunae | Tau ♉ | 19.91°   | N/A   | N/A   | -    | Third House   |
+| Pars Spiritus | Vir ♍ | 7.73°    | N/A   | N/A   | -    | Seventh House |
+| Pars Amoris   | Aqu ♒ | 20.58°   | N/A   | N/A   | -    | First House   |
+| Pars Fidei    | Can ♋ | 28.57°   | N/A   | N/A   | -    | Seventh House |
++---------------+--------+----------+-------+-------+------+---------------+
 
 +Natal Subject Houses (Placidus)-----+-------------------+
 | House          | Sign   | Position | Absolute Position |
@@ -197,18 +197,18 @@ Sample Natal Subject — Solar Return Comparison 1990
 +Return Subject Houses (Placidus)----+-------------------+
 | House          | Sign   | Position | Absolute Position |
 +----------------+--------+----------+-------------------+
-| First House    | Sco ♏ | 5.82°    | 215.82°           |
-| Second House   | Sag ♐ | 3.70°    | 243.70°           |
-| Third House    | Cap ♑ | 9.78°    | 279.78°           |
-| Fourth House   | Aqu ♒ | 19.91°   | 319.91°           |
-| Fifth House    | Pis ♓ | 23.00°   | 353.00°           |
-| Sixth House    | Ari ♈ | 17.47°   | 17.47°            |
-| Seventh House  | Tau ♉ | 5.82°    | 35.82°            |
-| Eighth House   | Gem ♊ | 3.70°    | 63.70°            |
-| Ninth House    | Can ♋ | 9.78°    | 99.78°            |
-| Tenth House    | Leo ♌ | 19.91°   | 139.91°           |
-| Eleventh House | Vir ♍ | 23.00°   | 173.00°           |
-| Twelfth House  | Lib ♎ | 17.47°   | 197.47°           |
+| First House    | Cap ♑ | 13.82°   | 283.82°           |
+| Second House   | Pis ♓ | 11.22°   | 341.22°           |
+| Third House    | Ari ♈ | 25.80°   | 25.80°            |
+| Fourth House   | Tau ♉ | 21.77°   | 51.77°            |
+| Fifth House    | Gem ♊ | 10.03°   | 70.03°            |
+| Sixth House    | Gem ♊ | 25.97°   | 85.97°            |
+| Seventh House  | Can ♋ | 13.82°   | 103.82°           |
+| Eighth House   | Vir ♍ | 11.22°   | 161.22°           |
+| Ninth House    | Lib ♎ | 25.80°   | 205.80°           |
+| Tenth House    | Sco ♏ | 21.77°   | 231.77°           |
+| Eleventh House | Sag ♐ | 10.03°   | 250.03°           |
+| Twelfth House  | Sag ♐ | 25.97°   | 265.97°           |
 +----------------+--------+----------+-------------------+
 
 +Lunar Phase--------------+--------------------+
@@ -251,166 +251,159 @@ Sample Natal Subject — Solar Return Comparison 1990
 | 9     | 4     | Sun, Moon, Mercury, Jupiter |
 +-------+-------+-----------------------------+
 
-+Return Subject Angularities--------+
-| Point   | Angle        | Distance |
-+---------+--------------+----------+
-| Mars    | Descendant   | 0.15°    |
-| Mercury | Medium Coeli | 2.30°    |
-+---------+--------------+----------+
-
-+Return Subject Stelliums---------------------+
-| House | Count | Points                      |
-+-------+-------+-----------------------------+
-| 9     | 4     | Sun, Moon, Mercury, Jupiter |
-+-------+-------+-----------------------------+
++Return Subject Stelliums----------------------------+
+| House | Count | Points                             |
++-------+-------+------------------------------------+
+| 7     | 5     | Sun, Mercury, Venus, Mars, Jupiter |
++-------+-------+------------------------------------+
 
 +Sample Natal Subject points in Sample Natal Subject Solar Return houses-------------------+------+--------+
 | Point                                        | Owner House         | Projected House     | Sign | Degree |
 +----------------------------------------------+---------------------+---------------------+------+--------+
-| Sample Natal Subject – Sun                   | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 28.54° |
-| Sample Natal Subject – Moon                  | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 21.21° |
-| Sample Natal Subject – Mercury               | 9 (Ninth House)     | 9 (Ninth House)     | Leo  | 17.61° |
-| Sample Natal Subject – Venus                 | 8 (Eighth House)    | 8 (Eighth House)    | Can  | 1.71°  |
-| Sample Natal Subject – Mars                  | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 5.97°  |
-| Sample Natal Subject – Jupiter               | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 23.91° |
-| Sample Natal Subject – Saturn                | 3 (Third House)     | 3 (Third House)     | Cap  | 21.52° |
-| Sample Natal Subject – Uranus                | 2 (Second House)    | 2 (Second House)    | Cap  | 6.74°  |
-| Sample Natal Subject – Neptune               | 3 (Third House)     | 3 (Third House)     | Cap  | 12.76° |
-| Sample Natal Subject – Pluto                 | 1 (First House)     | 1 (First House)     | Sco  | 14.97° |
-| Sample Natal Subject – Mean North Lunar Node | 3 (Third House)     | 3 (Third House)     | Aqu  | 7.79°  |
-| Sample Natal Subject – True North Lunar Node | 3 (Third House)     | 3 (Third House)     | Aqu  | 7.26°  |
-| Sample Natal Subject – Mean Lilith           | 1 (First House)     | 1 (First House)     | Sco  | 28.99° |
-| Sample Natal Subject – True Lilith           | 2 (Second House)    | 2 (Second House)    | Sag  | 18.01° |
-| Sample Natal Subject – Chiron                | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 19.88° |
-| Sample Natal Subject – Pholus                | 8 (Eighth House)    | 8 (Eighth House)    | Can  | 7.99°  |
-| Sample Natal Subject – Ceres                 | 9 (Ninth House)     | 9 (Ninth House)     | Leo  | 13.71° |
-| Sample Natal Subject – Pallas                | 8 (Eighth House)    | 8 (Eighth House)    | Can  | 7.25°  |
-| Sample Natal Subject – Juno                  | 1 (First House)     | 1 (First House)     | Sco  | 10.10° |
-| Sample Natal Subject – Vesta                 | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 18.15° |
-| Sample Natal Subject – Interpolated Lilith   | 1 (First House)     | 1 (First House)     | Sco  | 25.48° |
-| Sample Natal Subject – Interpolated Perigee  | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 20.98° |
-| Sample Natal Subject – Cupido                | 1 (First House)     | 1 (First House)     | Sco  | 18.62° |
-| Sample Natal Subject – Hades                 | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 9.92°  |
-| Sample Natal Subject – Zeus                  | 11 (Eleventh House) | 11 (Eleventh House) | Vir  | 26.03° |
-| Sample Natal Subject – Kronos                | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 21.89° |
-| Sample Natal Subject – Apollon               | 11 (Eleventh House) | 11 (Eleventh House) | Lib  | 13.82° |
-| Sample Natal Subject – Admetos               | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 14.96° |
-| Sample Natal Subject – Vulkanus              | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 15.34° |
-| Sample Natal Subject – Poseidon              | 12 (Twelfth House)  | 12 (Twelfth House)  | Lib  | 28.68° |
-| Sample Natal Subject – Eris                  | 6 (Sixth House)     | 6 (Sixth House)     | Ari  | 17.60° |
-| Sample Natal Subject – Sedna                 | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 11.55° |
-| Sample Natal Subject – Haumea                | 11 (Eleventh House) | 11 (Eleventh House) | Vir  | 26.32° |
-| Sample Natal Subject – Makemake              | 10 (Tenth House)    | 10 (Tenth House)    | Vir  | 4.50°  |
-| Sample Natal Subject – Ixion                 | 1 (First House)     | 1 (First House)     | Sco  | 22.70° |
-| Sample Natal Subject – Orcus                 | 9 (Ninth House)     | 9 (Ninth House)     | Leo  | 10.84° |
-| Sample Natal Subject – Quaoar                | 1 (First House)     | 1 (First House)     | Sco  | 24.08° |
-| Sample Natal Subject – Pars Fortunae         | 12 (Twelfth House)  | 12 (Twelfth House)  | Lib  | 28.49° |
-| Sample Natal Subject – Pars Spiritus         | 1 (First House)     | 1 (First House)     | Sco  | 13.16° |
-| Sample Natal Subject – Pars Amoris           | 11 (Eleventh House) | 11 (Eleventh House) | Lib  | 8.99°  |
-| Sample Natal Subject – Pars Fidei            | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 8.22°  |
-| Sample Natal Subject – Vertex                | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 11.46° |
-| Sample Natal Subject – White Moon            | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 26.43° |
-| Sample Natal Subject – Descendant            | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 5.82°  |
-| Sample Natal Subject – Imum Coeli            | 4 (Fourth House)    | 4 (Fourth House)    | Aqu  | 19.91° |
-| Sample Natal Subject – Anti Vertex           | 2 (Second House)    | 2 (Second House)    | Sag  | 11.46° |
-| Sample Natal Subject – Mean South Lunar Node | 9 (Ninth House)     | 9 (Ninth House)     | Leo  | 7.79°  |
-| Sample Natal Subject – True South Lunar Node | 9 (Ninth House)     | 9 (Ninth House)     | Leo  | 7.26°  |
-| Sample Natal Subject – Mean Priapus          | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 28.99° |
-| Sample Natal Subject – True Priapus          | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 18.01° |
-| Sample Natal Subject – Ascendant             | 1 (First House)     | 1 (First House)     | Sco  | 5.82°  |
-| Sample Natal Subject – Medium Coeli          | 10 (Tenth House)    | 10 (Tenth House)    | Leo  | 19.91° |
+| Sample Natal Subject – Sun                   | 9 (Ninth House)     | 7 (Seventh House)   | Can  | 28.54° |
+| Sample Natal Subject – Moon                  | 9 (Ninth House)     | 7 (Seventh House)   | Can  | 21.21° |
+| Sample Natal Subject – Mercury               | 9 (Ninth House)     | 7 (Seventh House)   | Leo  | 17.61° |
+| Sample Natal Subject – Venus                 | 8 (Eighth House)    | 6 (Sixth House)     | Can  | 1.71°  |
+| Sample Natal Subject – Mars                  | 7 (Seventh House)   | 3 (Third House)     | Tau  | 5.97°  |
+| Sample Natal Subject – Jupiter               | 9 (Ninth House)     | 7 (Seventh House)   | Can  | 23.91° |
+| Sample Natal Subject – Saturn                | 3 (Third House)     | 1 (First House)     | Cap  | 21.52° |
+| Sample Natal Subject – Uranus                | 2 (Second House)    | 12 (Twelfth House)  | Cap  | 6.74°  |
+| Sample Natal Subject – Neptune               | 3 (Third House)     | 12 (Twelfth House)  | Cap  | 12.76° |
+| Sample Natal Subject – Pluto                 | 1 (First House)     | 9 (Ninth House)     | Sco  | 14.97° |
+| Sample Natal Subject – Mean North Lunar Node | 3 (Third House)     | 1 (First House)     | Aqu  | 7.79°  |
+| Sample Natal Subject – True North Lunar Node | 3 (Third House)     | 1 (First House)     | Aqu  | 7.26°  |
+| Sample Natal Subject – Mean Lilith           | 1 (First House)     | 10 (Tenth House)    | Sco  | 28.99° |
+| Sample Natal Subject – True Lilith           | 2 (Second House)    | 11 (Eleventh House) | Sag  | 18.01° |
+| Sample Natal Subject – Chiron                | 9 (Ninth House)     | 7 (Seventh House)   | Can  | 19.88° |
+| Sample Natal Subject – Pholus                | 8 (Eighth House)    | 6 (Sixth House)     | Can  | 7.99°  |
+| Sample Natal Subject – Ceres                 | 9 (Ninth House)     | 7 (Seventh House)   | Leo  | 13.71° |
+| Sample Natal Subject – Pallas                | 8 (Eighth House)    | 6 (Sixth House)     | Can  | 7.25°  |
+| Sample Natal Subject – Juno                  | 1 (First House)     | 9 (Ninth House)     | Sco  | 10.10° |
+| Sample Natal Subject – Vesta                 | 7 (Seventh House)   | 3 (Third House)     | Tau  | 18.15° |
+| Sample Natal Subject – Interpolated Lilith   | 1 (First House)     | 10 (Tenth House)    | Sco  | 25.48° |
+| Sample Natal Subject – Interpolated Perigee  | 8 (Eighth House)    | 5 (Fifth House)     | Gem  | 20.98° |
+| Sample Natal Subject – Cupido                | 1 (First House)     | 9 (Ninth House)     | Sco  | 18.62° |
+| Sample Natal Subject – Hades                 | 8 (Eighth House)    | 4 (Fourth House)    | Gem  | 9.92°  |
+| Sample Natal Subject – Zeus                  | 11 (Eleventh House) | 8 (Eighth House)    | Vir  | 26.03° |
+| Sample Natal Subject – Kronos                | 8 (Eighth House)    | 5 (Fifth House)     | Gem  | 21.89° |
+| Sample Natal Subject – Apollon               | 11 (Eleventh House) | 8 (Eighth House)    | Lib  | 13.82° |
+| Sample Natal Subject – Admetos               | 7 (Seventh House)   | 3 (Third House)     | Tau  | 14.96° |
+| Sample Natal Subject – Vulkanus              | 9 (Ninth House)     | 7 (Seventh House)   | Can  | 15.34° |
+| Sample Natal Subject – Poseidon              | 12 (Twelfth House)  | 9 (Ninth House)     | Lib  | 28.68° |
+| Sample Natal Subject – Eris                  | 6 (Sixth House)     | 2 (Second House)    | Ari  | 17.60° |
+| Sample Natal Subject – Sedna                 | 7 (Seventh House)   | 3 (Third House)     | Tau  | 11.55° |
+| Sample Natal Subject – Haumea                | 11 (Eleventh House) | 8 (Eighth House)    | Vir  | 26.32° |
+| Sample Natal Subject – Makemake              | 10 (Tenth House)    | 7 (Seventh House)   | Vir  | 4.50°  |
+| Sample Natal Subject – Ixion                 | 1 (First House)     | 10 (Tenth House)    | Sco  | 22.70° |
+| Sample Natal Subject – Orcus                 | 9 (Ninth House)     | 7 (Seventh House)   | Leo  | 10.84° |
+| Sample Natal Subject – Quaoar                | 1 (First House)     | 10 (Tenth House)    | Sco  | 24.08° |
+| Sample Natal Subject – Pars Fortunae         | 12 (Twelfth House)  | 9 (Ninth House)     | Lib  | 28.49° |
+| Sample Natal Subject – Pars Spiritus         | 1 (First House)     | 9 (Ninth House)     | Sco  | 13.16° |
+| Sample Natal Subject – Pars Amoris           | 11 (Eleventh House) | 8 (Eighth House)    | Lib  | 8.99°  |
+| Sample Natal Subject – Pars Fidei            | 7 (Seventh House)   | 3 (Third House)     | Tau  | 8.22°  |
+| Sample Natal Subject – Vertex                | 8 (Eighth House)    | 5 (Fifth House)     | Gem  | 11.46° |
+| Sample Natal Subject – White Moon            | 9 (Ninth House)     | 7 (Seventh House)   | Can  | 26.43° |
+| Sample Natal Subject – Descendant            | 7 (Seventh House)   | 3 (Third House)     | Tau  | 5.82°  |
+| Sample Natal Subject – Imum Coeli            | 4 (Fourth House)    | 1 (First House)     | Aqu  | 19.91° |
+| Sample Natal Subject – Anti Vertex           | 2 (Second House)    | 11 (Eleventh House) | Sag  | 11.46° |
+| Sample Natal Subject – Mean South Lunar Node | 9 (Ninth House)     | 7 (Seventh House)   | Leo  | 7.79°  |
+| Sample Natal Subject – True South Lunar Node | 9 (Ninth House)     | 7 (Seventh House)   | Leo  | 7.26°  |
+| Sample Natal Subject – Mean Priapus          | 7 (Seventh House)   | 4 (Fourth House)    | Tau  | 28.99° |
+| Sample Natal Subject – True Priapus          | 8 (Eighth House)    | 5 (Fifth House)     | Gem  | 18.01° |
+| Sample Natal Subject – Ascendant             | 1 (First House)     | 9 (Ninth House)     | Sco  | 5.82°  |
+| Sample Natal Subject – Medium Coeli          | 10 (Tenth House)    | 7 (Seventh House)   | Leo  | 19.91° |
 +----------------------------------------------+---------------------+---------------------+------+--------+
 
-+Sample Natal Subject Solar Return points in Sample Natal Subject houses----------+---------------------+------+--------+
-| Point                                                     | Owner House         | Projected House     | Sign | Degree |
-+-----------------------------------------------------------+---------------------+---------------------+------+--------+
-| Sample Natal Subject Solar Return – Sun                   | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 28.54° |
-| Sample Natal Subject Solar Return – Moon                  | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 21.21° |
-| Sample Natal Subject Solar Return – Mercury               | 9 (Ninth House)     | 9 (Ninth House)     | Leo  | 17.61° |
-| Sample Natal Subject Solar Return – Venus                 | 8 (Eighth House)    | 8 (Eighth House)    | Can  | 1.71°  |
-| Sample Natal Subject Solar Return – Mars                  | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 5.97°  |
-| Sample Natal Subject Solar Return – Jupiter               | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 23.91° |
-| Sample Natal Subject Solar Return – Saturn                | 3 (Third House)     | 3 (Third House)     | Cap  | 21.52° |
-| Sample Natal Subject Solar Return – Uranus                | 2 (Second House)    | 2 (Second House)    | Cap  | 6.74°  |
-| Sample Natal Subject Solar Return – Neptune               | 3 (Third House)     | 3 (Third House)     | Cap  | 12.76° |
-| Sample Natal Subject Solar Return – Pluto                 | 1 (First House)     | 1 (First House)     | Sco  | 14.97° |
-| Sample Natal Subject Solar Return – Mean North Lunar Node | 3 (Third House)     | 3 (Third House)     | Aqu  | 7.79°  |
-| Sample Natal Subject Solar Return – True North Lunar Node | 3 (Third House)     | 3 (Third House)     | Aqu  | 7.26°  |
-| Sample Natal Subject Solar Return – Mean Lilith           | 1 (First House)     | 1 (First House)     | Sco  | 28.99° |
-| Sample Natal Subject Solar Return – True Lilith           | 2 (Second House)    | 2 (Second House)    | Sag  | 18.01° |
-| Sample Natal Subject Solar Return – Chiron                | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 19.88° |
-| Sample Natal Subject Solar Return – Pholus                | 8 (Eighth House)    | 8 (Eighth House)    | Can  | 7.99°  |
-| Sample Natal Subject Solar Return – Ceres                 | 9 (Ninth House)     | 9 (Ninth House)     | Leo  | 13.71° |
-| Sample Natal Subject Solar Return – Pallas                | 8 (Eighth House)    | 8 (Eighth House)    | Can  | 7.25°  |
-| Sample Natal Subject Solar Return – Juno                  | 1 (First House)     | 1 (First House)     | Sco  | 10.10° |
-| Sample Natal Subject Solar Return – Vesta                 | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 18.15° |
-| Sample Natal Subject Solar Return – Interpolated Lilith   | 1 (First House)     | 1 (First House)     | Sco  | 25.48° |
-| Sample Natal Subject Solar Return – Interpolated Perigee  | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 20.98° |
-| Sample Natal Subject Solar Return – Cupido                | 1 (First House)     | 1 (First House)     | Sco  | 18.62° |
-| Sample Natal Subject Solar Return – Hades                 | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 9.92°  |
-| Sample Natal Subject Solar Return – Zeus                  | 11 (Eleventh House) | 11 (Eleventh House) | Vir  | 26.03° |
-| Sample Natal Subject Solar Return – Kronos                | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 21.89° |
-| Sample Natal Subject Solar Return – Apollon               | 11 (Eleventh House) | 11 (Eleventh House) | Lib  | 13.82° |
-| Sample Natal Subject Solar Return – Admetos               | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 14.96° |
-| Sample Natal Subject Solar Return – Vulkanus              | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 15.34° |
-| Sample Natal Subject Solar Return – Poseidon              | 12 (Twelfth House)  | 12 (Twelfth House)  | Lib  | 28.68° |
-| Sample Natal Subject Solar Return – Eris                  | 6 (Sixth House)     | 6 (Sixth House)     | Ari  | 17.60° |
-| Sample Natal Subject Solar Return – Sedna                 | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 11.55° |
-| Sample Natal Subject Solar Return – Haumea                | 11 (Eleventh House) | 11 (Eleventh House) | Vir  | 26.32° |
-| Sample Natal Subject Solar Return – Makemake              | 10 (Tenth House)    | 10 (Tenth House)    | Vir  | 4.50°  |
-| Sample Natal Subject Solar Return – Ixion                 | 1 (First House)     | 1 (First House)     | Sco  | 22.70° |
-| Sample Natal Subject Solar Return – Orcus                 | 9 (Ninth House)     | 9 (Ninth House)     | Leo  | 10.84° |
-| Sample Natal Subject Solar Return – Quaoar                | 1 (First House)     | 1 (First House)     | Sco  | 24.08° |
-| Sample Natal Subject Solar Return – Pars Fortunae         | 12 (Twelfth House)  | 12 (Twelfth House)  | Lib  | 28.48° |
-| Sample Natal Subject Solar Return – Pars Spiritus         | 1 (First House)     | 1 (First House)     | Sco  | 13.15° |
-| Sample Natal Subject Solar Return – Pars Amoris           | 11 (Eleventh House) | 11 (Eleventh House) | Lib  | 8.98°  |
-| Sample Natal Subject Solar Return – Pars Fidei            | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 8.21°  |
-| Sample Natal Subject Solar Return – Vertex                | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 11.46° |
-| Sample Natal Subject Solar Return – White Moon            | 9 (Ninth House)     | 9 (Ninth House)     | Can  | 26.43° |
-| Sample Natal Subject Solar Return – Descendant            | 7 (Seventh House)   | 6 (Sixth House)     | Tau  | 5.82°  |
-| Sample Natal Subject Solar Return – Imum Coeli            | 4 (Fourth House)    | 3 (Third House)     | Aqu  | 19.91° |
-| Sample Natal Subject Solar Return – Anti Vertex           | 2 (Second House)    | 2 (Second House)    | Sag  | 11.46° |
-| Sample Natal Subject Solar Return – Mean South Lunar Node | 9 (Ninth House)     | 9 (Ninth House)     | Leo  | 7.79°  |
-| Sample Natal Subject Solar Return – True South Lunar Node | 9 (Ninth House)     | 9 (Ninth House)     | Leo  | 7.26°  |
-| Sample Natal Subject Solar Return – Mean Priapus          | 7 (Seventh House)   | 7 (Seventh House)   | Tau  | 28.99° |
-| Sample Natal Subject Solar Return – True Priapus          | 8 (Eighth House)    | 8 (Eighth House)    | Gem  | 18.01° |
-| Sample Natal Subject Solar Return – Ascendant             | 1 (First House)     | 12 (Twelfth House)  | Sco  | 5.82°  |
-| Sample Natal Subject Solar Return – Medium Coeli          | 10 (Tenth House)    | 9 (Ninth House)     | Leo  | 19.91° |
-+-----------------------------------------------------------+---------------------+---------------------+------+--------+
++Sample Natal Subject Solar Return points in Sample Natal Subject houses---------+---------------------+------+--------+
+| Point                                                     | Owner House        | Projected House     | Sign | Degree |
++-----------------------------------------------------------+--------------------+---------------------+------+--------+
+| Sample Natal Subject Solar Return – Sun                   | 7 (Seventh House)  | 9 (Ninth House)     | Can  | 28.54° |
+| Sample Natal Subject Solar Return – Moon                  | 10 (Tenth House)   | 2 (Second House)    | Sag  | 4.63°  |
+| Sample Natal Subject Solar Return – Mercury               | 7 (Seventh House)  | 10 (Tenth House)    | Leo  | 25.32° |
+| Sample Natal Subject Solar Return – Venus                 | 7 (Seventh House)  | 10 (Tenth House)    | Vir  | 5.30°  |
+| Sample Natal Subject Solar Return – Mars                  | 7 (Seventh House)  | 10 (Tenth House)    | Vir  | 3.87°  |
+| Sample Natal Subject Solar Return – Jupiter               | 7 (Seventh House)  | 9 (Ninth House)     | Leo  | 18.64° |
+| Sample Natal Subject Solar Return – Saturn                | 1 (First House)    | 3 (Third House)     | Aqu  | 3.89°  |
+| Sample Natal Subject Solar Return – Uranus                | 12 (Twelfth House) | 3 (Third House)     | Cap  | 11.13° |
+| Sample Natal Subject Solar Return – Neptune               | 1 (First House)    | 3 (Third House)     | Cap  | 15.01° |
+| Sample Natal Subject Solar Return – Pluto                 | 9 (Ninth House)    | 1 (First House)     | Sco  | 17.58° |
+| Sample Natal Subject Solar Return – Mean North Lunar Node | 1 (First House)    | 3 (Third House)     | Cap  | 18.45° |
+| Sample Natal Subject Solar Return – True North Lunar Node | 1 (First House)    | 3 (Third House)     | Cap  | 18.94° |
+| Sample Natal Subject Solar Return – Mean Lilith           | 12 (Twelfth House) | 2 (Second House)    | Cap  | 9.64°  |
+| Sample Natal Subject Solar Return – True Lilith           | 12 (Twelfth House) | 2 (Second House)    | Cap  | 1.04°  |
+| Sample Natal Subject Solar Return – Chiron                | 7 (Seventh House)  | 9 (Ninth House)     | Leo  | 0.02°  |
+| Sample Natal Subject Solar Return – Pholus                | 7 (Seventh House)  | 9 (Ninth House)     | Can  | 22.39° |
+| Sample Natal Subject Solar Return – Ceres                 | 9 (Ninth House)    | 12 (Twelfth House)  | Lib  | 26.79° |
+| Sample Natal Subject Solar Return – Pallas                | 8 (Eighth House)   | 11 (Eleventh House) | Vir  | 27.34° |
+| Sample Natal Subject Solar Return – Juno                  | 1 (First House)    | 3 (Third House)     | Cap  | 22.77° |
+| Sample Natal Subject Solar Return – Vesta                 | 7 (Seventh House)  | 9 (Ninth House)     | Can  | 22.37° |
+| Sample Natal Subject Solar Return – Interpolated Lilith   | 12 (Twelfth House) | 2 (Second House)    | Cap  | 5.98°  |
+| Sample Natal Subject Solar Return – Interpolated Perigee  | 7 (Seventh House)  | 9 (Ninth House)     | Can  | 18.48° |
+| Sample Natal Subject Solar Return – Cupido                | 9 (Ninth House)    | 1 (First House)     | Sco  | 20.02° |
+| Sample Natal Subject Solar Return – Hades                 | 5 (Fifth House)    | 8 (Eighth House)    | Gem  | 10.92° |
+| Sample Natal Subject Solar Return – Zeus                  | 8 (Eighth House)   | 11 (Eleventh House) | Vir  | 26.83° |
+| Sample Natal Subject Solar Return – Kronos                | 5 (Fifth House)    | 8 (Eighth House)    | Gem  | 22.59° |
+| Sample Natal Subject Solar Return – Apollon               | 8 (Eighth House)   | 11 (Eleventh House) | Lib  | 14.45° |
+| Sample Natal Subject Solar Return – Admetos               | 3 (Third House)    | 7 (Seventh House)   | Tau  | 15.54° |
+| Sample Natal Subject Solar Return – Vulkanus              | 7 (Seventh House)  | 9 (Ninth House)     | Can  | 15.88° |
+| Sample Natal Subject Solar Return – Poseidon              | 9 (Ninth House)    | 12 (Twelfth House)  | Lib  | 29.17° |
+| Sample Natal Subject Solar Return – Eris                  | 2 (Second House)   | 6 (Sixth House)     | Ari  | 17.83° |
+| Sample Natal Subject Solar Return – Sedna                 | 3 (Third House)    | 7 (Seventh House)   | Tau  | 12.06° |
+| Sample Natal Subject Solar Return – Haumea                | 8 (Eighth House)   | 11 (Eleventh House) | Vir  | 27.25° |
+| Sample Natal Subject Solar Return – Makemake              | 7 (Seventh House)  | 10 (Tenth House)    | Vir  | 5.55°  |
+| Sample Natal Subject Solar Return – Ixion                 | 10 (Tenth House)   | 1 (First House)     | Sco  | 23.74° |
+| Sample Natal Subject Solar Return – Orcus                 | 7 (Seventh House)  | 9 (Ninth House)     | Leo  | 11.85° |
+| Sample Natal Subject Solar Return – Quaoar                | 10 (Tenth House)   | 1 (First House)     | Sco  | 25.34° |
+| Sample Natal Subject Solar Return – Pars Fortunae         | 3 (Third House)    | 7 (Seventh House)   | Tau  | 19.91° |
+| Sample Natal Subject Solar Return – Pars Spiritus         | 7 (Seventh House)  | 10 (Tenth House)    | Vir  | 7.73°  |
+| Sample Natal Subject Solar Return – Pars Amoris           | 1 (First House)    | 4 (Fourth House)    | Aqu  | 20.58° |
+| Sample Natal Subject Solar Return – Pars Fidei            | 7 (Seventh House)  | 9 (Ninth House)     | Can  | 28.57° |
+| Sample Natal Subject Solar Return – Vertex                | 7 (Seventh House)  | 10 (Tenth House)    | Leo  | 26.69° |
+| Sample Natal Subject Solar Return – White Moon            | 8 (Eighth House)   | 10 (Tenth House)    | Vir  | 17.86° |
+| Sample Natal Subject Solar Return – Descendant            | 7 (Seventh House)  | 9 (Ninth House)     | Can  | 13.82° |
+| Sample Natal Subject Solar Return – Imum Coeli            | 4 (Fourth House)   | 7 (Seventh House)   | Tau  | 21.77° |
+| Sample Natal Subject Solar Return – Anti Vertex           | 1 (First House)    | 4 (Fourth House)    | Aqu  | 26.69° |
+| Sample Natal Subject Solar Return – Mean South Lunar Node | 7 (Seventh House)  | 9 (Ninth House)     | Can  | 18.45° |
+| Sample Natal Subject Solar Return – True South Lunar Node | 7 (Seventh House)  | 9 (Ninth House)     | Can  | 18.94° |
+| Sample Natal Subject Solar Return – Mean Priapus          | 6 (Sixth House)    | 8 (Eighth House)    | Can  | 9.64°  |
+| Sample Natal Subject Solar Return – True Priapus          | 6 (Sixth House)    | 8 (Eighth House)    | Can  | 1.04°  |
+| Sample Natal Subject Solar Return – Ascendant             | 1 (First House)    | 3 (Third House)     | Cap  | 13.82° |
+| Sample Natal Subject Solar Return – Medium Coeli          | 10 (Tenth House)   | 1 (First House)     | Sco  | 21.77° |
++-----------------------------------------------------------+--------------------+---------------------+------+--------+
 
-+Sample Natal Subject cusps in Sample Natal Subject Solar Return houses-------+
-| Point                                 | Projected House     | Sign | Degree |
-+---------------------------------------+---------------------+------+--------+
-| Sample Natal Subject – First House    | 1 (First House)     | Sco  | 5.82°  |
-| Sample Natal Subject – Second House   | 2 (Second House)    | Sag  | 3.71°  |
-| Sample Natal Subject – Third House    | 3 (Third House)     | Cap  | 9.79°  |
-| Sample Natal Subject – Fourth House   | 4 (Fourth House)    | Aqu  | 19.91° |
-| Sample Natal Subject – Fifth House    | 5 (Fifth House)     | Pis  | 23.00° |
-| Sample Natal Subject – Sixth House    | 6 (Sixth House)     | Ari  | 17.47° |
-| Sample Natal Subject – Seventh House  | 7 (Seventh House)   | Tau  | 5.82°  |
-| Sample Natal Subject – Eighth House   | 8 (Eighth House)    | Gem  | 3.71°  |
-| Sample Natal Subject – Ninth House    | 9 (Ninth House)     | Can  | 9.79°  |
-| Sample Natal Subject – Tenth House    | 10 (Tenth House)    | Leo  | 19.91° |
-| Sample Natal Subject – Eleventh House | 11 (Eleventh House) | Vir  | 23.00° |
-| Sample Natal Subject – Twelfth House  | 12 (Twelfth House)  | Lib  | 17.47° |
-+---------------------------------------+---------------------+------+--------+
++Sample Natal Subject cusps in Sample Natal Subject Solar Return houses------+
+| Point                                 | Projected House    | Sign | Degree |
++---------------------------------------+--------------------+------+--------+
+| Sample Natal Subject – First House    | 9 (Ninth House)    | Sco  | 5.82°  |
+| Sample Natal Subject – Second House   | 10 (Tenth House)   | Sag  | 3.71°  |
+| Sample Natal Subject – Third House    | 12 (Twelfth House) | Cap  | 9.79°  |
+| Sample Natal Subject – Fourth House   | 1 (First House)    | Aqu  | 19.91° |
+| Sample Natal Subject – Fifth House    | 2 (Second House)   | Pis  | 23.00° |
+| Sample Natal Subject – Sixth House    | 2 (Second House)   | Ari  | 17.47° |
+| Sample Natal Subject – Seventh House  | 3 (Third House)    | Tau  | 5.82°  |
+| Sample Natal Subject – Eighth House   | 4 (Fourth House)   | Gem  | 3.71°  |
+| Sample Natal Subject – Ninth House    | 6 (Sixth House)    | Can  | 9.79°  |
+| Sample Natal Subject – Tenth House    | 7 (Seventh House)  | Leo  | 19.91° |
+| Sample Natal Subject – Eleventh House | 8 (Eighth House)   | Vir  | 23.00° |
+| Sample Natal Subject – Twelfth House  | 8 (Eighth House)   | Lib  | 17.47° |
++---------------------------------------+--------------------+------+--------+
 
-+Sample Natal Subject Solar Return cusps in Sample Natal Subject houses----+------+--------+
-| Point                                              | Projected House     | Sign | Degree |
-+----------------------------------------------------+---------------------+------+--------+
-| Sample Natal Subject Solar Return – First House    | 12 (Twelfth House)  | Sco  | 5.82°  |
-| Sample Natal Subject Solar Return – Second House   | 1 (First House)     | Sag  | 3.70°  |
-| Sample Natal Subject Solar Return – Third House    | 2 (Second House)    | Cap  | 9.78°  |
-| Sample Natal Subject Solar Return – Fourth House   | 3 (Third House)     | Aqu  | 19.91° |
-| Sample Natal Subject Solar Return – Fifth House    | 4 (Fourth House)    | Pis  | 23.00° |
-| Sample Natal Subject Solar Return – Sixth House    | 5 (Fifth House)     | Ari  | 17.47° |
-| Sample Natal Subject Solar Return – Seventh House  | 6 (Sixth House)     | Tau  | 5.82°  |
-| Sample Natal Subject Solar Return – Eighth House   | 7 (Seventh House)   | Gem  | 3.70°  |
-| Sample Natal Subject Solar Return – Ninth House    | 8 (Eighth House)    | Can  | 9.78°  |
-| Sample Natal Subject Solar Return – Tenth House    | 9 (Ninth House)     | Leo  | 19.91° |
-| Sample Natal Subject Solar Return – Eleventh House | 10 (Tenth House)    | Vir  | 23.00° |
-| Sample Natal Subject Solar Return – Twelfth House  | 11 (Eleventh House) | Lib  | 17.47° |
-+----------------------------------------------------+---------------------+------+--------+
++Sample Natal Subject Solar Return cusps in Sample Natal Subject houses---+------+--------+
+| Point                                              | Projected House    | Sign | Degree |
++----------------------------------------------------+--------------------+------+--------+
+| Sample Natal Subject Solar Return – First House    | 3 (Third House)    | Cap  | 13.82° |
+| Sample Natal Subject Solar Return – Second House   | 4 (Fourth House)   | Pis  | 11.22° |
+| Sample Natal Subject Solar Return – Third House    | 6 (Sixth House)    | Ari  | 25.80° |
+| Sample Natal Subject Solar Return – Fourth House   | 7 (Seventh House)  | Tau  | 21.77° |
+| Sample Natal Subject Solar Return – Fifth House    | 8 (Eighth House)   | Gem  | 10.03° |
+| Sample Natal Subject Solar Return – Sixth House    | 8 (Eighth House)   | Gem  | 25.97° |
+| Sample Natal Subject Solar Return – Seventh House  | 9 (Ninth House)    | Can  | 13.82° |
+| Sample Natal Subject Solar Return – Eighth House   | 10 (Tenth House)   | Vir  | 11.22° |
+| Sample Natal Subject Solar Return – Ninth House    | 12 (Twelfth House) | Lib  | 25.80° |
+| Sample Natal Subject Solar Return – Tenth House    | 1 (First House)    | Sco  | 21.77° |
+| Sample Natal Subject Solar Return – Eleventh House | 2 (Second House)   | Sag  | 10.03° |
+| Sample Natal Subject Solar Return – Twelfth House  | 2 (Second House)   | Sag  | 25.97° |
++----------------------------------------------------+--------------------+------+--------+
 
 +Active Celestial Points-----+
 | #  | Active Point          |
@@ -489,1055 +482,1045 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Point 1               | Owner 1              | Aspect           | Point 2               | Owner 2                           | Orb   | Movement     |
 +-----------------------+----------------------+------------------+-----------------------+-----------------------------------+-------+--------------+
 | Sun                   | Sample Natal Subject | conjunction ☌    | Sun                   | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Sun                   | Sample Natal Subject | conjunction ☌    | Jupiter               | Sample Natal Subject Solar Return | 4.63° | Applying →   |
-| Sun                   | Sample Natal Subject | trine △          | Mean Lilith           | Sample Natal Subject Solar Return | 0.45° | Separating ← |
-| Sun                   | Sample Natal Subject | quintile Q       | Vesta                 | Sample Natal Subject Solar Return | 1.60° | Separating ← |
-| Sun                   | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 2.22° | Applying →   |
-| Sun                   | Sample Natal Subject | trine △          | Ixion                 | Sample Natal Subject Solar Return | 5.84° | Separating ← |
-| Sun                   | Sample Natal Subject | trine △          | Quaoar                | Sample Natal Subject Solar Return | 4.47° | Separating ← |
-| Sun                   | Sample Natal Subject | square □         | Pars Fortunae         | Sample Natal Subject Solar Return | 0.06° | Static =     |
-| Sun                   | Sample Natal Subject | quintile Q       | Pars Amoris           | Sample Natal Subject Solar Return | 1.56° | Static =     |
-| Sun                   | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 3.07° | Applying →   |
-| Sun                   | Sample Natal Subject | sextile ⚹        | Mean Priapus          | Sample Natal Subject Solar Return | 0.45° | Separating ← |
-| Sun                   | Sample Natal Subject | conjunction ☌    | White Moon            | Sample Natal Subject Solar Return | 2.11° | Applying →   |
-| Sun                   | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 2.51° | Applying →   |
-| Sun                   | Sample Natal Subject | quintile Q       | Admetos               | Sample Natal Subject Solar Return | 1.58° | Applying →   |
-| Sun                   | Sample Natal Subject | square □         | Poseidon              | Sample Natal Subject Solar Return | 0.14° | Separating ← |
-| Moon                  | Sample Natal Subject | conjunction ☌    | Moon                  | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Moon                  | Sample Natal Subject | conjunction ☌    | Jupiter               | Sample Natal Subject Solar Return | 2.70° | Separating ← |
-| Moon                  | Sample Natal Subject | opposition ☍     | Saturn                | Sample Natal Subject Solar Return | 0.31° | Applying →   |
-| Moon                  | Sample Natal Subject | conjunction ☌    | Chiron                | Sample Natal Subject Solar Return | 1.33° | Applying →   |
-| Moon                  | Sample Natal Subject | semi-sextile ⚺   | Medium Coeli          | Sample Natal Subject Solar Return | 1.30° | Applying →   |
-| Moon                  | Sample Natal Subject | quincunx ⚻       | Imum Coeli            | Sample Natal Subject Solar Return | 1.30° | Applying →   |
-| Moon                  | Sample Natal Subject | sextile ⚹        | Vesta                 | Sample Natal Subject Solar Return | 3.06° | Applying →   |
-| Moon                  | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 3.61° | Separating ← |
-| Moon                  | Sample Natal Subject | semi-square ∠    | Makemake              | Sample Natal Subject Solar Return | 1.71° | Applying →   |
-| Moon                  | Sample Natal Subject | trine △          | Ixion                 | Sample Natal Subject Solar Return | 1.49° | Applying →   |
-| Moon                  | Sample Natal Subject | trine △          | Quaoar                | Sample Natal Subject Solar Return | 2.87° | Applying →   |
-| Moon                  | Sample Natal Subject | quintile Q       | Pars Fidei            | Sample Natal Subject Solar Return | 0.99° | Static =     |
-| Moon                  | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 4.27° | Separating ← |
-| Moon                  | Sample Natal Subject | semi-sextile ⚺   | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.23° | Applying →   |
-| Moon                  | Sample Natal Subject | conjunction ☌    | White Moon            | Sample Natal Subject Solar Return | 5.22° | Separating ← |
-| Moon                  | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 2.59° | Separating ← |
-| Moon                  | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 4.82° | Separating ← |
-| Moon                  | Sample Natal Subject | semi-sextile ⚺   | Kronos                | Sample Natal Subject Solar Return | 0.69° | Separating ← |
-| Moon                  | Sample Natal Subject | conjunction ☌    | Vulkanus              | Sample Natal Subject Solar Return | 5.87° | Applying →   |
-| Mercury               | Sample Natal Subject | conjunction ☌    | Mercury               | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Mercury               | Sample Natal Subject | semi-square ∠    | Venus                 | Sample Natal Subject Solar Return | 0.90° | Applying →   |
-| Mercury               | Sample Natal Subject | biquintile bQ    | Neptune               | Sample Natal Subject Solar Return | 1.15° | Applying →   |
-| Mercury               | Sample Natal Subject | square □         | Pluto                 | Sample Natal Subject Solar Return | 2.63° | Separating ← |
-| Mercury               | Sample Natal Subject | conjunction ☌    | Medium Coeli          | Sample Natal Subject Solar Return | 2.30° | Separating ← |
-| Mercury               | Sample Natal Subject | opposition ☍     | Imum Coeli            | Sample Natal Subject Solar Return | 2.30° | Separating ← |
-| Mercury               | Sample Natal Subject | trine △          | True Lilith           | Sample Natal Subject Solar Return | 0.41° | Applying →   |
-| Mercury               | Sample Natal Subject | conjunction ☌    | Ceres                 | Sample Natal Subject Solar Return | 3.89° | Applying →   |
-| Mercury               | Sample Natal Subject | square □         | Vesta                 | Sample Natal Subject Solar Return | 0.54° | Separating ← |
-| Mercury               | Sample Natal Subject | trine △          | Eris                  | Sample Natal Subject Solar Return | 0.01° | Separating ← |
-| Mercury               | Sample Natal Subject | square □         | Ixion                 | Sample Natal Subject Solar Return | 5.09° | Applying →   |
-| Mercury               | Sample Natal Subject | quintile Q       | Pars Fortunae         | Sample Natal Subject Solar Return | 1.12° | Static =     |
-| Mercury               | Sample Natal Subject | square □         | Pars Spiritus         | Sample Natal Subject Solar Return | 4.46° | Static =     |
-| Mercury               | Sample Natal Subject | sextile ⚹        | True Priapus          | Sample Natal Subject Solar Return | 0.41° | Applying →   |
-| Mercury               | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | Sample Natal Subject Solar Return | 3.37° | Separating ← |
-| Mercury               | Sample Natal Subject | square □         | Cupido                | Sample Natal Subject Solar Return | 1.01° | Applying →   |
-| Mercury               | Sample Natal Subject | sextile ⚹        | Kronos                | Sample Natal Subject Solar Return | 4.29° | Separating ← |
-| Mercury               | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 3.78° | Applying →   |
-| Mercury               | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 2.65° | Applying →   |
-| Mercury               | Sample Natal Subject | quintile Q       | Poseidon              | Sample Natal Subject Solar Return | 0.93° | Applying →   |
-| Venus                 | Sample Natal Subject | semi-square ∠    | Mercury               | Sample Natal Subject Solar Return | 0.90° | Separating ← |
-| Venus                 | Sample Natal Subject | conjunction ☌    | Venus                 | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Venus                 | Sample Natal Subject | sextile ⚹        | Mars                  | Sample Natal Subject Solar Return | 4.26° | Separating ← |
-| Venus                 | Sample Natal Subject | opposition ☍     | Uranus                | Sample Natal Subject Solar Return | 5.03° | Applying →   |
-| Venus                 | Sample Natal Subject | sesquiquadrate ⚼ | Pluto                 | Sample Natal Subject Solar Return | 1.73° | Separating ← |
-| Venus                 | Sample Natal Subject | biquintile bQ    | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.08° | Applying →   |
-| Venus                 | Sample Natal Subject | biquintile bQ    | True North Lunar Node | Sample Natal Subject Solar Return | 0.44° | Separating ← |
-| Venus                 | Sample Natal Subject | trine △          | Ascendant             | Sample Natal Subject Solar Return | 4.11° | Separating ← |
-| Venus                 | Sample Natal Subject | sextile ⚹        | Descendant            | Sample Natal Subject Solar Return | 4.11° | Separating ← |
-| Venus                 | Sample Natal Subject | conjunction ☌    | Pallas                | Sample Natal Subject Solar Return | 5.54° | Separating ← |
-| Venus                 | Sample Natal Subject | semi-square ∠    | Vesta                 | Sample Natal Subject Solar Return | 1.44° | Separating ← |
-| Venus                 | Sample Natal Subject | square □         | Haumea                | Sample Natal Subject Solar Return | 5.39° | Applying →   |
-| Venus                 | Sample Natal Subject | sextile ⚹        | Makemake              | Sample Natal Subject Solar Return | 2.79° | Separating ← |
-| Venus                 | Sample Natal Subject | biquintile bQ    | Quaoar                | Sample Natal Subject Solar Return | 1.63° | Separating ← |
-| Venus                 | Sample Natal Subject | trine △          | Pars Fortunae         | Sample Natal Subject Solar Return | 3.22° | Static =     |
-| Venus                 | Sample Natal Subject | biquintile bQ    | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.23° | Applying →   |
-| Venus                 | Sample Natal Subject | sesquiquadrate ⚼ | Cupido                | Sample Natal Subject Solar Return | 1.91° | Applying →   |
-| Venus                 | Sample Natal Subject | square □         | Zeus                  | Sample Natal Subject Solar Return | 5.68° | Applying →   |
-| Venus                 | Sample Natal Subject | semi-square ∠    | Admetos               | Sample Natal Subject Solar Return | 1.75° | Applying →   |
-| Venus                 | Sample Natal Subject | trine △          | Poseidon              | Sample Natal Subject Solar Return | 3.03° | Applying →   |
-| Mars                  | Sample Natal Subject | sextile ⚹        | Venus                 | Sample Natal Subject Solar Return | 4.26° | Applying →   |
-| Mars                  | Sample Natal Subject | conjunction ☌    | Mars                  | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Mars                  | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 0.77° | Applying →   |
-| Mars                  | Sample Natal Subject | square □         | Mean North Lunar Node | Sample Natal Subject Solar Return | 1.82° | Applying →   |
-| Mars                  | Sample Natal Subject | square □         | True North Lunar Node | Sample Natal Subject Solar Return | 1.30° | Applying →   |
-| Mars                  | Sample Natal Subject | quintile Q       | Chiron                | Sample Natal Subject Solar Return | 1.91° | Separating ← |
-| Mars                  | Sample Natal Subject | opposition ☍     | Ascendant             | Sample Natal Subject Solar Return | 0.15° | Applying →   |
-| Mars                  | Sample Natal Subject | conjunction ☌    | Descendant            | Sample Natal Subject Solar Return | 0.15° | Applying →   |
-| Mars                  | Sample Natal Subject | square □         | Mean South Lunar Node | Sample Natal Subject Solar Return | 1.82° | Applying →   |
-| Mars                  | Sample Natal Subject | square □         | True South Lunar Node | Sample Natal Subject Solar Return | 1.30° | Applying →   |
-| Mars                  | Sample Natal Subject | sextile ⚹        | Pholus                | Sample Natal Subject Solar Return | 2.02° | Separating ← |
-| Mars                  | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 1.28° | Separating ← |
-| Mars                  | Sample Natal Subject | opposition ☍     | Juno                  | Sample Natal Subject Solar Return | 4.13° | Separating ← |
-| Mars                  | Sample Natal Subject | conjunction ☌    | Sedna                 | Sample Natal Subject Solar Return | 5.58° | Separating ← |
-| Mars                  | Sample Natal Subject | trine △          | Makemake              | Sample Natal Subject Solar Return | 1.47° | Applying →   |
-| Mars                  | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 4.87° | Separating ← |
-| Mars                  | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Sample Natal Subject Solar Return | 2.25° | Static =     |
-| Mars                  | Sample Natal Subject | biquintile bQ    | Anti Vertex           | Sample Natal Subject Solar Return | 0.51° | Static =     |
-| Mars                  | Sample Natal Subject | semi-square ∠    | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.02° | Separating ← |
-| Mars                  | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 0.93° | Separating ← |
+| Sun                   | Sample Natal Subject | opposition ☍     | Saturn                | Sample Natal Subject Solar Return | 5.35° | Applying →   |
+| Sun                   | Sample Natal Subject | conjunction ☌    | Chiron                | Sample Natal Subject Solar Return | 1.47° | Separating ← |
+| Sun                   | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 1.75° | Applying →   |
+| Sun                   | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 1.20° | Applying →   |
+| Sun                   | Sample Natal Subject | opposition ☍     | Juno                  | Sample Natal Subject Solar Return | 5.77° | Separating ← |
+| Sun                   | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 1.29° | Applying →   |
+| Sun                   | Sample Natal Subject | trine △          | Ixion                 | Sample Natal Subject Solar Return | 4.80° | Separating ← |
+| Sun                   | Sample Natal Subject | trine △          | Quaoar                | Sample Natal Subject Solar Return | 3.21° | Separating ← |
+| Sun                   | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Sample Natal Subject Solar Return | 0.03° | Static =     |
+| Sun                   | Sample Natal Subject | semi-sextile ⚺   | Vertex                | Sample Natal Subject Solar Return | 1.85° | Static =     |
+| Sun                   | Sample Natal Subject | quincunx ⚻       | Anti Vertex           | Sample Natal Subject Solar Return | 1.85° | Static =     |
+| Sun                   | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 1.72° | Applying →   |
+| Sun                   | Sample Natal Subject | quintile Q       | Admetos               | Sample Natal Subject Solar Return | 1.00° | Applying →   |
+| Sun                   | Sample Natal Subject | square □         | Poseidon              | Sample Natal Subject Solar Return | 0.62° | Separating ← |
+| Moon                  | Sample Natal Subject | sesquiquadrate ⚼ | Moon                  | Sample Natal Subject Solar Return | 1.58° | Applying →   |
+| Moon                  | Sample Natal Subject | semi-square ∠    | Venus                 | Sample Natal Subject Solar Return | 0.90° | Applying →   |
+| Moon                  | Sample Natal Subject | trine △          | Pluto                 | Sample Natal Subject Solar Return | 3.63° | Separating ← |
+| Moon                  | Sample Natal Subject | opposition ☍     | Mean North Lunar Node | Sample Natal Subject Solar Return | 2.76° | Separating ← |
+| Moon                  | Sample Natal Subject | opposition ☍     | True North Lunar Node | Sample Natal Subject Solar Return | 2.27° | Applying →   |
+| Moon                  | Sample Natal Subject | trine △          | Medium Coeli          | Sample Natal Subject Solar Return | 0.56° | Separating ← |
+| Moon                  | Sample Natal Subject | sextile ⚹        | Imum Coeli            | Sample Natal Subject Solar Return | 0.56° | Separating ← |
+| Moon                  | Sample Natal Subject | conjunction ☌    | Mean South Lunar Node | Sample Natal Subject Solar Return | 2.76° | Separating ← |
+| Moon                  | Sample Natal Subject | conjunction ☌    | True South Lunar Node | Sample Natal Subject Solar Return | 2.27° | Applying →   |
+| Moon                  | Sample Natal Subject | conjunction ☌    | Pholus                | Sample Natal Subject Solar Return | 1.18° | Separating ← |
+| Moon                  | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 5.58° | Separating ← |
+| Moon                  | Sample Natal Subject | opposition ☍     | Juno                  | Sample Natal Subject Solar Return | 1.56° | Applying →   |
+| Moon                  | Sample Natal Subject | conjunction ☌    | Vesta                 | Sample Natal Subject Solar Return | 1.17° | Separating ← |
+| Moon                  | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 3.38° | Separating ← |
+| Moon                  | Sample Natal Subject | semi-square ∠    | Makemake              | Sample Natal Subject Solar Return | 0.66° | Applying →   |
+| Moon                  | Sample Natal Subject | trine △          | Ixion                 | Sample Natal Subject Solar Return | 2.53° | Applying →   |
+| Moon                  | Sample Natal Subject | trine △          | Quaoar                | Sample Natal Subject Solar Return | 4.13° | Applying →   |
+| Moon                  | Sample Natal Subject | sextile ⚹        | Pars Fortunae         | Sample Natal Subject Solar Return | 1.30° | Static =     |
+| Moon                  | Sample Natal Subject | semi-square ∠    | Pars Spiritus         | Sample Natal Subject Solar Return | 1.52° | Static =     |
+| Moon                  | Sample Natal Subject | quincunx ⚻       | Pars Amoris           | Sample Natal Subject Solar Return | 0.62° | Static =     |
+| Moon                  | Sample Natal Subject | biquintile bQ    | Anti Vertex           | Sample Natal Subject Solar Return | 0.52° | Static =     |
+| Moon                  | Sample Natal Subject | conjunction ☌    | Interpolated Perigee  | Sample Natal Subject Solar Return | 2.73° | Applying →   |
+| Moon                  | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 3.34° | Applying →   |
+| Moon                  | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 1.19° | Separating ← |
+| Moon                  | Sample Natal Subject | semi-sextile ⚺   | Kronos                | Sample Natal Subject Solar Return | 1.38° | Separating ← |
+| Moon                  | Sample Natal Subject | conjunction ☌    | Vulkanus              | Sample Natal Subject Solar Return | 5.33° | Applying →   |
+| Mercury               | Sample Natal Subject | conjunction ☌    | Jupiter               | Sample Natal Subject Solar Return | 1.03° | Separating ← |
+| Mercury               | Sample Natal Subject | biquintile bQ    | Uranus                | Sample Natal Subject Solar Return | 0.47° | Separating ← |
+| Mercury               | Sample Natal Subject | square □         | Pluto                 | Sample Natal Subject Solar Return | 0.03° | Separating ← |
+| Mercury               | Sample Natal Subject | quincunx ⚻       | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.84° | Applying →   |
+| Mercury               | Sample Natal Subject | quincunx ⚻       | True North Lunar Node | Sample Natal Subject Solar Return | 1.33° | Separating ← |
+| Mercury               | Sample Natal Subject | square □         | Medium Coeli          | Sample Natal Subject Solar Return | 4.16° | Separating ← |
+| Mercury               | Sample Natal Subject | square □         | Imum Coeli            | Sample Natal Subject Solar Return | 4.16° | Separating ← |
+| Mercury               | Sample Natal Subject | biquintile bQ    | Mean Lilith           | Sample Natal Subject Solar Return | 1.97° | Applying →   |
+| Mercury               | Sample Natal Subject | semi-sextile ⚺   | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.84° | Applying →   |
+| Mercury               | Sample Natal Subject | semi-sextile ⚺   | True South Lunar Node | Sample Natal Subject Solar Return | 1.33° | Separating ← |
+| Mercury               | Sample Natal Subject | sesquiquadrate ⚼ | True Lilith           | Sample Natal Subject Solar Return | 1.57° | Applying →   |
+| Mercury               | Sample Natal Subject | trine △          | Eris                  | Sample Natal Subject Solar Return | 0.22° | Applying →   |
+| Mercury               | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 5.55° | Applying →   |
+| Mercury               | Sample Natal Subject | conjunction ☌    | Orcus                 | Sample Natal Subject Solar Return | 5.76° | Applying →   |
+| Mercury               | Sample Natal Subject | square □         | Pars Fortunae         | Sample Natal Subject Solar Return | 2.30° | Static =     |
+| Mercury               | Sample Natal Subject | opposition ☍     | Pars Amoris           | Sample Natal Subject Solar Return | 2.98° | Static =     |
+| Mercury               | Sample Natal Subject | semi-square ∠    | True Priapus          | Sample Natal Subject Solar Return | 1.57° | Applying →   |
+| Mercury               | Sample Natal Subject | semi-sextile ⚺   | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.87° | Separating ← |
+| Mercury               | Sample Natal Subject | semi-sextile ⚺   | White Moon            | Sample Natal Subject Solar Return | 0.26° | Separating ← |
+| Mercury               | Sample Natal Subject | square □         | Cupido                | Sample Natal Subject Solar Return | 2.41° | Applying →   |
+| Mercury               | Sample Natal Subject | sextile ⚹        | Kronos                | Sample Natal Subject Solar Return | 4.98° | Separating ← |
+| Mercury               | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 3.16° | Applying →   |
+| Mercury               | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 2.07° | Applying →   |
+| Mercury               | Sample Natal Subject | semi-sextile ⚺   | Vulkanus              | Sample Natal Subject Solar Return | 1.73° | Applying →   |
+| Mercury               | Sample Natal Subject | quintile Q       | Poseidon              | Sample Natal Subject Solar Return | 0.44° | Applying →   |
+| Venus                 | Sample Natal Subject | sextile ⚹        | Venus                 | Sample Natal Subject Solar Return | 3.60° | Separating ← |
+| Venus                 | Sample Natal Subject | sextile ⚹        | Mars                  | Sample Natal Subject Solar Return | 2.17° | Separating ← |
+| Venus                 | Sample Natal Subject | semi-square ∠    | Jupiter               | Sample Natal Subject Solar Return | 1.93° | Separating ← |
+| Venus                 | Sample Natal Subject | sesquiquadrate ⚼ | Pluto                 | Sample Natal Subject Solar Return | 0.87° | Applying →   |
+| Venus                 | Sample Natal Subject | semi-sextile ⚺   | Chiron                | Sample Natal Subject Solar Return | 1.69° | Applying →   |
+| Venus                 | Sample Natal Subject | opposition ☍     | True Lilith           | Sample Natal Subject Solar Return | 0.67° | Applying →   |
+| Venus                 | Sample Natal Subject | trine △          | Ceres                 | Sample Natal Subject Solar Return | 4.92° | Applying →   |
+| Venus                 | Sample Natal Subject | square □         | Pallas                | Sample Natal Subject Solar Return | 4.37° | Applying →   |
+| Venus                 | Sample Natal Subject | quintile Q       | Eris                  | Sample Natal Subject Solar Return | 1.88° | Separating ← |
+| Venus                 | Sample Natal Subject | square □         | Haumea                | Sample Natal Subject Solar Return | 4.46° | Applying →   |
+| Venus                 | Sample Natal Subject | sextile ⚹        | Makemake              | Sample Natal Subject Solar Return | 3.84° | Separating ← |
+| Venus                 | Sample Natal Subject | biquintile bQ    | Ixion                 | Sample Natal Subject Solar Return | 1.97° | Separating ← |
+| Venus                 | Sample Natal Subject | biquintile bQ    | Quaoar                | Sample Natal Subject Solar Return | 0.37° | Separating ← |
+| Venus                 | Sample Natal Subject | trine △          | Anti Vertex           | Sample Natal Subject Solar Return | 5.02° | Static =     |
+| Venus                 | Sample Natal Subject | opposition ☍     | Interpolated Lilith   | Sample Natal Subject Solar Return | 4.27° | Separating ← |
+| Venus                 | Sample Natal Subject | conjunction ☌    | True Priapus          | Sample Natal Subject Solar Return | 0.67° | Applying →   |
+| Venus                 | Sample Natal Subject | square □         | Zeus                  | Sample Natal Subject Solar Return | 4.88° | Applying →   |
+| Venus                 | Sample Natal Subject | semi-square ∠    | Admetos               | Sample Natal Subject Solar Return | 1.17° | Applying →   |
+| Venus                 | Sample Natal Subject | trine △          | Poseidon              | Sample Natal Subject Solar Return | 2.54° | Applying →   |
+| Mars                  | Sample Natal Subject | quincunx ⚻       | Moon                  | Sample Natal Subject Solar Return | 1.33° | Applying →   |
+| Mars                  | Sample Natal Subject | trine △          | Venus                 | Sample Natal Subject Solar Return | 0.66° | Applying →   |
+| Mars                  | Sample Natal Subject | trine △          | Mars                  | Sample Natal Subject Solar Return | 2.09° | Applying →   |
+| Mars                  | Sample Natal Subject | square □         | Saturn                | Sample Natal Subject Solar Return | 2.07° | Separating ← |
+| Mars                  | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 5.17° | Applying →   |
+| Mars                  | Sample Natal Subject | square □         | Chiron                | Sample Natal Subject Solar Return | 5.95° | Applying →   |
+| Mars                  | Sample Natal Subject | trine △          | Mean Lilith           | Sample Natal Subject Solar Return | 3.67° | Separating ← |
+| Mars                  | Sample Natal Subject | quintile Q       | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.48° | Applying →   |
+| Mars                  | Sample Natal Subject | quintile Q       | True South Lunar Node | Sample Natal Subject Solar Return | 0.97° | Separating ← |
+| Mars                  | Sample Natal Subject | trine △          | True Lilith           | Sample Natal Subject Solar Return | 4.93° | Applying →   |
+| Mars                  | Sample Natal Subject | trine △          | Makemake              | Sample Natal Subject Solar Return | 0.42° | Applying →   |
+| Mars                  | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 5.88° | Separating ← |
+| Mars                  | Sample Natal Subject | trine △          | Pars Spiritus         | Sample Natal Subject Solar Return | 1.77° | Static =     |
+| Mars                  | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.01° | Separating ← |
+| Mars                  | Sample Natal Subject | sextile ⚹        | Mean Priapus          | Sample Natal Subject Solar Return | 3.67° | Separating ← |
+| Mars                  | Sample Natal Subject | sextile ⚹        | True Priapus          | Sample Natal Subject Solar Return | 4.93° | Applying →   |
+| Mars                  | Sample Natal Subject | quintile Q       | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.51° | Separating ← |
+| Mars                  | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 1.62° | Separating ← |
 | Jupiter               | Sample Natal Subject | conjunction ☌    | Sun                   | Sample Natal Subject Solar Return | 4.63° | Separating ← |
-| Jupiter               | Sample Natal Subject | conjunction ☌    | Moon                  | Sample Natal Subject Solar Return | 2.70° | Applying →   |
-| Jupiter               | Sample Natal Subject | conjunction ☌    | Jupiter               | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Jupiter               | Sample Natal Subject | opposition ☍     | Saturn                | Sample Natal Subject Solar Return | 2.40° | Separating ← |
-| Jupiter               | Sample Natal Subject | conjunction ☌    | Chiron                | Sample Natal Subject Solar Return | 4.03° | Applying →   |
-| Jupiter               | Sample Natal Subject | trine △          | Mean Lilith           | Sample Natal Subject Solar Return | 5.08° | Separating ← |
-| Jupiter               | Sample Natal Subject | biquintile bQ    | True Lilith           | Sample Natal Subject Solar Return | 0.10° | Applying →   |
-| Jupiter               | Sample Natal Subject | quintile Q       | Sedna                 | Sample Natal Subject Solar Return | 0.36° | Applying →   |
-| Jupiter               | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 2.41° | Separating ← |
-| Jupiter               | Sample Natal Subject | trine △          | Ixion                 | Sample Natal Subject Solar Return | 1.21° | Separating ← |
-| Jupiter               | Sample Natal Subject | trine △          | Quaoar                | Sample Natal Subject Solar Return | 0.16° | Applying →   |
-| Jupiter               | Sample Natal Subject | square □         | Pars Fortunae         | Sample Natal Subject Solar Return | 4.57° | Static =     |
-| Jupiter               | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.56° | Separating ← |
-| Jupiter               | Sample Natal Subject | conjunction ☌    | White Moon            | Sample Natal Subject Solar Return | 2.52° | Separating ← |
-| Jupiter               | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 5.29° | Separating ← |
-| Jupiter               | Sample Natal Subject | semi-square ∠    | Hades                 | Sample Natal Subject Solar Return | 1.01° | Separating ← |
-| Jupiter               | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 2.12° | Separating ← |
-| Jupiter               | Sample Natal Subject | square □         | Poseidon              | Sample Natal Subject Solar Return | 4.77° | Separating ← |
-| Saturn                | Sample Natal Subject | opposition ☍     | Moon                  | Sample Natal Subject Solar Return | 0.31° | Applying →   |
-| Saturn                | Sample Natal Subject | opposition ☍     | Jupiter               | Sample Natal Subject Solar Return | 2.40° | Separating ← |
-| Saturn                | Sample Natal Subject | conjunction ☌    | Saturn                | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Saturn                | Sample Natal Subject | opposition ☍     | Chiron                | Sample Natal Subject Solar Return | 1.64° | Applying →   |
-| Saturn                | Sample Natal Subject | quincunx ⚻       | Medium Coeli          | Sample Natal Subject Solar Return | 1.61° | Applying →   |
-| Saturn                | Sample Natal Subject | semi-sextile ⚺   | Imum Coeli            | Sample Natal Subject Solar Return | 1.61° | Applying →   |
-| Saturn                | Sample Natal Subject | quintile Q       | Juno                  | Sample Natal Subject Solar Return | 0.58° | Separating ← |
-| Saturn                | Sample Natal Subject | trine △          | Vesta                 | Sample Natal Subject Solar Return | 3.37° | Applying →   |
-| Saturn                | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 3.92° | Separating ← |
-| Saturn                | Sample Natal Subject | trine △          | Haumea                | Sample Natal Subject Solar Return | 4.81° | Separating ← |
-| Saturn                | Sample Natal Subject | sextile ⚹        | Ixion                 | Sample Natal Subject Solar Return | 1.19° | Applying →   |
-| Saturn                | Sample Natal Subject | sextile ⚹        | Quaoar                | Sample Natal Subject Solar Return | 2.56° | Applying →   |
-| Saturn                | Sample Natal Subject | sextile ⚹        | Interpolated Lilith   | Sample Natal Subject Solar Return | 3.96° | Separating ← |
-| Saturn                | Sample Natal Subject | quincunx ⚻       | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.53° | Applying →   |
-| Saturn                | Sample Natal Subject | opposition ☍     | White Moon            | Sample Natal Subject Solar Return | 4.92° | Separating ← |
-| Saturn                | Sample Natal Subject | sextile ⚹        | Cupido                | Sample Natal Subject Solar Return | 2.90° | Separating ← |
-| Saturn                | Sample Natal Subject | trine △          | Zeus                  | Sample Natal Subject Solar Return | 4.51° | Separating ← |
-| Saturn                | Sample Natal Subject | quincunx ⚻       | Kronos                | Sample Natal Subject Solar Return | 0.38° | Separating ← |
-| Uranus                | Sample Natal Subject | opposition ☍     | Venus                 | Sample Natal Subject Solar Return | 5.03° | Applying →   |
-| Uranus                | Sample Natal Subject | trine △          | Mars                  | Sample Natal Subject Solar Return | 0.77° | Applying →   |
-| Uranus                | Sample Natal Subject | conjunction ☌    | Uranus                | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Uranus                | Sample Natal Subject | semi-sextile ⚺   | Mean North Lunar Node | Sample Natal Subject Solar Return | 1.05° | Applying →   |
-| Uranus                | Sample Natal Subject | semi-sextile ⚺   | True North Lunar Node | Sample Natal Subject Solar Return | 0.53° | Applying →   |
-| Uranus                | Sample Natal Subject | sextile ⚹        | Ascendant             | Sample Natal Subject Solar Return | 0.92° | Applying →   |
-| Uranus                | Sample Natal Subject | sesquiquadrate ⚼ | Medium Coeli          | Sample Natal Subject Solar Return | 1.83° | Applying →   |
-| Uranus                | Sample Natal Subject | trine △          | Descendant            | Sample Natal Subject Solar Return | 0.92° | Applying →   |
-| Uranus                | Sample Natal Subject | semi-square ∠    | Imum Coeli            | Sample Natal Subject Solar Return | 1.83° | Applying →   |
-| Uranus                | Sample Natal Subject | quincunx ⚻       | Mean South Lunar Node | Sample Natal Subject Solar Return | 1.05° | Applying →   |
-| Uranus                | Sample Natal Subject | quincunx ⚻       | True South Lunar Node | Sample Natal Subject Solar Return | 0.53° | Applying →   |
-| Uranus                | Sample Natal Subject | opposition ☍     | Pholus                | Sample Natal Subject Solar Return | 1.25° | Separating ← |
-| Uranus                | Sample Natal Subject | biquintile bQ    | Ceres                 | Sample Natal Subject Solar Return | 0.98° | Separating ← |
-| Uranus                | Sample Natal Subject | opposition ☍     | Pallas                | Sample Natal Subject Solar Return | 0.51° | Separating ← |
-| Uranus                | Sample Natal Subject | sextile ⚹        | Juno                  | Sample Natal Subject Solar Return | 3.36° | Separating ← |
-| Uranus                | Sample Natal Subject | trine △          | Sedna                 | Sample Natal Subject Solar Return | 4.81° | Separating ← |
-| Uranus                | Sample Natal Subject | trine △          | Makemake              | Sample Natal Subject Solar Return | 2.24° | Applying →   |
-| Uranus                | Sample Natal Subject | semi-square ∠    | Ixion                 | Sample Natal Subject Solar Return | 0.96° | Applying →   |
-| Uranus                | Sample Natal Subject | biquintile bQ    | Orcus                 | Sample Natal Subject Solar Return | 1.90° | Applying →   |
-| Uranus                | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 2.25° | Static =     |
-| Uranus                | Sample Natal Subject | trine △          | Pars Fidei            | Sample Natal Subject Solar Return | 1.48° | Static =     |
-| Uranus                | Sample Natal Subject | biquintile bQ    | Mean Priapus          | Sample Natal Subject Solar Return | 1.75° | Applying →   |
-| Neptune               | Sample Natal Subject | biquintile bQ    | Mercury               | Sample Natal Subject Solar Return | 1.15° | Applying →   |
-| Neptune               | Sample Natal Subject | conjunction ☌    | Neptune               | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Neptune               | Sample Natal Subject | sextile ⚹        | Pluto                 | Sample Natal Subject Solar Return | 2.21° | Applying →   |
-| Neptune               | Sample Natal Subject | biquintile bQ    | Medium Coeli          | Sample Natal Subject Solar Return | 1.15° | Separating ← |
-| Neptune               | Sample Natal Subject | semi-square ∠    | Mean Lilith           | Sample Natal Subject Solar Return | 1.23° | Separating ← |
-| Neptune               | Sample Natal Subject | opposition ☍     | Pholus                | Sample Natal Subject Solar Return | 4.77° | Applying →   |
-| Neptune               | Sample Natal Subject | quincunx ⚻       | Ceres                 | Sample Natal Subject Solar Return | 0.95° | Separating ← |
-| Neptune               | Sample Natal Subject | opposition ☍     | Pallas                | Sample Natal Subject Solar Return | 5.51° | Applying →   |
-| Neptune               | Sample Natal Subject | sextile ⚹        | Juno                  | Sample Natal Subject Solar Return | 2.67° | Applying →   |
-| Neptune               | Sample Natal Subject | trine △          | Vesta                 | Sample Natal Subject Solar Return | 5.38° | Separating ← |
-| Neptune               | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 4.83° | Applying →   |
-| Neptune               | Sample Natal Subject | trine △          | Sedna                 | Sample Natal Subject Solar Return | 1.21° | Applying →   |
-| Neptune               | Sample Natal Subject | quincunx ⚻       | Orcus                 | Sample Natal Subject Solar Return | 1.92° | Applying →   |
-| Neptune               | Sample Natal Subject | sextile ⚹        | Pars Spiritus         | Sample Natal Subject Solar Return | 0.39° | Static =     |
-| Neptune               | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 3.78° | Static =     |
-| Neptune               | Sample Natal Subject | trine △          | Pars Fidei            | Sample Natal Subject Solar Return | 4.55° | Static =     |
-| Neptune               | Sample Natal Subject | quincunx ⚻       | Vertex                | Sample Natal Subject Solar Return | 1.30° | Static =     |
-| Neptune               | Sample Natal Subject | semi-sextile ⚺   | Anti Vertex           | Sample Natal Subject Solar Return | 1.30° | Static =     |
-| Neptune               | Sample Natal Subject | sesquiquadrate ⚼ | Mean Priapus          | Sample Natal Subject Solar Return | 1.23° | Separating ← |
-| Neptune               | Sample Natal Subject | square □         | Apollon               | Sample Natal Subject Solar Return | 1.06° | Separating ← |
-| Neptune               | Sample Natal Subject | trine △          | Admetos               | Sample Natal Subject Solar Return | 2.20° | Separating ← |
-| Neptune               | Sample Natal Subject | opposition ☍     | Vulkanus              | Sample Natal Subject Solar Return | 2.58° | Separating ← |
-| Pluto                 | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 2.63° | Separating ← |
-| Pluto                 | Sample Natal Subject | sesquiquadrate ⚼ | Venus                 | Sample Natal Subject Solar Return | 1.73° | Separating ← |
-| Pluto                 | Sample Natal Subject | sextile ⚹        | Neptune               | Sample Natal Subject Solar Return | 2.21° | Separating ← |
-| Pluto                 | Sample Natal Subject | conjunction ☌    | Pluto                 | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Pluto                 | Sample Natal Subject | trine △          | Chiron                | Sample Natal Subject Solar Return | 4.91° | Separating ← |
-| Pluto                 | Sample Natal Subject | square □         | Medium Coeli          | Sample Natal Subject Solar Return | 4.94° | Separating ← |
-| Pluto                 | Sample Natal Subject | square □         | Imum Coeli            | Sample Natal Subject Solar Return | 4.94° | Separating ← |
-| Pluto                 | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 1.26° | Applying →   |
-| Pluto                 | Sample Natal Subject | conjunction ☌    | Juno                  | Sample Natal Subject Solar Return | 4.88° | Applying →   |
-| Pluto                 | Sample Natal Subject | opposition ☍     | Vesta                 | Sample Natal Subject Solar Return | 3.17° | Separating ← |
-| Pluto                 | Sample Natal Subject | opposition ☍     | Sedna                 | Sample Natal Subject Solar Return | 3.43° | Applying →   |
-| Pluto                 | Sample Natal Subject | quintile Q       | Makemake              | Sample Natal Subject Solar Return | 1.52° | Separating ← |
-| Pluto                 | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 4.13° | Applying →   |
-| Pluto                 | Sample Natal Subject | conjunction ☌    | Pars Spiritus         | Sample Natal Subject Solar Return | 1.82° | Static =     |
-| Pluto                 | Sample Natal Subject | biquintile bQ    | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.01° | Separating ← |
-| Pluto                 | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 3.64° | Applying →   |
-| Pluto                 | Sample Natal Subject | biquintile bQ    | Kronos                | Sample Natal Subject Solar Return | 0.92° | Separating ← |
-| Pluto                 | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Sample Natal Subject Solar Return | 1.15° | Applying →   |
-| Pluto                 | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 0.02° | Applying →   |
-| Pluto                 | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 0.37° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | biquintile bQ    | Venus                 | Sample Natal Subject Solar Return | 0.08° | Applying →   |
-| Mean North Lunar Node | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 1.82° | Applying →   |
-| Mean North Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Uranus                | Sample Natal Subject Solar Return | 1.05° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | conjunction ☌    | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | conjunction ☌    | True North Lunar Node | Sample Natal Subject Solar Return | 0.52° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | square □         | Ascendant             | Sample Natal Subject Solar Return | 1.97° | Applying →   |
-| Mean North Lunar Node | Sample Natal Subject | square □         | Descendant            | Sample Natal Subject Solar Return | 1.97° | Applying →   |
-| Mean North Lunar Node | Sample Natal Subject | opposition ☍     | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | opposition ☍     | True South Lunar Node | Sample Natal Subject Solar Return | 0.52° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | quincunx ⚻       | Pholus                | Sample Natal Subject Solar Return | 0.20° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | opposition ☍     | Ceres                 | Sample Natal Subject Solar Return | 5.93° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | quincunx ⚻       | Pallas                | Sample Natal Subject Solar Return | 0.54° | Applying →   |
-| Mean North Lunar Node | Sample Natal Subject | square □         | Juno                  | Sample Natal Subject Solar Return | 2.31° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 3.76° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | opposition ☍     | Orcus                 | Sample Natal Subject Solar Return | 3.05° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | quintile Q       | Quaoar                | Sample Natal Subject Solar Return | 1.71° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | square □         | Pars Spiritus         | Sample Natal Subject Solar Return | 5.36° | Static =     |
-| Mean North Lunar Node | Sample Natal Subject | trine △          | Pars Amoris           | Sample Natal Subject Solar Return | 1.20° | Static =     |
-| Mean North Lunar Node | Sample Natal Subject | square □         | Pars Fidei            | Sample Natal Subject Solar Return | 0.43° | Static =     |
-| Mean North Lunar Node | Sample Natal Subject | trine △          | Vertex                | Sample Natal Subject Solar Return | 3.67° | Static =     |
-| Mean North Lunar Node | Sample Natal Subject | sextile ⚹        | Anti Vertex           | Sample Natal Subject Solar Return | 3.67° | Static =     |
-| Mean North Lunar Node | Sample Natal Subject | quintile Q       | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.31° | Applying →   |
-| Mean North Lunar Node | Sample Natal Subject | sesquiquadrate ⚼ | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.81° | Applying →   |
-| Mean North Lunar Node | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 2.13° | Separating ← |
-| Mean North Lunar Node | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | Sample Natal Subject Solar Return | 0.89° | Applying →   |
-| True North Lunar Node | Sample Natal Subject | biquintile bQ    | Venus                 | Sample Natal Subject Solar Return | 0.44° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 1.30° | Applying →   |
-| True North Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Uranus                | Sample Natal Subject Solar Return | 0.53° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | conjunction ☌    | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.52° | Applying →   |
-| True North Lunar Node | Sample Natal Subject | conjunction ☌    | True North Lunar Node | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | square □         | Ascendant             | Sample Natal Subject Solar Return | 1.45° | Applying →   |
-| True North Lunar Node | Sample Natal Subject | square □         | Descendant            | Sample Natal Subject Solar Return | 1.45° | Applying →   |
-| True North Lunar Node | Sample Natal Subject | opposition ☍     | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.52° | Applying →   |
-| True North Lunar Node | Sample Natal Subject | opposition ☍     | True South Lunar Node | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | quincunx ⚻       | Pholus                | Sample Natal Subject Solar Return | 0.73° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | quincunx ⚻       | Pallas                | Sample Natal Subject Solar Return | 0.02° | Applying →   |
-| True North Lunar Node | Sample Natal Subject | square □         | Juno                  | Sample Natal Subject Solar Return | 2.83° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | quintile Q       | Eris                  | Sample Natal Subject Solar Return | 1.67° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 4.28° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | opposition ☍     | Orcus                 | Sample Natal Subject Solar Return | 3.57° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | quintile Q       | Quaoar                | Sample Natal Subject Solar Return | 1.19° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | square □         | Pars Spiritus         | Sample Natal Subject Solar Return | 5.89° | Static =     |
-| True North Lunar Node | Sample Natal Subject | trine △          | Pars Amoris           | Sample Natal Subject Solar Return | 1.72° | Static =     |
-| True North Lunar Node | Sample Natal Subject | square □         | Pars Fidei            | Sample Natal Subject Solar Return | 0.95° | Static =     |
-| True North Lunar Node | Sample Natal Subject | trine △          | Vertex                | Sample Natal Subject Solar Return | 4.20° | Static =     |
-| True North Lunar Node | Sample Natal Subject | sextile ⚹        | Anti Vertex           | Sample Natal Subject Solar Return | 4.20° | Static =     |
-| True North Lunar Node | Sample Natal Subject | quintile Q       | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.21° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | sesquiquadrate ⚼ | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.28° | Applying →   |
-| True North Lunar Node | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 2.66° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | Sample Natal Subject Solar Return | 0.37° | Applying →   |
-| Chiron                | Sample Natal Subject | conjunction ☌    | Moon                  | Sample Natal Subject Solar Return | 1.33° | Separating ← |
-| Chiron                | Sample Natal Subject | quintile Q       | Mars                  | Sample Natal Subject Solar Return | 1.91° | Applying →   |
-| Chiron                | Sample Natal Subject | conjunction ☌    | Jupiter               | Sample Natal Subject Solar Return | 4.03° | Separating ← |
-| Chiron                | Sample Natal Subject | opposition ☍     | Saturn                | Sample Natal Subject Solar Return | 1.64° | Applying →   |
-| Chiron                | Sample Natal Subject | trine △          | Pluto                 | Sample Natal Subject Solar Return | 4.91° | Separating ← |
-| Chiron                | Sample Natal Subject | conjunction ☌    | Chiron                | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Chiron                | Sample Natal Subject | semi-sextile ⚺   | Medium Coeli          | Sample Natal Subject Solar Return | 0.03° | Separating ← |
-| Chiron                | Sample Natal Subject | quincunx ⚻       | Imum Coeli            | Sample Natal Subject Solar Return | 0.03° | Separating ← |
-| Chiron                | Sample Natal Subject | quincunx ⚻       | True Lilith           | Sample Natal Subject Solar Return | 1.87° | Separating ← |
-| Chiron                | Sample Natal Subject | sextile ⚹        | Vesta                 | Sample Natal Subject Solar Return | 1.73° | Applying →   |
-| Chiron                | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 2.28° | Separating ← |
-| Chiron                | Sample Natal Subject | semi-square ∠    | Makemake              | Sample Natal Subject Solar Return | 0.38° | Applying →   |
-| Chiron                | Sample Natal Subject | trine △          | Ixion                 | Sample Natal Subject Solar Return | 2.82° | Applying →   |
-| Chiron                | Sample Natal Subject | trine △          | Quaoar                | Sample Natal Subject Solar Return | 4.20° | Applying →   |
-| Chiron                | Sample Natal Subject | quintile Q       | Pars Fidei            | Sample Natal Subject Solar Return | 0.33° | Static =     |
-| Chiron                | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 5.60° | Separating ← |
-| Chiron                | Sample Natal Subject | semi-sextile ⚺   | True Priapus          | Sample Natal Subject Solar Return | 1.87° | Separating ← |
-| Chiron                | Sample Natal Subject | semi-sextile ⚺   | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.10° | Separating ← |
-| Chiron                | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 1.26° | Separating ← |
-| Chiron                | Sample Natal Subject | sextile ⚹        | Admetos               | Sample Natal Subject Solar Return | 4.92° | Applying →   |
-| Chiron                | Sample Natal Subject | conjunction ☌    | Vulkanus              | Sample Natal Subject Solar Return | 4.54° | Applying →   |
-| Ascendant             | Sample Natal Subject | trine △          | Venus                 | Sample Natal Subject Solar Return | 4.11° | Applying →   |
-| Ascendant             | Sample Natal Subject | opposition ☍     | Mars                  | Sample Natal Subject Solar Return | 0.15° | Separating ← |
-| Ascendant             | Sample Natal Subject | sextile ⚹        | Uranus                | Sample Natal Subject Solar Return | 0.92° | Applying →   |
-| Ascendant             | Sample Natal Subject | square □         | Mean North Lunar Node | Sample Natal Subject Solar Return | 1.97° | Applying →   |
-| Ascendant             | Sample Natal Subject | square □         | True North Lunar Node | Sample Natal Subject Solar Return | 1.44° | Applying →   |
-| Ascendant             | Sample Natal Subject | conjunction ☌    | Ascendant             | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Ascendant             | Sample Natal Subject | opposition ☍     | Descendant            | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Ascendant             | Sample Natal Subject | square □         | Mean South Lunar Node | Sample Natal Subject Solar Return | 1.97° | Applying →   |
-| Ascendant             | Sample Natal Subject | square □         | True South Lunar Node | Sample Natal Subject Solar Return | 1.44° | Applying →   |
-| Ascendant             | Sample Natal Subject | trine △          | Pholus                | Sample Natal Subject Solar Return | 2.17° | Separating ← |
-| Ascendant             | Sample Natal Subject | trine △          | Pallas                | Sample Natal Subject Solar Return | 1.43° | Separating ← |
-| Ascendant             | Sample Natal Subject | conjunction ☌    | Juno                  | Sample Natal Subject Solar Return | 4.27° | Separating ← |
-| Ascendant             | Sample Natal Subject | opposition ☍     | Sedna                 | Sample Natal Subject Solar Return | 5.73° | Separating ← |
-| Ascendant             | Sample Natal Subject | sextile ⚹        | Makemake              | Sample Natal Subject Solar Return | 1.32° | Applying →   |
-| Ascendant             | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 5.02° | Separating ← |
-| Ascendant             | Sample Natal Subject | opposition ☍     | Pars Fidei            | Sample Natal Subject Solar Return | 2.39° | Static =     |
-| Ascendant             | Sample Natal Subject | biquintile bQ    | Vertex                | Sample Natal Subject Solar Return | 0.36° | Static =     |
-| Ascendant             | Sample Natal Subject | sesquiquadrate ⚼ | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.16° | Separating ← |
-| Ascendant             | Sample Natal Subject | biquintile bQ    | Hades                 | Sample Natal Subject Solar Return | 1.90° | Applying →   |
-| Ascendant             | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | Sample Natal Subject Solar Return | 1.07° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | semi-sextile ⚺   | Moon                  | Sample Natal Subject Solar Return | 1.29° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | conjunction ☌    | Mercury               | Sample Natal Subject Solar Return | 2.31° | Applying →   |
-| Medium Coeli          | Sample Natal Subject | quincunx ⚻       | Saturn                | Sample Natal Subject Solar Return | 1.60° | Applying →   |
-| Medium Coeli          | Sample Natal Subject | sesquiquadrate ⚼ | Uranus                | Sample Natal Subject Solar Return | 1.82° | Applying →   |
-| Medium Coeli          | Sample Natal Subject | biquintile bQ    | Neptune               | Sample Natal Subject Solar Return | 1.15° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | square □         | Pluto                 | Sample Natal Subject Solar Return | 4.94° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | semi-sextile ⚺   | Chiron                | Sample Natal Subject Solar Return | 0.03° | Applying →   |
-| Medium Coeli          | Sample Natal Subject | conjunction ☌    | Medium Coeli          | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Medium Coeli          | Sample Natal Subject | opposition ☍     | Imum Coeli            | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Medium Coeli          | Sample Natal Subject | trine △          | True Lilith           | Sample Natal Subject Solar Return | 1.90° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | square □         | Vesta                 | Sample Natal Subject Solar Return | 1.77° | Applying →   |
-| Medium Coeli          | Sample Natal Subject | trine △          | Eris                  | Sample Natal Subject Solar Return | 2.32° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | square □         | Ixion                 | Sample Natal Subject Solar Return | 2.79° | Applying →   |
-| Medium Coeli          | Sample Natal Subject | square □         | Quaoar                | Sample Natal Subject Solar Return | 4.16° | Applying →   |
-| Medium Coeli          | Sample Natal Subject | square □         | Interpolated Lilith   | Sample Natal Subject Solar Return | 5.56° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | sextile ⚹        | True Priapus          | Sample Natal Subject Solar Return | 1.90° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.07° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | square □         | Cupido                | Sample Natal Subject Solar Return | 1.30° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | sextile ⚹        | Kronos                | Sample Natal Subject Solar Return | 1.98° | Separating ← |
-| Medium Coeli          | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 4.96° | Applying →   |
-| Descendant            | Sample Natal Subject | sextile ⚹        | Venus                 | Sample Natal Subject Solar Return | 4.11° | Applying →   |
-| Descendant            | Sample Natal Subject | conjunction ☌    | Mars                  | Sample Natal Subject Solar Return | 0.15° | Separating ← |
-| Descendant            | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 0.92° | Applying →   |
-| Descendant            | Sample Natal Subject | square □         | Mean North Lunar Node | Sample Natal Subject Solar Return | 1.97° | Applying →   |
-| Descendant            | Sample Natal Subject | square □         | True North Lunar Node | Sample Natal Subject Solar Return | 1.44° | Applying →   |
-| Descendant            | Sample Natal Subject | opposition ☍     | Ascendant             | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Descendant            | Sample Natal Subject | conjunction ☌    | Descendant            | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Descendant            | Sample Natal Subject | square □         | Mean South Lunar Node | Sample Natal Subject Solar Return | 1.97° | Applying →   |
-| Descendant            | Sample Natal Subject | square □         | True South Lunar Node | Sample Natal Subject Solar Return | 1.44° | Applying →   |
-| Descendant            | Sample Natal Subject | sextile ⚹        | Pholus                | Sample Natal Subject Solar Return | 2.17° | Separating ← |
-| Descendant            | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 1.43° | Separating ← |
-| Descendant            | Sample Natal Subject | opposition ☍     | Juno                  | Sample Natal Subject Solar Return | 4.27° | Separating ← |
-| Descendant            | Sample Natal Subject | conjunction ☌    | Sedna                 | Sample Natal Subject Solar Return | 5.73° | Separating ← |
-| Descendant            | Sample Natal Subject | trine △          | Makemake              | Sample Natal Subject Solar Return | 1.32° | Applying →   |
-| Descendant            | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 5.02° | Separating ← |
-| Descendant            | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Sample Natal Subject Solar Return | 2.39° | Static =     |
-| Descendant            | Sample Natal Subject | biquintile bQ    | Anti Vertex           | Sample Natal Subject Solar Return | 0.36° | Static =     |
-| Descendant            | Sample Natal Subject | semi-square ∠    | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.16° | Separating ← |
-| Descendant            | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 1.07° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | quincunx ⚻       | Moon                  | Sample Natal Subject Solar Return | 1.29° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | opposition ☍     | Mercury               | Sample Natal Subject Solar Return | 2.31° | Applying →   |
-| Imum Coeli            | Sample Natal Subject | semi-sextile ⚺   | Saturn                | Sample Natal Subject Solar Return | 1.60° | Applying →   |
-| Imum Coeli            | Sample Natal Subject | semi-square ∠    | Uranus                | Sample Natal Subject Solar Return | 1.82° | Applying →   |
-| Imum Coeli            | Sample Natal Subject | square □         | Pluto                 | Sample Natal Subject Solar Return | 4.94° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | quincunx ⚻       | Chiron                | Sample Natal Subject Solar Return | 0.03° | Applying →   |
-| Imum Coeli            | Sample Natal Subject | opposition ☍     | Medium Coeli          | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Imum Coeli            | Sample Natal Subject | conjunction ☌    | Imum Coeli            | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Imum Coeli            | Sample Natal Subject | sextile ⚹        | True Lilith           | Sample Natal Subject Solar Return | 1.90° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | square □         | Vesta                 | Sample Natal Subject Solar Return | 1.77° | Applying →   |
-| Imum Coeli            | Sample Natal Subject | sextile ⚹        | Eris                  | Sample Natal Subject Solar Return | 2.32° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | biquintile bQ    | Haumea                | Sample Natal Subject Solar Return | 0.41° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | square □         | Ixion                 | Sample Natal Subject Solar Return | 2.79° | Applying →   |
-| Imum Coeli            | Sample Natal Subject | square □         | Quaoar                | Sample Natal Subject Solar Return | 4.16° | Applying →   |
-| Imum Coeli            | Sample Natal Subject | square □         | Interpolated Lilith   | Sample Natal Subject Solar Return | 5.56° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | trine △          | True Priapus          | Sample Natal Subject Solar Return | 1.90° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | trine △          | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.07° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | square □         | Cupido                | Sample Natal Subject Solar Return | 1.30° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | biquintile bQ    | Zeus                  | Sample Natal Subject Solar Return | 0.12° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | trine △          | Kronos                | Sample Natal Subject Solar Return | 1.98° | Separating ← |
-| Imum Coeli            | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 4.96° | Applying →   |
-| Imum Coeli            | Sample Natal Subject | biquintile bQ    | Vulkanus              | Sample Natal Subject Solar Return | 1.42° | Separating ← |
+| Jupiter               | Sample Natal Subject | semi-sextile ⚺   | Mercury               | Sample Natal Subject Solar Return | 1.40° | Separating ← |
+| Jupiter               | Sample Natal Subject | opposition ☍     | Mean North Lunar Node | Sample Natal Subject Solar Return | 5.46° | Separating ← |
+| Jupiter               | Sample Natal Subject | opposition ☍     | True North Lunar Node | Sample Natal Subject Solar Return | 4.97° | Applying →   |
+| Jupiter               | Sample Natal Subject | trine △          | Medium Coeli          | Sample Natal Subject Solar Return | 2.14° | Applying →   |
+| Jupiter               | Sample Natal Subject | sextile ⚹        | Imum Coeli            | Sample Natal Subject Solar Return | 2.14° | Applying →   |
+| Jupiter               | Sample Natal Subject | conjunction ☌    | Mean South Lunar Node | Sample Natal Subject Solar Return | 5.46° | Separating ← |
+| Jupiter               | Sample Natal Subject | conjunction ☌    | True South Lunar Node | Sample Natal Subject Solar Return | 4.97° | Applying →   |
+| Jupiter               | Sample Natal Subject | conjunction ☌    | Pholus                | Sample Natal Subject Solar Return | 1.52° | Applying →   |
+| Jupiter               | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 2.88° | Separating ← |
+| Jupiter               | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 3.43° | Separating ← |
+| Jupiter               | Sample Natal Subject | opposition ☍     | Juno                  | Sample Natal Subject Solar Return | 1.14° | Separating ← |
+| Jupiter               | Sample Natal Subject | conjunction ☌    | Vesta                 | Sample Natal Subject Solar Return | 1.54° | Applying →   |
+| Jupiter               | Sample Natal Subject | quintile Q       | Sedna                 | Sample Natal Subject Solar Return | 0.15° | Separating ← |
+| Jupiter               | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 3.34° | Separating ← |
+| Jupiter               | Sample Natal Subject | trine △          | Ixion                 | Sample Natal Subject Solar Return | 0.17° | Separating ← |
+| Jupiter               | Sample Natal Subject | trine △          | Quaoar                | Sample Natal Subject Solar Return | 1.42° | Applying →   |
+| Jupiter               | Sample Natal Subject | sextile ⚹        | Pars Fortunae         | Sample Natal Subject Solar Return | 4.00° | Static =     |
+| Jupiter               | Sample Natal Subject | semi-square ∠    | Pars Spiritus         | Sample Natal Subject Solar Return | 1.18° | Static =     |
+| Jupiter               | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Sample Natal Subject Solar Return | 4.66° | Static =     |
+| Jupiter               | Sample Natal Subject | conjunction ☌    | Interpolated Perigee  | Sample Natal Subject Solar Return | 5.43° | Applying →   |
+| Jupiter               | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 3.89° | Separating ← |
+| Jupiter               | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 2.91° | Separating ← |
+| Jupiter               | Sample Natal Subject | semi-sextile ⚺   | Kronos                | Sample Natal Subject Solar Return | 1.32° | Applying →   |
+| Jupiter               | Sample Natal Subject | square □         | Poseidon              | Sample Natal Subject Solar Return | 5.26° | Separating ← |
+| Saturn                | Sample Natal Subject | semi-square ∠    | Moon                  | Sample Natal Subject Solar Return | 1.88° | Applying →   |
+| Saturn                | Sample Natal Subject | sesquiquadrate ⚼ | Venus                 | Sample Natal Subject Solar Return | 1.21° | Applying →   |
+| Saturn                | Sample Natal Subject | sextile ⚹        | Pluto                 | Sample Natal Subject Solar Return | 3.94° | Separating ← |
+| Saturn                | Sample Natal Subject | conjunction ☌    | Mean North Lunar Node | Sample Natal Subject Solar Return | 3.07° | Separating ← |
+| Saturn                | Sample Natal Subject | conjunction ☌    | True North Lunar Node | Sample Natal Subject Solar Return | 2.57° | Applying →   |
+| Saturn                | Sample Natal Subject | sextile ⚹        | Medium Coeli          | Sample Natal Subject Solar Return | 0.26° | Separating ← |
+| Saturn                | Sample Natal Subject | trine △          | Imum Coeli            | Sample Natal Subject Solar Return | 0.26° | Separating ← |
+| Saturn                | Sample Natal Subject | opposition ☍     | Mean South Lunar Node | Sample Natal Subject Solar Return | 3.07° | Separating ← |
+| Saturn                | Sample Natal Subject | opposition ☍     | True South Lunar Node | Sample Natal Subject Solar Return | 2.57° | Applying →   |
+| Saturn                | Sample Natal Subject | opposition ☍     | Pholus                | Sample Natal Subject Solar Return | 0.88° | Separating ← |
+| Saturn                | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 5.28° | Separating ← |
+| Saturn                | Sample Natal Subject | trine △          | Pallas                | Sample Natal Subject Solar Return | 5.83° | Separating ← |
+| Saturn                | Sample Natal Subject | conjunction ☌    | Juno                  | Sample Natal Subject Solar Return | 1.26° | Applying →   |
+| Saturn                | Sample Natal Subject | opposition ☍     | Vesta                 | Sample Natal Subject Solar Return | 0.86° | Separating ← |
+| Saturn                | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 3.68° | Separating ← |
+| Saturn                | Sample Natal Subject | trine △          | Haumea                | Sample Natal Subject Solar Return | 5.73° | Separating ← |
+| Saturn                | Sample Natal Subject | sesquiquadrate ⚼ | Makemake              | Sample Natal Subject Solar Return | 0.97° | Applying →   |
+| Saturn                | Sample Natal Subject | sextile ⚹        | Ixion                 | Sample Natal Subject Solar Return | 2.23° | Applying →   |
+| Saturn                | Sample Natal Subject | sextile ⚹        | Quaoar                | Sample Natal Subject Solar Return | 3.82° | Applying →   |
+| Saturn                | Sample Natal Subject | trine △          | Pars Fortunae         | Sample Natal Subject Solar Return | 1.60° | Static =     |
+| Saturn                | Sample Natal Subject | sesquiquadrate ⚼ | Pars Spiritus         | Sample Natal Subject Solar Return | 1.22° | Static =     |
+| Saturn                | Sample Natal Subject | semi-sextile ⚺   | Pars Amoris           | Sample Natal Subject Solar Return | 0.93° | Static =     |
+| Saturn                | Sample Natal Subject | biquintile bQ    | Vertex                | Sample Natal Subject Solar Return | 0.82° | Static =     |
+| Saturn                | Sample Natal Subject | opposition ☍     | Interpolated Perigee  | Sample Natal Subject Solar Return | 3.04° | Applying →   |
+| Saturn                | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 3.65° | Applying →   |
+| Saturn                | Sample Natal Subject | sextile ⚹        | Cupido                | Sample Natal Subject Solar Return | 1.50° | Separating ← |
+| Saturn                | Sample Natal Subject | trine △          | Zeus                  | Sample Natal Subject Solar Return | 5.31° | Separating ← |
+| Saturn                | Sample Natal Subject | quincunx ⚻       | Kronos                | Sample Natal Subject Solar Return | 1.07° | Separating ← |
+| Saturn                | Sample Natal Subject | trine △          | Admetos               | Sample Natal Subject Solar Return | 5.98° | Applying →   |
+| Saturn                | Sample Natal Subject | opposition ☍     | Vulkanus              | Sample Natal Subject Solar Return | 5.64° | Applying →   |
+| Uranus                | Sample Natal Subject | trine △          | Venus                 | Sample Natal Subject Solar Return | 1.43° | Applying →   |
+| Uranus                | Sample Natal Subject | trine △          | Mars                  | Sample Natal Subject Solar Return | 2.86° | Applying →   |
+| Uranus                | Sample Natal Subject | conjunction ☌    | Uranus                | Sample Natal Subject Solar Return | 4.40° | Applying →   |
+| Uranus                | Sample Natal Subject | semi-square ∠    | Medium Coeli          | Sample Natal Subject Solar Return | 0.03° | Separating ← |
+| Uranus                | Sample Natal Subject | sesquiquadrate ⚼ | Imum Coeli            | Sample Natal Subject Solar Return | 0.03° | Separating ← |
+| Uranus                | Sample Natal Subject | conjunction ☌    | Mean Lilith           | Sample Natal Subject Solar Return | 2.90° | Separating ← |
+| Uranus                | Sample Natal Subject | conjunction ☌    | True Lilith           | Sample Natal Subject Solar Return | 5.70° | Applying →   |
+| Uranus                | Sample Natal Subject | trine △          | Sedna                 | Sample Natal Subject Solar Return | 5.32° | Separating ← |
+| Uranus                | Sample Natal Subject | trine △          | Makemake              | Sample Natal Subject Solar Return | 1.19° | Applying →   |
+| Uranus                | Sample Natal Subject | biquintile bQ    | Orcus                 | Sample Natal Subject Solar Return | 0.89° | Applying →   |
+| Uranus                | Sample Natal Subject | sesquiquadrate ⚼ | Pars Fortunae         | Sample Natal Subject Solar Return | 1.83° | Static =     |
+| Uranus                | Sample Natal Subject | trine △          | Pars Spiritus         | Sample Natal Subject Solar Return | 1.00° | Static =     |
+| Uranus                | Sample Natal Subject | semi-square ∠    | Pars Amoris           | Sample Natal Subject Solar Return | 1.15° | Static =     |
+| Uranus                | Sample Natal Subject | conjunction ☌    | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.76° | Applying →   |
+| Uranus                | Sample Natal Subject | opposition ☍     | Mean Priapus          | Sample Natal Subject Solar Return | 2.90° | Separating ← |
+| Uranus                | Sample Natal Subject | opposition ☍     | True Priapus          | Sample Natal Subject Solar Return | 5.70° | Applying →   |
+| Uranus                | Sample Natal Subject | semi-square ∠    | Cupido                | Sample Natal Subject Solar Return | 1.72° | Separating ← |
+| Neptune               | Sample Natal Subject | biquintile bQ    | Jupiter               | Sample Natal Subject Solar Return | 0.12° | Applying →   |
+| Neptune               | Sample Natal Subject | conjunction ☌    | Uranus                | Sample Natal Subject Solar Return | 1.63° | Separating ← |
+| Neptune               | Sample Natal Subject | conjunction ☌    | Neptune               | Sample Natal Subject Solar Return | 2.25° | Applying →   |
+| Neptune               | Sample Natal Subject | sextile ⚹        | Pluto                 | Sample Natal Subject Solar Return | 4.82° | Applying →   |
+| Neptune               | Sample Natal Subject | conjunction ☌    | Mean North Lunar Node | Sample Natal Subject Solar Return | 5.69° | Applying →   |
+| Neptune               | Sample Natal Subject | conjunction ☌    | Ascendant             | Sample Natal Subject Solar Return | 1.06° | Separating ← |
+| Neptune               | Sample Natal Subject | opposition ☍     | Descendant            | Sample Natal Subject Solar Return | 1.06° | Separating ← |
+| Neptune               | Sample Natal Subject | conjunction ☌    | Mean Lilith           | Sample Natal Subject Solar Return | 3.13° | Applying →   |
+| Neptune               | Sample Natal Subject | opposition ☍     | Mean South Lunar Node | Sample Natal Subject Solar Return | 5.69° | Applying →   |
+| Neptune               | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 5.07° | Applying →   |
+| Neptune               | Sample Natal Subject | trine △          | Sedna                 | Sample Natal Subject Solar Return | 0.71° | Applying →   |
+| Neptune               | Sample Natal Subject | quincunx ⚻       | Orcus                 | Sample Natal Subject Solar Return | 0.91° | Applying →   |
+| Neptune               | Sample Natal Subject | trine △          | Pars Spiritus         | Sample Natal Subject Solar Return | 5.03° | Static =     |
+| Neptune               | Sample Natal Subject | sesquiquadrate ⚼ | Vertex                | Sample Natal Subject Solar Return | 1.07° | Static =     |
+| Neptune               | Sample Natal Subject | semi-square ∠    | Anti Vertex           | Sample Natal Subject Solar Return | 1.07° | Static =     |
+| Neptune               | Sample Natal Subject | opposition ☍     | Mean Priapus          | Sample Natal Subject Solar Return | 3.13° | Applying →   |
+| Neptune               | Sample Natal Subject | opposition ☍     | Interpolated Perigee  | Sample Natal Subject Solar Return | 5.71° | Separating ← |
+| Neptune               | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 5.10° | Separating ← |
+| Neptune               | Sample Natal Subject | quincunx ⚻       | Hades                 | Sample Natal Subject Solar Return | 1.84° | Applying →   |
+| Neptune               | Sample Natal Subject | square □         | Apollon               | Sample Natal Subject Solar Return | 1.69° | Separating ← |
+| Neptune               | Sample Natal Subject | trine △          | Admetos               | Sample Natal Subject Solar Return | 2.78° | Separating ← |
+| Neptune               | Sample Natal Subject | opposition ☍     | Vulkanus              | Sample Natal Subject Solar Return | 3.12° | Separating ← |
+| Neptune               | Sample Natal Subject | quintile Q       | Poseidon              | Sample Natal Subject Solar Return | 1.59° | Applying →   |
+| Pluto                 | Sample Natal Subject | quintile Q       | Mars                  | Sample Natal Subject Solar Return | 0.90° | Separating ← |
+| Pluto                 | Sample Natal Subject | square □         | Jupiter               | Sample Natal Subject Solar Return | 3.66° | Separating ← |
+| Pluto                 | Sample Natal Subject | sextile ⚹        | Uranus                | Sample Natal Subject Solar Return | 3.84° | Separating ← |
+| Pluto                 | Sample Natal Subject | sextile ⚹        | Neptune               | Sample Natal Subject Solar Return | 0.04° | Applying →   |
+| Pluto                 | Sample Natal Subject | conjunction ☌    | Pluto                 | Sample Natal Subject Solar Return | 2.60° | Applying →   |
+| Pluto                 | Sample Natal Subject | sextile ⚹        | Mean North Lunar Node | Sample Natal Subject Solar Return | 3.47° | Applying →   |
+| Pluto                 | Sample Natal Subject | sextile ⚹        | True North Lunar Node | Sample Natal Subject Solar Return | 3.97° | Separating ← |
+| Pluto                 | Sample Natal Subject | sextile ⚹        | Ascendant             | Sample Natal Subject Solar Return | 1.15° | Applying →   |
+| Pluto                 | Sample Natal Subject | trine △          | Descendant            | Sample Natal Subject Solar Return | 1.15° | Applying →   |
+| Pluto                 | Sample Natal Subject | trine △          | Mean South Lunar Node | Sample Natal Subject Solar Return | 3.47° | Applying →   |
+| Pluto                 | Sample Natal Subject | trine △          | True South Lunar Node | Sample Natal Subject Solar Return | 3.97° | Separating ← |
+| Pluto                 | Sample Natal Subject | semi-square ∠    | True Lilith           | Sample Natal Subject Solar Return | 1.07° | Separating ← |
+| Pluto                 | Sample Natal Subject | opposition ☍     | Sedna                 | Sample Natal Subject Solar Return | 2.92° | Applying →   |
+| Pluto                 | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 3.12° | Applying →   |
+| Pluto                 | Sample Natal Subject | opposition ☍     | Pars Fortunae         | Sample Natal Subject Solar Return | 4.94° | Static =     |
+| Pluto                 | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 5.61° | Static =     |
+| Pluto                 | Sample Natal Subject | trine △          | Mean Priapus          | Sample Natal Subject Solar Return | 5.34° | Applying →   |
+| Pluto                 | Sample Natal Subject | sesquiquadrate ⚼ | True Priapus          | Sample Natal Subject Solar Return | 1.07° | Separating ← |
+| Pluto                 | Sample Natal Subject | trine △          | Interpolated Perigee  | Sample Natal Subject Solar Return | 3.50° | Separating ← |
+| Pluto                 | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 2.89° | Separating ← |
+| Pluto                 | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 5.05° | Applying →   |
+| Pluto                 | Sample Natal Subject | biquintile bQ    | Kronos                | Sample Natal Subject Solar Return | 1.61° | Separating ← |
+| Pluto                 | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Sample Natal Subject Solar Return | 0.53° | Applying →   |
+| Pluto                 | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 0.57° | Separating ← |
+| Pluto                 | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 0.90° | Separating ← |
+| Mean North Lunar Node | Sample Natal Subject | sextile ⚹        | Moon                  | Sample Natal Subject Solar Return | 3.16° | Applying →   |
+| Mean North Lunar Node | Sample Natal Subject | conjunction ☌    | Saturn                | Sample Natal Subject Solar Return | 3.89° | Separating ← |
+| Mean North Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Mean Lilith           | Sample Natal Subject Solar Return | 1.85° | Separating ← |
+| Mean North Lunar Node | Sample Natal Subject | quintile Q       | Eris                  | Sample Natal Subject Solar Return | 1.96° | Separating ← |
+| Mean North Lunar Node | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 4.27° | Separating ← |
+| Mean North Lunar Node | Sample Natal Subject | opposition ☍     | Orcus                 | Sample Natal Subject Solar Return | 4.06° | Separating ← |
+| Mean North Lunar Node | Sample Natal Subject | quintile Q       | Quaoar                | Sample Natal Subject Solar Return | 0.45° | Separating ← |
+| Mean North Lunar Node | Sample Natal Subject | quincunx ⚻       | Pars Spiritus         | Sample Natal Subject Solar Return | 0.05° | Static =     |
+| Mean North Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.81° | Applying →   |
+| Mean North Lunar Node | Sample Natal Subject | quincunx ⚻       | Mean Priapus          | Sample Natal Subject Solar Return | 1.85° | Separating ← |
+| Mean North Lunar Node | Sample Natal Subject | biquintile bQ    | True Priapus          | Sample Natal Subject Solar Return | 0.75° | Applying →   |
+| Mean North Lunar Node | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 3.13° | Separating ← |
+| Mean North Lunar Node | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | Sample Natal Subject Solar Return | 0.20° | Applying →   |
+| True North Lunar Node | Sample Natal Subject | sextile ⚹        | Moon                  | Sample Natal Subject Solar Return | 2.63° | Applying →   |
+| True North Lunar Node | Sample Natal Subject | quincunx ⚻       | Venus                 | Sample Natal Subject Solar Return | 1.96° | Applying →   |
+| True North Lunar Node | Sample Natal Subject | conjunction ☌    | Saturn                | Sample Natal Subject Solar Return | 3.37° | Separating ← |
+| True North Lunar Node | Sample Natal Subject | quintile Q       | Eris                  | Sample Natal Subject Solar Return | 1.43° | Separating ← |
+| True North Lunar Node | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 4.79° | Separating ← |
+| True North Lunar Node | Sample Natal Subject | quincunx ⚻       | Makemake              | Sample Natal Subject Solar Return | 1.72° | Applying →   |
+| True North Lunar Node | Sample Natal Subject | quintile Q       | Ixion                 | Sample Natal Subject Solar Return | 1.52° | Separating ← |
+| True North Lunar Node | Sample Natal Subject | opposition ☍     | Orcus                 | Sample Natal Subject Solar Return | 4.59° | Separating ← |
+| True North Lunar Node | Sample Natal Subject | quintile Q       | Quaoar                | Sample Natal Subject Solar Return | 0.07° | Applying →   |
+| True North Lunar Node | Sample Natal Subject | quincunx ⚻       | Pars Spiritus         | Sample Natal Subject Solar Return | 0.47° | Static =     |
+| True North Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.28° | Applying →   |
+| True North Lunar Node | Sample Natal Subject | biquintile bQ    | True Priapus          | Sample Natal Subject Solar Return | 0.22° | Applying →   |
+| True North Lunar Node | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 3.65° | Separating ← |
+| True North Lunar Node | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | Sample Natal Subject Solar Return | 0.32° | Separating ← |
+| Chiron                | Sample Natal Subject | sesquiquadrate ⚼ | Moon                  | Sample Natal Subject Solar Return | 0.25° | Applying →   |
+| Chiron                | Sample Natal Subject | semi-square ∠    | Venus                 | Sample Natal Subject Solar Return | 0.42° | Separating ← |
+| Chiron                | Sample Natal Subject | semi-square ∠    | Mars                  | Sample Natal Subject Solar Return | 1.01° | Applying →   |
+| Chiron                | Sample Natal Subject | semi-sextile ⚺   | Jupiter               | Sample Natal Subject Solar Return | 1.24° | Applying →   |
+| Chiron                | Sample Natal Subject | opposition ☍     | Neptune               | Sample Natal Subject Solar Return | 4.87° | Separating ← |
+| Chiron                | Sample Natal Subject | trine △          | Pluto                 | Sample Natal Subject Solar Return | 2.30° | Separating ← |
+| Chiron                | Sample Natal Subject | opposition ☍     | Mean North Lunar Node | Sample Natal Subject Solar Return | 1.43° | Separating ← |
+| Chiron                | Sample Natal Subject | opposition ☍     | True North Lunar Node | Sample Natal Subject Solar Return | 0.94° | Applying →   |
+| Chiron                | Sample Natal Subject | trine △          | Medium Coeli          | Sample Natal Subject Solar Return | 1.89° | Separating ← |
+| Chiron                | Sample Natal Subject | sextile ⚹        | Imum Coeli            | Sample Natal Subject Solar Return | 1.89° | Separating ← |
+| Chiron                | Sample Natal Subject | conjunction ☌    | Mean South Lunar Node | Sample Natal Subject Solar Return | 1.43° | Separating ← |
+| Chiron                | Sample Natal Subject | conjunction ☌    | True South Lunar Node | Sample Natal Subject Solar Return | 0.94° | Applying →   |
+| Chiron                | Sample Natal Subject | conjunction ☌    | Pholus                | Sample Natal Subject Solar Return | 2.51° | Separating ← |
+| Chiron                | Sample Natal Subject | opposition ☍     | Juno                  | Sample Natal Subject Solar Return | 2.89° | Applying →   |
+| Chiron                | Sample Natal Subject | conjunction ☌    | Vesta                 | Sample Natal Subject Solar Return | 2.49° | Separating ← |
+| Chiron                | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 2.05° | Separating ← |
+| Chiron                | Sample Natal Subject | semi-square ∠    | Makemake              | Sample Natal Subject Solar Return | 0.67° | Separating ← |
+| Chiron                | Sample Natal Subject | trine △          | Ixion                 | Sample Natal Subject Solar Return | 3.86° | Applying →   |
+| Chiron                | Sample Natal Subject | trine △          | Quaoar                | Sample Natal Subject Solar Return | 5.46° | Applying →   |
+| Chiron                | Sample Natal Subject | sextile ⚹        | Pars Fortunae         | Sample Natal Subject Solar Return | 0.03° | Static =     |
+| Chiron                | Sample Natal Subject | quincunx ⚻       | Pars Amoris           | Sample Natal Subject Solar Return | 0.70° | Static =     |
+| Chiron                | Sample Natal Subject | biquintile bQ    | Anti Vertex           | Sample Natal Subject Solar Return | 0.81° | Static =     |
+| Chiron                | Sample Natal Subject | conjunction ☌    | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.40° | Applying →   |
+| Chiron                | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 2.02° | Applying →   |
+| Chiron                | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 0.14° | Applying →   |
+| Chiron                | Sample Natal Subject | square □         | Apollon               | Sample Natal Subject Solar Return | 5.43° | Applying →   |
+| Chiron                | Sample Natal Subject | sextile ⚹        | Admetos               | Sample Natal Subject Solar Return | 4.34° | Applying →   |
+| Chiron                | Sample Natal Subject | conjunction ☌    | Vulkanus              | Sample Natal Subject Solar Return | 4.00° | Applying →   |
+| Ascendant             | Sample Natal Subject | semi-sextile ⚺   | Moon                  | Sample Natal Subject Solar Return | 1.19° | Applying →   |
+| Ascendant             | Sample Natal Subject | quintile Q       | Mercury               | Sample Natal Subject Solar Return | 1.49° | Separating ← |
+| Ascendant             | Sample Natal Subject | sextile ⚹        | Venus                 | Sample Natal Subject Solar Return | 0.52° | Applying →   |
+| Ascendant             | Sample Natal Subject | sextile ⚹        | Mars                  | Sample Natal Subject Solar Return | 1.95° | Applying →   |
+| Ascendant             | Sample Natal Subject | square □         | Saturn                | Sample Natal Subject Solar Return | 1.93° | Separating ← |
+| Ascendant             | Sample Natal Subject | quintile Q       | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.63° | Applying →   |
+| Ascendant             | Sample Natal Subject | quintile Q       | True North Lunar Node | Sample Natal Subject Solar Return | 1.12° | Separating ← |
+| Ascendant             | Sample Natal Subject | square □         | Chiron                | Sample Natal Subject Solar Return | 5.80° | Applying →   |
+| Ascendant             | Sample Natal Subject | sextile ⚹        | Mean Lilith           | Sample Natal Subject Solar Return | 3.82° | Separating ← |
+| Ascendant             | Sample Natal Subject | sextile ⚹        | True Lilith           | Sample Natal Subject Solar Return | 4.78° | Applying →   |
+| Ascendant             | Sample Natal Subject | sextile ⚹        | Makemake              | Sample Natal Subject Solar Return | 0.27° | Applying →   |
+| Ascendant             | Sample Natal Subject | sextile ⚹        | Pars Spiritus         | Sample Natal Subject Solar Return | 1.91° | Static =     |
+| Ascendant             | Sample Natal Subject | sextile ⚹        | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.16° | Separating ← |
+| Ascendant             | Sample Natal Subject | trine △          | Mean Priapus          | Sample Natal Subject Solar Return | 3.82° | Separating ← |
+| Ascendant             | Sample Natal Subject | trine △          | True Priapus          | Sample Natal Subject Solar Return | 4.78° | Applying →   |
+| Ascendant             | Sample Natal Subject | biquintile bQ    | Hades                 | Sample Natal Subject Solar Return | 0.90° | Applying →   |
+| Ascendant             | Sample Natal Subject | sesquiquadrate ⚼ | Kronos                | Sample Natal Subject Solar Return | 1.77° | Separating ← |
+| Medium Coeli          | Sample Natal Subject | conjunction ☌    | Mercury               | Sample Natal Subject Solar Return | 5.40° | Separating ← |
+| Medium Coeli          | Sample Natal Subject | conjunction ☌    | Jupiter               | Sample Natal Subject Solar Return | 1.28° | Applying →   |
+| Medium Coeli          | Sample Natal Subject | biquintile bQ    | Neptune               | Sample Natal Subject Solar Return | 1.10° | Applying →   |
+| Medium Coeli          | Sample Natal Subject | square □         | Pluto                 | Sample Natal Subject Solar Return | 2.34° | Separating ← |
+| Medium Coeli          | Sample Natal Subject | quincunx ⚻       | Mean North Lunar Node | Sample Natal Subject Solar Return | 1.47° | Separating ← |
+| Medium Coeli          | Sample Natal Subject | quincunx ⚻       | True North Lunar Node | Sample Natal Subject Solar Return | 0.97° | Applying →   |
+| Medium Coeli          | Sample Natal Subject | biquintile bQ    | Ascendant             | Sample Natal Subject Solar Return | 0.09° | Static =     |
+| Medium Coeli          | Sample Natal Subject | square □         | Medium Coeli          | Sample Natal Subject Solar Return | 1.86° | Static =     |
+| Medium Coeli          | Sample Natal Subject | square □         | Imum Coeli            | Sample Natal Subject Solar Return | 1.86° | Static =     |
+| Medium Coeli          | Sample Natal Subject | semi-sextile ⚺   | Mean South Lunar Node | Sample Natal Subject Solar Return | 1.47° | Separating ← |
+| Medium Coeli          | Sample Natal Subject | semi-sextile ⚺   | True South Lunar Node | Sample Natal Subject Solar Return | 0.97° | Applying →   |
+| Medium Coeli          | Sample Natal Subject | trine △          | Eris                  | Sample Natal Subject Solar Return | 2.08° | Separating ← |
+| Medium Coeli          | Sample Natal Subject | square □         | Ixion                 | Sample Natal Subject Solar Return | 3.83° | Applying →   |
+| Medium Coeli          | Sample Natal Subject | square □         | Quaoar                | Sample Natal Subject Solar Return | 5.42° | Applying →   |
+| Medium Coeli          | Sample Natal Subject | square □         | Pars Fortunae         | Sample Natal Subject Solar Return | 0.00° | Static =     |
+| Medium Coeli          | Sample Natal Subject | opposition ☍     | Pars Amoris           | Sample Natal Subject Solar Return | 0.67° | Static =     |
+| Medium Coeli          | Sample Natal Subject | sesquiquadrate ⚼ | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.07° | Separating ← |
+| Medium Coeli          | Sample Natal Subject | semi-sextile ⚺   | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.44° | Applying →   |
+| Medium Coeli          | Sample Natal Subject | square □         | Cupido                | Sample Natal Subject Solar Return | 0.11° | Applying →   |
+| Medium Coeli          | Sample Natal Subject | sextile ⚹        | Kronos                | Sample Natal Subject Solar Return | 2.67° | Separating ← |
+| Medium Coeli          | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 4.37° | Applying →   |
+| Descendant            | Sample Natal Subject | quincunx ⚻       | Moon                  | Sample Natal Subject Solar Return | 1.19° | Applying →   |
+| Descendant            | Sample Natal Subject | trine △          | Venus                 | Sample Natal Subject Solar Return | 0.52° | Applying →   |
+| Descendant            | Sample Natal Subject | trine △          | Mars                  | Sample Natal Subject Solar Return | 1.95° | Applying →   |
+| Descendant            | Sample Natal Subject | square □         | Saturn                | Sample Natal Subject Solar Return | 1.93° | Separating ← |
+| Descendant            | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 5.31° | Applying →   |
+| Descendant            | Sample Natal Subject | square □         | Chiron                | Sample Natal Subject Solar Return | 5.80° | Applying →   |
+| Descendant            | Sample Natal Subject | trine △          | Mean Lilith           | Sample Natal Subject Solar Return | 3.82° | Separating ← |
+| Descendant            | Sample Natal Subject | quintile Q       | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.63° | Applying →   |
+| Descendant            | Sample Natal Subject | quintile Q       | True South Lunar Node | Sample Natal Subject Solar Return | 1.12° | Separating ← |
+| Descendant            | Sample Natal Subject | trine △          | True Lilith           | Sample Natal Subject Solar Return | 4.78° | Applying →   |
+| Descendant            | Sample Natal Subject | trine △          | Makemake              | Sample Natal Subject Solar Return | 0.27° | Applying →   |
+| Descendant            | Sample Natal Subject | trine △          | Pars Spiritus         | Sample Natal Subject Solar Return | 1.91° | Static =     |
+| Descendant            | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.16° | Separating ← |
+| Descendant            | Sample Natal Subject | sextile ⚹        | Mean Priapus          | Sample Natal Subject Solar Return | 3.82° | Separating ← |
+| Descendant            | Sample Natal Subject | sextile ⚹        | True Priapus          | Sample Natal Subject Solar Return | 4.78° | Applying →   |
+| Descendant            | Sample Natal Subject | quintile Q       | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.66° | Separating ← |
+| Descendant            | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 1.77° | Separating ← |
+| Descendant            | Sample Natal Subject | quintile Q       | Vulkanus              | Sample Natal Subject Solar Return | 1.94° | Applying →   |
+| Imum Coeli            | Sample Natal Subject | opposition ☍     | Mercury               | Sample Natal Subject Solar Return | 5.40° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | opposition ☍     | Jupiter               | Sample Natal Subject Solar Return | 1.28° | Applying →   |
+| Imum Coeli            | Sample Natal Subject | square □         | Pluto                 | Sample Natal Subject Solar Return | 2.34° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | semi-sextile ⚺   | Mean North Lunar Node | Sample Natal Subject Solar Return | 1.47° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | semi-sextile ⚺   | True North Lunar Node | Sample Natal Subject Solar Return | 0.97° | Applying →   |
+| Imum Coeli            | Sample Natal Subject | square □         | Medium Coeli          | Sample Natal Subject Solar Return | 1.86° | Static =     |
+| Imum Coeli            | Sample Natal Subject | biquintile bQ    | Descendant            | Sample Natal Subject Solar Return | 0.09° | Static =     |
+| Imum Coeli            | Sample Natal Subject | square □         | Imum Coeli            | Sample Natal Subject Solar Return | 1.86° | Static =     |
+| Imum Coeli            | Sample Natal Subject | quincunx ⚻       | Mean South Lunar Node | Sample Natal Subject Solar Return | 1.47° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | quincunx ⚻       | True South Lunar Node | Sample Natal Subject Solar Return | 0.97° | Applying →   |
+| Imum Coeli            | Sample Natal Subject | biquintile bQ    | Pallas                | Sample Natal Subject Solar Return | 1.43° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | sextile ⚹        | Eris                  | Sample Natal Subject Solar Return | 2.08° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | biquintile bQ    | Haumea                | Sample Natal Subject Solar Return | 1.33° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | square □         | Ixion                 | Sample Natal Subject Solar Return | 3.83° | Applying →   |
+| Imum Coeli            | Sample Natal Subject | square □         | Quaoar                | Sample Natal Subject Solar Return | 5.42° | Applying →   |
+| Imum Coeli            | Sample Natal Subject | square □         | Pars Fortunae         | Sample Natal Subject Solar Return | 0.00° | Static =     |
+| Imum Coeli            | Sample Natal Subject | conjunction ☌    | Pars Amoris           | Sample Natal Subject Solar Return | 0.67° | Static =     |
+| Imum Coeli            | Sample Natal Subject | semi-square ∠    | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.07° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | quincunx ⚻       | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.44° | Applying →   |
+| Imum Coeli            | Sample Natal Subject | square □         | Cupido                | Sample Natal Subject Solar Return | 0.11° | Applying →   |
+| Imum Coeli            | Sample Natal Subject | biquintile bQ    | Zeus                  | Sample Natal Subject Solar Return | 0.91° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | trine △          | Kronos                | Sample Natal Subject Solar Return | 2.67° | Separating ← |
+| Imum Coeli            | Sample Natal Subject | trine △          | Apollon               | Sample Natal Subject Solar Return | 5.47° | Applying →   |
+| Imum Coeli            | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 4.37° | Applying →   |
+| Imum Coeli            | Sample Natal Subject | biquintile bQ    | Vulkanus              | Sample Natal Subject Solar Return | 1.96° | Separating ← |
 | Mean Lilith           | Sample Natal Subject | trine △          | Sun                   | Sample Natal Subject Solar Return | 0.45° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | trine △          | Jupiter               | Sample Natal Subject Solar Return | 5.08° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | semi-square ∠    | Neptune               | Sample Natal Subject Solar Return | 1.23° | Separating ← |
-| Mean Lilith           | Sample Natal Subject | conjunction ☌    | Mean Lilith           | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 2.67° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | square □         | Makemake              | Sample Natal Subject Solar Return | 5.51° | Separating ← |
-| Mean Lilith           | Sample Natal Subject | conjunction ☌    | Quaoar                | Sample Natal Subject Solar Return | 4.91° | Separating ← |
-| Mean Lilith           | Sample Natal Subject | semi-sextile ⚺   | Pars Fortunae         | Sample Natal Subject Solar Return | 0.51° | Static =     |
-| Mean Lilith           | Sample Natal Subject | conjunction ☌    | Interpolated Lilith   | Sample Natal Subject Solar Return | 3.51° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | opposition ☍     | Mean Priapus          | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 2.56° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 2.96° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | semi-square ∠    | Apollon               | Sample Natal Subject Solar Return | 0.17° | Applying →   |
-| Mean Lilith           | Sample Natal Subject | sesquiquadrate ⚼ | Vulkanus              | Sample Natal Subject Solar Return | 1.35° | Separating ← |
-| Mean Lilith           | Sample Natal Subject | semi-sextile ⚺   | Poseidon              | Sample Natal Subject Solar Return | 0.31° | Applying →   |
-| Mean South Lunar Node | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 1.82° | Applying →   |
-| Mean South Lunar Node | Sample Natal Subject | quincunx ⚻       | Uranus                | Sample Natal Subject Solar Return | 1.05° | Separating ← |
-| Mean South Lunar Node | Sample Natal Subject | opposition ☍     | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Mean South Lunar Node | Sample Natal Subject | opposition ☍     | True North Lunar Node | Sample Natal Subject Solar Return | 0.52° | Separating ← |
-| Mean South Lunar Node | Sample Natal Subject | square □         | Ascendant             | Sample Natal Subject Solar Return | 1.97° | Applying →   |
-| Mean South Lunar Node | Sample Natal Subject | square □         | Descendant            | Sample Natal Subject Solar Return | 1.97° | Applying →   |
-| Mean South Lunar Node | Sample Natal Subject | conjunction ☌    | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Mean South Lunar Node | Sample Natal Subject | conjunction ☌    | True South Lunar Node | Sample Natal Subject Solar Return | 0.52° | Separating ← |
-| Mean South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Pholus                | Sample Natal Subject Solar Return | 0.20° | Separating ← |
-| Mean South Lunar Node | Sample Natal Subject | conjunction ☌    | Ceres                 | Sample Natal Subject Solar Return | 5.93° | Separating ← |
-| Mean South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Pallas                | Sample Natal Subject Solar Return | 0.54° | Applying →   |
-| Mean South Lunar Node | Sample Natal Subject | square □         | Juno                  | Sample Natal Subject Solar Return | 2.31° | Separating ← |
-| Mean South Lunar Node | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 3.76° | Separating ← |
-| Mean South Lunar Node | Sample Natal Subject | conjunction ☌    | Orcus                 | Sample Natal Subject Solar Return | 3.05° | Separating ← |
-| Mean South Lunar Node | Sample Natal Subject | square □         | Pars Spiritus         | Sample Natal Subject Solar Return | 5.36° | Static =     |
-| Mean South Lunar Node | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Sample Natal Subject Solar Return | 1.20° | Static =     |
-| Mean South Lunar Node | Sample Natal Subject | square □         | Pars Fidei            | Sample Natal Subject Solar Return | 0.43° | Static =     |
-| Mean South Lunar Node | Sample Natal Subject | sextile ⚹        | Vertex                | Sample Natal Subject Solar Return | 3.67° | Static =     |
-| Mean South Lunar Node | Sample Natal Subject | trine △          | Anti Vertex           | Sample Natal Subject Solar Return | 3.67° | Static =     |
-| Mean South Lunar Node | Sample Natal Subject | semi-square ∠    | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.81° | Applying →   |
-| Mean South Lunar Node | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 2.13° | Separating ← |
-| Mean South Lunar Node | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 0.89° | Applying →   |
-| True South Lunar Node | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 1.30° | Applying →   |
-| True South Lunar Node | Sample Natal Subject | quincunx ⚻       | Uranus                | Sample Natal Subject Solar Return | 0.53° | Separating ← |
-| True South Lunar Node | Sample Natal Subject | opposition ☍     | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.52° | Applying →   |
-| True South Lunar Node | Sample Natal Subject | opposition ☍     | True North Lunar Node | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| True South Lunar Node | Sample Natal Subject | square □         | Ascendant             | Sample Natal Subject Solar Return | 1.45° | Applying →   |
-| True South Lunar Node | Sample Natal Subject | square □         | Descendant            | Sample Natal Subject Solar Return | 1.45° | Applying →   |
-| True South Lunar Node | Sample Natal Subject | conjunction ☌    | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.52° | Applying →   |
-| True South Lunar Node | Sample Natal Subject | conjunction ☌    | True South Lunar Node | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| True South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Pholus                | Sample Natal Subject Solar Return | 0.73° | Separating ← |
-| True South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Pallas                | Sample Natal Subject Solar Return | 0.02° | Applying →   |
-| True South Lunar Node | Sample Natal Subject | square □         | Juno                  | Sample Natal Subject Solar Return | 2.83° | Separating ← |
-| True South Lunar Node | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 4.28° | Separating ← |
-| True South Lunar Node | Sample Natal Subject | conjunction ☌    | Orcus                 | Sample Natal Subject Solar Return | 3.57° | Separating ← |
-| True South Lunar Node | Sample Natal Subject | square □         | Pars Spiritus         | Sample Natal Subject Solar Return | 5.89° | Static =     |
-| True South Lunar Node | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Sample Natal Subject Solar Return | 1.72° | Static =     |
-| True South Lunar Node | Sample Natal Subject | square □         | Pars Fidei            | Sample Natal Subject Solar Return | 0.95° | Static =     |
-| True South Lunar Node | Sample Natal Subject | sextile ⚹        | Vertex                | Sample Natal Subject Solar Return | 4.20° | Static =     |
-| True South Lunar Node | Sample Natal Subject | trine △          | Anti Vertex           | Sample Natal Subject Solar Return | 4.20° | Static =     |
-| True South Lunar Node | Sample Natal Subject | semi-square ∠    | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.28° | Applying →   |
-| True South Lunar Node | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 2.66° | Separating ← |
-| True South Lunar Node | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 0.37° | Applying →   |
-| True Lilith           | Sample Natal Subject | trine △          | Mercury               | Sample Natal Subject Solar Return | 0.41° | Applying →   |
-| True Lilith           | Sample Natal Subject | biquintile bQ    | Jupiter               | Sample Natal Subject Solar Return | 0.10° | Applying →   |
-| True Lilith           | Sample Natal Subject | quincunx ⚻       | Chiron                | Sample Natal Subject Solar Return | 1.87° | Separating ← |
-| True Lilith           | Sample Natal Subject | trine △          | Medium Coeli          | Sample Natal Subject Solar Return | 1.90° | Separating ← |
-| True Lilith           | Sample Natal Subject | sextile ⚹        | Imum Coeli            | Sample Natal Subject Solar Return | 1.90° | Separating ← |
-| True Lilith           | Sample Natal Subject | conjunction ☌    | True Lilith           | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| True Lilith           | Sample Natal Subject | trine △          | Ceres                 | Sample Natal Subject Solar Return | 4.30° | Applying →   |
-| True Lilith           | Sample Natal Subject | quincunx ⚻       | Vesta                 | Sample Natal Subject Solar Return | 0.13° | Separating ← |
-| True Lilith           | Sample Natal Subject | trine △          | Eris                  | Sample Natal Subject Solar Return | 0.42° | Separating ← |
-| True Lilith           | Sample Natal Subject | biquintile bQ    | Sedna                 | Sample Natal Subject Solar Return | 0.47° | Applying →   |
-| True Lilith           | Sample Natal Subject | opposition ☍     | True Priapus          | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| True Lilith           | Sample Natal Subject | opposition ☍     | Interpolated Perigee  | Sample Natal Subject Solar Return | 2.97° | Separating ← |
-| True Lilith           | Sample Natal Subject | semi-sextile ⚺   | Cupido                | Sample Natal Subject Solar Return | 0.60° | Applying →   |
-| True Lilith           | Sample Natal Subject | opposition ☍     | Kronos                | Sample Natal Subject Solar Return | 3.88° | Separating ← |
-| True Lilith           | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 4.19° | Applying →   |
-| Pholus                | Sample Natal Subject | sextile ⚹        | Mars                  | Sample Natal Subject Solar Return | 2.02° | Applying →   |
-| Pholus                | Sample Natal Subject | opposition ☍     | Uranus                | Sample Natal Subject Solar Return | 1.25° | Separating ← |
-| Pholus                | Sample Natal Subject | opposition ☍     | Neptune               | Sample Natal Subject Solar Return | 4.77° | Applying →   |
-| Pholus                | Sample Natal Subject | quincunx ⚻       | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.20° | Separating ← |
-| Pholus                | Sample Natal Subject | quincunx ⚻       | True North Lunar Node | Sample Natal Subject Solar Return | 0.73° | Separating ← |
-| Pholus                | Sample Natal Subject | trine △          | Ascendant             | Sample Natal Subject Solar Return | 2.17° | Applying →   |
-| Pholus                | Sample Natal Subject | sextile ⚹        | Descendant            | Sample Natal Subject Solar Return | 2.17° | Applying →   |
-| Pholus                | Sample Natal Subject | semi-sextile ⚺   | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.20° | Separating ← |
-| Pholus                | Sample Natal Subject | semi-sextile ⚺   | True South Lunar Node | Sample Natal Subject Solar Return | 0.73° | Separating ← |
-| Pholus                | Sample Natal Subject | conjunction ☌    | Pholus                | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Pholus                | Sample Natal Subject | conjunction ☌    | Pallas                | Sample Natal Subject Solar Return | 0.74° | Applying →   |
-| Pholus                | Sample Natal Subject | trine △          | Juno                  | Sample Natal Subject Solar Return | 2.11° | Separating ← |
-| Pholus                | Sample Natal Subject | sextile ⚹        | Sedna                 | Sample Natal Subject Solar Return | 3.56° | Separating ← |
-| Pholus                | Sample Natal Subject | sextile ⚹        | Makemake              | Sample Natal Subject Solar Return | 3.49° | Applying →   |
-| Pholus                | Sample Natal Subject | sesquiquadrate ⚼ | Ixion                 | Sample Natal Subject Solar Return | 0.29° | Separating ← |
-| Pholus                | Sample Natal Subject | sesquiquadrate ⚼ | Quaoar                | Sample Natal Subject Solar Return | 1.08° | Applying →   |
-| Pholus                | Sample Natal Subject | trine △          | Pars Spiritus         | Sample Natal Subject Solar Return | 5.16° | Static =     |
-| Pholus                | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 0.99° | Static =     |
-| Pholus                | Sample Natal Subject | sextile ⚹        | Pars Fidei            | Sample Natal Subject Solar Return | 0.22° | Static =     |
-| Pholus                | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Sample Natal Subject Solar Return | 1.93° | Separating ← |
-| Pholus                | Sample Natal Subject | square □         | Apollon               | Sample Natal Subject Solar Return | 5.83° | Separating ← |
-| Ceres                 | Sample Natal Subject | conjunction ☌    | Mercury               | Sample Natal Subject Solar Return | 3.89° | Separating ← |
-| Ceres                 | Sample Natal Subject | biquintile bQ    | Uranus                | Sample Natal Subject Solar Return | 0.98° | Separating ← |
-| Ceres                 | Sample Natal Subject | quincunx ⚻       | Neptune               | Sample Natal Subject Solar Return | 0.95° | Separating ← |
-| Ceres                 | Sample Natal Subject | square □         | Pluto                 | Sample Natal Subject Solar Return | 1.26° | Applying →   |
-| Ceres                 | Sample Natal Subject | opposition ☍     | Mean North Lunar Node | Sample Natal Subject Solar Return | 5.93° | Separating ← |
-| Ceres                 | Sample Natal Subject | conjunction ☌    | Mean South Lunar Node | Sample Natal Subject Solar Return | 5.93° | Separating ← |
-| Ceres                 | Sample Natal Subject | trine △          | True Lilith           | Sample Natal Subject Solar Return | 4.30° | Applying →   |
-| Ceres                 | Sample Natal Subject | conjunction ☌    | Ceres                 | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Ceres                 | Sample Natal Subject | square □         | Juno                  | Sample Natal Subject Solar Return | 3.62° | Applying →   |
-| Ceres                 | Sample Natal Subject | square □         | Vesta                 | Sample Natal Subject Solar Return | 4.43° | Separating ← |
-| Ceres                 | Sample Natal Subject | trine △          | Eris                  | Sample Natal Subject Solar Return | 3.88° | Applying →   |
-| Ceres                 | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 2.17° | Applying →   |
-| Ceres                 | Sample Natal Subject | conjunction ☌    | Orcus                 | Sample Natal Subject Solar Return | 2.88° | Applying →   |
-| Ceres                 | Sample Natal Subject | square □         | Pars Spiritus         | Sample Natal Subject Solar Return | 0.56° | Static =     |
-| Ceres                 | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Sample Natal Subject Solar Return | 4.73° | Static =     |
-| Ceres                 | Sample Natal Subject | square □         | Pars Fidei            | Sample Natal Subject Solar Return | 5.50° | Static =     |
-| Ceres                 | Sample Natal Subject | sextile ⚹        | Vertex                | Sample Natal Subject Solar Return | 2.25° | Static =     |
-| Ceres                 | Sample Natal Subject | trine △          | Anti Vertex           | Sample Natal Subject Solar Return | 2.25° | Static =     |
-| Ceres                 | Sample Natal Subject | sextile ⚹        | True Priapus          | Sample Natal Subject Solar Return | 4.30° | Applying →   |
-| Ceres                 | Sample Natal Subject | square □         | Cupido                | Sample Natal Subject Solar Return | 4.90° | Applying →   |
-| Ceres                 | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 3.79° | Applying →   |
-| Ceres                 | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 0.11° | Separating ← |
-| Ceres                 | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 1.24° | Separating ← |
-| Ceres                 | Sample Natal Subject | semi-sextile ⚺   | Vulkanus              | Sample Natal Subject Solar Return | 1.63° | Separating ← |
-| Pallas                | Sample Natal Subject | conjunction ☌    | Venus                 | Sample Natal Subject Solar Return | 5.54° | Applying →   |
-| Pallas                | Sample Natal Subject | sextile ⚹        | Mars                  | Sample Natal Subject Solar Return | 1.28° | Applying →   |
-| Pallas                | Sample Natal Subject | opposition ☍     | Uranus                | Sample Natal Subject Solar Return | 0.51° | Separating ← |
-| Pallas                | Sample Natal Subject | opposition ☍     | Neptune               | Sample Natal Subject Solar Return | 5.51° | Applying →   |
-| Pallas                | Sample Natal Subject | quincunx ⚻       | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.54° | Applying →   |
-| Pallas                | Sample Natal Subject | quincunx ⚻       | True North Lunar Node | Sample Natal Subject Solar Return | 0.02° | Applying →   |
-| Pallas                | Sample Natal Subject | trine △          | Ascendant             | Sample Natal Subject Solar Return | 1.43° | Applying →   |
-| Pallas                | Sample Natal Subject | sextile ⚹        | Descendant            | Sample Natal Subject Solar Return | 1.43° | Applying →   |
-| Pallas                | Sample Natal Subject | semi-sextile ⚺   | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.54° | Applying →   |
-| Pallas                | Sample Natal Subject | semi-sextile ⚺   | True South Lunar Node | Sample Natal Subject Solar Return | 0.02° | Applying →   |
-| Pallas                | Sample Natal Subject | conjunction ☌    | Pholus                | Sample Natal Subject Solar Return | 0.74° | Separating ← |
-| Pallas                | Sample Natal Subject | conjunction ☌    | Pallas                | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Pallas                | Sample Natal Subject | trine △          | Juno                  | Sample Natal Subject Solar Return | 2.85° | Separating ← |
-| Pallas                | Sample Natal Subject | sextile ⚹        | Sedna                 | Sample Natal Subject Solar Return | 4.30° | Separating ← |
-| Pallas                | Sample Natal Subject | sextile ⚹        | Makemake              | Sample Natal Subject Solar Return | 2.75° | Applying →   |
-| Pallas                | Sample Natal Subject | sesquiquadrate ⚼ | Ixion                 | Sample Natal Subject Solar Return | 0.45° | Applying →   |
-| Pallas                | Sample Natal Subject | sesquiquadrate ⚼ | Quaoar                | Sample Natal Subject Solar Return | 1.83° | Applying →   |
-| Pallas                | Sample Natal Subject | trine △          | Pars Spiritus         | Sample Natal Subject Solar Return | 5.90° | Static =     |
-| Pallas                | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 1.73° | Static =     |
-| Pallas                | Sample Natal Subject | sextile ⚹        | Pars Fidei            | Sample Natal Subject Solar Return | 0.97° | Static =     |
-| Juno                  | Sample Natal Subject | opposition ☍     | Mars                  | Sample Natal Subject Solar Return | 4.13° | Applying →   |
-| Juno                  | Sample Natal Subject | quintile Q       | Saturn                | Sample Natal Subject Solar Return | 0.58° | Separating ← |
-| Juno                  | Sample Natal Subject | sextile ⚹        | Uranus                | Sample Natal Subject Solar Return | 3.36° | Separating ← |
-| Juno                  | Sample Natal Subject | sextile ⚹        | Neptune               | Sample Natal Subject Solar Return | 2.67° | Applying →   |
-| Juno                  | Sample Natal Subject | conjunction ☌    | Pluto                 | Sample Natal Subject Solar Return | 4.88° | Applying →   |
-| Juno                  | Sample Natal Subject | square □         | Mean North Lunar Node | Sample Natal Subject Solar Return | 2.31° | Separating ← |
-| Juno                  | Sample Natal Subject | square □         | True North Lunar Node | Sample Natal Subject Solar Return | 2.83° | Separating ← |
-| Juno                  | Sample Natal Subject | conjunction ☌    | Ascendant             | Sample Natal Subject Solar Return | 4.28° | Applying →   |
-| Juno                  | Sample Natal Subject | opposition ☍     | Descendant            | Sample Natal Subject Solar Return | 4.28° | Applying →   |
-| Juno                  | Sample Natal Subject | square □         | Mean South Lunar Node | Sample Natal Subject Solar Return | 2.31° | Separating ← |
-| Juno                  | Sample Natal Subject | square □         | True South Lunar Node | Sample Natal Subject Solar Return | 2.83° | Separating ← |
-| Juno                  | Sample Natal Subject | trine △          | Pholus                | Sample Natal Subject Solar Return | 2.11° | Applying →   |
-| Juno                  | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 3.62° | Separating ← |
-| Juno                  | Sample Natal Subject | trine △          | Pallas                | Sample Natal Subject Solar Return | 2.85° | Applying →   |
-| Juno                  | Sample Natal Subject | conjunction ☌    | Juno                  | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Juno                  | Sample Natal Subject | opposition ☍     | Sedna                 | Sample Natal Subject Solar Return | 1.45° | Separating ← |
-| Juno                  | Sample Natal Subject | semi-square ∠    | Haumea                | Sample Natal Subject Solar Return | 1.23° | Separating ← |
-| Juno                  | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 0.74° | Separating ← |
-| Juno                  | Sample Natal Subject | conjunction ☌    | Pars Spiritus         | Sample Natal Subject Solar Return | 3.06° | Static =     |
-| Juno                  | Sample Natal Subject | semi-sextile ⚺   | Pars Amoris           | Sample Natal Subject Solar Return | 1.11° | Static =     |
-| Juno                  | Sample Natal Subject | opposition ☍     | Pars Fidei            | Sample Natal Subject Solar Return | 1.88° | Static =     |
-| Juno                  | Sample Natal Subject | quincunx ⚻       | Vertex                | Sample Natal Subject Solar Return | 1.36° | Static =     |
-| Juno                  | Sample Natal Subject | semi-sextile ⚺   | Anti Vertex           | Sample Natal Subject Solar Return | 1.36° | Static =     |
-| Juno                  | Sample Natal Subject | biquintile bQ    | True Priapus          | Sample Natal Subject Solar Return | 1.92° | Applying →   |
-| Juno                  | Sample Natal Subject | quincunx ⚻       | Hades                 | Sample Natal Subject Solar Return | 0.17° | Applying →   |
-| Juno                  | Sample Natal Subject | semi-square ∠    | Zeus                  | Sample Natal Subject Solar Return | 0.93° | Separating ← |
-| Juno                  | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 4.86° | Separating ← |
-| Juno                  | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 5.24° | Separating ← |
+| Mean Lilith           | Sample Natal Subject | conjunction ☌    | Moon                  | Sample Natal Subject Solar Return | 5.64° | Separating ← |
+| Mean Lilith           | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 3.67° | Applying →   |
+| Mean Lilith           | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 4.89° | Separating ← |
+| Mean Lilith           | Sample Natal Subject | sextile ⚹        | Saturn                | Sample Natal Subject Solar Return | 4.90° | Applying →   |
+| Mean Lilith           | Sample Natal Subject | semi-square ∠    | Neptune               | Sample Natal Subject Solar Return | 1.02° | Applying →   |
+| Mean Lilith           | Sample Natal Subject | trine △          | Chiron                | Sample Natal Subject Solar Return | 1.03° | Separating ← |
+| Mean Lilith           | Sample Natal Subject | semi-square ∠    | Ascendant             | Sample Natal Subject Solar Return | 0.17° | Applying →   |
+| Mean Lilith           | Sample Natal Subject | sesquiquadrate ⚼ | Descendant            | Sample Natal Subject Solar Return | 0.17° | Applying →   |
+| Mean Lilith           | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 1.65° | Applying →   |
+| Mean Lilith           | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 1.74° | Applying →   |
+| Mean Lilith           | Sample Natal Subject | conjunction ☌    | Ixion                 | Sample Natal Subject Solar Return | 5.25° | Separating ← |
+| Mean Lilith           | Sample Natal Subject | conjunction ☌    | Quaoar                | Sample Natal Subject Solar Return | 3.65° | Separating ← |
+| Mean Lilith           | Sample Natal Subject | trine △          | Pars Fidei            | Sample Natal Subject Solar Return | 0.42° | Static =     |
+| Mean Lilith           | Sample Natal Subject | square □         | Vertex                | Sample Natal Subject Solar Return | 2.30° | Static =     |
+| Mean Lilith           | Sample Natal Subject | square □         | Anti Vertex           | Sample Natal Subject Solar Return | 2.30° | Static =     |
+| Mean Lilith           | Sample Natal Subject | quintile Q       | White Moon            | Sample Natal Subject Solar Return | 0.87° | Separating ← |
+| Mean Lilith           | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 2.16° | Applying →   |
+| Mean Lilith           | Sample Natal Subject | semi-square ∠    | Apollon               | Sample Natal Subject Solar Return | 0.46° | Separating ← |
+| Mean Lilith           | Sample Natal Subject | sesquiquadrate ⚼ | Vulkanus              | Sample Natal Subject Solar Return | 1.89° | Separating ← |
+| Mean Lilith           | Sample Natal Subject | semi-sextile ⚺   | Poseidon              | Sample Natal Subject Solar Return | 0.18° | Separating ← |
+| Mean South Lunar Node | Sample Natal Subject | trine △          | Moon                  | Sample Natal Subject Solar Return | 3.16° | Applying →   |
+| Mean South Lunar Node | Sample Natal Subject | opposition ☍     | Saturn                | Sample Natal Subject Solar Return | 3.89° | Separating ← |
+| Mean South Lunar Node | Sample Natal Subject | quincunx ⚻       | Mean Lilith           | Sample Natal Subject Solar Return | 1.85° | Separating ← |
+| Mean South Lunar Node | Sample Natal Subject | biquintile bQ    | True Lilith           | Sample Natal Subject Solar Return | 0.75° | Applying →   |
+| Mean South Lunar Node | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 4.27° | Separating ← |
+| Mean South Lunar Node | Sample Natal Subject | conjunction ☌    | Orcus                 | Sample Natal Subject Solar Return | 4.06° | Separating ← |
+| Mean South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Pars Spiritus         | Sample Natal Subject Solar Return | 0.05° | Static =     |
+| Mean South Lunar Node | Sample Natal Subject | quincunx ⚻       | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.81° | Applying →   |
+| Mean South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Mean Priapus          | Sample Natal Subject Solar Return | 1.85° | Separating ← |
+| Mean South Lunar Node | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 3.13° | Separating ← |
+| Mean South Lunar Node | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 0.20° | Applying →   |
+| True South Lunar Node | Sample Natal Subject | trine △          | Moon                  | Sample Natal Subject Solar Return | 2.63° | Applying →   |
+| True South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Venus                 | Sample Natal Subject Solar Return | 1.96° | Applying →   |
+| True South Lunar Node | Sample Natal Subject | opposition ☍     | Saturn                | Sample Natal Subject Solar Return | 3.37° | Separating ← |
+| True South Lunar Node | Sample Natal Subject | biquintile bQ    | True Lilith           | Sample Natal Subject Solar Return | 0.22° | Applying →   |
+| True South Lunar Node | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 4.79° | Separating ← |
+| True South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Makemake              | Sample Natal Subject Solar Return | 1.72° | Applying →   |
+| True South Lunar Node | Sample Natal Subject | conjunction ☌    | Orcus                 | Sample Natal Subject Solar Return | 4.59° | Separating ← |
+| True South Lunar Node | Sample Natal Subject | semi-sextile ⚺   | Pars Spiritus         | Sample Natal Subject Solar Return | 0.47° | Static =     |
+| True South Lunar Node | Sample Natal Subject | quincunx ⚻       | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.28° | Applying →   |
+| True South Lunar Node | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 3.65° | Separating ← |
+| True South Lunar Node | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 0.32° | Separating ← |
+| True Lilith           | Sample Natal Subject | trine △          | Jupiter               | Sample Natal Subject Solar Return | 0.62° | Separating ← |
+| True Lilith           | Sample Natal Subject | semi-square ∠    | Saturn                | Sample Natal Subject Solar Return | 0.88° | Applying →   |
+| True Lilith           | Sample Natal Subject | semi-sextile ⚺   | Pluto                 | Sample Natal Subject Solar Return | 0.44° | Separating ← |
+| True Lilith           | Sample Natal Subject | semi-sextile ⚺   | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.43° | Applying →   |
+| True Lilith           | Sample Natal Subject | semi-sextile ⚺   | True North Lunar Node | Sample Natal Subject Solar Return | 0.93° | Separating ← |
+| True Lilith           | Sample Natal Subject | quincunx ⚻       | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.43° | Applying →   |
+| True Lilith           | Sample Natal Subject | quincunx ⚻       | True South Lunar Node | Sample Natal Subject Solar Return | 0.93° | Separating ← |
+| True Lilith           | Sample Natal Subject | biquintile bQ    | Pholus                | Sample Natal Subject Solar Return | 1.62° | Applying →   |
+| True Lilith           | Sample Natal Subject | biquintile bQ    | Vesta                 | Sample Natal Subject Solar Return | 1.64° | Applying →   |
+| True Lilith           | Sample Natal Subject | trine △          | Eris                  | Sample Natal Subject Solar Return | 0.18° | Separating ← |
+| True Lilith           | Sample Natal Subject | biquintile bQ    | Sedna                 | Sample Natal Subject Solar Return | 0.04° | Separating ← |
+| True Lilith           | Sample Natal Subject | quincunx ⚻       | Pars Fortunae         | Sample Natal Subject Solar Return | 1.90° | Static =     |
+| True Lilith           | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Sample Natal Subject Solar Return | 2.57° | Static =     |
+| True Lilith           | Sample Natal Subject | quincunx ⚻       | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.46° | Separating ← |
+| True Lilith           | Sample Natal Subject | square □         | White Moon            | Sample Natal Subject Solar Return | 0.15° | Applying →   |
+| True Lilith           | Sample Natal Subject | opposition ☍     | Kronos                | Sample Natal Subject Solar Return | 4.57° | Separating ← |
+| True Lilith           | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 3.57° | Applying →   |
+| Pholus                | Sample Natal Subject | sextile ⚹        | Venus                 | Sample Natal Subject Solar Return | 2.69° | Applying →   |
+| Pholus                | Sample Natal Subject | sextile ⚹        | Mars                  | Sample Natal Subject Solar Return | 4.12° | Applying →   |
+| Pholus                | Sample Natal Subject | opposition ☍     | Uranus                | Sample Natal Subject Solar Return | 3.14° | Applying →   |
+| Pholus                | Sample Natal Subject | opposition ☍     | Ascendant             | Sample Natal Subject Solar Return | 5.83° | Separating ← |
+| Pholus                | Sample Natal Subject | sesquiquadrate ⚼ | Medium Coeli          | Sample Natal Subject Solar Return | 1.22° | Applying →   |
+| Pholus                | Sample Natal Subject | conjunction ☌    | Descendant            | Sample Natal Subject Solar Return | 5.83° | Separating ← |
+| Pholus                | Sample Natal Subject | semi-square ∠    | Imum Coeli            | Sample Natal Subject Solar Return | 1.22° | Applying →   |
+| Pholus                | Sample Natal Subject | opposition ☍     | Mean Lilith           | Sample Natal Subject Solar Return | 1.65° | Separating ← |
+| Pholus                | Sample Natal Subject | sextile ⚹        | Sedna                 | Sample Natal Subject Solar Return | 4.07° | Separating ← |
+| Pholus                | Sample Natal Subject | sextile ⚹        | Makemake              | Sample Natal Subject Solar Return | 2.44° | Applying →   |
+| Pholus                | Sample Natal Subject | sesquiquadrate ⚼ | Ixion                 | Sample Natal Subject Solar Return | 0.75° | Applying →   |
+| Pholus                | Sample Natal Subject | sextile ⚹        | Pars Spiritus         | Sample Natal Subject Solar Return | 0.26° | Static =     |
+| Pholus                | Sample Natal Subject | opposition ☍     | Interpolated Lilith   | Sample Natal Subject Solar Return | 2.01° | Applying →   |
+| Pholus                | Sample Natal Subject | conjunction ☌    | Mean Priapus          | Sample Natal Subject Solar Return | 1.65° | Separating ← |
+| Ceres                 | Sample Natal Subject | conjunction ☌    | Jupiter               | Sample Natal Subject Solar Return | 4.92° | Separating ← |
+| Ceres                 | Sample Natal Subject | quincunx ⚻       | Neptune               | Sample Natal Subject Solar Return | 1.30° | Applying →   |
+| Ceres                 | Sample Natal Subject | square □         | Pluto                 | Sample Natal Subject Solar Return | 3.86° | Applying →   |
+| Ceres                 | Sample Natal Subject | quincunx ⚻       | Ascendant             | Sample Natal Subject Solar Return | 0.11° | Separating ← |
+| Ceres                 | Sample Natal Subject | semi-sextile ⚺   | Descendant            | Sample Natal Subject Solar Return | 0.11° | Separating ← |
+| Ceres                 | Sample Natal Subject | biquintile bQ    | Mean Lilith           | Sample Natal Subject Solar Return | 1.92° | Separating ← |
+| Ceres                 | Sample Natal Subject | quintile Q       | Ceres                 | Sample Natal Subject Solar Return | 1.08° | Separating ← |
+| Ceres                 | Sample Natal Subject | semi-square ∠    | Pallas                | Sample Natal Subject Solar Return | 1.37° | Applying →   |
+| Ceres                 | Sample Natal Subject | trine △          | Eris                  | Sample Natal Subject Solar Return | 4.12° | Applying →   |
+| Ceres                 | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 1.66° | Applying →   |
+| Ceres                 | Sample Natal Subject | semi-square ∠    | Haumea                | Sample Natal Subject Solar Return | 1.47° | Applying →   |
+| Ceres                 | Sample Natal Subject | conjunction ☌    | Orcus                 | Sample Natal Subject Solar Return | 1.86° | Applying →   |
+| Ceres                 | Sample Natal Subject | biquintile bQ    | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.73° | Applying →   |
+| Ceres                 | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 2.80° | Applying →   |
+| Ceres                 | Sample Natal Subject | semi-square ∠    | Zeus                  | Sample Natal Subject Solar Return | 1.89° | Applying →   |
+| Ceres                 | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 0.73° | Separating ← |
+| Ceres                 | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 1.83° | Separating ← |
+| Pallas                | Sample Natal Subject | sextile ⚹        | Venus                 | Sample Natal Subject Solar Return | 1.95° | Applying →   |
+| Pallas                | Sample Natal Subject | sextile ⚹        | Mars                  | Sample Natal Subject Solar Return | 3.37° | Applying →   |
+| Pallas                | Sample Natal Subject | opposition ☍     | Uranus                | Sample Natal Subject Solar Return | 3.89° | Applying →   |
+| Pallas                | Sample Natal Subject | sesquiquadrate ⚼ | Medium Coeli          | Sample Natal Subject Solar Return | 0.48° | Applying →   |
+| Pallas                | Sample Natal Subject | semi-square ∠    | Imum Coeli            | Sample Natal Subject Solar Return | 0.48° | Applying →   |
+| Pallas                | Sample Natal Subject | opposition ☍     | Mean Lilith           | Sample Natal Subject Solar Return | 2.39° | Separating ← |
+| Pallas                | Sample Natal Subject | sextile ⚹        | Sedna                 | Sample Natal Subject Solar Return | 4.81° | Separating ← |
+| Pallas                | Sample Natal Subject | sextile ⚹        | Makemake              | Sample Natal Subject Solar Return | 1.70° | Applying →   |
+| Pallas                | Sample Natal Subject | sesquiquadrate ⚼ | Ixion                 | Sample Natal Subject Solar Return | 1.49° | Applying →   |
+| Pallas                | Sample Natal Subject | sextile ⚹        | Pars Spiritus         | Sample Natal Subject Solar Return | 0.48° | Static =     |
+| Pallas                | Sample Natal Subject | sesquiquadrate ⚼ | Pars Amoris           | Sample Natal Subject Solar Return | 1.67° | Static =     |
+| Pallas                | Sample Natal Subject | opposition ☍     | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.27° | Applying →   |
+| Pallas                | Sample Natal Subject | conjunction ☌    | Mean Priapus          | Sample Natal Subject Solar Return | 2.39° | Separating ← |
+| Pallas                | Sample Natal Subject | quintile Q       | White Moon            | Sample Natal Subject Solar Return | 1.38° | Applying →   |
+| Juno                  | Sample Natal Subject | sextile ⚹        | Venus                 | Sample Natal Subject Solar Return | 4.79° | Applying →   |
+| Juno                  | Sample Natal Subject | sextile ⚹        | Uranus                | Sample Natal Subject Solar Return | 1.04° | Applying →   |
+| Juno                  | Sample Natal Subject | sextile ⚹        | Neptune               | Sample Natal Subject Solar Return | 4.92° | Applying →   |
+| Juno                  | Sample Natal Subject | sextile ⚹        | Ascendant             | Sample Natal Subject Solar Return | 3.73° | Separating ← |
+| Juno                  | Sample Natal Subject | trine △          | Descendant            | Sample Natal Subject Solar Return | 3.73° | Separating ← |
+| Juno                  | Sample Natal Subject | sextile ⚹        | Mean Lilith           | Sample Natal Subject Solar Return | 0.46° | Applying →   |
+| Juno                  | Sample Natal Subject | quintile Q       | Juno                  | Sample Natal Subject Solar Return | 0.67° | Applying →   |
+| Juno                  | Sample Natal Subject | opposition ☍     | Sedna                 | Sample Natal Subject Solar Return | 1.96° | Separating ← |
+| Juno                  | Sample Natal Subject | sextile ⚹        | Makemake              | Sample Natal Subject Solar Return | 4.55° | Applying →   |
+| Juno                  | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 1.75° | Separating ← |
+| Juno                  | Sample Natal Subject | sextile ⚹        | Pars Spiritus         | Sample Natal Subject Solar Return | 2.36° | Static =     |
+| Juno                  | Sample Natal Subject | quintile Q       | Vertex                | Sample Natal Subject Solar Return | 1.40° | Static =     |
+| Juno                  | Sample Natal Subject | sextile ⚹        | Interpolated Lilith   | Sample Natal Subject Solar Return | 4.12° | Applying →   |
+| Juno                  | Sample Natal Subject | trine △          | Mean Priapus          | Sample Natal Subject Solar Return | 0.46° | Applying →   |
+| Juno                  | Sample Natal Subject | quincunx ⚻       | Hades                 | Sample Natal Subject Solar Return | 0.82° | Separating ← |
+| Juno                  | Sample Natal Subject | semi-square ∠    | Zeus                  | Sample Natal Subject Solar Return | 1.73° | Separating ← |
+| Juno                  | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 5.44° | Separating ← |
+| Juno                  | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 5.78° | Separating ← |
 | Vesta                 | Sample Natal Subject | quintile Q       | Sun                   | Sample Natal Subject Solar Return | 1.60° | Applying →   |
-| Vesta                 | Sample Natal Subject | sextile ⚹        | Moon                  | Sample Natal Subject Solar Return | 3.06° | Separating ← |
-| Vesta                 | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 0.54° | Applying →   |
-| Vesta                 | Sample Natal Subject | semi-square ∠    | Venus                 | Sample Natal Subject Solar Return | 1.44° | Applying →   |
-| Vesta                 | Sample Natal Subject | trine △          | Saturn                | Sample Natal Subject Solar Return | 3.37° | Applying →   |
-| Vesta                 | Sample Natal Subject | trine △          | Neptune               | Sample Natal Subject Solar Return | 5.38° | Separating ← |
-| Vesta                 | Sample Natal Subject | opposition ☍     | Pluto                 | Sample Natal Subject Solar Return | 3.17° | Separating ← |
-| Vesta                 | Sample Natal Subject | sextile ⚹        | Chiron                | Sample Natal Subject Solar Return | 1.73° | Separating ← |
-| Vesta                 | Sample Natal Subject | square □         | Medium Coeli          | Sample Natal Subject Solar Return | 1.76° | Separating ← |
-| Vesta                 | Sample Natal Subject | square □         | Imum Coeli            | Sample Natal Subject Solar Return | 1.76° | Separating ← |
-| Vesta                 | Sample Natal Subject | quincunx ⚻       | True Lilith           | Sample Natal Subject Solar Return | 0.13° | Separating ← |
-| Vesta                 | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 4.43° | Applying →   |
-| Vesta                 | Sample Natal Subject | conjunction ☌    | Vesta                 | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Vesta                 | Sample Natal Subject | semi-sextile ⚺   | Eris                  | Sample Natal Subject Solar Return | 0.55° | Separating ← |
-| Vesta                 | Sample Natal Subject | opposition ☍     | Ixion                 | Sample Natal Subject Solar Return | 4.56° | Applying →   |
-| Vesta                 | Sample Natal Subject | opposition ☍     | Quaoar                | Sample Natal Subject Solar Return | 5.93° | Applying →   |
-| Vesta                 | Sample Natal Subject | opposition ☍     | Pars Spiritus         | Sample Natal Subject Solar Return | 4.99° | Static =     |
-| Vesta                 | Sample Natal Subject | semi-sextile ⚺   | True Priapus          | Sample Natal Subject Solar Return | 0.13° | Separating ← |
-| Vesta                 | Sample Natal Subject | opposition ☍     | Cupido                | Sample Natal Subject Solar Return | 0.47° | Applying →   |
-| Vesta                 | Sample Natal Subject | biquintile bQ    | Apollon               | Sample Natal Subject Solar Return | 1.68° | Separating ← |
-| Vesta                 | Sample Natal Subject | conjunction ☌    | Admetos               | Sample Natal Subject Solar Return | 3.19° | Applying →   |
-| Vesta                 | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 2.81° | Applying →   |
-| Eris                  | Sample Natal Subject | square □         | Moon                  | Sample Natal Subject Solar Return | 3.61° | Separating ← |
-| Eris                  | Sample Natal Subject | trine △          | Mercury               | Sample Natal Subject Solar Return | 0.01° | Separating ← |
-| Eris                  | Sample Natal Subject | square □         | Saturn                | Sample Natal Subject Solar Return | 3.92° | Applying →   |
-| Eris                  | Sample Natal Subject | square □         | Neptune               | Sample Natal Subject Solar Return | 4.83° | Separating ← |
-| Eris                  | Sample Natal Subject | quintile Q       | True North Lunar Node | Sample Natal Subject Solar Return | 1.67° | Applying →   |
-| Eris                  | Sample Natal Subject | square □         | Chiron                | Sample Natal Subject Solar Return | 2.28° | Separating ← |
-| Eris                  | Sample Natal Subject | trine △          | Medium Coeli          | Sample Natal Subject Solar Return | 2.31° | Separating ← |
-| Eris                  | Sample Natal Subject | sextile ⚹        | Imum Coeli            | Sample Natal Subject Solar Return | 2.31° | Separating ← |
-| Eris                  | Sample Natal Subject | trine △          | True Lilith           | Sample Natal Subject Solar Return | 0.42° | Applying →   |
-| Eris                  | Sample Natal Subject | trine △          | Ceres                 | Sample Natal Subject Solar Return | 3.88° | Applying →   |
-| Eris                  | Sample Natal Subject | semi-sextile ⚺   | Vesta                 | Sample Natal Subject Solar Return | 0.55° | Separating ← |
-| Eris                  | Sample Natal Subject | conjunction ☌    | Eris                  | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Eris                  | Sample Natal Subject | sesquiquadrate ⚼ | Makemake              | Sample Natal Subject Solar Return | 1.90° | Separating ← |
-| Eris                  | Sample Natal Subject | biquintile bQ    | Ixion                 | Sample Natal Subject Solar Return | 0.89° | Separating ← |
-| Eris                  | Sample Natal Subject | biquintile bQ    | Quaoar                | Sample Natal Subject Solar Return | 0.48° | Applying →   |
-| Eris                  | Sample Natal Subject | biquintile bQ    | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.88° | Separating ← |
-| Eris                  | Sample Natal Subject | sextile ⚹        | True Priapus          | Sample Natal Subject Solar Return | 0.42° | Applying →   |
-| Eris                  | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | Sample Natal Subject Solar Return | 3.39° | Separating ← |
-| Eris                  | Sample Natal Subject | quincunx ⚻       | Cupido                | Sample Natal Subject Solar Return | 1.02° | Applying →   |
-| Eris                  | Sample Natal Subject | sextile ⚹        | Kronos                | Sample Natal Subject Solar Return | 4.30° | Separating ← |
-| Eris                  | Sample Natal Subject | opposition ☍     | Apollon               | Sample Natal Subject Solar Return | 3.77° | Applying →   |
-| Eris                  | Sample Natal Subject | square □         | Vulkanus              | Sample Natal Subject Solar Return | 2.26° | Applying →   |
-| Sedna                 | Sample Natal Subject | conjunction ☌    | Mars                  | Sample Natal Subject Solar Return | 5.58° | Applying →   |
-| Sedna                 | Sample Natal Subject | quintile Q       | Jupiter               | Sample Natal Subject Solar Return | 0.36° | Separating ← |
-| Sedna                 | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 4.81° | Separating ← |
-| Sedna                 | Sample Natal Subject | trine △          | Neptune               | Sample Natal Subject Solar Return | 1.21° | Applying →   |
-| Sedna                 | Sample Natal Subject | opposition ☍     | Pluto                 | Sample Natal Subject Solar Return | 3.43° | Applying →   |
-| Sedna                 | Sample Natal Subject | square □         | Mean North Lunar Node | Sample Natal Subject Solar Return | 3.76° | Separating ← |
-| Sedna                 | Sample Natal Subject | square □         | True North Lunar Node | Sample Natal Subject Solar Return | 4.28° | Separating ← |
-| Sedna                 | Sample Natal Subject | opposition ☍     | Ascendant             | Sample Natal Subject Solar Return | 5.73° | Applying →   |
-| Sedna                 | Sample Natal Subject | conjunction ☌    | Descendant            | Sample Natal Subject Solar Return | 5.73° | Applying →   |
-| Sedna                 | Sample Natal Subject | square □         | Mean South Lunar Node | Sample Natal Subject Solar Return | 3.76° | Separating ← |
-| Sedna                 | Sample Natal Subject | square □         | True South Lunar Node | Sample Natal Subject Solar Return | 4.28° | Separating ← |
-| Sedna                 | Sample Natal Subject | biquintile bQ    | True Lilith           | Sample Natal Subject Solar Return | 0.47° | Applying →   |
-| Sedna                 | Sample Natal Subject | sextile ⚹        | Pholus                | Sample Natal Subject Solar Return | 3.56° | Applying →   |
-| Sedna                 | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 2.17° | Separating ← |
-| Sedna                 | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 4.30° | Applying →   |
-| Sedna                 | Sample Natal Subject | opposition ☍     | Juno                  | Sample Natal Subject Solar Return | 1.45° | Applying →   |
-| Sedna                 | Sample Natal Subject | conjunction ☌    | Sedna                 | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Sedna                 | Sample Natal Subject | sesquiquadrate ⚼ | Haumea                | Sample Natal Subject Solar Return | 0.23° | Applying →   |
-| Sedna                 | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 0.71° | Applying →   |
-| Sedna                 | Sample Natal Subject | opposition ☍     | Pars Spiritus         | Sample Natal Subject Solar Return | 1.60° | Static =     |
-| Sedna                 | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Sample Natal Subject Solar Return | 3.33° | Static =     |
-| Sedna                 | Sample Natal Subject | semi-sextile ⚺   | Vertex                | Sample Natal Subject Solar Return | 0.09° | Static =     |
-| Sedna                 | Sample Natal Subject | quincunx ⚻       | Anti Vertex           | Sample Natal Subject Solar Return | 0.09° | Static =     |
-| Sedna                 | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Sample Natal Subject Solar Return | 1.63° | Applying →   |
-| Sedna                 | Sample Natal Subject | sesquiquadrate ⚼ | Zeus                  | Sample Natal Subject Solar Return | 0.52° | Applying →   |
-| Sedna                 | Sample Natal Subject | conjunction ☌    | Admetos               | Sample Natal Subject Solar Return | 3.41° | Separating ← |
-| Sedna                 | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 3.79° | Separating ← |
+| Vesta                 | Sample Natal Subject | square □         | Jupiter               | Sample Natal Subject Solar Return | 0.49° | Separating ← |
+| Vesta                 | Sample Natal Subject | trine △          | Neptune               | Sample Natal Subject Solar Return | 3.13° | Separating ← |
+| Vesta                 | Sample Natal Subject | opposition ☍     | Pluto                 | Sample Natal Subject Solar Return | 0.57° | Separating ← |
+| Vesta                 | Sample Natal Subject | trine △          | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.30° | Applying →   |
+| Vesta                 | Sample Natal Subject | trine △          | True North Lunar Node | Sample Natal Subject Solar Return | 0.80° | Separating ← |
+| Vesta                 | Sample Natal Subject | quintile Q       | Chiron                | Sample Natal Subject Solar Return | 0.13° | Applying →   |
+| Vesta                 | Sample Natal Subject | trine △          | Ascendant             | Sample Natal Subject Solar Return | 4.32° | Applying →   |
+| Vesta                 | Sample Natal Subject | opposition ☍     | Medium Coeli          | Sample Natal Subject Solar Return | 3.62° | Separating ← |
+| Vesta                 | Sample Natal Subject | sextile ⚹        | Descendant            | Sample Natal Subject Solar Return | 4.32° | Applying →   |
+| Vesta                 | Sample Natal Subject | conjunction ☌    | Imum Coeli            | Sample Natal Subject Solar Return | 3.62° | Separating ← |
+| Vesta                 | Sample Natal Subject | sextile ⚹        | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.30° | Applying →   |
+| Vesta                 | Sample Natal Subject | sextile ⚹        | True South Lunar Node | Sample Natal Subject Solar Return | 0.80° | Separating ← |
+| Vesta                 | Sample Natal Subject | sextile ⚹        | Pholus                | Sample Natal Subject Solar Return | 4.25° | Separating ← |
+| Vesta                 | Sample Natal Subject | trine △          | Juno                  | Sample Natal Subject Solar Return | 4.62° | Applying →   |
+| Vesta                 | Sample Natal Subject | sextile ⚹        | Vesta                 | Sample Natal Subject Solar Return | 4.23° | Separating ← |
+| Vesta                 | Sample Natal Subject | semi-sextile ⚺   | Eris                  | Sample Natal Subject Solar Return | 0.31° | Separating ← |
+| Vesta                 | Sample Natal Subject | opposition ☍     | Ixion                 | Sample Natal Subject Solar Return | 5.60° | Applying →   |
+| Vesta                 | Sample Natal Subject | conjunction ☌    | Pars Fortunae         | Sample Natal Subject Solar Return | 1.77° | Static =     |
+| Vesta                 | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 2.44° | Static =     |
+| Vesta                 | Sample Natal Subject | quintile Q       | Pars Fidei            | Sample Natal Subject Solar Return | 1.58° | Static =     |
+| Vesta                 | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.33° | Separating ← |
+| Vesta                 | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 0.28° | Applying →   |
+| Vesta                 | Sample Natal Subject | opposition ☍     | Cupido                | Sample Natal Subject Solar Return | 1.87° | Applying →   |
+| Vesta                 | Sample Natal Subject | conjunction ☌    | Admetos               | Sample Natal Subject Solar Return | 2.61° | Applying →   |
+| Vesta                 | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 2.27° | Applying →   |
+| Eris                  | Sample Natal Subject | sesquiquadrate ⚼ | Mars                  | Sample Natal Subject Solar Return | 1.28° | Separating ← |
+| Eris                  | Sample Natal Subject | trine △          | Jupiter               | Sample Natal Subject Solar Return | 1.04° | Separating ← |
+| Eris                  | Sample Natal Subject | quintile Q       | Saturn                | Sample Natal Subject Solar Return | 1.70° | Separating ← |
+| Eris                  | Sample Natal Subject | square □         | Neptune               | Sample Natal Subject Solar Return | 2.58° | Separating ← |
+| Eris                  | Sample Natal Subject | quincunx ⚻       | Pluto                 | Sample Natal Subject Solar Return | 0.02° | Separating ← |
+| Eris                  | Sample Natal Subject | square □         | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.85° | Applying →   |
+| Eris                  | Sample Natal Subject | square □         | True North Lunar Node | Sample Natal Subject Solar Return | 1.35° | Separating ← |
+| Eris                  | Sample Natal Subject | square □         | Ascendant             | Sample Natal Subject Solar Return | 3.77° | Applying →   |
+| Eris                  | Sample Natal Subject | biquintile bQ    | Medium Coeli          | Sample Natal Subject Solar Return | 1.82° | Applying →   |
+| Eris                  | Sample Natal Subject | square □         | Descendant            | Sample Natal Subject Solar Return | 3.77° | Applying →   |
+| Eris                  | Sample Natal Subject | square □         | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.85° | Applying →   |
+| Eris                  | Sample Natal Subject | square □         | True South Lunar Node | Sample Natal Subject Solar Return | 1.35° | Separating ← |
+| Eris                  | Sample Natal Subject | square □         | Pholus                | Sample Natal Subject Solar Return | 4.80° | Separating ← |
+| Eris                  | Sample Natal Subject | square □         | Juno                  | Sample Natal Subject Solar Return | 5.18° | Applying →   |
+| Eris                  | Sample Natal Subject | square □         | Vesta                 | Sample Natal Subject Solar Return | 4.78° | Separating ← |
+| Eris                  | Sample Natal Subject | conjunction ☌    | Eris                  | Sample Natal Subject Solar Return | 0.24° | Applying →   |
+| Eris                  | Sample Natal Subject | biquintile bQ    | Ixion                 | Sample Natal Subject Solar Return | 0.15° | Applying →   |
+| Eris                  | Sample Natal Subject | trine △          | Orcus                 | Sample Natal Subject Solar Return | 5.75° | Applying →   |
+| Eris                  | Sample Natal Subject | biquintile bQ    | Quaoar                | Sample Natal Subject Solar Return | 1.74° | Applying →   |
+| Eris                  | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Sample Natal Subject Solar Return | 2.99° | Static =     |
+| Eris                  | Sample Natal Subject | quintile Q       | True Priapus          | Sample Natal Subject Solar Return | 1.45° | Separating ← |
+| Eris                  | Sample Natal Subject | square □         | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.88° | Separating ← |
+| Eris                  | Sample Natal Subject | quincunx ⚻       | White Moon            | Sample Natal Subject Solar Return | 0.27° | Separating ← |
+| Eris                  | Sample Natal Subject | sextile ⚹        | Kronos                | Sample Natal Subject Solar Return | 4.99° | Separating ← |
+| Eris                  | Sample Natal Subject | opposition ☍     | Apollon               | Sample Natal Subject Solar Return | 3.15° | Applying →   |
+| Eris                  | Sample Natal Subject | square □         | Vulkanus              | Sample Natal Subject Solar Return | 1.72° | Applying →   |
+| Sedna                 | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 0.41° | Separating ← |
+| Sedna                 | Sample Natal Subject | trine △          | Neptune               | Sample Natal Subject Solar Return | 3.46° | Applying →   |
+| Sedna                 | Sample Natal Subject | trine △          | Ascendant             | Sample Natal Subject Solar Return | 2.27° | Separating ← |
+| Sedna                 | Sample Natal Subject | sextile ⚹        | Descendant            | Sample Natal Subject Solar Return | 2.27° | Separating ← |
+| Sedna                 | Sample Natal Subject | trine △          | Mean Lilith           | Sample Natal Subject Solar Return | 1.91° | Applying →   |
+| Sedna                 | Sample Natal Subject | quintile Q       | Pholus                | Sample Natal Subject Solar Return | 1.16° | Applying →   |
+| Sedna                 | Sample Natal Subject | sesquiquadrate ⚼ | Pallas                | Sample Natal Subject Solar Return | 0.79° | Separating ← |
+| Sedna                 | Sample Natal Subject | quintile Q       | Vesta                 | Sample Natal Subject Solar Return | 1.17° | Applying →   |
+| Sedna                 | Sample Natal Subject | conjunction ☌    | Sedna                 | Sample Natal Subject Solar Return | 0.51° | Separating ← |
+| Sedna                 | Sample Natal Subject | sesquiquadrate ⚼ | Haumea                | Sample Natal Subject Solar Return | 0.70° | Separating ← |
+| Sedna                 | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 0.30° | Separating ← |
+| Sedna                 | Sample Natal Subject | trine △          | Pars Spiritus         | Sample Natal Subject Solar Return | 3.81° | Static =     |
+| Sedna                 | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 5.57° | Applying →   |
+| Sedna                 | Sample Natal Subject | sextile ⚹        | Mean Priapus          | Sample Natal Subject Solar Return | 1.91° | Applying →   |
+| Sedna                 | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Sample Natal Subject Solar Return | 0.63° | Applying →   |
+| Sedna                 | Sample Natal Subject | sesquiquadrate ⚼ | Zeus                  | Sample Natal Subject Solar Return | 0.28° | Separating ← |
+| Sedna                 | Sample Natal Subject | conjunction ☌    | Admetos               | Sample Natal Subject Solar Return | 3.99° | Separating ← |
+| Sedna                 | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 4.33° | Separating ← |
 | Haumea                | Sample Natal Subject | sextile ⚹        | Sun                   | Sample Natal Subject Solar Return | 2.22° | Separating ← |
-| Haumea                | Sample Natal Subject | square □         | Venus                 | Sample Natal Subject Solar Return | 5.39° | Separating ← |
-| Haumea                | Sample Natal Subject | sextile ⚹        | Jupiter               | Sample Natal Subject Solar Return | 2.41° | Applying →   |
-| Haumea                | Sample Natal Subject | trine △          | Saturn                | Sample Natal Subject Solar Return | 4.81° | Separating ← |
-| Haumea                | Sample Natal Subject | biquintile bQ    | Imum Coeli            | Sample Natal Subject Solar Return | 0.41° | Applying →   |
-| Haumea                | Sample Natal Subject | sextile ⚹        | Mean Lilith           | Sample Natal Subject Solar Return | 2.67° | Separating ← |
-| Haumea                | Sample Natal Subject | semi-square ∠    | Juno                  | Sample Natal Subject Solar Return | 1.23° | Applying →   |
-| Haumea                | Sample Natal Subject | sesquiquadrate ⚼ | Sedna                 | Sample Natal Subject Solar Return | 0.23° | Separating ← |
-| Haumea                | Sample Natal Subject | conjunction ☌    | Haumea                | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Haumea                | Sample Natal Subject | sextile ⚹        | Ixion                 | Sample Natal Subject Solar Return | 3.62° | Separating ← |
-| Haumea                | Sample Natal Subject | semi-square ∠    | Orcus                 | Sample Natal Subject Solar Return | 0.48° | Applying →   |
-| Haumea                | Sample Natal Subject | sextile ⚹        | Quaoar                | Sample Natal Subject Solar Return | 2.25° | Separating ← |
-| Haumea                | Sample Natal Subject | semi-square ∠    | Pars Spiritus         | Sample Natal Subject Solar Return | 1.83° | Static =     |
-| Haumea                | Sample Natal Subject | sextile ⚹        | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.85° | Applying →   |
-| Haumea                | Sample Natal Subject | trine △          | Mean Priapus          | Sample Natal Subject Solar Return | 2.67° | Separating ← |
-| Haumea                | Sample Natal Subject | square □         | Interpolated Perigee  | Sample Natal Subject Solar Return | 5.34° | Applying →   |
-| Haumea                | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 0.11° | Separating ← |
-| Haumea                | Sample Natal Subject | conjunction ☌    | Zeus                  | Sample Natal Subject Solar Return | 0.29° | Applying →   |
-| Haumea                | Sample Natal Subject | square □         | Kronos                | Sample Natal Subject Solar Return | 4.43° | Applying →   |
-| Haumea                | Sample Natal Subject | quintile Q       | Vulkanus              | Sample Natal Subject Solar Return | 1.02° | Separating ← |
-| Makemake              | Sample Natal Subject | semi-square ∠    | Moon                  | Sample Natal Subject Solar Return | 1.71° | Separating ← |
-| Makemake              | Sample Natal Subject | sextile ⚹        | Venus                 | Sample Natal Subject Solar Return | 2.79° | Applying →   |
-| Makemake              | Sample Natal Subject | trine △          | Mars                  | Sample Natal Subject Solar Return | 1.47° | Separating ← |
-| Makemake              | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 2.24° | Applying →   |
-| Makemake              | Sample Natal Subject | quintile Q       | Pluto                 | Sample Natal Subject Solar Return | 1.52° | Separating ← |
-| Makemake              | Sample Natal Subject | semi-square ∠    | Chiron                | Sample Natal Subject Solar Return | 0.38° | Separating ← |
-| Makemake              | Sample Natal Subject | sextile ⚹        | Ascendant             | Sample Natal Subject Solar Return | 1.32° | Separating ← |
-| Makemake              | Sample Natal Subject | trine △          | Descendant            | Sample Natal Subject Solar Return | 1.32° | Separating ← |
-| Makemake              | Sample Natal Subject | square □         | Mean Lilith           | Sample Natal Subject Solar Return | 5.51° | Applying →   |
-| Makemake              | Sample Natal Subject | sextile ⚹        | Pholus                | Sample Natal Subject Solar Return | 3.49° | Separating ← |
-| Makemake              | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 2.75° | Separating ← |
-| Makemake              | Sample Natal Subject | sesquiquadrate ⚼ | Eris                  | Sample Natal Subject Solar Return | 1.90° | Separating ← |
-| Makemake              | Sample Natal Subject | conjunction ☌    | Makemake              | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Makemake              | Sample Natal Subject | trine △          | Pars Fidei            | Sample Natal Subject Solar Return | 3.72° | Static =     |
-| Makemake              | Sample Natal Subject | square □         | Mean Priapus          | Sample Natal Subject Solar Return | 5.51° | Applying →   |
-| Makemake              | Sample Natal Subject | quintile Q       | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.51° | Applying →   |
-| Makemake              | Sample Natal Subject | square □         | Hades                 | Sample Natal Subject Solar Return | 5.42° | Separating ← |
-| Makemake              | Sample Natal Subject | quintile Q       | Kronos                | Sample Natal Subject Solar Return | 0.60° | Applying →   |
+| Haumea                | Sample Natal Subject | semi-sextile ⚺   | Mercury               | Sample Natal Subject Solar Return | 1.01° | Applying →   |
+| Haumea                | Sample Natal Subject | sextile ⚹        | Chiron                | Sample Natal Subject Solar Return | 3.70° | Separating ← |
+| Haumea                | Sample Natal Subject | sextile ⚹        | Medium Coeli          | Sample Natal Subject Solar Return | 4.55° | Applying →   |
+| Haumea                | Sample Natal Subject | quintile Q       | Descendant            | Sample Natal Subject Solar Return | 0.50° | Applying →   |
+| Haumea                | Sample Natal Subject | trine △          | Imum Coeli            | Sample Natal Subject Solar Return | 4.55° | Applying →   |
+| Haumea                | Sample Natal Subject | square □         | True Lilith           | Sample Natal Subject Solar Return | 4.72° | Separating ← |
+| Haumea                | Sample Natal Subject | sextile ⚹        | Pholus                | Sample Natal Subject Solar Return | 3.93° | Applying →   |
+| Haumea                | Sample Natal Subject | semi-sextile ⚺   | Ceres                 | Sample Natal Subject Solar Return | 0.47° | Separating ← |
+| Haumea                | Sample Natal Subject | conjunction ☌    | Pallas                | Sample Natal Subject Solar Return | 1.02° | Separating ← |
+| Haumea                | Sample Natal Subject | trine △          | Juno                  | Sample Natal Subject Solar Return | 3.55° | Separating ← |
+| Haumea                | Sample Natal Subject | sextile ⚹        | Vesta                 | Sample Natal Subject Solar Return | 3.95° | Applying →   |
+| Haumea                | Sample Natal Subject | sesquiquadrate ⚼ | Sedna                 | Sample Natal Subject Solar Return | 0.74° | Separating ← |
+| Haumea                | Sample Natal Subject | conjunction ☌    | Haumea                | Sample Natal Subject Solar Return | 0.93° | Separating ← |
+| Haumea                | Sample Natal Subject | sextile ⚹        | Ixion                 | Sample Natal Subject Solar Return | 2.58° | Separating ← |
+| Haumea                | Sample Natal Subject | semi-square ∠    | Orcus                 | Sample Natal Subject Solar Return | 0.53° | Separating ← |
+| Haumea                | Sample Natal Subject | sextile ⚹        | Quaoar                | Sample Natal Subject Solar Return | 0.99° | Separating ← |
+| Haumea                | Sample Natal Subject | biquintile bQ    | Pars Amoris           | Sample Natal Subject Solar Return | 0.26° | Static =     |
+| Haumea                | Sample Natal Subject | sextile ⚹        | Pars Fidei            | Sample Natal Subject Solar Return | 2.25° | Static =     |
+| Haumea                | Sample Natal Subject | semi-sextile ⚺   | Vertex                | Sample Natal Subject Solar Return | 0.37° | Static =     |
+| Haumea                | Sample Natal Subject | quincunx ⚻       | Anti Vertex           | Sample Natal Subject Solar Return | 0.37° | Static =     |
+| Haumea                | Sample Natal Subject | square □         | True Priapus          | Sample Natal Subject Solar Return | 4.72° | Separating ← |
+| Haumea                | Sample Natal Subject | conjunction ☌    | Zeus                  | Sample Natal Subject Solar Return | 0.50° | Separating ← |
+| Haumea                | Sample Natal Subject | square □         | Kronos                | Sample Natal Subject Solar Return | 3.73° | Applying →   |
+| Haumea                | Sample Natal Subject | quintile Q       | Vulkanus              | Sample Natal Subject Solar Return | 1.56° | Separating ← |
+| Makemake              | Sample Natal Subject | square □         | Moon                  | Sample Natal Subject Solar Return | 0.14° | Separating ← |
+| Makemake              | Sample Natal Subject | conjunction ☌    | Venus                 | Sample Natal Subject Solar Return | 0.81° | Separating ← |
+| Makemake              | Sample Natal Subject | conjunction ☌    | Mars                  | Sample Natal Subject Solar Return | 0.62° | Applying →   |
+| Makemake              | Sample Natal Subject | quincunx ⚻       | Saturn                | Sample Natal Subject Solar Return | 0.60° | Separating ← |
+| Makemake              | Sample Natal Subject | quintile Q       | Pluto                 | Sample Natal Subject Solar Return | 1.08° | Applying →   |
+| Makemake              | Sample Natal Subject | sesquiquadrate ⚼ | Mean North Lunar Node | Sample Natal Subject Solar Return | 1.05° | Separating ← |
+| Makemake              | Sample Natal Subject | sesquiquadrate ⚼ | True North Lunar Node | Sample Natal Subject Solar Return | 0.56° | Applying →   |
+| Makemake              | Sample Natal Subject | trine △          | Mean Lilith           | Sample Natal Subject Solar Return | 5.14° | Separating ← |
+| Makemake              | Sample Natal Subject | semi-square ∠    | Mean South Lunar Node | Sample Natal Subject Solar Return | 1.05° | Separating ← |
+| Makemake              | Sample Natal Subject | semi-square ∠    | True South Lunar Node | Sample Natal Subject Solar Return | 0.56° | Applying →   |
+| Makemake              | Sample Natal Subject | trine △          | True Lilith           | Sample Natal Subject Solar Return | 3.46° | Applying →   |
+| Makemake              | Sample Natal Subject | sesquiquadrate ⚼ | Eris                  | Sample Natal Subject Solar Return | 1.67° | Separating ← |
+| Makemake              | Sample Natal Subject | conjunction ☌    | Makemake              | Sample Natal Subject Solar Return | 1.05° | Separating ← |
+| Makemake              | Sample Natal Subject | conjunction ☌    | Pars Spiritus         | Sample Natal Subject Solar Return | 3.24° | Static =     |
+| Makemake              | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.48° | Separating ← |
+| Makemake              | Sample Natal Subject | sextile ⚹        | True Priapus          | Sample Natal Subject Solar Return | 3.46° | Applying →   |
+| Makemake              | Sample Natal Subject | semi-square ∠    | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.02° | Applying →   |
+| Makemake              | Sample Natal Subject | quintile Q       | Kronos                | Sample Natal Subject Solar Return | 0.09° | Separating ← |
 | Ixion                 | Sample Natal Subject | trine △          | Sun                   | Sample Natal Subject Solar Return | 5.84° | Separating ← |
-| Ixion                 | Sample Natal Subject | trine △          | Moon                  | Sample Natal Subject Solar Return | 1.49° | Applying →   |
-| Ixion                 | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 5.09° | Applying →   |
-| Ixion                 | Sample Natal Subject | trine △          | Jupiter               | Sample Natal Subject Solar Return | 1.21° | Separating ← |
-| Ixion                 | Sample Natal Subject | sextile ⚹        | Saturn                | Sample Natal Subject Solar Return | 1.19° | Separating ← |
-| Ixion                 | Sample Natal Subject | semi-square ∠    | Uranus                | Sample Natal Subject Solar Return | 0.96° | Separating ← |
-| Ixion                 | Sample Natal Subject | trine △          | Chiron                | Sample Natal Subject Solar Return | 2.82° | Applying →   |
-| Ixion                 | Sample Natal Subject | square □         | Medium Coeli          | Sample Natal Subject Solar Return | 2.79° | Applying →   |
-| Ixion                 | Sample Natal Subject | square □         | Imum Coeli            | Sample Natal Subject Solar Return | 2.79° | Applying →   |
-| Ixion                 | Sample Natal Subject | sesquiquadrate ⚼ | Pholus                | Sample Natal Subject Solar Return | 0.29° | Separating ← |
-| Ixion                 | Sample Natal Subject | sesquiquadrate ⚼ | Pallas                | Sample Natal Subject Solar Return | 0.45° | Applying →   |
-| Ixion                 | Sample Natal Subject | opposition ☍     | Vesta                 | Sample Natal Subject Solar Return | 4.56° | Applying →   |
-| Ixion                 | Sample Natal Subject | biquintile bQ    | Eris                  | Sample Natal Subject Solar Return | 0.89° | Applying →   |
-| Ixion                 | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 3.62° | Separating ← |
-| Ixion                 | Sample Natal Subject | conjunction ☌    | Ixion                 | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Ixion                 | Sample Natal Subject | conjunction ☌    | Quaoar                | Sample Natal Subject Solar Return | 1.37° | Applying →   |
-| Ixion                 | Sample Natal Subject | semi-square ∠    | Pars Amoris           | Sample Natal Subject Solar Return | 1.28° | Static =     |
-| Ixion                 | Sample Natal Subject | conjunction ☌    | Interpolated Lilith   | Sample Natal Subject Solar Return | 2.77° | Separating ← |
-| Ixion                 | Sample Natal Subject | quincunx ⚻       | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.72° | Applying →   |
-| Ixion                 | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 3.73° | Separating ← |
-| Ixion                 | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 4.09° | Separating ← |
-| Ixion                 | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 3.33° | Separating ← |
-| Ixion                 | Sample Natal Subject | quincunx ⚻       | Kronos                | Sample Natal Subject Solar Return | 0.81° | Applying →   |
-| Orcus                 | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 4.87° | Applying →   |
-| Orcus                 | Sample Natal Subject | biquintile bQ    | Uranus                | Sample Natal Subject Solar Return | 1.90° | Applying →   |
-| Orcus                 | Sample Natal Subject | quincunx ⚻       | Neptune               | Sample Natal Subject Solar Return | 1.92° | Applying →   |
-| Orcus                 | Sample Natal Subject | square □         | Pluto                 | Sample Natal Subject Solar Return | 4.13° | Applying →   |
-| Orcus                 | Sample Natal Subject | opposition ☍     | Mean North Lunar Node | Sample Natal Subject Solar Return | 3.05° | Separating ← |
-| Orcus                 | Sample Natal Subject | opposition ☍     | True North Lunar Node | Sample Natal Subject Solar Return | 3.57° | Separating ← |
-| Orcus                 | Sample Natal Subject | square □         | Ascendant             | Sample Natal Subject Solar Return | 5.02° | Applying →   |
-| Orcus                 | Sample Natal Subject | square □         | Descendant            | Sample Natal Subject Solar Return | 5.02° | Applying →   |
-| Orcus                 | Sample Natal Subject | conjunction ☌    | Mean South Lunar Node | Sample Natal Subject Solar Return | 3.05° | Separating ← |
-| Orcus                 | Sample Natal Subject | conjunction ☌    | True South Lunar Node | Sample Natal Subject Solar Return | 3.57° | Separating ← |
-| Orcus                 | Sample Natal Subject | conjunction ☌    | Ceres                 | Sample Natal Subject Solar Return | 2.88° | Separating ← |
-| Orcus                 | Sample Natal Subject | square □         | Juno                  | Sample Natal Subject Solar Return | 0.74° | Applying →   |
-| Orcus                 | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 0.71° | Separating ← |
-| Orcus                 | Sample Natal Subject | semi-square ∠    | Haumea                | Sample Natal Subject Solar Return | 0.48° | Separating ← |
-| Orcus                 | Sample Natal Subject | conjunction ☌    | Orcus                 | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Orcus                 | Sample Natal Subject | square □         | Pars Spiritus         | Sample Natal Subject Solar Return | 2.31° | Static =     |
-| Orcus                 | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Sample Natal Subject Solar Return | 1.86° | Static =     |
-| Orcus                 | Sample Natal Subject | square □         | Pars Fidei            | Sample Natal Subject Solar Return | 2.62° | Static =     |
-| Orcus                 | Sample Natal Subject | sextile ⚹        | Vertex                | Sample Natal Subject Solar Return | 0.62° | Static =     |
-| Orcus                 | Sample Natal Subject | trine △          | Anti Vertex           | Sample Natal Subject Solar Return | 0.62° | Static =     |
-| Orcus                 | Sample Natal Subject | quintile Q       | Mean Priapus          | Sample Natal Subject Solar Return | 0.15° | Separating ← |
-| Orcus                 | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 0.92° | Applying →   |
-| Orcus                 | Sample Natal Subject | semi-square ∠    | Zeus                  | Sample Natal Subject Solar Return | 0.19° | Separating ← |
-| Orcus                 | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 2.99° | Separating ← |
-| Orcus                 | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 4.12° | Separating ← |
+| Ixion                 | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 2.61° | Separating ← |
+| Ixion                 | Sample Natal Subject | square □         | Jupiter               | Sample Natal Subject Solar Return | 4.06° | Applying →   |
+| Ixion                 | Sample Natal Subject | quintile Q       | Saturn                | Sample Natal Subject Solar Return | 0.81° | Separating ← |
+| Ixion                 | Sample Natal Subject | conjunction ☌    | Pluto                 | Sample Natal Subject Solar Return | 5.13° | Separating ← |
+| Ixion                 | Sample Natal Subject | sextile ⚹        | Mean North Lunar Node | Sample Natal Subject Solar Return | 4.26° | Separating ← |
+| Ixion                 | Sample Natal Subject | sextile ⚹        | True North Lunar Node | Sample Natal Subject Solar Return | 3.76° | Applying →   |
+| Ixion                 | Sample Natal Subject | conjunction ☌    | Medium Coeli          | Sample Natal Subject Solar Return | 0.93° | Applying →   |
+| Ixion                 | Sample Natal Subject | opposition ☍     | Imum Coeli            | Sample Natal Subject Solar Return | 0.93° | Applying →   |
+| Ixion                 | Sample Natal Subject | semi-square ∠    | Mean Lilith           | Sample Natal Subject Solar Return | 1.93° | Separating ← |
+| Ixion                 | Sample Natal Subject | trine △          | Mean South Lunar Node | Sample Natal Subject Solar Return | 4.26° | Separating ← |
+| Ixion                 | Sample Natal Subject | trine △          | True South Lunar Node | Sample Natal Subject Solar Return | 3.76° | Applying →   |
+| Ixion                 | Sample Natal Subject | trine △          | Pholus                | Sample Natal Subject Solar Return | 0.31° | Applying →   |
+| Ixion                 | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 4.64° | Separating ← |
+| Ixion                 | Sample Natal Subject | sextile ⚹        | Juno                  | Sample Natal Subject Solar Return | 0.07° | Applying →   |
+| Ixion                 | Sample Natal Subject | trine △          | Vesta                 | Sample Natal Subject Solar Return | 0.33° | Applying →   |
+| Ixion                 | Sample Natal Subject | biquintile bQ    | Eris                  | Sample Natal Subject Solar Return | 1.13° | Applying →   |
+| Ixion                 | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 4.55° | Separating ← |
+| Ixion                 | Sample Natal Subject | conjunction ☌    | Ixion                 | Sample Natal Subject Solar Return | 1.04° | Applying →   |
+| Ixion                 | Sample Natal Subject | conjunction ☌    | Quaoar                | Sample Natal Subject Solar Return | 2.63° | Applying →   |
+| Ixion                 | Sample Natal Subject | opposition ☍     | Pars Fortunae         | Sample Natal Subject Solar Return | 2.79° | Static =     |
+| Ixion                 | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 2.12° | Static =     |
+| Ixion                 | Sample Natal Subject | trine △          | Pars Fidei            | Sample Natal Subject Solar Return | 5.87° | Static =     |
+| Ixion                 | Sample Natal Subject | square □         | Vertex                | Sample Natal Subject Solar Return | 3.99° | Static =     |
+| Ixion                 | Sample Natal Subject | square □         | Anti Vertex           | Sample Natal Subject Solar Return | 3.99° | Static =     |
+| Ixion                 | Sample Natal Subject | semi-square ∠    | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.72° | Applying →   |
+| Ixion                 | Sample Natal Subject | sesquiquadrate ⚼ | Mean Priapus          | Sample Natal Subject Solar Return | 1.93° | Separating ← |
+| Ixion                 | Sample Natal Subject | trine △          | Interpolated Perigee  | Sample Natal Subject Solar Return | 4.23° | Applying →   |
+| Ixion                 | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 4.84° | Applying →   |
+| Ixion                 | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 2.68° | Separating ← |
+| Ixion                 | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 4.12° | Separating ← |
+| Ixion                 | Sample Natal Subject | quincunx ⚻       | Kronos                | Sample Natal Subject Solar Return | 0.12° | Applying →   |
+| Orcus                 | Sample Natal Subject | quincunx ⚻       | Uranus                | Sample Natal Subject Solar Return | 0.30° | Applying →   |
+| Orcus                 | Sample Natal Subject | quincunx ⚻       | Mean Lilith           | Sample Natal Subject Solar Return | 1.20° | Applying →   |
+| Orcus                 | Sample Natal Subject | semi-square ∠    | Pallas                | Sample Natal Subject Solar Return | 1.50° | Separating ← |
+| Orcus                 | Sample Natal Subject | square □         | Sedna                 | Sample Natal Subject Solar Return | 1.22° | Separating ← |
+| Orcus                 | Sample Natal Subject | semi-square ∠    | Haumea                | Sample Natal Subject Solar Return | 1.41° | Separating ← |
+| Orcus                 | Sample Natal Subject | conjunction ☌    | Orcus                 | Sample Natal Subject Solar Return | 1.01° | Separating ← |
+| Orcus                 | Sample Natal Subject | biquintile bQ    | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.14° | Separating ← |
+| Orcus                 | Sample Natal Subject | semi-sextile ⚺   | Mean Priapus          | Sample Natal Subject Solar Return | 1.20° | Applying →   |
+| Orcus                 | Sample Natal Subject | sextile ⚹        | Hades                 | Sample Natal Subject Solar Return | 0.08° | Separating ← |
+| Orcus                 | Sample Natal Subject | semi-square ∠    | Zeus                  | Sample Natal Subject Solar Return | 0.99° | Separating ← |
+| Orcus                 | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 3.61° | Separating ← |
+| Orcus                 | Sample Natal Subject | square □         | Admetos               | Sample Natal Subject Solar Return | 4.70° | Separating ← |
 | Quaoar                | Sample Natal Subject | trine △          | Sun                   | Sample Natal Subject Solar Return | 4.47° | Separating ← |
-| Quaoar                | Sample Natal Subject | trine △          | Moon                  | Sample Natal Subject Solar Return | 2.87° | Applying →   |
-| Quaoar                | Sample Natal Subject | biquintile bQ    | Venus                 | Sample Natal Subject Solar Return | 1.63° | Separating ← |
-| Quaoar                | Sample Natal Subject | trine △          | Jupiter               | Sample Natal Subject Solar Return | 0.16° | Applying →   |
-| Quaoar                | Sample Natal Subject | sextile ⚹        | Saturn                | Sample Natal Subject Solar Return | 2.56° | Separating ← |
-| Quaoar                | Sample Natal Subject | quintile Q       | Mean North Lunar Node | Sample Natal Subject Solar Return | 1.71° | Applying →   |
-| Quaoar                | Sample Natal Subject | quintile Q       | True North Lunar Node | Sample Natal Subject Solar Return | 1.19° | Applying →   |
-| Quaoar                | Sample Natal Subject | trine △          | Chiron                | Sample Natal Subject Solar Return | 4.20° | Applying →   |
-| Quaoar                | Sample Natal Subject | square □         | Medium Coeli          | Sample Natal Subject Solar Return | 4.16° | Applying →   |
-| Quaoar                | Sample Natal Subject | square □         | Imum Coeli            | Sample Natal Subject Solar Return | 4.16° | Applying →   |
-| Quaoar                | Sample Natal Subject | conjunction ☌    | Mean Lilith           | Sample Natal Subject Solar Return | 4.91° | Separating ← |
-| Quaoar                | Sample Natal Subject | sesquiquadrate ⚼ | Pholus                | Sample Natal Subject Solar Return | 1.08° | Applying →   |
-| Quaoar                | Sample Natal Subject | sesquiquadrate ⚼ | Pallas                | Sample Natal Subject Solar Return | 1.83° | Applying →   |
-| Quaoar                | Sample Natal Subject | opposition ☍     | Vesta                 | Sample Natal Subject Solar Return | 5.93° | Applying →   |
-| Quaoar                | Sample Natal Subject | biquintile bQ    | Eris                  | Sample Natal Subject Solar Return | 0.48° | Separating ← |
-| Quaoar                | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 2.25° | Separating ← |
-| Quaoar                | Sample Natal Subject | conjunction ☌    | Ixion                 | Sample Natal Subject Solar Return | 1.37° | Separating ← |
-| Quaoar                | Sample Natal Subject | conjunction ☌    | Quaoar                | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Quaoar                | Sample Natal Subject | semi-square ∠    | Pars Amoris           | Sample Natal Subject Solar Return | 0.09° | Static =     |
-| Quaoar                | Sample Natal Subject | conjunction ☌    | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.40° | Separating ← |
-| Quaoar                | Sample Natal Subject | opposition ☍     | Mean Priapus          | Sample Natal Subject Solar Return | 4.91° | Separating ← |
-| Quaoar                | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 2.36° | Separating ← |
-| Quaoar                | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 5.46° | Separating ← |
-| Quaoar                | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 1.95° | Separating ← |
+| Quaoar                | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 1.24° | Separating ← |
+| Quaoar                | Sample Natal Subject | square □         | Jupiter               | Sample Natal Subject Solar Return | 5.44° | Applying →   |
+| Quaoar                | Sample Natal Subject | trine △          | Chiron                | Sample Natal Subject Solar Return | 5.94° | Separating ← |
+| Quaoar                | Sample Natal Subject | conjunction ☌    | Medium Coeli          | Sample Natal Subject Solar Return | 2.30° | Applying →   |
+| Quaoar                | Sample Natal Subject | opposition ☍     | Imum Coeli            | Sample Natal Subject Solar Return | 2.30° | Applying →   |
+| Quaoar                | Sample Natal Subject | semi-square ∠    | Mean Lilith           | Sample Natal Subject Solar Return | 0.56° | Separating ← |
+| Quaoar                | Sample Natal Subject | trine △          | Mean South Lunar Node | Sample Natal Subject Solar Return | 5.63° | Separating ← |
+| Quaoar                | Sample Natal Subject | trine △          | True South Lunar Node | Sample Natal Subject Solar Return | 5.13° | Applying →   |
+| Quaoar                | Sample Natal Subject | trine △          | Pholus                | Sample Natal Subject Solar Return | 1.68° | Applying →   |
+| Quaoar                | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 3.27° | Separating ← |
+| Quaoar                | Sample Natal Subject | sextile ⚹        | Juno                  | Sample Natal Subject Solar Return | 1.30° | Separating ← |
+| Quaoar                | Sample Natal Subject | trine △          | Vesta                 | Sample Natal Subject Solar Return | 1.70° | Applying →   |
+| Quaoar                | Sample Natal Subject | biquintile bQ    | Eris                  | Sample Natal Subject Solar Return | 0.24° | Separating ← |
+| Quaoar                | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 3.17° | Separating ← |
+| Quaoar                | Sample Natal Subject | conjunction ☌    | Ixion                 | Sample Natal Subject Solar Return | 0.33° | Separating ← |
+| Quaoar                | Sample Natal Subject | conjunction ☌    | Quaoar                | Sample Natal Subject Solar Return | 1.26° | Applying →   |
+| Quaoar                | Sample Natal Subject | opposition ☍     | Pars Fortunae         | Sample Natal Subject Solar Return | 4.16° | Static =     |
+| Quaoar                | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 3.49° | Static =     |
+| Quaoar                | Sample Natal Subject | trine △          | Pars Fidei            | Sample Natal Subject Solar Return | 4.49° | Static =     |
+| Quaoar                | Sample Natal Subject | square □         | Vertex                | Sample Natal Subject Solar Return | 2.62° | Static =     |
+| Quaoar                | Sample Natal Subject | square □         | Anti Vertex           | Sample Natal Subject Solar Return | 2.62° | Static =     |
+| Quaoar                | Sample Natal Subject | sesquiquadrate ⚼ | Mean Priapus          | Sample Natal Subject Solar Return | 0.56° | Separating ← |
+| Quaoar                | Sample Natal Subject | biquintile bQ    | True Priapus          | Sample Natal Subject Solar Return | 0.97° | Separating ← |
+| Quaoar                | Sample Natal Subject | trine △          | Interpolated Perigee  | Sample Natal Subject Solar Return | 5.60° | Applying →   |
+| Quaoar                | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 4.05° | Separating ← |
+| Quaoar                | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 2.75° | Separating ← |
+| Quaoar                | Sample Natal Subject | quincunx ⚻       | Kronos                | Sample Natal Subject Solar Return | 1.49° | Applying →   |
 | Pars Fortunae         | Sample Natal Subject | square □         | Sun                   | Sample Natal Subject Solar Return | 0.06° | Separating ← |
-| Pars Fortunae         | Sample Natal Subject | quintile Q       | Mercury               | Sample Natal Subject Solar Return | 1.12° | Separating ← |
-| Pars Fortunae         | Sample Natal Subject | trine △          | Venus                 | Sample Natal Subject Solar Return | 3.22° | Separating ← |
-| Pars Fortunae         | Sample Natal Subject | square □         | Jupiter               | Sample Natal Subject Solar Return | 4.58° | Applying →   |
-| Pars Fortunae         | Sample Natal Subject | semi-sextile ⚺   | Mean Lilith           | Sample Natal Subject Solar Return | 0.50° | Separating ← |
-| Pars Fortunae         | Sample Natal Subject | conjunction ☌    | Pars Fortunae         | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Pars Fortunae         | Sample Natal Subject | quincunx ⚻       | Mean Priapus          | Sample Natal Subject Solar Return | 0.50° | Separating ← |
-| Pars Fortunae         | Sample Natal Subject | square □         | White Moon            | Sample Natal Subject Solar Return | 2.06° | Applying →   |
-| Pars Fortunae         | Sample Natal Subject | conjunction ☌    | Poseidon              | Sample Natal Subject Solar Return | 0.20° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 4.45° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | sextile ⚹        | Neptune               | Sample Natal Subject Solar Return | 0.39° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | conjunction ☌    | Pluto                 | Sample Natal Subject Solar Return | 1.82° | Applying →   |
-| Pars Spiritus         | Sample Natal Subject | square □         | Mean North Lunar Node | Sample Natal Subject Solar Return | 5.37° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | square □         | True North Lunar Node | Sample Natal Subject Solar Return | 5.89° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | square □         | Mean South Lunar Node | Sample Natal Subject Solar Return | 5.37° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | square □         | True South Lunar Node | Sample Natal Subject Solar Return | 5.89° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | trine △          | Pholus                | Sample Natal Subject Solar Return | 5.17° | Applying →   |
-| Pars Spiritus         | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 0.56° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | trine △          | Pallas                | Sample Natal Subject Solar Return | 5.91° | Applying →   |
-| Pars Spiritus         | Sample Natal Subject | conjunction ☌    | Juno                  | Sample Natal Subject Solar Return | 3.06° | Applying →   |
-| Pars Spiritus         | Sample Natal Subject | opposition ☍     | Vesta                 | Sample Natal Subject Solar Return | 4.99° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | opposition ☍     | Sedna                 | Sample Natal Subject Solar Return | 1.61° | Applying →   |
-| Pars Spiritus         | Sample Natal Subject | semi-square ∠    | Haumea                | Sample Natal Subject Solar Return | 1.83° | Applying →   |
-| Pars Spiritus         | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 2.32° | Applying →   |
-| Pars Spiritus         | Sample Natal Subject | conjunction ☌    | Pars Spiritus         | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Pars Spiritus         | Sample Natal Subject | opposition ☍     | Pars Fidei            | Sample Natal Subject Solar Return | 4.94° | Static =     |
-| Pars Spiritus         | Sample Natal Subject | quincunx ⚻       | Vertex                | Sample Natal Subject Solar Return | 1.70° | Static =     |
-| Pars Spiritus         | Sample Natal Subject | semi-sextile ⚺   | Anti Vertex           | Sample Natal Subject Solar Return | 1.70° | Static =     |
-| Pars Spiritus         | Sample Natal Subject | biquintile bQ    | True Priapus          | Sample Natal Subject Solar Return | 1.14° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | biquintile bQ    | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.83° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 5.46° | Applying →   |
-| Pars Spiritus         | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Sample Natal Subject Solar Return | 0.67° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 1.80° | Separating ← |
-| Pars Spiritus         | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 2.18° | Separating ← |
+| Pars Fortunae         | Sample Natal Subject | sextile ⚹        | Mercury               | Sample Natal Subject Solar Return | 3.17° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | square □         | Saturn                | Sample Natal Subject Solar Return | 5.41° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | quintile Q       | Uranus                | Sample Natal Subject Solar Return | 0.65° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | square □         | Chiron                | Sample Natal Subject Solar Return | 1.53° | Separating ← |
+| Pars Fortunae         | Sample Natal Subject | quintile Q       | Mean Lilith           | Sample Natal Subject Solar Return | 0.85° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | sextile ⚹        | True Lilith           | Sample Natal Subject Solar Return | 2.55° | Separating ← |
+| Pars Fortunae         | Sample Natal Subject | conjunction ☌    | Ceres                 | Sample Natal Subject Solar Return | 1.69° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | semi-sextile ⚺   | Pallas                | Sample Natal Subject Solar Return | 1.15° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | square □         | Juno                  | Sample Natal Subject Solar Return | 5.72° | Separating ← |
+| Pars Fortunae         | Sample Natal Subject | semi-sextile ⚺   | Haumea                | Sample Natal Subject Solar Return | 1.24° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | square □         | Pars Fidei            | Sample Natal Subject Solar Return | 0.08° | Static =     |
+| Pars Fortunae         | Sample Natal Subject | sextile ⚹        | Vertex                | Sample Natal Subject Solar Return | 1.79° | Static =     |
+| Pars Fortunae         | Sample Natal Subject | trine △          | Anti Vertex           | Sample Natal Subject Solar Return | 1.79° | Static =     |
+| Pars Fortunae         | Sample Natal Subject | trine △          | True Priapus          | Sample Natal Subject Solar Return | 2.55° | Separating ← |
+| Pars Fortunae         | Sample Natal Subject | semi-sextile ⚺   | Zeus                  | Sample Natal Subject Solar Return | 1.66° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | trine △          | Kronos                | Sample Natal Subject Solar Return | 5.90° | Applying →   |
+| Pars Fortunae         | Sample Natal Subject | conjunction ☌    | Poseidon              | Sample Natal Subject Solar Return | 0.68° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | square □         | Jupiter               | Sample Natal Subject Solar Return | 5.48° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | sextile ⚹        | Uranus                | Sample Natal Subject Solar Return | 2.02° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | sextile ⚹        | Neptune               | Sample Natal Subject Solar Return | 1.86° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | conjunction ☌    | Pluto                 | Sample Natal Subject Solar Return | 4.42° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | sextile ⚹        | Ascendant             | Sample Natal Subject Solar Return | 0.67° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | trine △          | Descendant            | Sample Natal Subject Solar Return | 0.67° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | sextile ⚹        | Mean Lilith           | Sample Natal Subject Solar Return | 3.52° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | trine △          | Mean South Lunar Node | Sample Natal Subject Solar Return | 5.29° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | trine △          | True South Lunar Node | Sample Natal Subject Solar Return | 5.79° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | semi-square ∠    | Pallas                | Sample Natal Subject Solar Return | 0.81° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | opposition ☍     | Sedna                 | Sample Natal Subject Solar Return | 1.10° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | semi-square ∠    | Haumea                | Sample Natal Subject Solar Return | 0.91° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 1.31° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | trine △          | Mean Priapus          | Sample Natal Subject Solar Return | 3.52° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | trine △          | Interpolated Perigee  | Sample Natal Subject Solar Return | 5.32° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 4.71° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | semi-square ∠    | Zeus                  | Sample Natal Subject Solar Return | 1.33° | Applying →   |
+| Pars Spiritus         | Sample Natal Subject | semi-sextile ⚺   | Apollon               | Sample Natal Subject Solar Return | 1.29° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 2.38° | Separating ← |
+| Pars Spiritus         | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 2.72° | Separating ← |
 | Pars Amoris           | Sample Natal Subject | quintile Q       | Sun                   | Sample Natal Subject Solar Return | 1.56° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | square □         | Uranus                | Sample Natal Subject Solar Return | 2.25° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | square □         | Neptune               | Sample Natal Subject Solar Return | 3.78° | Applying →   |
-| Pars Amoris           | Sample Natal Subject | trine △          | Mean North Lunar Node | Sample Natal Subject Solar Return | 1.20° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | trine △          | True North Lunar Node | Sample Natal Subject Solar Return | 1.72° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | sextile ⚹        | Mean South Lunar Node | Sample Natal Subject Solar Return | 1.20° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | sextile ⚹        | True South Lunar Node | Sample Natal Subject Solar Return | 1.72° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | square □         | Pholus                | Sample Natal Subject Solar Return | 1.00° | Applying →   |
-| Pars Amoris           | Sample Natal Subject | sextile ⚹        | Ceres                 | Sample Natal Subject Solar Return | 4.73° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | square □         | Pallas                | Sample Natal Subject Solar Return | 1.74° | Applying →   |
-| Pars Amoris           | Sample Natal Subject | semi-sextile ⚺   | Juno                  | Sample Natal Subject Solar Return | 1.11° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | semi-square ∠    | Ixion                 | Sample Natal Subject Solar Return | 1.28° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | sextile ⚹        | Orcus                 | Sample Natal Subject Solar Return | 1.85° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | semi-square ∠    | Quaoar                | Sample Natal Subject Solar Return | 0.09° | Applying →   |
-| Pars Amoris           | Sample Natal Subject | conjunction ☌    | Pars Amoris           | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Pars Amoris           | Sample Natal Subject | quincunx ⚻       | Pars Fidei            | Sample Natal Subject Solar Return | 0.77° | Static =     |
-| Pars Amoris           | Sample Natal Subject | trine △          | Vertex                | Sample Natal Subject Solar Return | 2.47° | Static =     |
-| Pars Amoris           | Sample Natal Subject | sextile ⚹        | Anti Vertex           | Sample Natal Subject Solar Return | 2.47° | Static =     |
-| Pars Amoris           | Sample Natal Subject | semi-square ∠    | Interpolated Lilith   | Sample Natal Subject Solar Return | 1.49° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | quintile Q       | White Moon            | Sample Natal Subject Solar Return | 0.56° | Applying →   |
-| Pars Amoris           | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 0.93° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | conjunction ☌    | Apollon               | Sample Natal Subject Solar Return | 4.84° | Separating ← |
-| Pars Amoris           | Sample Natal Subject | biquintile bQ    | Admetos               | Sample Natal Subject Solar Return | 0.03° | Applying →   |
-| Pars Fidei            | Sample Natal Subject | quintile Q       | Moon                  | Sample Natal Subject Solar Return | 0.99° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | conjunction ☌    | Mars                  | Sample Natal Subject Solar Return | 2.25° | Applying →   |
-| Pars Fidei            | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 1.48° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | trine △          | Neptune               | Sample Natal Subject Solar Return | 4.54° | Applying →   |
-| Pars Fidei            | Sample Natal Subject | square □         | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.43° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | square □         | True North Lunar Node | Sample Natal Subject Solar Return | 0.95° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | quintile Q       | Chiron                | Sample Natal Subject Solar Return | 0.34° | Applying →   |
-| Pars Fidei            | Sample Natal Subject | opposition ☍     | Ascendant             | Sample Natal Subject Solar Return | 2.40° | Applying →   |
-| Pars Fidei            | Sample Natal Subject | conjunction ☌    | Descendant            | Sample Natal Subject Solar Return | 2.40° | Applying →   |
-| Pars Fidei            | Sample Natal Subject | square □         | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.43° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | square □         | True South Lunar Node | Sample Natal Subject Solar Return | 0.95° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | sextile ⚹        | Pholus                | Sample Natal Subject Solar Return | 0.23° | Applying →   |
-| Pars Fidei            | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 5.50° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 0.97° | Applying →   |
-| Pars Fidei            | Sample Natal Subject | opposition ☍     | Juno                  | Sample Natal Subject Solar Return | 1.88° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | conjunction ☌    | Sedna                 | Sample Natal Subject Solar Return | 3.33° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | trine △          | Makemake              | Sample Natal Subject Solar Return | 3.72° | Applying →   |
-| Pars Fidei            | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 2.62° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | opposition ☍     | Pars Spiritus         | Sample Natal Subject Solar Return | 4.94° | Static =     |
-| Pars Fidei            | Sample Natal Subject | quincunx ⚻       | Pars Amoris           | Sample Natal Subject Solar Return | 0.77° | Static =     |
-| Pars Fidei            | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Pars Fidei            | Sample Natal Subject | semi-sextile ⚺   | Hades                 | Sample Natal Subject Solar Return | 1.70° | Separating ← |
-| Pars Fidei            | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 1.32° | Applying →   |
-| Vertex                | Sample Natal Subject | quincunx ⚻       | Neptune               | Sample Natal Subject Solar Return | 1.30° | Applying →   |
-| Vertex                | Sample Natal Subject | trine △          | Mean North Lunar Node | Sample Natal Subject Solar Return | 3.68° | Separating ← |
-| Vertex                | Sample Natal Subject | trine △          | True North Lunar Node | Sample Natal Subject Solar Return | 4.20° | Separating ← |
-| Vertex                | Sample Natal Subject | biquintile bQ    | Ascendant             | Sample Natal Subject Solar Return | 0.35° | Separating ← |
-| Vertex                | Sample Natal Subject | sextile ⚹        | Mean South Lunar Node | Sample Natal Subject Solar Return | 3.68° | Separating ← |
-| Vertex                | Sample Natal Subject | sextile ⚹        | True South Lunar Node | Sample Natal Subject Solar Return | 4.20° | Separating ← |
-| Vertex                | Sample Natal Subject | sextile ⚹        | Ceres                 | Sample Natal Subject Solar Return | 2.25° | Separating ← |
-| Vertex                | Sample Natal Subject | quincunx ⚻       | Juno                  | Sample Natal Subject Solar Return | 1.37° | Applying →   |
-| Vertex                | Sample Natal Subject | semi-sextile ⚺   | Sedna                 | Sample Natal Subject Solar Return | 0.08° | Separating ← |
-| Vertex                | Sample Natal Subject | sextile ⚹        | Orcus                 | Sample Natal Subject Solar Return | 0.63° | Applying →   |
-| Vertex                | Sample Natal Subject | quincunx ⚻       | Pars Spiritus         | Sample Natal Subject Solar Return | 1.69° | Static =     |
-| Vertex                | Sample Natal Subject | trine △          | Pars Amoris           | Sample Natal Subject Solar Return | 2.48° | Static =     |
-| Vertex                | Sample Natal Subject | conjunction ☌    | Vertex                | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Vertex                | Sample Natal Subject | opposition ☍     | Anti Vertex           | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Vertex                | Sample Natal Subject | semi-square ∠    | White Moon            | Sample Natal Subject Solar Return | 0.03° | Applying →   |
-| Vertex                | Sample Natal Subject | conjunction ☌    | Hades                 | Sample Natal Subject Solar Return | 1.54° | Applying →   |
-| Vertex                | Sample Natal Subject | trine △          | Apollon               | Sample Natal Subject Solar Return | 2.36° | Separating ← |
-| Anti Vertex           | Sample Natal Subject | biquintile bQ    | Mars                  | Sample Natal Subject Solar Return | 0.50° | Separating ← |
-| Anti Vertex           | Sample Natal Subject | semi-sextile ⚺   | Neptune               | Sample Natal Subject Solar Return | 1.30° | Applying →   |
-| Anti Vertex           | Sample Natal Subject | sextile ⚹        | Mean North Lunar Node | Sample Natal Subject Solar Return | 3.68° | Separating ← |
-| Anti Vertex           | Sample Natal Subject | sextile ⚹        | True North Lunar Node | Sample Natal Subject Solar Return | 4.20° | Separating ← |
-| Anti Vertex           | Sample Natal Subject | biquintile bQ    | Descendant            | Sample Natal Subject Solar Return | 0.35° | Separating ← |
-| Anti Vertex           | Sample Natal Subject | trine △          | Mean South Lunar Node | Sample Natal Subject Solar Return | 3.68° | Separating ← |
-| Anti Vertex           | Sample Natal Subject | trine △          | True South Lunar Node | Sample Natal Subject Solar Return | 4.20° | Separating ← |
-| Anti Vertex           | Sample Natal Subject | trine △          | Ceres                 | Sample Natal Subject Solar Return | 2.25° | Separating ← |
-| Anti Vertex           | Sample Natal Subject | semi-sextile ⚺   | Juno                  | Sample Natal Subject Solar Return | 1.37° | Applying →   |
-| Anti Vertex           | Sample Natal Subject | quincunx ⚻       | Sedna                 | Sample Natal Subject Solar Return | 0.08° | Separating ← |
-| Anti Vertex           | Sample Natal Subject | trine △          | Orcus                 | Sample Natal Subject Solar Return | 0.63° | Applying →   |
-| Anti Vertex           | Sample Natal Subject | semi-sextile ⚺   | Pars Spiritus         | Sample Natal Subject Solar Return | 1.69° | Static =     |
-| Anti Vertex           | Sample Natal Subject | sextile ⚹        | Pars Amoris           | Sample Natal Subject Solar Return | 2.48° | Static =     |
-| Anti Vertex           | Sample Natal Subject | opposition ☍     | Vertex                | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Anti Vertex           | Sample Natal Subject | conjunction ☌    | Anti Vertex           | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Anti Vertex           | Sample Natal Subject | sesquiquadrate ⚼ | White Moon            | Sample Natal Subject Solar Return | 0.03° | Applying →   |
-| Anti Vertex           | Sample Natal Subject | opposition ☍     | Hades                 | Sample Natal Subject Solar Return | 1.54° | Applying →   |
-| Anti Vertex           | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 2.36° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | sextile ⚹        | Moon                  | Sample Natal Subject Solar Return | 4.35° | Applying →   |
+| Pars Amoris           | Sample Natal Subject | semi-square ∠    | Mercury               | Sample Natal Subject Solar Return | 1.33° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | trine △          | Saturn                | Sample Natal Subject Solar Return | 5.09° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | square □         | Uranus                | Sample Natal Subject Solar Return | 2.15° | Applying →   |
+| Pars Amoris           | Sample Natal Subject | square □         | Ascendant             | Sample Natal Subject Solar Return | 4.84° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | square □         | Descendant            | Sample Natal Subject Solar Return | 4.84° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | square □         | Mean Lilith           | Sample Natal Subject Solar Return | 0.65° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | semi-square ∠    | Ixion                 | Sample Natal Subject Solar Return | 0.24° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | sextile ⚹        | Orcus                 | Sample Natal Subject Solar Return | 2.86° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | semi-square ∠    | Quaoar                | Sample Natal Subject Solar Return | 1.35° | Applying →   |
+| Pars Amoris           | Sample Natal Subject | semi-sextile ⚺   | Pars Spiritus         | Sample Natal Subject Solar Return | 1.25° | Static =     |
+| Pars Amoris           | Sample Natal Subject | quintile Q       | Pars Fidei            | Sample Natal Subject Solar Return | 1.58° | Static =     |
+| Pars Amoris           | Sample Natal Subject | square □         | Interpolated Lilith   | Sample Natal Subject Solar Return | 3.01° | Applying →   |
+| Pars Amoris           | Sample Natal Subject | square □         | Mean Priapus          | Sample Natal Subject Solar Return | 0.65° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 1.93° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | conjunction ☌    | Apollon               | Sample Natal Subject Solar Return | 5.46° | Separating ← |
+| Pars Amoris           | Sample Natal Subject | biquintile bQ    | Admetos               | Sample Natal Subject Solar Return | 0.55° | Separating ← |
+| Pars Fidei            | Sample Natal Subject | trine △          | Venus                 | Sample Natal Subject Solar Return | 2.91° | Applying →   |
+| Pars Fidei            | Sample Natal Subject | trine △          | Mars                  | Sample Natal Subject Solar Return | 4.34° | Applying →   |
+| Pars Fidei            | Sample Natal Subject | square □         | Saturn                | Sample Natal Subject Solar Return | 4.32° | Separating ← |
+| Pars Fidei            | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 2.92° | Applying →   |
+| Pars Fidei            | Sample Natal Subject | trine △          | Ascendant             | Sample Natal Subject Solar Return | 5.61° | Separating ← |
+| Pars Fidei            | Sample Natal Subject | trine △          | Mean Lilith           | Sample Natal Subject Solar Return | 1.42° | Separating ← |
+| Pars Fidei            | Sample Natal Subject | quintile Q       | Mean South Lunar Node | Sample Natal Subject Solar Return | 1.77° | Separating ← |
+| Pars Fidei            | Sample Natal Subject | quintile Q       | True South Lunar Node | Sample Natal Subject Solar Return | 1.28° | Applying →   |
+| Pars Fidei            | Sample Natal Subject | conjunction ☌    | Sedna                 | Sample Natal Subject Solar Return | 3.84° | Separating ← |
+| Pars Fidei            | Sample Natal Subject | trine △          | Makemake              | Sample Natal Subject Solar Return | 2.67° | Applying →   |
+| Pars Fidei            | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 3.63° | Separating ← |
+| Pars Fidei            | Sample Natal Subject | trine △          | Pars Spiritus         | Sample Natal Subject Solar Return | 0.48° | Static =     |
+| Pars Fidei            | Sample Natal Subject | quintile Q       | Anti Vertex           | Sample Natal Subject Solar Return | 0.48° | Static =     |
+| Pars Fidei            | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 2.24° | Applying →   |
+| Pars Fidei            | Sample Natal Subject | sextile ⚹        | Mean Priapus          | Sample Natal Subject Solar Return | 1.42° | Separating ← |
+| Pars Fidei            | Sample Natal Subject | quintile Q       | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.74° | Applying →   |
+| Pars Fidei            | Sample Natal Subject | semi-square ∠    | Kronos                | Sample Natal Subject Solar Return | 0.63° | Applying →   |
+| Vertex                | Sample Natal Subject | quintile Q       | Mercury               | Sample Natal Subject Solar Return | 1.85° | Separating ← |
+| Vertex                | Sample Natal Subject | quincunx ⚻       | Uranus                | Sample Natal Subject Solar Return | 0.33° | Separating ← |
+| Vertex                | Sample Natal Subject | biquintile bQ    | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.98° | Applying →   |
+| Vertex                | Sample Natal Subject | biquintile bQ    | True North Lunar Node | Sample Natal Subject Solar Return | 1.48° | Separating ← |
+| Vertex                | Sample Natal Subject | quincunx ⚻       | Mean Lilith           | Sample Natal Subject Solar Return | 1.83° | Applying →   |
+| Vertex                | Sample Natal Subject | sesquiquadrate ⚼ | Ceres                 | Sample Natal Subject Solar Return | 0.33° | Separating ← |
+| Vertex                | Sample Natal Subject | semi-sextile ⚺   | Sedna                 | Sample Natal Subject Solar Return | 0.59° | Separating ← |
+| Vertex                | Sample Natal Subject | square □         | Makemake              | Sample Natal Subject Solar Return | 5.92° | Applying →   |
+| Vertex                | Sample Natal Subject | sextile ⚹        | Orcus                 | Sample Natal Subject Solar Return | 0.39° | Separating ← |
+| Vertex                | Sample Natal Subject | square □         | Pars Spiritus         | Sample Natal Subject Solar Return | 3.73° | Static =     |
+| Vertex                | Sample Natal Subject | semi-sextile ⚺   | Mean Priapus          | Sample Natal Subject Solar Return | 1.83° | Applying →   |
+| Vertex                | Sample Natal Subject | conjunction ☌    | Hades                 | Sample Natal Subject Solar Return | 0.55° | Applying →   |
+| Vertex                | Sample Natal Subject | trine △          | Apollon               | Sample Natal Subject Solar Return | 2.98° | Separating ← |
+| Anti Vertex           | Sample Natal Subject | semi-sextile ⚺   | Uranus                | Sample Natal Subject Solar Return | 0.33° | Separating ← |
+| Anti Vertex           | Sample Natal Subject | semi-sextile ⚺   | Mean Lilith           | Sample Natal Subject Solar Return | 1.83° | Applying →   |
+| Anti Vertex           | Sample Natal Subject | biquintile bQ    | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.98° | Applying →   |
+| Anti Vertex           | Sample Natal Subject | biquintile bQ    | True South Lunar Node | Sample Natal Subject Solar Return | 1.48° | Separating ← |
+| Anti Vertex           | Sample Natal Subject | semi-square ∠    | Ceres                 | Sample Natal Subject Solar Return | 0.33° | Separating ← |
+| Anti Vertex           | Sample Natal Subject | quincunx ⚻       | Sedna                 | Sample Natal Subject Solar Return | 0.59° | Separating ← |
+| Anti Vertex           | Sample Natal Subject | square □         | Makemake              | Sample Natal Subject Solar Return | 5.92° | Applying →   |
+| Anti Vertex           | Sample Natal Subject | trine △          | Orcus                 | Sample Natal Subject Solar Return | 0.39° | Separating ← |
+| Anti Vertex           | Sample Natal Subject | square □         | Pars Spiritus         | Sample Natal Subject Solar Return | 3.73° | Static =     |
+| Anti Vertex           | Sample Natal Subject | quincunx ⚻       | Mean Priapus          | Sample Natal Subject Solar Return | 1.83° | Applying →   |
+| Anti Vertex           | Sample Natal Subject | biquintile bQ    | Interpolated Perigee  | Sample Natal Subject Solar Return | 1.01° | Separating ← |
+| Anti Vertex           | Sample Natal Subject | opposition ☍     | Hades                 | Sample Natal Subject Solar Return | 0.55° | Applying →   |
+| Anti Vertex           | Sample Natal Subject | sextile ⚹        | Apollon               | Sample Natal Subject Solar Return | 2.98° | Separating ← |
+| Anti Vertex           | Sample Natal Subject | biquintile bQ    | Vulkanus              | Sample Natal Subject Solar Return | 1.59° | Applying →   |
 | Interpolated Lilith   | Sample Natal Subject | trine △          | Sun                   | Sample Natal Subject Solar Return | 3.07° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | trine △          | Moon                  | Sample Natal Subject Solar Return | 4.27° | Applying →   |
-| Interpolated Lilith   | Sample Natal Subject | biquintile bQ    | Venus                 | Sample Natal Subject Solar Return | 0.23° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | trine △          | Jupiter               | Sample Natal Subject Solar Return | 1.56° | Applying →   |
-| Interpolated Lilith   | Sample Natal Subject | sextile ⚹        | Saturn                | Sample Natal Subject Solar Return | 3.96° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | quintile Q       | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.31° | Applying →   |
-| Interpolated Lilith   | Sample Natal Subject | quintile Q       | True North Lunar Node | Sample Natal Subject Solar Return | 0.21° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | trine △          | Chiron                | Sample Natal Subject Solar Return | 5.60° | Applying →   |
-| Interpolated Lilith   | Sample Natal Subject | square □         | Medium Coeli          | Sample Natal Subject Solar Return | 5.57° | Applying →   |
-| Interpolated Lilith   | Sample Natal Subject | square □         | Imum Coeli            | Sample Natal Subject Solar Return | 5.57° | Applying →   |
-| Interpolated Lilith   | Sample Natal Subject | conjunction ☌    | Mean Lilith           | Sample Natal Subject Solar Return | 3.51° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | biquintile bQ    | Eris                  | Sample Natal Subject Solar Return | 1.88° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 0.85° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | conjunction ☌    | Ixion                 | Sample Natal Subject Solar Return | 2.77° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | conjunction ☌    | Quaoar                | Sample Natal Subject Solar Return | 1.40° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | semi-square ∠    | Pars Amoris           | Sample Natal Subject Solar Return | 1.49° | Static =     |
-| Interpolated Lilith   | Sample Natal Subject | conjunction ☌    | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Interpolated Lilith   | Sample Natal Subject | opposition ☍     | Mean Priapus          | Sample Natal Subject Solar Return | 3.51° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 0.96° | Separating ← |
-| Interpolated Lilith   | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 0.55° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 0.16° | Applying →   |
+| Interpolated Lilith   | Sample Natal Subject | semi-square ∠    | Uranus                | Sample Natal Subject Solar Return | 0.66° | Applying →   |
+| Interpolated Lilith   | Sample Natal Subject | trine △          | Chiron                | Sample Natal Subject Solar Return | 4.54° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | conjunction ☌    | Medium Coeli          | Sample Natal Subject Solar Return | 3.70° | Applying →   |
+| Interpolated Lilith   | Sample Natal Subject | opposition ☍     | Imum Coeli            | Sample Natal Subject Solar Return | 3.70° | Applying →   |
+| Interpolated Lilith   | Sample Natal Subject | semi-square ∠    | Mean Lilith           | Sample Natal Subject Solar Return | 0.84° | Applying →   |
+| Interpolated Lilith   | Sample Natal Subject | trine △          | Pholus                | Sample Natal Subject Solar Return | 3.08° | Applying →   |
+| Interpolated Lilith   | Sample Natal Subject | semi-sextile ⚺   | Ceres                 | Sample Natal Subject Solar Return | 1.32° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 1.87° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | sextile ⚹        | Juno                  | Sample Natal Subject Solar Return | 2.70° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | trine △          | Vesta                 | Sample Natal Subject Solar Return | 3.10° | Applying →   |
+| Interpolated Lilith   | Sample Natal Subject | biquintile bQ    | Eris                  | Sample Natal Subject Solar Return | 1.64° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 1.77° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | conjunction ☌    | Ixion                 | Sample Natal Subject Solar Return | 1.73° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | conjunction ☌    | Quaoar                | Sample Natal Subject Solar Return | 0.14° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | opposition ☍     | Pars Fortunae         | Sample Natal Subject Solar Return | 5.56° | Static =     |
+| Interpolated Lilith   | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 4.89° | Static =     |
+| Interpolated Lilith   | Sample Natal Subject | trine △          | Pars Fidei            | Sample Natal Subject Solar Return | 3.09° | Static =     |
+| Interpolated Lilith   | Sample Natal Subject | square □         | Vertex                | Sample Natal Subject Solar Return | 1.22° | Static =     |
+| Interpolated Lilith   | Sample Natal Subject | square □         | Anti Vertex           | Sample Natal Subject Solar Return | 1.22° | Static =     |
+| Interpolated Lilith   | Sample Natal Subject | sesquiquadrate ⚼ | Mean Priapus          | Sample Natal Subject Solar Return | 0.84° | Applying →   |
+| Interpolated Lilith   | Sample Natal Subject | biquintile bQ    | True Priapus          | Sample Natal Subject Solar Return | 0.43° | Applying →   |
+| Interpolated Lilith   | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 5.46° | Separating ← |
+| Interpolated Lilith   | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 1.35° | Separating ← |
 | Mean Priapus          | Sample Natal Subject | sextile ⚹        | Sun                   | Sample Natal Subject Solar Return | 0.45° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | biquintile bQ    | Uranus                | Sample Natal Subject Solar Return | 1.75° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | sesquiquadrate ⚼ | Neptune               | Sample Natal Subject Solar Return | 1.23° | Separating ← |
-| Mean Priapus          | Sample Natal Subject | opposition ☍     | Mean Lilith           | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | trine △          | Haumea                | Sample Natal Subject Solar Return | 2.67° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | square □         | Makemake              | Sample Natal Subject Solar Return | 5.51° | Separating ← |
-| Mean Priapus          | Sample Natal Subject | quintile Q       | Orcus                 | Sample Natal Subject Solar Return | 0.15° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | opposition ☍     | Quaoar                | Sample Natal Subject Solar Return | 4.91° | Separating ← |
-| Mean Priapus          | Sample Natal Subject | quincunx ⚻       | Pars Fortunae         | Sample Natal Subject Solar Return | 0.51° | Static =     |
-| Mean Priapus          | Sample Natal Subject | opposition ☍     | Interpolated Lilith   | Sample Natal Subject Solar Return | 3.51° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | conjunction ☌    | Mean Priapus          | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 2.56° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | trine △          | Zeus                  | Sample Natal Subject Solar Return | 2.96° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | sesquiquadrate ⚼ | Apollon               | Sample Natal Subject Solar Return | 0.17° | Applying →   |
-| Mean Priapus          | Sample Natal Subject | semi-square ∠    | Vulkanus              | Sample Natal Subject Solar Return | 1.35° | Separating ← |
-| Mean Priapus          | Sample Natal Subject | quincunx ⚻       | Poseidon              | Sample Natal Subject Solar Return | 0.31° | Applying →   |
-| True Priapus          | Sample Natal Subject | sextile ⚹        | Mercury               | Sample Natal Subject Solar Return | 0.41° | Applying →   |
-| True Priapus          | Sample Natal Subject | semi-sextile ⚺   | Chiron                | Sample Natal Subject Solar Return | 1.87° | Separating ← |
-| True Priapus          | Sample Natal Subject | sextile ⚹        | Medium Coeli          | Sample Natal Subject Solar Return | 1.90° | Separating ← |
-| True Priapus          | Sample Natal Subject | trine △          | Imum Coeli            | Sample Natal Subject Solar Return | 1.90° | Separating ← |
-| True Priapus          | Sample Natal Subject | opposition ☍     | True Lilith           | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| True Priapus          | Sample Natal Subject | sextile ⚹        | Ceres                 | Sample Natal Subject Solar Return | 4.30° | Applying →   |
-| True Priapus          | Sample Natal Subject | biquintile bQ    | Juno                  | Sample Natal Subject Solar Return | 1.92° | Applying →   |
-| True Priapus          | Sample Natal Subject | semi-sextile ⚺   | Vesta                 | Sample Natal Subject Solar Return | 0.13° | Separating ← |
-| True Priapus          | Sample Natal Subject | sextile ⚹        | Eris                  | Sample Natal Subject Solar Return | 0.42° | Separating ← |
-| True Priapus          | Sample Natal Subject | biquintile bQ    | Pars Spiritus         | Sample Natal Subject Solar Return | 1.14° | Static =     |
-| True Priapus          | Sample Natal Subject | conjunction ☌    | True Priapus          | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| True Priapus          | Sample Natal Subject | conjunction ☌    | Interpolated Perigee  | Sample Natal Subject Solar Return | 2.97° | Separating ← |
-| True Priapus          | Sample Natal Subject | quincunx ⚻       | Cupido                | Sample Natal Subject Solar Return | 0.60° | Applying →   |
-| True Priapus          | Sample Natal Subject | conjunction ☌    | Kronos                | Sample Natal Subject Solar Return | 3.88° | Separating ← |
-| True Priapus          | Sample Natal Subject | trine △          | Apollon               | Sample Natal Subject Solar Return | 4.19° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | semi-sextile ⚺   | Moon                  | Sample Natal Subject Solar Return | 0.23° | Separating ← |
-| Interpolated Perigee  | Sample Natal Subject | sextile ⚹        | Mercury               | Sample Natal Subject Solar Return | 3.37° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | semi-square ∠    | Mars                  | Sample Natal Subject Solar Return | 0.02° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | quincunx ⚻       | Saturn                | Sample Natal Subject Solar Return | 0.53° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | biquintile bQ    | Pluto                 | Sample Natal Subject Solar Return | 0.01° | Separating ← |
-| Interpolated Perigee  | Sample Natal Subject | sesquiquadrate ⚼ | Mean North Lunar Node | Sample Natal Subject Solar Return | 1.81° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | sesquiquadrate ⚼ | True North Lunar Node | Sample Natal Subject Solar Return | 1.28° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | semi-sextile ⚺   | Chiron                | Sample Natal Subject Solar Return | 1.10° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | sesquiquadrate ⚼ | Ascendant             | Sample Natal Subject Solar Return | 0.16° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | sextile ⚹        | Medium Coeli          | Sample Natal Subject Solar Return | 1.07° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | semi-square ∠    | Descendant            | Sample Natal Subject Solar Return | 0.16° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | trine △          | Imum Coeli            | Sample Natal Subject Solar Return | 1.07° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | semi-square ∠    | Mean South Lunar Node | Sample Natal Subject Solar Return | 1.81° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | semi-square ∠    | True South Lunar Node | Sample Natal Subject Solar Return | 1.28° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | opposition ☍     | True Lilith           | Sample Natal Subject Solar Return | 2.97° | Separating ← |
-| Interpolated Perigee  | Sample Natal Subject | sextile ⚹        | Eris                  | Sample Natal Subject Solar Return | 3.39° | Separating ← |
-| Interpolated Perigee  | Sample Natal Subject | square □         | Haumea                | Sample Natal Subject Solar Return | 5.34° | Separating ← |
-| Interpolated Perigee  | Sample Natal Subject | quintile Q       | Makemake              | Sample Natal Subject Solar Return | 1.51° | Separating ← |
-| Interpolated Perigee  | Sample Natal Subject | quincunx ⚻       | Ixion                 | Sample Natal Subject Solar Return | 1.72° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | biquintile bQ    | Pars Spiritus         | Sample Natal Subject Solar Return | 1.83° | Static =     |
-| Interpolated Perigee  | Sample Natal Subject | conjunction ☌    | True Priapus          | Sample Natal Subject Solar Return | 2.97° | Separating ← |
-| Interpolated Perigee  | Sample Natal Subject | conjunction ☌    | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Interpolated Perigee  | Sample Natal Subject | square □         | Zeus                  | Sample Natal Subject Solar Return | 5.05° | Separating ← |
-| Interpolated Perigee  | Sample Natal Subject | conjunction ☌    | Kronos                | Sample Natal Subject Solar Return | 0.91° | Separating ← |
+| Mean Priapus          | Sample Natal Subject | opposition ☍     | Moon                  | Sample Natal Subject Solar Return | 5.64° | Separating ← |
+| Mean Priapus          | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 3.67° | Applying →   |
+| Mean Priapus          | Sample Natal Subject | square □         | Mars                  | Sample Natal Subject Solar Return | 4.89° | Separating ← |
+| Mean Priapus          | Sample Natal Subject | trine △          | Saturn                | Sample Natal Subject Solar Return | 4.90° | Applying →   |
+| Mean Priapus          | Sample Natal Subject | sesquiquadrate ⚼ | Neptune               | Sample Natal Subject Solar Return | 1.02° | Applying →   |
+| Mean Priapus          | Sample Natal Subject | sextile ⚹        | Chiron                | Sample Natal Subject Solar Return | 1.03° | Separating ← |
+| Mean Priapus          | Sample Natal Subject | sesquiquadrate ⚼ | Ascendant             | Sample Natal Subject Solar Return | 0.17° | Applying →   |
+| Mean Priapus          | Sample Natal Subject | semi-square ∠    | Descendant            | Sample Natal Subject Solar Return | 0.17° | Applying →   |
+| Mean Priapus          | Sample Natal Subject | trine △          | Pallas                | Sample Natal Subject Solar Return | 1.65° | Applying →   |
+| Mean Priapus          | Sample Natal Subject | trine △          | Haumea                | Sample Natal Subject Solar Return | 1.74° | Applying →   |
+| Mean Priapus          | Sample Natal Subject | opposition ☍     | Ixion                 | Sample Natal Subject Solar Return | 5.25° | Separating ← |
+| Mean Priapus          | Sample Natal Subject | quintile Q       | Orcus                 | Sample Natal Subject Solar Return | 0.86° | Separating ← |
+| Mean Priapus          | Sample Natal Subject | opposition ☍     | Quaoar                | Sample Natal Subject Solar Return | 3.65° | Separating ← |
+| Mean Priapus          | Sample Natal Subject | sextile ⚹        | Pars Fidei            | Sample Natal Subject Solar Return | 0.42° | Static =     |
+| Mean Priapus          | Sample Natal Subject | square □         | Vertex                | Sample Natal Subject Solar Return | 2.30° | Static =     |
+| Mean Priapus          | Sample Natal Subject | square □         | Anti Vertex           | Sample Natal Subject Solar Return | 2.30° | Static =     |
+| Mean Priapus          | Sample Natal Subject | biquintile bQ    | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.99° | Separating ← |
+| Mean Priapus          | Sample Natal Subject | trine △          | Zeus                  | Sample Natal Subject Solar Return | 2.16° | Applying →   |
+| Mean Priapus          | Sample Natal Subject | sesquiquadrate ⚼ | Apollon               | Sample Natal Subject Solar Return | 0.46° | Separating ← |
+| Mean Priapus          | Sample Natal Subject | semi-square ∠    | Vulkanus              | Sample Natal Subject Solar Return | 1.89° | Separating ← |
+| Mean Priapus          | Sample Natal Subject | quincunx ⚻       | Poseidon              | Sample Natal Subject Solar Return | 0.18° | Separating ← |
+| True Priapus          | Sample Natal Subject | sextile ⚹        | Jupiter               | Sample Natal Subject Solar Return | 0.62° | Separating ← |
+| True Priapus          | Sample Natal Subject | sesquiquadrate ⚼ | Saturn                | Sample Natal Subject Solar Return | 0.88° | Applying →   |
+| True Priapus          | Sample Natal Subject | quincunx ⚻       | Pluto                 | Sample Natal Subject Solar Return | 0.44° | Separating ← |
+| True Priapus          | Sample Natal Subject | quincunx ⚻       | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.43° | Applying →   |
+| True Priapus          | Sample Natal Subject | quincunx ⚻       | True North Lunar Node | Sample Natal Subject Solar Return | 0.93° | Separating ← |
+| True Priapus          | Sample Natal Subject | semi-sextile ⚺   | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.43° | Applying →   |
+| True Priapus          | Sample Natal Subject | semi-sextile ⚺   | True South Lunar Node | Sample Natal Subject Solar Return | 0.93° | Separating ← |
+| True Priapus          | Sample Natal Subject | biquintile bQ    | Juno                  | Sample Natal Subject Solar Return | 1.24° | Separating ← |
+| True Priapus          | Sample Natal Subject | sextile ⚹        | Eris                  | Sample Natal Subject Solar Return | 0.18° | Separating ← |
+| True Priapus          | Sample Natal Subject | semi-sextile ⚺   | Pars Fortunae         | Sample Natal Subject Solar Return | 1.90° | Static =     |
+| True Priapus          | Sample Natal Subject | trine △          | Pars Amoris           | Sample Natal Subject Solar Return | 2.57° | Static =     |
+| True Priapus          | Sample Natal Subject | semi-sextile ⚺   | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.46° | Separating ← |
+| True Priapus          | Sample Natal Subject | square □         | White Moon            | Sample Natal Subject Solar Return | 0.15° | Applying →   |
+| True Priapus          | Sample Natal Subject | conjunction ☌    | Kronos                | Sample Natal Subject Solar Return | 4.57° | Separating ← |
+| True Priapus          | Sample Natal Subject | trine △          | Apollon               | Sample Natal Subject Solar Return | 3.57° | Applying →   |
+| Interpolated Perigee  | Sample Natal Subject | sextile ⚹        | Mercury               | Sample Natal Subject Solar Return | 4.33° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | quintile Q       | Mars                  | Sample Natal Subject Solar Return | 0.89° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | sextile ⚹        | Jupiter               | Sample Natal Subject Solar Return | 2.34° | Applying →   |
+| Interpolated Perigee  | Sample Natal Subject | quincunx ⚻       | Medium Coeli          | Sample Natal Subject Solar Return | 0.79° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | semi-sextile ⚺   | Imum Coeli            | Sample Natal Subject Solar Return | 0.79° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | semi-sextile ⚺   | Pholus                | Sample Natal Subject Solar Return | 1.41° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | trine △          | Ceres                 | Sample Natal Subject Solar Return | 5.81° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | quincunx ⚻       | Juno                  | Sample Natal Subject Solar Return | 1.79° | Applying →   |
+| Interpolated Perigee  | Sample Natal Subject | semi-sextile ⚺   | Vesta                 | Sample Natal Subject Solar Return | 1.39° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | sextile ⚹        | Eris                  | Sample Natal Subject Solar Return | 3.15° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | semi-sextile ⚺   | Pars Fortunae         | Sample Natal Subject Solar Return | 1.07° | Static =     |
+| Interpolated Perigee  | Sample Natal Subject | trine △          | Pars Amoris           | Sample Natal Subject Solar Return | 0.40° | Static =     |
+| Interpolated Perigee  | Sample Natal Subject | trine △          | Anti Vertex           | Sample Natal Subject Solar Return | 5.71° | Static =     |
+| Interpolated Perigee  | Sample Natal Subject | square □         | White Moon            | Sample Natal Subject Solar Return | 3.12° | Applying →   |
+| Interpolated Perigee  | Sample Natal Subject | quincunx ⚻       | Cupido                | Sample Natal Subject Solar Return | 0.96° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | square □         | Zeus                  | Sample Natal Subject Solar Return | 5.84° | Separating ← |
+| Interpolated Perigee  | Sample Natal Subject | conjunction ☌    | Kronos                | Sample Natal Subject Solar Return | 1.60° | Separating ← |
 | White Moon            | Sample Natal Subject | conjunction ☌    | Sun                   | Sample Natal Subject Solar Return | 2.11° | Separating ← |
-| White Moon            | Sample Natal Subject | conjunction ☌    | Moon                  | Sample Natal Subject Solar Return | 5.22° | Applying →   |
-| White Moon            | Sample Natal Subject | conjunction ☌    | Jupiter               | Sample Natal Subject Solar Return | 2.52° | Applying →   |
-| White Moon            | Sample Natal Subject | opposition ☍     | Saturn                | Sample Natal Subject Solar Return | 4.92° | Separating ← |
-| White Moon            | Sample Natal Subject | trine △          | Mean Lilith           | Sample Natal Subject Solar Return | 2.56° | Separating ← |
-| White Moon            | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 0.11° | Applying →   |
-| White Moon            | Sample Natal Subject | trine △          | Ixion                 | Sample Natal Subject Solar Return | 3.73° | Separating ← |
-| White Moon            | Sample Natal Subject | trine △          | Quaoar                | Sample Natal Subject Solar Return | 2.36° | Separating ← |
-| White Moon            | Sample Natal Subject | square □         | Pars Fortunae         | Sample Natal Subject Solar Return | 2.05° | Static =     |
-| White Moon            | Sample Natal Subject | quintile Q       | Pars Amoris           | Sample Natal Subject Solar Return | 0.55° | Static =     |
-| White Moon            | Sample Natal Subject | semi-square ∠    | Vertex                | Sample Natal Subject Solar Return | 0.03° | Static =     |
-| White Moon            | Sample Natal Subject | sesquiquadrate ⚼ | Anti Vertex           | Sample Natal Subject Solar Return | 0.03° | Static =     |
-| White Moon            | Sample Natal Subject | trine △          | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.96° | Applying →   |
-| White Moon            | Sample Natal Subject | sextile ⚹        | Mean Priapus          | Sample Natal Subject Solar Return | 2.56° | Separating ← |
-| White Moon            | Sample Natal Subject | conjunction ☌    | White Moon            | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| White Moon            | Sample Natal Subject | semi-square ∠    | Hades                 | Sample Natal Subject Solar Return | 1.51° | Applying →   |
-| White Moon            | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 0.40° | Applying →   |
-| White Moon            | Sample Natal Subject | quintile Q       | Admetos               | Sample Natal Subject Solar Return | 0.53° | Separating ← |
-| White Moon            | Sample Natal Subject | square □         | Poseidon              | Sample Natal Subject Solar Return | 2.25° | Separating ← |
-| Cupido                | Sample Natal Subject | trine △          | Moon                  | Sample Natal Subject Solar Return | 2.59° | Separating ← |
-| Cupido                | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 1.01° | Applying →   |
-| Cupido                | Sample Natal Subject | sesquiquadrate ⚼ | Venus                 | Sample Natal Subject Solar Return | 1.91° | Applying →   |
-| Cupido                | Sample Natal Subject | trine △          | Jupiter               | Sample Natal Subject Solar Return | 5.29° | Separating ← |
-| Cupido                | Sample Natal Subject | sextile ⚹        | Saturn                | Sample Natal Subject Solar Return | 2.90° | Applying →   |
-| Cupido                | Sample Natal Subject | conjunction ☌    | Pluto                 | Sample Natal Subject Solar Return | 3.64° | Separating ← |
-| Cupido                | Sample Natal Subject | trine △          | Chiron                | Sample Natal Subject Solar Return | 1.26° | Separating ← |
-| Cupido                | Sample Natal Subject | square □         | Medium Coeli          | Sample Natal Subject Solar Return | 1.29° | Separating ← |
-| Cupido                | Sample Natal Subject | square □         | Imum Coeli            | Sample Natal Subject Solar Return | 1.29° | Separating ← |
-| Cupido                | Sample Natal Subject | semi-sextile ⚺   | True Lilith           | Sample Natal Subject Solar Return | 0.60° | Separating ← |
-| Cupido                | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 4.90° | Applying →   |
-| Cupido                | Sample Natal Subject | opposition ☍     | Vesta                 | Sample Natal Subject Solar Return | 0.47° | Applying →   |
-| Cupido                | Sample Natal Subject | quincunx ⚻       | Eris                  | Sample Natal Subject Solar Return | 1.02° | Separating ← |
-| Cupido                | Sample Natal Subject | conjunction ☌    | Ixion                 | Sample Natal Subject Solar Return | 4.09° | Applying →   |
-| Cupido                | Sample Natal Subject | conjunction ☌    | Quaoar                | Sample Natal Subject Solar Return | 5.46° | Applying →   |
-| Cupido                | Sample Natal Subject | conjunction ☌    | Pars Spiritus         | Sample Natal Subject Solar Return | 5.46° | Static =     |
-| Cupido                | Sample Natal Subject | quincunx ⚻       | True Priapus          | Sample Natal Subject Solar Return | 0.60° | Separating ← |
-| Cupido                | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Cupido                | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 3.66° | Applying →   |
-| Cupido                | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 3.28° | Applying →   |
-| Hades                 | Sample Natal Subject | semi-square ∠    | Jupiter               | Sample Natal Subject Solar Return | 1.01° | Applying →   |
-| Hades                 | Sample Natal Subject | trine △          | Mean North Lunar Node | Sample Natal Subject Solar Return | 2.13° | Separating ← |
-| Hades                 | Sample Natal Subject | trine △          | True North Lunar Node | Sample Natal Subject Solar Return | 2.66° | Separating ← |
-| Hades                 | Sample Natal Subject | biquintile bQ    | Ascendant             | Sample Natal Subject Solar Return | 1.90° | Separating ← |
-| Hades                 | Sample Natal Subject | sextile ⚹        | Mean South Lunar Node | Sample Natal Subject Solar Return | 2.13° | Separating ← |
-| Hades                 | Sample Natal Subject | sextile ⚹        | True South Lunar Node | Sample Natal Subject Solar Return | 2.66° | Separating ← |
-| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Pholus                | Sample Natal Subject Solar Return | 1.93° | Applying →   |
-| Hades                 | Sample Natal Subject | sextile ⚹        | Ceres                 | Sample Natal Subject Solar Return | 3.79° | Separating ← |
-| Hades                 | Sample Natal Subject | quincunx ⚻       | Juno                  | Sample Natal Subject Solar Return | 0.17° | Separating ← |
-| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Sedna                 | Sample Natal Subject Solar Return | 1.63° | Separating ← |
-| Hades                 | Sample Natal Subject | square □         | Makemake              | Sample Natal Subject Solar Return | 5.42° | Applying →   |
-| Hades                 | Sample Natal Subject | sextile ⚹        | Orcus                 | Sample Natal Subject Solar Return | 0.92° | Separating ← |
-| Hades                 | Sample Natal Subject | trine △          | Pars Amoris           | Sample Natal Subject Solar Return | 0.94° | Static =     |
-| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Pars Fidei            | Sample Natal Subject Solar Return | 1.71° | Static =     |
-| Hades                 | Sample Natal Subject | conjunction ☌    | Vertex                | Sample Natal Subject Solar Return | 1.54° | Static =     |
-| Hades                 | Sample Natal Subject | opposition ☍     | Anti Vertex           | Sample Natal Subject Solar Return | 1.54° | Static =     |
-| Hades                 | Sample Natal Subject | semi-square ∠    | White Moon            | Sample Natal Subject Solar Return | 1.51° | Separating ← |
-| Hades                 | Sample Natal Subject | conjunction ☌    | Hades                 | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Hades                 | Sample Natal Subject | trine △          | Apollon               | Sample Natal Subject Solar Return | 3.90° | Separating ← |
+| White Moon            | Sample Natal Subject | semi-sextile ⚺   | Mercury               | Sample Natal Subject Solar Return | 1.11° | Applying →   |
+| White Moon            | Sample Natal Subject | conjunction ☌    | Chiron                | Sample Natal Subject Solar Return | 3.59° | Separating ← |
+| White Moon            | Sample Natal Subject | trine △          | Medium Coeli          | Sample Natal Subject Solar Return | 4.66° | Applying →   |
+| White Moon            | Sample Natal Subject | sextile ⚹        | Imum Coeli            | Sample Natal Subject Solar Return | 4.66° | Applying →   |
+| White Moon            | Sample Natal Subject | conjunction ☌    | Pholus                | Sample Natal Subject Solar Return | 4.04° | Applying →   |
+| White Moon            | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 0.36° | Separating ← |
+| White Moon            | Sample Natal Subject | sextile ⚹        | Pallas                | Sample Natal Subject Solar Return | 0.91° | Separating ← |
+| White Moon            | Sample Natal Subject | opposition ☍     | Juno                  | Sample Natal Subject Solar Return | 3.66° | Separating ← |
+| White Moon            | Sample Natal Subject | conjunction ☌    | Vesta                 | Sample Natal Subject Solar Return | 4.06° | Applying →   |
+| White Moon            | Sample Natal Subject | sextile ⚹        | Haumea                | Sample Natal Subject Solar Return | 0.82° | Separating ← |
+| White Moon            | Sample Natal Subject | trine △          | Ixion                 | Sample Natal Subject Solar Return | 2.69° | Separating ← |
+| White Moon            | Sample Natal Subject | trine △          | Quaoar                | Sample Natal Subject Solar Return | 1.10° | Separating ← |
+| White Moon            | Sample Natal Subject | conjunction ☌    | Pars Fidei            | Sample Natal Subject Solar Return | 2.14° | Static =     |
+| White Moon            | Sample Natal Subject | semi-sextile ⚺   | Vertex                | Sample Natal Subject Solar Return | 0.26° | Static =     |
+| White Moon            | Sample Natal Subject | quincunx ⚻       | Anti Vertex           | Sample Natal Subject Solar Return | 0.26° | Static =     |
+| White Moon            | Sample Natal Subject | semi-square ∠    | Hades                 | Sample Natal Subject Solar Return | 0.51° | Applying →   |
+| White Moon            | Sample Natal Subject | sextile ⚹        | Zeus                  | Sample Natal Subject Solar Return | 0.40° | Separating ← |
+| White Moon            | Sample Natal Subject | quintile Q       | Admetos               | Sample Natal Subject Solar Return | 1.11° | Separating ← |
+| White Moon            | Sample Natal Subject | square □         | Poseidon              | Sample Natal Subject Solar Return | 2.74° | Separating ← |
+| Cupido                | Sample Natal Subject | quintile Q       | Venus                 | Sample Natal Subject Solar Return | 1.31° | Applying →   |
+| Cupido                | Sample Natal Subject | square □         | Jupiter               | Sample Natal Subject Solar Return | 0.02° | Separating ← |
+| Cupido                | Sample Natal Subject | sextile ⚹        | Neptune               | Sample Natal Subject Solar Return | 3.61° | Separating ← |
+| Cupido                | Sample Natal Subject | conjunction ☌    | Pluto                 | Sample Natal Subject Solar Return | 1.04° | Separating ← |
+| Cupido                | Sample Natal Subject | sextile ⚹        | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.17° | Separating ← |
+| Cupido                | Sample Natal Subject | sextile ⚹        | True North Lunar Node | Sample Natal Subject Solar Return | 0.32° | Separating ← |
+| Cupido                | Sample Natal Subject | sextile ⚹        | Ascendant             | Sample Natal Subject Solar Return | 4.79° | Applying →   |
+| Cupido                | Sample Natal Subject | conjunction ☌    | Medium Coeli          | Sample Natal Subject Solar Return | 3.15° | Separating ← |
+| Cupido                | Sample Natal Subject | trine △          | Descendant            | Sample Natal Subject Solar Return | 4.79° | Applying →   |
+| Cupido                | Sample Natal Subject | opposition ☍     | Imum Coeli            | Sample Natal Subject Solar Return | 3.15° | Separating ← |
+| Cupido                | Sample Natal Subject | trine △          | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.17° | Separating ← |
+| Cupido                | Sample Natal Subject | trine △          | True South Lunar Node | Sample Natal Subject Solar Return | 0.32° | Separating ← |
+| Cupido                | Sample Natal Subject | trine △          | Pholus                | Sample Natal Subject Solar Return | 3.77° | Separating ← |
+| Cupido                | Sample Natal Subject | sextile ⚹        | Juno                  | Sample Natal Subject Solar Return | 4.15° | Applying →   |
+| Cupido                | Sample Natal Subject | trine △          | Vesta                 | Sample Natal Subject Solar Return | 3.76° | Separating ← |
+| Cupido                | Sample Natal Subject | quincunx ⚻       | Eris                  | Sample Natal Subject Solar Return | 0.79° | Separating ← |
+| Cupido                | Sample Natal Subject | quintile Q       | Makemake              | Sample Natal Subject Solar Return | 1.07° | Applying →   |
+| Cupido                | Sample Natal Subject | conjunction ☌    | Ixion                 | Sample Natal Subject Solar Return | 5.13° | Applying →   |
+| Cupido                | Sample Natal Subject | opposition ☍     | Pars Fortunae         | Sample Natal Subject Solar Return | 1.29° | Static =     |
+| Cupido                | Sample Natal Subject | quintile Q       | Pars Spiritus         | Sample Natal Subject Solar Return | 1.12° | Static =     |
+| Cupido                | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 1.97° | Static =     |
+| Cupido                | Sample Natal Subject | trine △          | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.14° | Applying →   |
+| Cupido                | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 0.75° | Applying →   |
+| Cupido                | Sample Natal Subject | conjunction ☌    | Cupido                | Sample Natal Subject Solar Return | 1.40° | Applying →   |
+| Cupido                | Sample Natal Subject | opposition ☍     | Admetos               | Sample Natal Subject Solar Return | 3.08° | Applying →   |
+| Cupido                | Sample Natal Subject | trine △          | Vulkanus              | Sample Natal Subject Solar Return | 2.74° | Applying →   |
+| Hades                 | Sample Natal Subject | opposition ☍     | Moon                  | Sample Natal Subject Solar Return | 5.29° | Applying →   |
+| Hades                 | Sample Natal Subject | square □         | Venus                 | Sample Natal Subject Solar Return | 4.62° | Applying →   |
+| Hades                 | Sample Natal Subject | quincunx ⚻       | Uranus                | Sample Natal Subject Solar Return | 1.21° | Applying →   |
+| Hades                 | Sample Natal Subject | biquintile bQ    | Neptune               | Sample Natal Subject Solar Return | 0.91° | Separating ← |
+| Hades                 | Sample Natal Subject | quincunx ⚻       | Mean Lilith           | Sample Natal Subject Solar Return | 0.28° | Applying →   |
+| Hades                 | Sample Natal Subject | sesquiquadrate ⚼ | Ceres                 | Sample Natal Subject Solar Return | 1.87° | Separating ← |
+| Hades                 | Sample Natal Subject | square □         | Makemake              | Sample Natal Subject Solar Return | 4.37° | Applying →   |
+| Hades                 | Sample Natal Subject | sextile ⚹        | Orcus                 | Sample Natal Subject Solar Return | 1.93° | Separating ← |
+| Hades                 | Sample Natal Subject | square □         | Pars Spiritus         | Sample Natal Subject Solar Return | 2.19° | Static =     |
+| Hades                 | Sample Natal Subject | semi-sextile ⚺   | Mean Priapus          | Sample Natal Subject Solar Return | 0.28° | Applying →   |
+| Hades                 | Sample Natal Subject | conjunction ☌    | Hades                 | Sample Natal Subject Solar Return | 1.00° | Separating ← |
+| Hades                 | Sample Natal Subject | trine △          | Apollon               | Sample Natal Subject Solar Return | 4.53° | Separating ← |
 | Zeus                  | Sample Natal Subject | sextile ⚹        | Sun                   | Sample Natal Subject Solar Return | 2.51° | Separating ← |
-| Zeus                  | Sample Natal Subject | sextile ⚹        | Moon                  | Sample Natal Subject Solar Return | 4.82° | Applying →   |
-| Zeus                  | Sample Natal Subject | square □         | Venus                 | Sample Natal Subject Solar Return | 5.68° | Separating ← |
-| Zeus                  | Sample Natal Subject | sextile ⚹        | Jupiter               | Sample Natal Subject Solar Return | 2.12° | Applying →   |
-| Zeus                  | Sample Natal Subject | trine △          | Saturn                | Sample Natal Subject Solar Return | 4.51° | Separating ← |
-| Zeus                  | Sample Natal Subject | biquintile bQ    | Imum Coeli            | Sample Natal Subject Solar Return | 0.12° | Applying →   |
-| Zeus                  | Sample Natal Subject | sextile ⚹        | Mean Lilith           | Sample Natal Subject Solar Return | 2.96° | Separating ← |
-| Zeus                  | Sample Natal Subject | semi-square ∠    | Juno                  | Sample Natal Subject Solar Return | 0.93° | Applying →   |
-| Zeus                  | Sample Natal Subject | sesquiquadrate ⚼ | Sedna                 | Sample Natal Subject Solar Return | 0.52° | Separating ← |
-| Zeus                  | Sample Natal Subject | conjunction ☌    | Haumea                | Sample Natal Subject Solar Return | 0.29° | Separating ← |
-| Zeus                  | Sample Natal Subject | sextile ⚹        | Ixion                 | Sample Natal Subject Solar Return | 3.33° | Separating ← |
-| Zeus                  | Sample Natal Subject | semi-square ∠    | Orcus                 | Sample Natal Subject Solar Return | 0.19° | Applying →   |
-| Zeus                  | Sample Natal Subject | sextile ⚹        | Quaoar                | Sample Natal Subject Solar Return | 1.95° | Separating ← |
-| Zeus                  | Sample Natal Subject | sextile ⚹        | Interpolated Lilith   | Sample Natal Subject Solar Return | 0.55° | Applying →   |
-| Zeus                  | Sample Natal Subject | trine △          | Mean Priapus          | Sample Natal Subject Solar Return | 2.96° | Separating ← |
-| Zeus                  | Sample Natal Subject | square □         | Interpolated Perigee  | Sample Natal Subject Solar Return | 5.05° | Applying →   |
-| Zeus                  | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 0.40° | Separating ← |
-| Zeus                  | Sample Natal Subject | conjunction ☌    | Zeus                  | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Zeus                  | Sample Natal Subject | square □         | Kronos                | Sample Natal Subject Solar Return | 4.14° | Applying →   |
-| Zeus                  | Sample Natal Subject | quintile Q       | Vulkanus              | Sample Natal Subject Solar Return | 1.31° | Separating ← |
-| Kronos                | Sample Natal Subject | semi-sextile ⚺   | Moon                  | Sample Natal Subject Solar Return | 0.69° | Applying →   |
-| Kronos                | Sample Natal Subject | sextile ⚹        | Mercury               | Sample Natal Subject Solar Return | 4.29° | Applying →   |
-| Kronos                | Sample Natal Subject | semi-square ∠    | Mars                  | Sample Natal Subject Solar Return | 0.93° | Applying →   |
-| Kronos                | Sample Natal Subject | quincunx ⚻       | Saturn                | Sample Natal Subject Solar Return | 0.38° | Separating ← |
-| Kronos                | Sample Natal Subject | biquintile bQ    | Pluto                 | Sample Natal Subject Solar Return | 0.92° | Separating ← |
-| Kronos                | Sample Natal Subject | sesquiquadrate ⚼ | Mean North Lunar Node | Sample Natal Subject Solar Return | 0.89° | Applying →   |
-| Kronos                | Sample Natal Subject | sesquiquadrate ⚼ | True North Lunar Node | Sample Natal Subject Solar Return | 0.37° | Applying →   |
-| Kronos                | Sample Natal Subject | sesquiquadrate ⚼ | Ascendant             | Sample Natal Subject Solar Return | 1.08° | Applying →   |
-| Kronos                | Sample Natal Subject | sextile ⚹        | Medium Coeli          | Sample Natal Subject Solar Return | 1.98° | Applying →   |
-| Kronos                | Sample Natal Subject | semi-square ∠    | Descendant            | Sample Natal Subject Solar Return | 1.08° | Applying →   |
-| Kronos                | Sample Natal Subject | trine △          | Imum Coeli            | Sample Natal Subject Solar Return | 1.98° | Applying →   |
-| Kronos                | Sample Natal Subject | semi-square ∠    | Mean South Lunar Node | Sample Natal Subject Solar Return | 0.89° | Applying →   |
-| Kronos                | Sample Natal Subject | semi-square ∠    | True South Lunar Node | Sample Natal Subject Solar Return | 0.37° | Applying →   |
-| Kronos                | Sample Natal Subject | opposition ☍     | True Lilith           | Sample Natal Subject Solar Return | 3.88° | Separating ← |
-| Kronos                | Sample Natal Subject | sextile ⚹        | Eris                  | Sample Natal Subject Solar Return | 4.30° | Separating ← |
-| Kronos                | Sample Natal Subject | square □         | Haumea                | Sample Natal Subject Solar Return | 4.43° | Separating ← |
-| Kronos                | Sample Natal Subject | quintile Q       | Makemake              | Sample Natal Subject Solar Return | 0.60° | Separating ← |
-| Kronos                | Sample Natal Subject | quincunx ⚻       | Ixion                 | Sample Natal Subject Solar Return | 0.81° | Applying →   |
-| Kronos                | Sample Natal Subject | semi-square ∠    | Pars Fidei            | Sample Natal Subject Solar Return | 1.32° | Static =     |
-| Kronos                | Sample Natal Subject | conjunction ☌    | True Priapus          | Sample Natal Subject Solar Return | 3.88° | Separating ← |
-| Kronos                | Sample Natal Subject | conjunction ☌    | Interpolated Perigee  | Sample Natal Subject Solar Return | 0.91° | Applying →   |
-| Kronos                | Sample Natal Subject | square □         | Zeus                  | Sample Natal Subject Solar Return | 4.14° | Separating ← |
-| Kronos                | Sample Natal Subject | conjunction ☌    | Kronos                | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Apollon               | Sample Natal Subject | sextile ⚹        | Mercury               | Sample Natal Subject Solar Return | 3.78° | Separating ← |
-| Apollon               | Sample Natal Subject | square □         | Neptune               | Sample Natal Subject Solar Return | 1.06° | Separating ← |
-| Apollon               | Sample Natal Subject | semi-sextile ⚺   | Pluto                 | Sample Natal Subject Solar Return | 1.15° | Applying →   |
-| Apollon               | Sample Natal Subject | semi-square ∠    | Mean Lilith           | Sample Natal Subject Solar Return | 0.17° | Separating ← |
-| Apollon               | Sample Natal Subject | sextile ⚹        | True Lilith           | Sample Natal Subject Solar Return | 4.19° | Applying →   |
-| Apollon               | Sample Natal Subject | square □         | Pholus                | Sample Natal Subject Solar Return | 5.83° | Applying →   |
-| Apollon               | Sample Natal Subject | sextile ⚹        | Ceres                 | Sample Natal Subject Solar Return | 0.11° | Applying →   |
-| Apollon               | Sample Natal Subject | biquintile bQ    | Vesta                 | Sample Natal Subject Solar Return | 1.68° | Applying →   |
-| Apollon               | Sample Natal Subject | opposition ☍     | Eris                  | Sample Natal Subject Solar Return | 3.77° | Applying →   |
-| Apollon               | Sample Natal Subject | sextile ⚹        | Orcus                 | Sample Natal Subject Solar Return | 2.99° | Applying →   |
-| Apollon               | Sample Natal Subject | semi-sextile ⚺   | Pars Spiritus         | Sample Natal Subject Solar Return | 0.67° | Static =     |
-| Apollon               | Sample Natal Subject | conjunction ☌    | Pars Amoris           | Sample Natal Subject Solar Return | 4.84° | Static =     |
-| Apollon               | Sample Natal Subject | trine △          | Vertex                | Sample Natal Subject Solar Return | 2.36° | Static =     |
-| Apollon               | Sample Natal Subject | sextile ⚹        | Anti Vertex           | Sample Natal Subject Solar Return | 2.36° | Static =     |
-| Apollon               | Sample Natal Subject | sesquiquadrate ⚼ | Mean Priapus          | Sample Natal Subject Solar Return | 0.17° | Separating ← |
-| Apollon               | Sample Natal Subject | trine △          | True Priapus          | Sample Natal Subject Solar Return | 4.19° | Applying →   |
-| Apollon               | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 3.90° | Applying →   |
-| Apollon               | Sample Natal Subject | conjunction ☌    | Apollon               | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Apollon               | Sample Natal Subject | quincunx ⚻       | Admetos               | Sample Natal Subject Solar Return | 1.13° | Separating ← |
-| Apollon               | Sample Natal Subject | square □         | Vulkanus              | Sample Natal Subject Solar Return | 1.52° | Separating ← |
+| Zeus                  | Sample Natal Subject | semi-sextile ⚺   | Mercury               | Sample Natal Subject Solar Return | 0.71° | Applying →   |
+| Zeus                  | Sample Natal Subject | sextile ⚹        | Chiron                | Sample Natal Subject Solar Return | 3.99° | Separating ← |
+| Zeus                  | Sample Natal Subject | sextile ⚹        | Medium Coeli          | Sample Natal Subject Solar Return | 4.26° | Applying →   |
+| Zeus                  | Sample Natal Subject | quintile Q       | Descendant            | Sample Natal Subject Solar Return | 0.21° | Applying →   |
+| Zeus                  | Sample Natal Subject | trine △          | Imum Coeli            | Sample Natal Subject Solar Return | 4.26° | Applying →   |
+| Zeus                  | Sample Natal Subject | square □         | True Lilith           | Sample Natal Subject Solar Return | 5.01° | Separating ← |
+| Zeus                  | Sample Natal Subject | sextile ⚹        | Pholus                | Sample Natal Subject Solar Return | 3.64° | Applying →   |
+| Zeus                  | Sample Natal Subject | semi-sextile ⚺   | Ceres                 | Sample Natal Subject Solar Return | 0.76° | Separating ← |
+| Zeus                  | Sample Natal Subject | conjunction ☌    | Pallas                | Sample Natal Subject Solar Return | 1.31° | Separating ← |
+| Zeus                  | Sample Natal Subject | trine △          | Juno                  | Sample Natal Subject Solar Return | 3.26° | Separating ← |
+| Zeus                  | Sample Natal Subject | sextile ⚹        | Vesta                 | Sample Natal Subject Solar Return | 3.66° | Applying →   |
+| Zeus                  | Sample Natal Subject | sesquiquadrate ⚼ | Sedna                 | Sample Natal Subject Solar Return | 1.03° | Separating ← |
+| Zeus                  | Sample Natal Subject | conjunction ☌    | Haumea                | Sample Natal Subject Solar Return | 1.22° | Separating ← |
+| Zeus                  | Sample Natal Subject | sextile ⚹        | Ixion                 | Sample Natal Subject Solar Return | 2.29° | Separating ← |
+| Zeus                  | Sample Natal Subject | semi-square ∠    | Orcus                 | Sample Natal Subject Solar Return | 0.82° | Separating ← |
+| Zeus                  | Sample Natal Subject | sextile ⚹        | Quaoar                | Sample Natal Subject Solar Return | 0.69° | Separating ← |
+| Zeus                  | Sample Natal Subject | biquintile bQ    | Pars Amoris           | Sample Natal Subject Solar Return | 0.55° | Static =     |
+| Zeus                  | Sample Natal Subject | sextile ⚹        | Pars Fidei            | Sample Natal Subject Solar Return | 2.54° | Static =     |
+| Zeus                  | Sample Natal Subject | semi-sextile ⚺   | Vertex                | Sample Natal Subject Solar Return | 0.66° | Static =     |
+| Zeus                  | Sample Natal Subject | quincunx ⚻       | Anti Vertex           | Sample Natal Subject Solar Return | 0.66° | Static =     |
+| Zeus                  | Sample Natal Subject | square □         | True Priapus          | Sample Natal Subject Solar Return | 5.01° | Separating ← |
+| Zeus                  | Sample Natal Subject | conjunction ☌    | Zeus                  | Sample Natal Subject Solar Return | 0.80° | Separating ← |
+| Zeus                  | Sample Natal Subject | square □         | Kronos                | Sample Natal Subject Solar Return | 3.44° | Applying →   |
+| Zeus                  | Sample Natal Subject | quintile Q       | Vulkanus              | Sample Natal Subject Solar Return | 1.85° | Separating ← |
+| Kronos                | Sample Natal Subject | sextile ⚹        | Mercury               | Sample Natal Subject Solar Return | 3.42° | Separating ← |
+| Kronos                | Sample Natal Subject | quintile Q       | Venus                 | Sample Natal Subject Solar Return | 1.41° | Separating ← |
+| Kronos                | Sample Natal Subject | quintile Q       | Mars                  | Sample Natal Subject Solar Return | 0.02° | Applying →   |
+| Kronos                | Sample Natal Subject | sextile ⚹        | Jupiter               | Sample Natal Subject Solar Return | 3.26° | Applying →   |
+| Kronos                | Sample Natal Subject | biquintile bQ    | Pluto                 | Sample Natal Subject Solar Return | 1.68° | Applying →   |
+| Kronos                | Sample Natal Subject | quincunx ⚻       | Medium Coeli          | Sample Natal Subject Solar Return | 0.12° | Applying →   |
+| Kronos                | Sample Natal Subject | semi-sextile ⚺   | Imum Coeli            | Sample Natal Subject Solar Return | 0.12° | Applying →   |
+| Kronos                | Sample Natal Subject | semi-sextile ⚺   | Pholus                | Sample Natal Subject Solar Return | 0.50° | Separating ← |
+| Kronos                | Sample Natal Subject | trine △          | Ceres                 | Sample Natal Subject Solar Return | 4.90° | Separating ← |
+| Kronos                | Sample Natal Subject | square □         | Pallas                | Sample Natal Subject Solar Return | 5.45° | Separating ← |
+| Kronos                | Sample Natal Subject | quincunx ⚻       | Juno                  | Sample Natal Subject Solar Return | 0.88° | Applying →   |
+| Kronos                | Sample Natal Subject | semi-sextile ⚺   | Vesta                 | Sample Natal Subject Solar Return | 0.48° | Separating ← |
+| Kronos                | Sample Natal Subject | sextile ⚹        | Eris                  | Sample Natal Subject Solar Return | 4.06° | Separating ← |
+| Kronos                | Sample Natal Subject | square □         | Haumea                | Sample Natal Subject Solar Return | 5.35° | Separating ← |
+| Kronos                | Sample Natal Subject | quintile Q       | Makemake              | Sample Natal Subject Solar Return | 1.65° | Separating ← |
+| Kronos                | Sample Natal Subject | quincunx ⚻       | Ixion                 | Sample Natal Subject Solar Return | 1.85° | Applying →   |
+| Kronos                | Sample Natal Subject | semi-sextile ⚺   | Pars Fortunae         | Sample Natal Subject Solar Return | 1.98° | Static =     |
+| Kronos                | Sample Natal Subject | trine △          | Pars Amoris           | Sample Natal Subject Solar Return | 1.31° | Static =     |
+| Kronos                | Sample Natal Subject | sextile ⚹        | Vertex                | Sample Natal Subject Solar Return | 4.80° | Static =     |
+| Kronos                | Sample Natal Subject | trine △          | Anti Vertex           | Sample Natal Subject Solar Return | 4.80° | Static =     |
+| Kronos                | Sample Natal Subject | square □         | White Moon            | Sample Natal Subject Solar Return | 4.03° | Applying →   |
+| Kronos                | Sample Natal Subject | quincunx ⚻       | Cupido                | Sample Natal Subject Solar Return | 1.87° | Separating ← |
+| Kronos                | Sample Natal Subject | square □         | Zeus                  | Sample Natal Subject Solar Return | 4.93° | Separating ← |
+| Kronos                | Sample Natal Subject | conjunction ☌    | Kronos                | Sample Natal Subject Solar Return | 0.69° | Separating ← |
+| Apollon               | Sample Natal Subject | sextile ⚹        | Jupiter               | Sample Natal Subject Solar Return | 4.81° | Separating ← |
+| Apollon               | Sample Natal Subject | square □         | Uranus                | Sample Natal Subject Solar Return | 2.69° | Separating ← |
+| Apollon               | Sample Natal Subject | square □         | Neptune               | Sample Natal Subject Solar Return | 1.19° | Applying →   |
+| Apollon               | Sample Natal Subject | square □         | Mean North Lunar Node | Sample Natal Subject Solar Return | 4.62° | Applying →   |
+| Apollon               | Sample Natal Subject | square □         | True North Lunar Node | Sample Natal Subject Solar Return | 5.12° | Separating ← |
+| Apollon               | Sample Natal Subject | quintile Q       | Chiron                | Sample Natal Subject Solar Return | 1.81° | Applying →   |
+| Apollon               | Sample Natal Subject | square □         | Ascendant             | Sample Natal Subject Solar Return | 0.00° | Applying →   |
+| Apollon               | Sample Natal Subject | square □         | Descendant            | Sample Natal Subject Solar Return | 0.00° | Applying →   |
+| Apollon               | Sample Natal Subject | biquintile bQ    | Imum Coeli            | Sample Natal Subject Solar Return | 1.95° | Separating ← |
+| Apollon               | Sample Natal Subject | square □         | Mean Lilith           | Sample Natal Subject Solar Return | 4.19° | Applying →   |
+| Apollon               | Sample Natal Subject | square □         | Mean South Lunar Node | Sample Natal Subject Solar Return | 4.62° | Applying →   |
+| Apollon               | Sample Natal Subject | square □         | True South Lunar Node | Sample Natal Subject Solar Return | 5.12° | Separating ← |
+| Apollon               | Sample Natal Subject | opposition ☍     | Eris                  | Sample Natal Subject Solar Return | 4.01° | Applying →   |
+| Apollon               | Sample Natal Subject | quincunx ⚻       | Sedna                 | Sample Natal Subject Solar Return | 1.77° | Applying →   |
+| Apollon               | Sample Natal Subject | sextile ⚹        | Orcus                 | Sample Natal Subject Solar Return | 1.97° | Applying →   |
+| Apollon               | Sample Natal Subject | biquintile bQ    | Pars Fortunae         | Sample Natal Subject Solar Return | 0.09° | Static =     |
+| Apollon               | Sample Natal Subject | square □         | Mean Priapus          | Sample Natal Subject Solar Return | 4.19° | Applying →   |
+| Apollon               | Sample Natal Subject | square □         | Interpolated Perigee  | Sample Natal Subject Solar Return | 4.65° | Separating ← |
+| Apollon               | Sample Natal Subject | trine △          | Hades                 | Sample Natal Subject Solar Return | 2.91° | Applying →   |
+| Apollon               | Sample Natal Subject | conjunction ☌    | Apollon               | Sample Natal Subject Solar Return | 0.62° | Separating ← |
+| Apollon               | Sample Natal Subject | quincunx ⚻       | Admetos               | Sample Natal Subject Solar Return | 1.72° | Separating ← |
+| Apollon               | Sample Natal Subject | square □         | Vulkanus              | Sample Natal Subject Solar Return | 2.05° | Separating ← |
 | Admetos               | Sample Natal Subject | quintile Q       | Sun                   | Sample Natal Subject Solar Return | 1.58° | Separating ← |
-| Admetos               | Sample Natal Subject | square □         | Mercury               | Sample Natal Subject Solar Return | 2.65° | Separating ← |
-| Admetos               | Sample Natal Subject | semi-square ∠    | Venus                 | Sample Natal Subject Solar Return | 1.75° | Separating ← |
-| Admetos               | Sample Natal Subject | trine △          | Neptune               | Sample Natal Subject Solar Return | 2.20° | Separating ← |
-| Admetos               | Sample Natal Subject | opposition ☍     | Pluto                 | Sample Natal Subject Solar Return | 0.02° | Applying →   |
-| Admetos               | Sample Natal Subject | sextile ⚹        | Chiron                | Sample Natal Subject Solar Return | 4.92° | Separating ← |
-| Admetos               | Sample Natal Subject | square □         | Medium Coeli          | Sample Natal Subject Solar Return | 4.95° | Separating ← |
-| Admetos               | Sample Natal Subject | square □         | Imum Coeli            | Sample Natal Subject Solar Return | 4.95° | Separating ← |
-| Admetos               | Sample Natal Subject | square □         | Ceres                 | Sample Natal Subject Solar Return | 1.24° | Applying →   |
-| Admetos               | Sample Natal Subject | opposition ☍     | Juno                  | Sample Natal Subject Solar Return | 4.86° | Applying →   |
-| Admetos               | Sample Natal Subject | conjunction ☌    | Vesta                 | Sample Natal Subject Solar Return | 3.19° | Separating ← |
-| Admetos               | Sample Natal Subject | conjunction ☌    | Sedna                 | Sample Natal Subject Solar Return | 3.41° | Applying →   |
-| Admetos               | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 4.12° | Applying →   |
-| Admetos               | Sample Natal Subject | opposition ☍     | Pars Spiritus         | Sample Natal Subject Solar Return | 1.81° | Static =     |
-| Admetos               | Sample Natal Subject | biquintile bQ    | Pars Amoris           | Sample Natal Subject Solar Return | 0.03° | Static =     |
-| Admetos               | Sample Natal Subject | quintile Q       | White Moon            | Sample Natal Subject Solar Return | 0.53° | Applying →   |
-| Admetos               | Sample Natal Subject | opposition ☍     | Cupido                | Sample Natal Subject Solar Return | 3.66° | Applying →   |
-| Admetos               | Sample Natal Subject | quincunx ⚻       | Apollon               | Sample Natal Subject Solar Return | 1.13° | Applying →   |
-| Admetos               | Sample Natal Subject | conjunction ☌    | Admetos               | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Admetos               | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 0.38° | Separating ← |
-| Vulkanus              | Sample Natal Subject | conjunction ☌    | Moon                  | Sample Natal Subject Solar Return | 5.87° | Separating ← |
-| Vulkanus              | Sample Natal Subject | opposition ☍     | Neptune               | Sample Natal Subject Solar Return | 2.58° | Separating ← |
-| Vulkanus              | Sample Natal Subject | trine △          | Pluto                 | Sample Natal Subject Solar Return | 0.37° | Separating ← |
-| Vulkanus              | Sample Natal Subject | conjunction ☌    | Chiron                | Sample Natal Subject Solar Return | 4.54° | Separating ← |
-| Vulkanus              | Sample Natal Subject | biquintile bQ    | Imum Coeli            | Sample Natal Subject Solar Return | 1.43° | Applying →   |
-| Vulkanus              | Sample Natal Subject | sesquiquadrate ⚼ | Mean Lilith           | Sample Natal Subject Solar Return | 1.35° | Applying →   |
-| Vulkanus              | Sample Natal Subject | semi-sextile ⚺   | Ceres                 | Sample Natal Subject Solar Return | 1.63° | Applying →   |
-| Vulkanus              | Sample Natal Subject | trine △          | Juno                  | Sample Natal Subject Solar Return | 5.24° | Applying →   |
-| Vulkanus              | Sample Natal Subject | sextile ⚹        | Vesta                 | Sample Natal Subject Solar Return | 2.81° | Separating ← |
-| Vulkanus              | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 2.26° | Applying →   |
-| Vulkanus              | Sample Natal Subject | sextile ⚹        | Sedna                 | Sample Natal Subject Solar Return | 3.79° | Applying →   |
-| Vulkanus              | Sample Natal Subject | quintile Q       | Haumea                | Sample Natal Subject Solar Return | 1.02° | Applying →   |
-| Vulkanus              | Sample Natal Subject | trine △          | Pars Spiritus         | Sample Natal Subject Solar Return | 2.19° | Static =     |
-| Vulkanus              | Sample Natal Subject | semi-square ∠    | Mean Priapus          | Sample Natal Subject Solar Return | 1.35° | Applying →   |
-| Vulkanus              | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 3.28° | Applying →   |
-| Vulkanus              | Sample Natal Subject | quintile Q       | Zeus                  | Sample Natal Subject Solar Return | 1.31° | Applying →   |
-| Vulkanus              | Sample Natal Subject | square □         | Apollon               | Sample Natal Subject Solar Return | 1.52° | Applying →   |
-| Vulkanus              | Sample Natal Subject | sextile ⚹        | Admetos               | Sample Natal Subject Solar Return | 0.38° | Applying →   |
-| Vulkanus              | Sample Natal Subject | conjunction ☌    | Vulkanus              | Sample Natal Subject Solar Return | 0.00° | Separating ← |
+| Admetos               | Sample Natal Subject | square □         | Jupiter               | Sample Natal Subject Solar Return | 3.68° | Separating ← |
+| Admetos               | Sample Natal Subject | trine △          | Uranus                | Sample Natal Subject Solar Return | 3.82° | Separating ← |
+| Admetos               | Sample Natal Subject | trine △          | Neptune               | Sample Natal Subject Solar Return | 0.05° | Applying →   |
+| Admetos               | Sample Natal Subject | opposition ☍     | Pluto                 | Sample Natal Subject Solar Return | 2.62° | Applying →   |
+| Admetos               | Sample Natal Subject | trine △          | Mean North Lunar Node | Sample Natal Subject Solar Return | 3.49° | Applying →   |
+| Admetos               | Sample Natal Subject | trine △          | True North Lunar Node | Sample Natal Subject Solar Return | 3.98° | Separating ← |
+| Admetos               | Sample Natal Subject | trine △          | Ascendant             | Sample Natal Subject Solar Return | 1.14° | Applying →   |
+| Admetos               | Sample Natal Subject | sextile ⚹        | Descendant            | Sample Natal Subject Solar Return | 1.14° | Applying →   |
+| Admetos               | Sample Natal Subject | trine △          | Mean Lilith           | Sample Natal Subject Solar Return | 5.32° | Applying →   |
+| Admetos               | Sample Natal Subject | sextile ⚹        | Mean South Lunar Node | Sample Natal Subject Solar Return | 3.49° | Applying →   |
+| Admetos               | Sample Natal Subject | sextile ⚹        | True South Lunar Node | Sample Natal Subject Solar Return | 3.98° | Separating ← |
+| Admetos               | Sample Natal Subject | sesquiquadrate ⚼ | True Lilith           | Sample Natal Subject Solar Return | 1.08° | Separating ← |
+| Admetos               | Sample Natal Subject | conjunction ☌    | Sedna                 | Sample Natal Subject Solar Return | 2.90° | Applying →   |
+| Admetos               | Sample Natal Subject | square □         | Orcus                 | Sample Natal Subject Solar Return | 3.11° | Applying →   |
+| Admetos               | Sample Natal Subject | conjunction ☌    | Pars Fortunae         | Sample Natal Subject Solar Return | 4.95° | Static =     |
+| Admetos               | Sample Natal Subject | square □         | Pars Amoris           | Sample Natal Subject Solar Return | 5.63° | Static =     |
+| Admetos               | Sample Natal Subject | quintile Q       | Pars Fidei            | Sample Natal Subject Solar Return | 1.61° | Static =     |
+| Admetos               | Sample Natal Subject | semi-square ∠    | True Priapus          | Sample Natal Subject Solar Return | 1.08° | Separating ← |
+| Admetos               | Sample Natal Subject | sextile ⚹        | Interpolated Perigee  | Sample Natal Subject Solar Return | 3.52° | Separating ← |
+| Admetos               | Sample Natal Subject | trine △          | White Moon            | Sample Natal Subject Solar Return | 2.91° | Separating ← |
+| Admetos               | Sample Natal Subject | opposition ☍     | Cupido                | Sample Natal Subject Solar Return | 5.06° | Applying →   |
+| Admetos               | Sample Natal Subject | quincunx ⚻       | Apollon               | Sample Natal Subject Solar Return | 0.51° | Applying →   |
+| Admetos               | Sample Natal Subject | conjunction ☌    | Admetos               | Sample Natal Subject Solar Return | 0.58° | Separating ← |
+| Admetos               | Sample Natal Subject | sextile ⚹        | Vulkanus              | Sample Natal Subject Solar Return | 0.92° | Separating ← |
+| Vulkanus              | Sample Natal Subject | opposition ☍     | Uranus                | Sample Natal Subject Solar Return | 4.21° | Separating ← |
+| Vulkanus              | Sample Natal Subject | opposition ☍     | Neptune               | Sample Natal Subject Solar Return | 0.33° | Separating ← |
+| Vulkanus              | Sample Natal Subject | trine △          | Pluto                 | Sample Natal Subject Solar Return | 2.24° | Applying →   |
+| Vulkanus              | Sample Natal Subject | opposition ☍     | Mean North Lunar Node | Sample Natal Subject Solar Return | 3.11° | Applying →   |
+| Vulkanus              | Sample Natal Subject | opposition ☍     | True North Lunar Node | Sample Natal Subject Solar Return | 3.60° | Separating ← |
+| Vulkanus              | Sample Natal Subject | opposition ☍     | Ascendant             | Sample Natal Subject Solar Return | 1.52° | Applying →   |
+| Vulkanus              | Sample Natal Subject | conjunction ☌    | Descendant            | Sample Natal Subject Solar Return | 1.52° | Applying →   |
+| Vulkanus              | Sample Natal Subject | opposition ☍     | Mean Lilith           | Sample Natal Subject Solar Return | 5.70° | Applying →   |
+| Vulkanus              | Sample Natal Subject | conjunction ☌    | Mean South Lunar Node | Sample Natal Subject Solar Return | 3.11° | Applying →   |
+| Vulkanus              | Sample Natal Subject | conjunction ☌    | True South Lunar Node | Sample Natal Subject Solar Return | 3.60° | Separating ← |
+| Vulkanus              | Sample Natal Subject | quintile Q       | Pallas                | Sample Natal Subject Solar Return | 0.00° | Separating ← |
+| Vulkanus              | Sample Natal Subject | square □         | Eris                  | Sample Natal Subject Solar Return | 2.49° | Applying →   |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | Sedna                 | Sample Natal Subject Solar Return | 3.28° | Applying →   |
+| Vulkanus              | Sample Natal Subject | quintile Q       | Haumea                | Sample Natal Subject Solar Return | 0.09° | Applying →   |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | Pars Fortunae         | Sample Natal Subject Solar Return | 4.57° | Static =     |
+| Vulkanus              | Sample Natal Subject | biquintile bQ    | Pars Amoris           | Sample Natal Subject Solar Return | 0.76° | Static =     |
+| Vulkanus              | Sample Natal Subject | conjunction ☌    | Mean Priapus          | Sample Natal Subject Solar Return | 5.70° | Applying →   |
+| Vulkanus              | Sample Natal Subject | conjunction ☌    | Interpolated Perigee  | Sample Natal Subject Solar Return | 3.14° | Separating ← |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | White Moon            | Sample Natal Subject Solar Return | 2.52° | Separating ← |
+| Vulkanus              | Sample Natal Subject | trine △          | Cupido                | Sample Natal Subject Solar Return | 4.68° | Applying →   |
+| Vulkanus              | Sample Natal Subject | quintile Q       | Zeus                  | Sample Natal Subject Solar Return | 0.51° | Applying →   |
+| Vulkanus              | Sample Natal Subject | square □         | Apollon               | Sample Natal Subject Solar Return | 0.89° | Applying →   |
+| Vulkanus              | Sample Natal Subject | sextile ⚹        | Admetos               | Sample Natal Subject Solar Return | 0.20° | Separating ← |
+| Vulkanus              | Sample Natal Subject | conjunction ☌    | Vulkanus              | Sample Natal Subject Solar Return | 0.54° | Separating ← |
 | Poseidon              | Sample Natal Subject | square □         | Sun                   | Sample Natal Subject Solar Return | 0.14° | Applying →   |
-| Poseidon              | Sample Natal Subject | quintile Q       | Mercury               | Sample Natal Subject Solar Return | 0.93° | Separating ← |
-| Poseidon              | Sample Natal Subject | trine △          | Venus                 | Sample Natal Subject Solar Return | 3.03° | Separating ← |
-| Poseidon              | Sample Natal Subject | square □         | Jupiter               | Sample Natal Subject Solar Return | 4.77° | Applying →   |
-| Poseidon              | Sample Natal Subject | semi-sextile ⚺   | Mean Lilith           | Sample Natal Subject Solar Return | 0.31° | Separating ← |
-| Poseidon              | Sample Natal Subject | conjunction ☌    | Pars Fortunae         | Sample Natal Subject Solar Return | 0.20° | Static =     |
-| Poseidon              | Sample Natal Subject | quincunx ⚻       | Mean Priapus          | Sample Natal Subject Solar Return | 0.31° | Separating ← |
-| Poseidon              | Sample Natal Subject | square □         | White Moon            | Sample Natal Subject Solar Return | 2.25° | Applying →   |
-| Poseidon              | Sample Natal Subject | conjunction ☌    | Poseidon              | Sample Natal Subject Solar Return | 0.00° | Separating ← |
+| Poseidon              | Sample Natal Subject | sextile ⚹        | Mercury               | Sample Natal Subject Solar Return | 3.37° | Applying →   |
+| Poseidon              | Sample Natal Subject | quintile Q       | Jupiter               | Sample Natal Subject Solar Return | 1.96° | Separating ← |
+| Poseidon              | Sample Natal Subject | square □         | Saturn                | Sample Natal Subject Solar Return | 5.21° | Applying →   |
+| Poseidon              | Sample Natal Subject | quintile Q       | Uranus                | Sample Natal Subject Solar Return | 0.45° | Applying →   |
+| Poseidon              | Sample Natal Subject | square □         | Chiron                | Sample Natal Subject Solar Return | 1.33° | Separating ← |
+| Poseidon              | Sample Natal Subject | quintile Q       | Mean Lilith           | Sample Natal Subject Solar Return | 1.05° | Applying →   |
+| Poseidon              | Sample Natal Subject | sextile ⚹        | True Lilith           | Sample Natal Subject Solar Return | 2.36° | Separating ← |
+| Poseidon              | Sample Natal Subject | conjunction ☌    | Ceres                 | Sample Natal Subject Solar Return | 1.89° | Applying →   |
+| Poseidon              | Sample Natal Subject | semi-sextile ⚺   | Pallas                | Sample Natal Subject Solar Return | 1.34° | Applying →   |
+| Poseidon              | Sample Natal Subject | square □         | Juno                  | Sample Natal Subject Solar Return | 5.91° | Separating ← |
+| Poseidon              | Sample Natal Subject | semi-sextile ⚺   | Haumea                | Sample Natal Subject Solar Return | 1.43° | Applying →   |
+| Poseidon              | Sample Natal Subject | square □         | Pars Fidei            | Sample Natal Subject Solar Return | 0.11° | Static =     |
+| Poseidon              | Sample Natal Subject | sextile ⚹        | Vertex                | Sample Natal Subject Solar Return | 1.99° | Static =     |
+| Poseidon              | Sample Natal Subject | trine △          | Anti Vertex           | Sample Natal Subject Solar Return | 1.99° | Static =     |
+| Poseidon              | Sample Natal Subject | trine △          | True Priapus          | Sample Natal Subject Solar Return | 2.36° | Separating ← |
+| Poseidon              | Sample Natal Subject | semi-sextile ⚺   | Zeus                  | Sample Natal Subject Solar Return | 1.86° | Applying →   |
+| Poseidon              | Sample Natal Subject | conjunction ☌    | Poseidon              | Sample Natal Subject Solar Return | 0.49° | Separating ← |
 +-----------------------+----------------------+------------------+-----------------------+-----------------------------------+-------+--------------+

--- a/tests/fixtures/dual_return_report.txt
+++ b/tests/fixtures/dual_return_report.txt
@@ -1,5 +1,5 @@
 ===================================================
-Sample Natal Subject — Solar Return Comparison 1990
+Sample Natal Subject — Solar Return Comparison 1991
 ===================================================
 
 +Natal Subject — Birth Data----------------------+
@@ -38,8 +38,8 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Latitude           | 53.4084°                          |
 | Longitude          | -2.9916°                          |
 | Timezone           | Europe/London                     |
-| Day of Week        | Saturday                          |
-| ISO Local Datetime | 1990-07-21T14:44:59+01:00         |
+| Day of Week        | Sunday                            |
+| ISO Local Datetime | 1991-07-21T20:33:06+01:00         |
 | Diurnality         | Diurnal                           |
 +--------------------+-----------------------------------+
 
@@ -49,7 +49,7 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Zodiac Type         | Tropical            |
 | Houses System       | Placidus            |
 | Perspective Type    | Apparent Geocentric |
-| Julian Day          | 2448094.072905      |
+| Julian Day          | 2448459.314653      |
 | Active Points Count | 14                  |
 +---------------------+---------------------+
 
@@ -75,20 +75,20 @@ Sample Natal Subject — Solar Return Comparison 1990
 +Return Subject Celestial Points-+----------+--------------+------------+---------+-----+------+---------------+
 | Point                 | Sign   | Position | Speed        | Motion     | Decl.   | OOB | Ret. | House         |
 +-----------------------+--------+----------+--------------+------------+---------+-----+------+---------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | -          | N/A     | -   | -    | First House   |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6364°/d | -          | N/A     | -   | -    | Tenth House   |
-| Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | Average    | +20.45° | -   | -    | Ninth House   |
-| Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | Average    | +23.21° | -   | -    | Ninth House   |
-| Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | Fast       | +16.88° | -   | -    | Ninth House   |
-| Venus                 | Can ♋ | 1.71°    | +1.2038°/d   | Average    | +22.74° | -   | -    | Eighth House  |
-| Mars                  | Tau ♉ | 5.97°    | +0.6554°/d   | Fast       | +11.57° | -   | -    | Seventh House |
-| Jupiter               | Can ♋ | 23.91°   | +0.2240°/d   | Fast       | +21.56° | -   | -    | Ninth House   |
-| Saturn                | Cap ♑ | 21.52°   | -0.0732°/d   | Retrograde | -21.66° | -   | R    | Third House   |
-| Uranus                | Cap ♑ | 6.74°    | -0.0366°/d   | Retrograde | -23.60° | Y   | R    | Second House  |
-| Neptune               | Cap ♑ | 12.76°   | -0.0257°/d   | Retrograde | -21.96° | -   | R    | Third House   |
-| Pluto                 | Sco ♏ | 14.97°   | -0.0025°/d   | Retrograde | -1.42°  | -   | R    | First House   |
-| True North Lunar Node | Aqu ♒ | 7.26°    | -0.0080°/d   | -          | -18.46° | -   | R    | Third House   |
-| Chiron                | Can ♋ | 19.88°   | +0.1071°/d   | -          | +15.79° | -   | -    | Ninth House   |
+| Ascendant             | Cap ♑ | 13.82°   | +409.8309°/d | -          | N/A     | -   | -    | First House   |
+| Medium Coeli          | Sco ♏ | 21.77°   | +355.0355°/d | -          | N/A     | -   | -    | Tenth House   |
+| Sun                   | Can ♋ | 28.54°   | +0.9545°/d   | Average    | +20.45° | -   | -    | Seventh House |
+| Moon                  | Sag ♐ | 4.63°    | +11.9554°/d  | Average    | -24.70° | Y   | -    | Tenth House   |
+| Mercury               | Leo ♌ | 25.32°   | +1.1015°/d   | Slow       | +12.70° | -   | -    | Seventh House |
+| Venus                 | Vir ♍ | 5.30°    | +0.3635°/d   | Slow       | +7.49°  | -   | -    | Seventh House |
+| Mars                  | Vir ♍ | 3.87°    | +0.6178°/d   | Average    | +11.07° | -   | -    | Seventh House |
+| Jupiter               | Leo ♌ | 18.64°   | +0.2120°/d   | Fast       | +15.95° | -   | -    | Seventh House |
+| Saturn                | Aqu ♒ | 3.89°    | -0.0738°/d   | Retrograde | -19.74° | -   | R    | First House   |
+| Uranus                | Cap ♑ | 11.13°   | -0.0379°/d   | Retrograde | -23.35° | -   | R    | Twelfth House |
+| Neptune               | Cap ♑ | 15.01°   | -0.0261°/d   | Retrograde | -21.79° | -   | R    | First House   |
+| Pluto                 | Sco ♏ | 17.58°   | -0.0040°/d   | Retrograde | -2.43°  | -   | R    | Ninth House   |
+| True North Lunar Node | Cap ♑ | 18.94°   | +0.0160°/d   | -          | -22.10° | -   | -    | First House   |
+| Chiron                | Leo ♌ | 0.02°    | +0.1160°/d   | -          | +13.98° | -   | -    | Seventh House |
 +-----------------------+--------+----------+--------------+------------+---------+-----+------+---------------+
 
 +Natal Subject Houses (Placidus)-----+-------------------+
@@ -111,18 +111,18 @@ Sample Natal Subject — Solar Return Comparison 1990
 +Return Subject Houses (Placidus)----+-------------------+
 | House          | Sign   | Position | Absolute Position |
 +----------------+--------+----------+-------------------+
-| First House    | Sco ♏ | 5.82°    | 215.82°           |
-| Second House   | Sag ♐ | 3.70°    | 243.70°           |
-| Third House    | Cap ♑ | 9.78°    | 279.78°           |
-| Fourth House   | Aqu ♒ | 19.91°   | 319.91°           |
-| Fifth House    | Pis ♓ | 23.00°   | 353.00°           |
-| Sixth House    | Ari ♈ | 17.47°   | 17.47°            |
-| Seventh House  | Tau ♉ | 5.82°    | 35.82°            |
-| Eighth House   | Gem ♊ | 3.70°    | 63.70°            |
-| Ninth House    | Can ♋ | 9.78°    | 99.78°            |
-| Tenth House    | Leo ♌ | 19.91°   | 139.91°           |
-| Eleventh House | Vir ♍ | 23.00°   | 173.00°           |
-| Twelfth House  | Lib ♎ | 17.47°   | 197.47°           |
+| First House    | Cap ♑ | 13.82°   | 283.82°           |
+| Second House   | Pis ♓ | 11.22°   | 341.22°           |
+| Third House    | Ari ♈ | 25.80°   | 25.80°            |
+| Fourth House   | Tau ♉ | 21.77°   | 51.77°            |
+| Fifth House    | Gem ♊ | 10.03°   | 70.03°            |
+| Sixth House    | Gem ♊ | 25.97°   | 85.97°            |
+| Seventh House  | Can ♋ | 13.82°   | 103.82°           |
+| Eighth House   | Vir ♍ | 11.22°   | 161.22°           |
+| Ninth House    | Lib ♎ | 25.80°   | 205.80°           |
+| Tenth House    | Sco ♏ | 21.77°   | 231.77°           |
+| Eleventh House | Sag ♐ | 10.03°   | 250.03°           |
+| Twelfth House  | Sag ♐ | 25.97°   | 265.97°           |
 +----------------+--------+----------+-------------------+
 
 +Lunar Phase--------------+--------------------+
@@ -165,90 +165,83 @@ Sample Natal Subject — Solar Return Comparison 1990
 | 9     | 4     | Sun, Moon, Mercury, Jupiter |
 +-------+-------+-----------------------------+
 
-+Return Subject Angularities--------+
-| Point   | Angle        | Distance |
-+---------+--------------+----------+
-| Mars    | Descendant   | 0.15°    |
-| Mercury | Medium Coeli | 2.30°    |
-+---------+--------------+----------+
++Return Subject Stelliums----------------------------+
+| House | Count | Points                             |
++-------+-------+------------------------------------+
+| 7     | 5     | Sun, Mercury, Venus, Mars, Jupiter |
++-------+-------+------------------------------------+
 
-+Return Subject Stelliums---------------------+
-| House | Count | Points                      |
-+-------+-------+-----------------------------+
-| 9     | 4     | Sun, Moon, Mercury, Jupiter |
-+-------+-------+-----------------------------+
++Sample Natal Subject points in Sample Natal Subject Solar Return houses----------------+------+--------+
+| Point                                        | Owner House       | Projected House    | Sign | Degree |
++----------------------------------------------+-------------------+--------------------+------+--------+
+| Sample Natal Subject – Sun                   | 9 (Ninth House)   | 7 (Seventh House)  | Can  | 28.54° |
+| Sample Natal Subject – Moon                  | 9 (Ninth House)   | 7 (Seventh House)  | Can  | 21.21° |
+| Sample Natal Subject – Mercury               | 9 (Ninth House)   | 7 (Seventh House)  | Leo  | 17.61° |
+| Sample Natal Subject – Venus                 | 8 (Eighth House)  | 6 (Sixth House)    | Can  | 1.71°  |
+| Sample Natal Subject – Mars                  | 7 (Seventh House) | 3 (Third House)    | Tau  | 5.97°  |
+| Sample Natal Subject – Jupiter               | 9 (Ninth House)   | 7 (Seventh House)  | Can  | 23.91° |
+| Sample Natal Subject – Saturn                | 3 (Third House)   | 1 (First House)    | Cap  | 21.52° |
+| Sample Natal Subject – Uranus                | 2 (Second House)  | 12 (Twelfth House) | Cap  | 6.74°  |
+| Sample Natal Subject – Neptune               | 3 (Third House)   | 12 (Twelfth House) | Cap  | 12.76° |
+| Sample Natal Subject – Pluto                 | 1 (First House)   | 9 (Ninth House)    | Sco  | 14.97° |
+| Sample Natal Subject – True North Lunar Node | 3 (Third House)   | 1 (First House)    | Aqu  | 7.26°  |
+| Sample Natal Subject – Chiron                | 9 (Ninth House)   | 7 (Seventh House)  | Can  | 19.88° |
+| Sample Natal Subject – Ascendant             | 1 (First House)   | 9 (Ninth House)    | Sco  | 5.82°  |
+| Sample Natal Subject – Medium Coeli          | 10 (Tenth House)  | 7 (Seventh House)  | Leo  | 19.91° |
++----------------------------------------------+-------------------+--------------------+------+--------+
 
-+Sample Natal Subject points in Sample Natal Subject Solar Return houses---------------+------+--------+
-| Point                                        | Owner House       | Projected House   | Sign | Degree |
-+----------------------------------------------+-------------------+-------------------+------+--------+
-| Sample Natal Subject – Sun                   | 9 (Ninth House)   | 9 (Ninth House)   | Can  | 28.54° |
-| Sample Natal Subject – Moon                  | 9 (Ninth House)   | 9 (Ninth House)   | Can  | 21.21° |
-| Sample Natal Subject – Mercury               | 9 (Ninth House)   | 9 (Ninth House)   | Leo  | 17.61° |
-| Sample Natal Subject – Venus                 | 8 (Eighth House)  | 8 (Eighth House)  | Can  | 1.71°  |
-| Sample Natal Subject – Mars                  | 7 (Seventh House) | 7 (Seventh House) | Tau  | 5.97°  |
-| Sample Natal Subject – Jupiter               | 9 (Ninth House)   | 9 (Ninth House)   | Can  | 23.91° |
-| Sample Natal Subject – Saturn                | 3 (Third House)   | 3 (Third House)   | Cap  | 21.52° |
-| Sample Natal Subject – Uranus                | 2 (Second House)  | 2 (Second House)  | Cap  | 6.74°  |
-| Sample Natal Subject – Neptune               | 3 (Third House)   | 3 (Third House)   | Cap  | 12.76° |
-| Sample Natal Subject – Pluto                 | 1 (First House)   | 1 (First House)   | Sco  | 14.97° |
-| Sample Natal Subject – True North Lunar Node | 3 (Third House)   | 3 (Third House)   | Aqu  | 7.26°  |
-| Sample Natal Subject – Chiron                | 9 (Ninth House)   | 9 (Ninth House)   | Can  | 19.88° |
-| Sample Natal Subject – Ascendant             | 1 (First House)   | 1 (First House)   | Sco  | 5.82°  |
-| Sample Natal Subject – Medium Coeli          | 10 (Tenth House)  | 10 (Tenth House)  | Leo  | 19.91° |
-+----------------------------------------------+-------------------+-------------------+------+--------+
++Sample Natal Subject Solar Return points in Sample Natal Subject houses---------+------------------+------+--------+
+| Point                                                     | Owner House        | Projected House  | Sign | Degree |
++-----------------------------------------------------------+--------------------+------------------+------+--------+
+| Sample Natal Subject Solar Return – Sun                   | 7 (Seventh House)  | 9 (Ninth House)  | Can  | 28.54° |
+| Sample Natal Subject Solar Return – Moon                  | 10 (Tenth House)   | 2 (Second House) | Sag  | 4.63°  |
+| Sample Natal Subject Solar Return – Mercury               | 7 (Seventh House)  | 10 (Tenth House) | Leo  | 25.32° |
+| Sample Natal Subject Solar Return – Venus                 | 7 (Seventh House)  | 10 (Tenth House) | Vir  | 5.30°  |
+| Sample Natal Subject Solar Return – Mars                  | 7 (Seventh House)  | 10 (Tenth House) | Vir  | 3.87°  |
+| Sample Natal Subject Solar Return – Jupiter               | 7 (Seventh House)  | 9 (Ninth House)  | Leo  | 18.64° |
+| Sample Natal Subject Solar Return – Saturn                | 1 (First House)    | 3 (Third House)  | Aqu  | 3.89°  |
+| Sample Natal Subject Solar Return – Uranus                | 12 (Twelfth House) | 3 (Third House)  | Cap  | 11.13° |
+| Sample Natal Subject Solar Return – Neptune               | 1 (First House)    | 3 (Third House)  | Cap  | 15.01° |
+| Sample Natal Subject Solar Return – Pluto                 | 9 (Ninth House)    | 1 (First House)  | Sco  | 17.58° |
+| Sample Natal Subject Solar Return – True North Lunar Node | 1 (First House)    | 3 (Third House)  | Cap  | 18.94° |
+| Sample Natal Subject Solar Return – Chiron                | 7 (Seventh House)  | 9 (Ninth House)  | Leo  | 0.02°  |
+| Sample Natal Subject Solar Return – Ascendant             | 1 (First House)    | 3 (Third House)  | Cap  | 13.82° |
+| Sample Natal Subject Solar Return – Medium Coeli          | 10 (Tenth House)   | 1 (First House)  | Sco  | 21.77° |
++-----------------------------------------------------------+--------------------+------------------+------+--------+
 
-+Sample Natal Subject Solar Return points in Sample Natal Subject houses--------+--------------------+------+--------+
-| Point                                                     | Owner House       | Projected House    | Sign | Degree |
-+-----------------------------------------------------------+-------------------+--------------------+------+--------+
-| Sample Natal Subject Solar Return – Sun                   | 9 (Ninth House)   | 9 (Ninth House)    | Can  | 28.54° |
-| Sample Natal Subject Solar Return – Moon                  | 9 (Ninth House)   | 9 (Ninth House)    | Can  | 21.21° |
-| Sample Natal Subject Solar Return – Mercury               | 9 (Ninth House)   | 9 (Ninth House)    | Leo  | 17.61° |
-| Sample Natal Subject Solar Return – Venus                 | 8 (Eighth House)  | 8 (Eighth House)   | Can  | 1.71°  |
-| Sample Natal Subject Solar Return – Mars                  | 7 (Seventh House) | 7 (Seventh House)  | Tau  | 5.97°  |
-| Sample Natal Subject Solar Return – Jupiter               | 9 (Ninth House)   | 9 (Ninth House)    | Can  | 23.91° |
-| Sample Natal Subject Solar Return – Saturn                | 3 (Third House)   | 3 (Third House)    | Cap  | 21.52° |
-| Sample Natal Subject Solar Return – Uranus                | 2 (Second House)  | 2 (Second House)   | Cap  | 6.74°  |
-| Sample Natal Subject Solar Return – Neptune               | 3 (Third House)   | 3 (Third House)    | Cap  | 12.76° |
-| Sample Natal Subject Solar Return – Pluto                 | 1 (First House)   | 1 (First House)    | Sco  | 14.97° |
-| Sample Natal Subject Solar Return – True North Lunar Node | 3 (Third House)   | 3 (Third House)    | Aqu  | 7.26°  |
-| Sample Natal Subject Solar Return – Chiron                | 9 (Ninth House)   | 9 (Ninth House)    | Can  | 19.88° |
-| Sample Natal Subject Solar Return – Ascendant             | 1 (First House)   | 12 (Twelfth House) | Sco  | 5.82°  |
-| Sample Natal Subject Solar Return – Medium Coeli          | 10 (Tenth House)  | 9 (Ninth House)    | Leo  | 19.91° |
-+-----------------------------------------------------------+-------------------+--------------------+------+--------+
++Sample Natal Subject cusps in Sample Natal Subject Solar Return houses------+
+| Point                                 | Projected House    | Sign | Degree |
++---------------------------------------+--------------------+------+--------+
+| Sample Natal Subject – First House    | 9 (Ninth House)    | Sco  | 5.82°  |
+| Sample Natal Subject – Second House   | 10 (Tenth House)   | Sag  | 3.71°  |
+| Sample Natal Subject – Third House    | 12 (Twelfth House) | Cap  | 9.79°  |
+| Sample Natal Subject – Fourth House   | 1 (First House)    | Aqu  | 19.91° |
+| Sample Natal Subject – Fifth House    | 2 (Second House)   | Pis  | 23.00° |
+| Sample Natal Subject – Sixth House    | 2 (Second House)   | Ari  | 17.47° |
+| Sample Natal Subject – Seventh House  | 3 (Third House)    | Tau  | 5.82°  |
+| Sample Natal Subject – Eighth House   | 4 (Fourth House)   | Gem  | 3.71°  |
+| Sample Natal Subject – Ninth House    | 6 (Sixth House)    | Can  | 9.79°  |
+| Sample Natal Subject – Tenth House    | 7 (Seventh House)  | Leo  | 19.91° |
+| Sample Natal Subject – Eleventh House | 8 (Eighth House)   | Vir  | 23.00° |
+| Sample Natal Subject – Twelfth House  | 8 (Eighth House)   | Lib  | 17.47° |
++---------------------------------------+--------------------+------+--------+
 
-+Sample Natal Subject cusps in Sample Natal Subject Solar Return houses-------+
-| Point                                 | Projected House     | Sign | Degree |
-+---------------------------------------+---------------------+------+--------+
-| Sample Natal Subject – First House    | 1 (First House)     | Sco  | 5.82°  |
-| Sample Natal Subject – Second House   | 2 (Second House)    | Sag  | 3.71°  |
-| Sample Natal Subject – Third House    | 3 (Third House)     | Cap  | 9.79°  |
-| Sample Natal Subject – Fourth House   | 4 (Fourth House)    | Aqu  | 19.91° |
-| Sample Natal Subject – Fifth House    | 5 (Fifth House)     | Pis  | 23.00° |
-| Sample Natal Subject – Sixth House    | 6 (Sixth House)     | Ari  | 17.47° |
-| Sample Natal Subject – Seventh House  | 7 (Seventh House)   | Tau  | 5.82°  |
-| Sample Natal Subject – Eighth House   | 8 (Eighth House)    | Gem  | 3.71°  |
-| Sample Natal Subject – Ninth House    | 9 (Ninth House)     | Can  | 9.79°  |
-| Sample Natal Subject – Tenth House    | 10 (Tenth House)    | Leo  | 19.91° |
-| Sample Natal Subject – Eleventh House | 11 (Eleventh House) | Vir  | 23.00° |
-| Sample Natal Subject – Twelfth House  | 12 (Twelfth House)  | Lib  | 17.47° |
-+---------------------------------------+---------------------+------+--------+
-
-+Sample Natal Subject Solar Return cusps in Sample Natal Subject houses----+------+--------+
-| Point                                              | Projected House     | Sign | Degree |
-+----------------------------------------------------+---------------------+------+--------+
-| Sample Natal Subject Solar Return – First House    | 12 (Twelfth House)  | Sco  | 5.82°  |
-| Sample Natal Subject Solar Return – Second House   | 1 (First House)     | Sag  | 3.70°  |
-| Sample Natal Subject Solar Return – Third House    | 2 (Second House)    | Cap  | 9.78°  |
-| Sample Natal Subject Solar Return – Fourth House   | 3 (Third House)     | Aqu  | 19.91° |
-| Sample Natal Subject Solar Return – Fifth House    | 4 (Fourth House)    | Pis  | 23.00° |
-| Sample Natal Subject Solar Return – Sixth House    | 5 (Fifth House)     | Ari  | 17.47° |
-| Sample Natal Subject Solar Return – Seventh House  | 6 (Sixth House)     | Tau  | 5.82°  |
-| Sample Natal Subject Solar Return – Eighth House   | 7 (Seventh House)   | Gem  | 3.70°  |
-| Sample Natal Subject Solar Return – Ninth House    | 8 (Eighth House)    | Can  | 9.78°  |
-| Sample Natal Subject Solar Return – Tenth House    | 9 (Ninth House)     | Leo  | 19.91° |
-| Sample Natal Subject Solar Return – Eleventh House | 10 (Tenth House)    | Vir  | 23.00° |
-| Sample Natal Subject Solar Return – Twelfth House  | 11 (Eleventh House) | Lib  | 17.47° |
-+----------------------------------------------------+---------------------+------+--------+
++Sample Natal Subject Solar Return cusps in Sample Natal Subject houses---+------+--------+
+| Point                                              | Projected House    | Sign | Degree |
++----------------------------------------------------+--------------------+------+--------+
+| Sample Natal Subject Solar Return – First House    | 3 (Third House)    | Cap  | 13.82° |
+| Sample Natal Subject Solar Return – Second House   | 4 (Fourth House)   | Pis  | 11.22° |
+| Sample Natal Subject Solar Return – Third House    | 6 (Sixth House)    | Ari  | 25.80° |
+| Sample Natal Subject Solar Return – Fourth House   | 7 (Seventh House)  | Tau  | 21.77° |
+| Sample Natal Subject Solar Return – Fifth House    | 8 (Eighth House)   | Gem  | 10.03° |
+| Sample Natal Subject Solar Return – Sixth House    | 8 (Eighth House)   | Gem  | 25.97° |
+| Sample Natal Subject Solar Return – Seventh House  | 9 (Ninth House)    | Can  | 13.82° |
+| Sample Natal Subject Solar Return – Eighth House   | 10 (Tenth House)   | Vir  | 11.22° |
+| Sample Natal Subject Solar Return – Ninth House    | 12 (Twelfth House) | Lib  | 25.80° |
+| Sample Natal Subject Solar Return – Tenth House    | 1 (First House)    | Sco  | 21.77° |
+| Sample Natal Subject Solar Return – Eleventh House | 2 (Second House)   | Sag  | 10.03° |
+| Sample Natal Subject Solar Return – Twelfth House  | 2 (Second House)   | Sag  | 25.97° |
++----------------------------------------------------+--------------------+------+--------+
 
 +Active Celestial Points-----+
 | #  | Active Point          |
@@ -283,43 +276,34 @@ Sample Natal Subject — Solar Return Comparison 1990
 | Point 1               | Owner 1              | Aspect        | Point 2               | Owner 2                           | Orb   | Movement     |
 +-----------------------+----------------------+---------------+-----------------------+-----------------------------------+-------+--------------+
 | Sun                   | Sample Natal Subject | conjunction ☌ | Sun                   | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Moon                  | Sample Natal Subject | conjunction ☌ | Moon                  | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Moon                  | Sample Natal Subject | conjunction ☌ | Jupiter               | Sample Natal Subject Solar Return | 2.70° | Separating ← |
-| Moon                  | Sample Natal Subject | opposition ☍  | Saturn                | Sample Natal Subject Solar Return | 0.31° | Applying →   |
-| Moon                  | Sample Natal Subject | conjunction ☌ | Chiron                | Sample Natal Subject Solar Return | 1.33° | Applying →   |
-| Mercury               | Sample Natal Subject | conjunction ☌ | Mercury               | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Mercury               | Sample Natal Subject | square □      | Pluto                 | Sample Natal Subject Solar Return | 2.63° | Separating ← |
-| Mercury               | Sample Natal Subject | conjunction ☌ | Medium Coeli          | Sample Natal Subject Solar Return | 2.30° | Separating ← |
-| Venus                 | Sample Natal Subject | conjunction ☌ | Venus                 | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Mars                  | Sample Natal Subject | conjunction ☌ | Mars                  | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Mars                  | Sample Natal Subject | trine △       | Uranus                | Sample Natal Subject Solar Return | 0.77° | Applying →   |
-| Mars                  | Sample Natal Subject | square □      | True North Lunar Node | Sample Natal Subject Solar Return | 1.30° | Applying →   |
-| Mars                  | Sample Natal Subject | opposition ☍  | Ascendant             | Sample Natal Subject Solar Return | 0.15° | Applying →   |
-| Jupiter               | Sample Natal Subject | conjunction ☌ | Moon                  | Sample Natal Subject Solar Return | 2.70° | Applying →   |
-| Jupiter               | Sample Natal Subject | conjunction ☌ | Jupiter               | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Jupiter               | Sample Natal Subject | opposition ☍  | Saturn                | Sample Natal Subject Solar Return | 2.40° | Separating ← |
-| Saturn                | Sample Natal Subject | opposition ☍  | Moon                  | Sample Natal Subject Solar Return | 0.31° | Applying →   |
-| Saturn                | Sample Natal Subject | opposition ☍  | Jupiter               | Sample Natal Subject Solar Return | 2.40° | Separating ← |
-| Saturn                | Sample Natal Subject | conjunction ☌ | Saturn                | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Saturn                | Sample Natal Subject | opposition ☍  | Chiron                | Sample Natal Subject Solar Return | 1.64° | Applying →   |
-| Uranus                | Sample Natal Subject | trine △       | Mars                  | Sample Natal Subject Solar Return | 0.77° | Applying →   |
-| Uranus                | Sample Natal Subject | conjunction ☌ | Uranus                | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Uranus                | Sample Natal Subject | sextile ⚹     | Ascendant             | Sample Natal Subject Solar Return | 0.92° | Applying →   |
-| Neptune               | Sample Natal Subject | conjunction ☌ | Neptune               | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| Neptune               | Sample Natal Subject | sextile ⚹     | Pluto                 | Sample Natal Subject Solar Return | 2.21° | Applying →   |
-| Pluto                 | Sample Natal Subject | square □      | Mercury               | Sample Natal Subject Solar Return | 2.63° | Separating ← |
-| Pluto                 | Sample Natal Subject | sextile ⚹     | Neptune               | Sample Natal Subject Solar Return | 2.21° | Separating ← |
-| Pluto                 | Sample Natal Subject | conjunction ☌ | Pluto                 | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | square □      | Mars                  | Sample Natal Subject Solar Return | 1.30° | Applying →   |
-| True North Lunar Node | Sample Natal Subject | conjunction ☌ | True North Lunar Node | Sample Natal Subject Solar Return | 0.00° | Separating ← |
-| True North Lunar Node | Sample Natal Subject | square □      | Ascendant             | Sample Natal Subject Solar Return | 1.45° | Applying →   |
-| Chiron                | Sample Natal Subject | conjunction ☌ | Moon                  | Sample Natal Subject Solar Return | 1.33° | Separating ← |
-| Chiron                | Sample Natal Subject | opposition ☍  | Saturn                | Sample Natal Subject Solar Return | 1.64° | Applying →   |
-| Chiron                | Sample Natal Subject | conjunction ☌ | Chiron                | Sample Natal Subject Solar Return | 0.00° | Applying →   |
-| Ascendant             | Sample Natal Subject | opposition ☍  | Mars                  | Sample Natal Subject Solar Return | 0.15° | Separating ← |
-| Ascendant             | Sample Natal Subject | sextile ⚹     | Uranus                | Sample Natal Subject Solar Return | 0.92° | Applying →   |
-| Ascendant             | Sample Natal Subject | square □      | True North Lunar Node | Sample Natal Subject Solar Return | 1.44° | Applying →   |
-| Ascendant             | Sample Natal Subject | conjunction ☌ | Ascendant             | Sample Natal Subject Solar Return | 0.00° | Static =     |
-| Medium Coeli          | Sample Natal Subject | conjunction ☌ | Mercury               | Sample Natal Subject Solar Return | 2.31° | Applying →   |
-| Medium Coeli          | Sample Natal Subject | conjunction ☌ | Medium Coeli          | Sample Natal Subject Solar Return | 0.00° | Static =     |
+| Sun                   | Sample Natal Subject | conjunction ☌ | Chiron                | Sample Natal Subject Solar Return | 1.47° | Separating ← |
+| Moon                  | Sample Natal Subject | opposition ☍  | True North Lunar Node | Sample Natal Subject Solar Return | 2.27° | Applying →   |
+| Moon                  | Sample Natal Subject | trine △       | Medium Coeli          | Sample Natal Subject Solar Return | 0.56° | Separating ← |
+| Mercury               | Sample Natal Subject | conjunction ☌ | Jupiter               | Sample Natal Subject Solar Return | 1.03° | Separating ← |
+| Mercury               | Sample Natal Subject | square □      | Pluto                 | Sample Natal Subject Solar Return | 0.03° | Separating ← |
+| Venus                 | Sample Natal Subject | sextile ⚹     | Mars                  | Sample Natal Subject Solar Return | 2.17° | Separating ← |
+| Mars                  | Sample Natal Subject | trine △       | Venus                 | Sample Natal Subject Solar Return | 0.66° | Applying →   |
+| Mars                  | Sample Natal Subject | trine △       | Mars                  | Sample Natal Subject Solar Return | 2.09° | Applying →   |
+| Mars                  | Sample Natal Subject | square □      | Saturn                | Sample Natal Subject Solar Return | 2.07° | Separating ← |
+| Jupiter               | Sample Natal Subject | trine △       | Medium Coeli          | Sample Natal Subject Solar Return | 2.14° | Applying →   |
+| Saturn                | Sample Natal Subject | conjunction ☌ | True North Lunar Node | Sample Natal Subject Solar Return | 2.57° | Applying →   |
+| Saturn                | Sample Natal Subject | sextile ⚹     | Medium Coeli          | Sample Natal Subject Solar Return | 0.26° | Separating ← |
+| Uranus                | Sample Natal Subject | trine △       | Venus                 | Sample Natal Subject Solar Return | 1.43° | Applying →   |
+| Uranus                | Sample Natal Subject | trine △       | Mars                  | Sample Natal Subject Solar Return | 2.86° | Applying →   |
+| Neptune               | Sample Natal Subject | conjunction ☌ | Uranus                | Sample Natal Subject Solar Return | 1.63° | Separating ← |
+| Neptune               | Sample Natal Subject | conjunction ☌ | Neptune               | Sample Natal Subject Solar Return | 2.25° | Applying →   |
+| Neptune               | Sample Natal Subject | conjunction ☌ | Ascendant             | Sample Natal Subject Solar Return | 1.06° | Separating ← |
+| Pluto                 | Sample Natal Subject | sextile ⚹     | Neptune               | Sample Natal Subject Solar Return | 0.04° | Applying →   |
+| Pluto                 | Sample Natal Subject | conjunction ☌ | Pluto                 | Sample Natal Subject Solar Return | 2.60° | Applying →   |
+| Pluto                 | Sample Natal Subject | sextile ⚹     | Ascendant             | Sample Natal Subject Solar Return | 1.15° | Applying →   |
+| True North Lunar Node | Sample Natal Subject | sextile ⚹     | Moon                  | Sample Natal Subject Solar Return | 2.63° | Applying →   |
+| Chiron                | Sample Natal Subject | trine △       | Pluto                 | Sample Natal Subject Solar Return | 2.30° | Separating ← |
+| Chiron                | Sample Natal Subject | opposition ☍  | True North Lunar Node | Sample Natal Subject Solar Return | 0.94° | Applying →   |
+| Chiron                | Sample Natal Subject | trine △       | Medium Coeli          | Sample Natal Subject Solar Return | 1.89° | Separating ← |
+| Ascendant             | Sample Natal Subject | sextile ⚹     | Venus                 | Sample Natal Subject Solar Return | 0.52° | Applying →   |
+| Ascendant             | Sample Natal Subject | sextile ⚹     | Mars                  | Sample Natal Subject Solar Return | 1.95° | Applying →   |
+| Ascendant             | Sample Natal Subject | square □      | Saturn                | Sample Natal Subject Solar Return | 1.93° | Separating ← |
+| Medium Coeli          | Sample Natal Subject | conjunction ☌ | Jupiter               | Sample Natal Subject Solar Return | 1.28° | Applying →   |
+| Medium Coeli          | Sample Natal Subject | square □      | Pluto                 | Sample Natal Subject Solar Return | 2.34° | Separating ← |
+| Medium Coeli          | Sample Natal Subject | square □      | Medium Coeli          | Sample Natal Subject Solar Return | 1.86° | Static =     |
 +-----------------------+----------------------+---------------+-----------------------+-----------------------------------+-------+--------------+

--- a/tests/fixtures/solar_return_all_points_report.txt
+++ b/tests/fixtures/solar_return_all_points_report.txt
@@ -1,5 +1,5 @@
 =====================================================
-Sample Natal Subject Solar Return — Solar Return 1990
+Sample Natal Subject Solar Return — Solar Return 1991
 =====================================================
 
 +Solar Return Chart — Birth Data-------------------------+
@@ -12,8 +12,8 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Latitude           | 53.4084°                          |
 | Longitude          | -2.9916°                          |
 | Timezone           | Europe/London                     |
-| Day of Week        | Saturday                          |
-| ISO Local Datetime | 1990-07-21T14:44:59+01:00         |
+| Day of Week        | Sunday                            |
+| ISO Local Datetime | 1991-07-21T20:33:06+01:00         |
 | Diurnality         | Diurnal                           |
 +--------------------+-----------------------------------+
 
@@ -23,128 +23,121 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Zodiac Type         | Tropical            |
 | Houses System       | Placidus            |
 | Perspective Type    | Apparent Geocentric |
-| Julian Day          | 2448094.072905      |
+| Julian Day          | 2448459.314653      |
 | Active Points Count | 52                  |
 +---------------------+---------------------+
 
-+Solar Return Chart Celestial Points--------+--------------+------------+---------+-----+------+----------------+
-| Point                 | Sign   | Position | Speed        | Motion     | Decl.   | OOB | Ret. | House          |
-+-----------------------+--------+----------+--------------+------------+---------+-----+------+----------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | -          | N/A     | -   | -    | First House    |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6364°/d | -          | N/A     | -   | -    | Tenth House    |
-| Descendant            | Tau ♉ | 5.82°    | +245.7250°/d | -          | N/A     | -   | -    | Seventh House  |
-| Imum Coeli            | Aqu ♒ | 19.91°   | +367.6364°/d | -          | N/A     | -   | -    | Fourth House   |
-| Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | Average    | +20.45° | -   | -    | Ninth House    |
-| Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | Average    | +23.21° | -   | -    | Ninth House    |
-| Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | Fast       | +16.88° | -   | -    | Ninth House    |
-| Venus                 | Can ♋ | 1.71°    | +1.2038°/d   | Average    | +22.74° | -   | -    | Eighth House   |
-| Mars                  | Tau ♉ | 5.97°    | +0.6554°/d   | Fast       | +11.57° | -   | -    | Seventh House  |
-| Jupiter               | Can ♋ | 23.91°   | +0.2240°/d   | Fast       | +21.56° | -   | -    | Ninth House    |
-| Saturn                | Cap ♑ | 21.52°   | -0.0732°/d   | Retrograde | -21.66° | -   | R    | Third House    |
-| Uranus                | Cap ♑ | 6.74°    | -0.0366°/d   | Retrograde | -23.60° | Y   | R    | Second House   |
-| Neptune               | Cap ♑ | 12.76°   | -0.0257°/d   | Retrograde | -21.96° | -   | R    | Third House    |
-| Pluto                 | Sco ♏ | 14.97°   | -0.0025°/d   | Retrograde | -1.42°  | -   | R    | First House    |
-| Mean North Lunar Node | Aqu ♒ | 7.79°    | -0.0529°/d   | -          | -18.32° | -   | R    | Third House    |
-| True North Lunar Node | Aqu ♒ | 7.26°    | -0.0080°/d   | -          | -18.46° | -   | R    | Third House    |
-| Mean Lilith           | Sco ♏ | 28.99°   | +0.1119°/d   | -          | -24.62° | Y   | -    | First House    |
-| True Lilith           | Sag ♐ | 18.01°   | -1.4330°/d   | -          | -26.88° | Y   | R    | Second House   |
-| Chiron                | Can ♋ | 19.88°   | +0.1071°/d   | -          | +15.79° | -   | -    | Ninth House    |
-| Pholus                | Can ♋ | 7.99°    | +0.1329°/d   | -          | +13.79° | -   | -    | Eighth House   |
-| Ceres                 | Leo ♌ | 13.71°   | +0.4493°/d   | -          | +23.05° | -   | -    | Ninth House    |
-| Pallas                | Can ♋ | 7.25°    | +0.5959°/d   | -          | -1.55°  | -   | -    | Eighth House   |
-| Juno                  | Sco ♏ | 10.10°   | +0.0843°/d   | -          | -2.06°  | -   | -    | First House    |
-| Vesta                 | Tau ♉ | 18.15°   | +0.3292°/d   | -          | +10.88° | -   | -    | Seventh House  |
-| Interpolated Lilith   | Sco ♏ | 25.48°   | +0.1694°/d   | -          | -23.89° | Y   | -    | First House    |
-| Interpolated Perigee  | Gem ♊ | 20.98°   | +0.1733°/d   | -          | +26.84° | Y   | -    | Eighth House   |
-| Cupido                | Sco ♏ | 18.62°   | -0.0043°/d   | -          | -16.34° | -   | R    | First House    |
-| Hades                 | Gem ♊ | 9.92°    | +0.0153°/d   | -          | +20.93° | -   | -    | Eighth House   |
-| Zeus                  | Vir ♍ | 26.03°   | +0.0109°/d   | -          | +1.58°  | -   | -    | Eleventh House |
-| Kronos                | Gem ♊ | 21.89°   | +0.0138°/d   | -          | +23.21° | -   | -    | Eighth House   |
-| Apollon               | Lib ♎ | 13.82°   | +0.0052°/d   | -          | -5.46°  | -   | -    | Eleventh House |
-| Admetos               | Tau ♉ | 14.96°   | +0.0054°/d   | -          | +16.33° | -   | -    | Seventh House  |
-| Vulkanus              | Can ♋ | 15.34°   | +0.0136°/d   | -          | +22.57° | -   | -    | Ninth House    |
-| Poseidon              | Lib ♎ | 28.68°   | +0.0013°/d   | -          | -11.01° | -   | -    | Twelfth House  |
-| Eris                  | Ari ♈ | 17.60°   | -0.0013°/d   | -          | -9.16°  | -   | R    | Sixth House    |
-| Sedna                 | Tau ♉ | 11.55°   | +0.0038°/d   | -          | +4.25°  | -   | -    | Seventh House  |
-| Haumea                | Vir ♍ | 26.32°   | +0.0134°/d   | -          | +23.02° | -   | -    | Eleventh House |
-| Makemake              | Vir ♍ | 4.50°    | +0.0202°/d   | -          | +35.44° | Y   | -    | Tenth House    |
-| Ixion                 | Sco ♏ | 22.70°   | -0.0060°/d   | -          | -12.62° | -   | R    | First House    |
-| Orcus                 | Leo ♌ | 10.84°   | +0.0234°/d   | -          | +4.04°  | -   | -    | Ninth House    |
-| Quaoar                | Sco ♏ | 24.08°   | -0.0062°/d   | -          | -13.09° | -   | R    | First House    |
-| Vertex                | Gem ♊ | 11.46°   | N/A          | -          | N/A     | -   | -    | Eighth House   |
-| White Moon            | Can ♋ | 26.43°   | +0.1409°/d   | -          | +20.87° | -   | -    | Ninth House    |
-| Anti Vertex           | Sag ♐ | 11.46°   | N/A          | -          | N/A     | -   | -    | Second House   |
-| Mean South Lunar Node | Leo ♌ | 7.79°    | -0.0529°/d   | -          | +18.32° | -   | R    | Ninth House    |
-| True South Lunar Node | Leo ♌ | 7.26°    | -0.0080°/d   | -          | +18.46° | -   | R    | Ninth House    |
-| Mean Priapus          | Tau ♉ | 28.99°   | +0.1119°/d   | -          | +24.62° | Y   | -    | Seventh House  |
-| True Priapus          | Gem ♊ | 18.01°   | -1.4330°/d   | -          | +26.88° | Y   | R    | Eighth House   |
-+-----------------------+--------+----------+--------------+------------+---------+-----+------+----------------+
++Solar Return Chart Celestial Points--------+--------------+------------+---------+-----+------+---------------+
+| Point                 | Sign   | Position | Speed        | Motion     | Decl.   | OOB | Ret. | House         |
++-----------------------+--------+----------+--------------+------------+---------+-----+------+---------------+
+| Ascendant             | Cap ♑ | 13.82°   | +409.8309°/d | -          | N/A     | -   | -    | First House   |
+| Medium Coeli          | Sco ♏ | 21.77°   | +355.0355°/d | -          | N/A     | -   | -    | Tenth House   |
+| Descendant            | Can ♋ | 13.82°   | +409.8309°/d | -          | N/A     | -   | -    | Seventh House |
+| Imum Coeli            | Tau ♉ | 21.77°   | +355.0355°/d | -          | N/A     | -   | -    | Fourth House  |
+| Sun                   | Can ♋ | 28.54°   | +0.9545°/d   | Average    | +20.45° | -   | -    | Seventh House |
+| Moon                  | Sag ♐ | 4.63°    | +11.9554°/d  | Average    | -24.70° | Y   | -    | Tenth House   |
+| Mercury               | Leo ♌ | 25.32°   | +1.1015°/d   | Slow       | +12.70° | -   | -    | Seventh House |
+| Venus                 | Vir ♍ | 5.30°    | +0.3635°/d   | Slow       | +7.49°  | -   | -    | Seventh House |
+| Mars                  | Vir ♍ | 3.87°    | +0.6178°/d   | Average    | +11.07° | -   | -    | Seventh House |
+| Jupiter               | Leo ♌ | 18.64°   | +0.2120°/d   | Fast       | +15.95° | -   | -    | Seventh House |
+| Saturn                | Aqu ♒ | 3.89°    | -0.0738°/d   | Retrograde | -19.74° | -   | R    | First House   |
+| Uranus                | Cap ♑ | 11.13°   | -0.0379°/d   | Retrograde | -23.35° | -   | R    | Twelfth House |
+| Neptune               | Cap ♑ | 15.01°   | -0.0261°/d   | Retrograde | -21.79° | -   | R    | First House   |
+| Pluto                 | Sco ♏ | 17.58°   | -0.0040°/d   | Retrograde | -2.43°  | -   | R    | Ninth House   |
+| Mean North Lunar Node | Cap ♑ | 18.45°   | -0.0529°/d   | -          | -22.17° | -   | R    | First House   |
+| True North Lunar Node | Cap ♑ | 18.94°   | +0.0160°/d   | -          | -22.10° | -   | -    | First House   |
+| Mean Lilith           | Cap ♑ | 9.64°    | +0.1108°/d   | -          | -23.88° | Y   | -    | Twelfth House |
+| True Lilith           | Cap ♑ | 1.04°    | +1.6109°/d   | -          | -25.07° | Y   | -    | Twelfth House |
+| Chiron                | Leo ♌ | 0.02°    | +0.1160°/d   | -          | +13.98° | -   | -    | Seventh House |
+| Pholus                | Can ♋ | 22.39°   | +0.1390°/d   | -          | +18.51° | -   | -    | Seventh House |
+| Ceres                 | Lib ♎ | 26.79°   | +0.2408°/d   | -          | -4.75°  | -   | -    | Ninth House   |
+| Pallas                | Vir ♍ | 27.34°   | +0.3701°/d   | -          | +14.30° | -   | -    | Eighth House  |
+| Juno                  | Cap ♑ | 22.77°   | -0.2378°/d   | -          | -5.27°  | -   | R    | First House   |
+| Vesta                 | Can ♋ | 22.37°   | +0.4407°/d   | -          | +22.11° | -   | -    | Seventh House |
+| Interpolated Lilith   | Cap ♑ | 5.98°    | +0.0063°/d   | -          | -24.42° | Y   | -    | Twelfth House |
+| Interpolated Perigee  | Can ♋ | 18.48°   | +0.4813°/d   | -          | +22.16° | -   | -    | Seventh House |
+| Cupido                | Sco ♏ | 20.02°   | -0.0049°/d   | -          | -16.72° | -   | R    | Ninth House   |
+| Hades                 | Gem ♊ | 10.92°   | +0.0155°/d   | -          | +21.07° | -   | -    | Fifth House   |
+| Zeus                  | Vir ♍ | 26.83°   | +0.0107°/d   | -          | +1.26°  | -   | -    | Eighth House  |
+| Kronos                | Gem ♊ | 22.59°   | +0.0139°/d   | -          | +23.25° | -   | -    | Fifth House   |
+| Apollon               | Lib ♎ | 14.45°   | +0.0050°/d   | -          | -5.70°  | -   | -    | Eighth House  |
+| Admetos               | Tau ♉ | 15.54°   | +0.0055°/d   | -          | +16.50° | -   | -    | Third House   |
+| Vulkanus              | Can ♋ | 15.88°   | +0.0136°/d   | -          | +22.51° | -   | -    | Seventh House |
+| Poseidon              | Lib ♎ | 29.17°   | +0.0012°/d   | -          | -11.19° | -   | -    | Ninth House   |
+| Eris                  | Ari ♈ | 17.83°   | -0.0012°/d   | -          | -8.90°  | -   | R    | Second House  |
+| Sedna                 | Tau ♉ | 12.06°   | +0.0039°/d   | -          | +4.38°  | -   | -    | Third House   |
+| Haumea                | Vir ♍ | 27.25°   | +0.0132°/d   | -          | +22.86° | -   | -    | Eighth House  |
+| Makemake              | Vir ♍ | 5.55°    | +0.0199°/d   | -          | +35.13° | Y   | -    | Seventh House |
+| Ixion                 | Sco ♏ | 23.74°   | -0.0064°/d   | -          | -13.21° | -   | R    | Tenth House   |
+| Orcus                 | Leo ♌ | 11.85°   | +0.0233°/d   | -          | +3.54°  | -   | -    | Seventh House |
+| Quaoar                | Sco ♏ | 25.34°   | -0.0066°/d   | -          | -13.27° | -   | R    | Tenth House   |
+| Vertex                | Leo ♌ | 26.69°   | N/A          | -          | N/A     | -   | -    | Seventh House |
+| White Moon            | Vir ♍ | 17.86°   | +0.1408°/d   | -          | +4.80°  | -   | -    | Eighth House  |
+| Anti Vertex           | Aqu ♒ | 26.69°   | N/A          | -          | N/A     | -   | -    | First House   |
+| Mean South Lunar Node | Can ♋ | 18.45°   | -0.0529°/d   | -          | +22.17° | -   | R    | Seventh House |
+| True South Lunar Node | Can ♋ | 18.94°   | +0.0160°/d   | -          | +22.10° | -   | -    | Seventh House |
+| Mean Priapus          | Can ♋ | 9.64°    | +0.1108°/d   | -          | +23.88° | Y   | -    | Sixth House   |
+| True Priapus          | Can ♋ | 1.04°    | +1.6109°/d   | -          | +25.07° | Y   | -    | Sixth House   |
++-----------------------+--------+----------+--------------+------------+---------+-----+------+---------------+
 
-+Solar Return Chart Arabic Parts----+-------+-------+------+----------------+
-| Point         | Sign   | Position | Speed | Decl. | Ret. | House          |
-+---------------+--------+----------+-------+-------+------+----------------+
-| Pars Fortunae | Lib ♎ | 28.48°   | N/A   | N/A   | -    | Twelfth House  |
-| Pars Spiritus | Sco ♏ | 13.15°   | N/A   | N/A   | -    | First House    |
-| Pars Amoris   | Lib ♎ | 8.98°    | N/A   | N/A   | -    | Eleventh House |
-| Pars Fidei    | Tau ♉ | 8.21°    | N/A   | N/A   | -    | Seventh House  |
-+---------------+--------+----------+-------+-------+------+----------------+
++Solar Return Chart Arabic Parts----+-------+-------+------+---------------+
+| Point         | Sign   | Position | Speed | Decl. | Ret. | House         |
++---------------+--------+----------+-------+-------+------+---------------+
+| Pars Fortunae | Tau ♉ | 19.91°   | N/A   | N/A   | -    | Third House   |
+| Pars Spiritus | Vir ♍ | 7.73°    | N/A   | N/A   | -    | Seventh House |
+| Pars Amoris   | Aqu ♒ | 20.58°   | N/A   | N/A   | -    | First House   |
+| Pars Fidei    | Can ♋ | 28.57°   | N/A   | N/A   | -    | Seventh House |
++---------------+--------+----------+-------+-------+------+---------------+
 
 +Solar Return Chart Houses (Placidus)+-------------------+
 | House          | Sign   | Position | Absolute Position |
 +----------------+--------+----------+-------------------+
-| First House    | Sco ♏ | 5.82°    | 215.82°           |
-| Second House   | Sag ♐ | 3.70°    | 243.70°           |
-| Third House    | Cap ♑ | 9.78°    | 279.78°           |
-| Fourth House   | Aqu ♒ | 19.91°   | 319.91°           |
-| Fifth House    | Pis ♓ | 23.00°   | 353.00°           |
-| Sixth House    | Ari ♈ | 17.47°   | 17.47°            |
-| Seventh House  | Tau ♉ | 5.82°    | 35.82°            |
-| Eighth House   | Gem ♊ | 3.70°    | 63.70°            |
-| Ninth House    | Can ♋ | 9.78°    | 99.78°            |
-| Tenth House    | Leo ♌ | 19.91°   | 139.91°           |
-| Eleventh House | Vir ♍ | 23.00°   | 173.00°           |
-| Twelfth House  | Lib ♎ | 17.47°   | 197.47°           |
+| First House    | Cap ♑ | 13.82°   | 283.82°           |
+| Second House   | Pis ♓ | 11.22°   | 341.22°           |
+| Third House    | Ari ♈ | 25.80°   | 25.80°            |
+| Fourth House   | Tau ♉ | 21.77°   | 51.77°            |
+| Fifth House    | Gem ♊ | 10.03°   | 70.03°            |
+| Sixth House    | Gem ♊ | 25.97°   | 85.97°            |
+| Seventh House  | Can ♋ | 13.82°   | 103.82°           |
+| Eighth House   | Vir ♍ | 11.22°   | 161.22°           |
+| Ninth House    | Lib ♎ | 25.80°   | 205.80°           |
+| Tenth House    | Sco ♏ | 21.77°   | 231.77°           |
+| Eleventh House | Sag ♐ | 10.03°   | 250.03°           |
+| Twelfth House  | Sag ♐ | 25.97°   | 265.97°           |
 +----------------+--------+----------+-------------------+
 
-+Lunar Phase--------------+--------------------+
-| Lunar Phase Information | Value              |
-+-------------------------+--------------------+
-| Phase Name              | Waning Crescent 🌘 |
-| Sun-Moon Angle          | 352.67°            |
-| Lunation Day            | 28                 |
-+-------------------------+--------------------+
++Lunar Phase--------------+-------------------+
+| Lunar Phase Information | Value             |
++-------------------------+-------------------+
+| Phase Name              | Waxing Gibbous 🌔 |
+| Sun-Moon Angle          | 126.09°           |
+| Lunation Day            | 10                |
++-------------------------+-------------------+
 
 +Element Distribution-----------+------------+
 | Element  | Count              | Percentage |
 +----------+--------------------+------------+
-| Fire 🔥  | 6.3999999999999995 | 18%        |
-| Earth 🌍 | 7.999999999999999  | 23%        |
-| Air 💨   | 6.8999999999999995 | 19%        |
-| Water 💧 | 14.100000000000003 | 40%        |
-| Total    | 35.4               | 100%       |
+| Fire 🔥  | 6.499999999999999  | 18%        |
+| Earth 🌍 | 14.300000000000004 | 40%        |
+| Air 💨   | 4.1                | 12%        |
+| Water 💧 | 10.500000000000002 | 30%        |
+| Total    | 35.400000000000006 | 100%       |
 +----------+--------------------+------------+
 
 +Quality Distribution-----------+------------+
 | Quality  | Count              | Percentage |
 +----------+--------------------+------------+
-| Cardinal | 12.900000000000004 | 36%        |
-| Fixed    | 17.900000000000006 | 51%        |
-| Mutable  | 4.6                | 13%        |
-| Total    | 35.40000000000001  | 100%       |
+| Cardinal | 14.900000000000004 | 42%        |
+| Fixed    | 12.400000000000004 | 35%        |
+| Mutable  | 8.1                | 23%        |
+| Total    | 35.400000000000006 | 100%       |
 +----------+--------------------+------------+
 
-+Angularities------------+----------+
-| Point   | Angle        | Distance |
-+---------+--------------+----------+
-| Mars    | Descendant   | 0.15°    |
-| Mercury | Medium Coeli | 2.30°    |
-+---------+--------------+----------+
-
-+Stelliums------+-----------------------------+
-| House | Count | Points                      |
-+-------+-------+-----------------------------+
-| 9     | 4     | Sun, Moon, Mercury, Jupiter |
-+-------+-------+-----------------------------+
++Stelliums------+------------------------------------+
+| House | Count | Points                             |
++-------+-------+------------------------------------+
+| 7     | 5     | Sun, Mercury, Venus, Mars, Jupiter |
++-------+-------+------------------------------------+
 
 +Active Celestial Points-----+
 | #  | Active Point          |
@@ -222,493 +215,528 @@ Sample Natal Subject Solar Return — Solar Return 1990
 +Aspects----------------+------------------+-----------------------+-------+--------------+
 | Point 1               | Aspect           | Point 2               | Orb   | Movement     |
 +-----------------------+------------------+-----------------------+-------+--------------+
-| Sun                   | conjunction ☌    | Jupiter               | 4.63° | Separating ← |
-| Sun                   | trine △          | Mean Lilith           | 0.45° | Applying →   |
-| Sun                   | quintile Q       | Vesta                 | 1.60° | Applying →   |
-| Sun                   | sextile ⚹        | Haumea                | 2.22° | Separating ← |
-| Sun                   | trine △          | Ixion                 | 5.84° | Separating ← |
-| Sun                   | trine △          | Quaoar                | 4.47° | Separating ← |
-| Sun                   | square □         | Pars Fortunae         | 0.06° | Separating ← |
-| Sun                   | quintile Q       | Pars Amoris           | 1.56° | Separating ← |
-| Sun                   | trine △          | Interpolated Lilith   | 3.07° | Separating ← |
-| Sun                   | sextile ⚹        | Mean Priapus          | 0.45° | Applying →   |
-| Sun                   | conjunction ☌    | White Moon            | 2.11° | Separating ← |
-| Sun                   | sextile ⚹        | Zeus                  | 2.51° | Separating ← |
-| Sun                   | quintile Q       | Admetos               | 1.58° | Separating ← |
-| Sun                   | square □         | Poseidon              | 0.14° | Applying →   |
-| Moon                  | conjunction ☌    | Jupiter               | 2.70° | Applying →   |
-| Moon                  | opposition ☍     | Saturn                | 0.31° | Applying →   |
-| Moon                  | conjunction ☌    | Chiron                | 1.33° | Separating ← |
-| Moon                  | semi-sextile ⚺   | Medium Coeli          | 1.30° | Applying →   |
-| Moon                  | quincunx ⚻       | Imum Coeli            | 1.30° | Applying →   |
-| Moon                  | sextile ⚹        | Vesta                 | 3.06° | Separating ← |
-| Moon                  | square □         | Eris                  | 3.61° | Separating ← |
-| Moon                  | semi-square ∠    | Makemake              | 1.71° | Separating ← |
-| Moon                  | trine △          | Ixion                 | 1.49° | Applying →   |
-| Moon                  | trine △          | Quaoar                | 2.87° | Applying →   |
-| Moon                  | quintile Q       | Pars Fidei            | 0.99° | Separating ← |
-| Moon                  | trine △          | Interpolated Lilith   | 4.27° | Applying →   |
-| Moon                  | semi-sextile ⚺   | Interpolated Perigee  | 0.23° | Separating ← |
-| Moon                  | conjunction ☌    | White Moon            | 5.22° | Applying →   |
-| Moon                  | trine △          | Cupido                | 2.59° | Separating ← |
-| Moon                  | sextile ⚹        | Zeus                  | 4.82° | Applying →   |
-| Moon                  | semi-sextile ⚺   | Kronos                | 0.69° | Applying →   |
-| Moon                  | conjunction ☌    | Vulkanus              | 5.87° | Separating ← |
-| Mercury               | semi-square ∠    | Venus                 | 0.90° | Separating ← |
-| Mercury               | biquintile bQ    | Neptune               | 1.15° | Applying →   |
-| Mercury               | square □         | Pluto                 | 2.63° | Separating ← |
-| Mercury               | conjunction ☌    | Medium Coeli          | 2.30° | Separating ← |
-| Mercury               | opposition ☍     | Imum Coeli            | 2.30° | Separating ← |
-| Mercury               | trine △          | True Lilith           | 0.41° | Applying →   |
-| Mercury               | conjunction ☌    | Ceres                 | 3.89° | Separating ← |
-| Mercury               | square □         | Vesta                 | 0.54° | Applying →   |
-| Mercury               | trine △          | Eris                  | 0.01° | Separating ← |
-| Mercury               | square □         | Ixion                 | 5.09° | Applying →   |
-| Mercury               | quintile Q       | Pars Fortunae         | 1.12° | Separating ← |
-| Mercury               | square □         | Pars Spiritus         | 4.46° | Separating ← |
-| Mercury               | sextile ⚹        | True Priapus          | 0.41° | Applying →   |
-| Mercury               | sextile ⚹        | Interpolated Perigee  | 3.37° | Applying →   |
-| Mercury               | square □         | Cupido                | 1.01° | Applying →   |
-| Mercury               | sextile ⚹        | Kronos                | 4.29° | Applying →   |
-| Mercury               | sextile ⚹        | Apollon               | 3.78° | Separating ← |
-| Mercury               | square □         | Admetos               | 2.65° | Separating ← |
-| Mercury               | quintile Q       | Poseidon              | 0.93° | Separating ← |
-| Venus                 | sextile ⚹        | Mars                  | 4.26° | Applying →   |
-| Venus                 | opposition ☍     | Uranus                | 5.03° | Applying →   |
-| Venus                 | sesquiquadrate ⚼ | Pluto                 | 1.73° | Separating ← |
-| Venus                 | biquintile bQ    | Mean North Lunar Node | 0.08° | Applying →   |
-| Venus                 | biquintile bQ    | True North Lunar Node | 0.44° | Separating ← |
-| Venus                 | trine △          | Ascendant             | 4.11° | Separating ← |
-| Venus                 | sextile ⚹        | Descendant            | 4.11° | Separating ← |
-| Venus                 | conjunction ☌    | Pallas                | 5.54° | Applying →   |
-| Venus                 | semi-square ∠    | Vesta                 | 1.44° | Applying →   |
-| Venus                 | square □         | Haumea                | 5.39° | Separating ← |
-| Venus                 | sextile ⚹        | Makemake              | 2.79° | Applying →   |
-| Venus                 | biquintile bQ    | Quaoar                | 1.63° | Separating ← |
-| Venus                 | trine △          | Pars Fortunae         | 3.22° | Separating ← |
-| Venus                 | biquintile bQ    | Interpolated Lilith   | 0.23° | Separating ← |
-| Venus                 | sesquiquadrate ⚼ | Cupido                | 1.91° | Applying →   |
-| Venus                 | square □         | Zeus                  | 5.68° | Separating ← |
-| Venus                 | semi-square ∠    | Admetos               | 1.75° | Separating ← |
-| Venus                 | trine △          | Poseidon              | 3.03° | Separating ← |
-| Mars                  | trine △          | Uranus                | 0.77° | Applying →   |
-| Mars                  | square □         | Mean North Lunar Node | 1.82° | Applying →   |
-| Mars                  | square □         | True North Lunar Node | 1.30° | Applying →   |
-| Mars                  | quintile Q       | Chiron                | 1.91° | Applying →   |
-| Mars                  | opposition ☍     | Ascendant             | 0.15° | Applying →   |
-| Mars                  | conjunction ☌    | Descendant            | 0.15° | Applying →   |
-| Mars                  | square □         | Mean South Lunar Node | 1.82° | Applying →   |
-| Mars                  | square □         | True South Lunar Node | 1.30° | Applying →   |
-| Mars                  | sextile ⚹        | Pholus                | 2.02° | Applying →   |
-| Mars                  | sextile ⚹        | Pallas                | 1.28° | Applying →   |
-| Mars                  | opposition ☍     | Juno                  | 4.13° | Applying →   |
-| Mars                  | conjunction ☌    | Sedna                 | 5.58° | Applying →   |
-| Mars                  | trine △          | Makemake              | 1.47° | Separating ← |
-| Mars                  | square □         | Orcus                 | 4.87° | Applying →   |
-| Mars                  | conjunction ☌    | Pars Fidei            | 2.25° | Applying →   |
-| Mars                  | biquintile bQ    | Anti Vertex           | 0.51° | Separating ← |
-| Mars                  | semi-square ∠    | Interpolated Perigee  | 0.02° | Applying →   |
-| Mars                  | semi-square ∠    | Kronos                | 0.93° | Applying →   |
-| Jupiter               | opposition ☍     | Saturn                | 2.40° | Separating ← |
-| Jupiter               | conjunction ☌    | Chiron                | 4.03° | Separating ← |
-| Jupiter               | trine △          | Mean Lilith           | 5.08° | Applying →   |
-| Jupiter               | biquintile bQ    | True Lilith           | 0.10° | Applying →   |
-| Jupiter               | quintile Q       | Sedna                 | 0.36° | Separating ← |
-| Jupiter               | sextile ⚹        | Haumea                | 2.41° | Applying →   |
-| Jupiter               | trine △          | Ixion                 | 1.21° | Separating ← |
-| Jupiter               | trine △          | Quaoar                | 0.16° | Applying →   |
-| Jupiter               | square □         | Pars Fortunae         | 4.57° | Applying →   |
-| Jupiter               | trine △          | Interpolated Lilith   | 1.56° | Applying →   |
-| Jupiter               | conjunction ☌    | White Moon            | 2.52° | Applying →   |
-| Jupiter               | trine △          | Cupido                | 5.29° | Separating ← |
-| Jupiter               | semi-square ∠    | Hades                 | 1.01° | Applying →   |
-| Jupiter               | sextile ⚹        | Zeus                  | 2.12° | Applying →   |
-| Jupiter               | square □         | Poseidon              | 4.77° | Applying →   |
-| Saturn                | opposition ☍     | Chiron                | 1.64° | Applying →   |
-| Saturn                | quincunx ⚻       | Medium Coeli          | 1.61° | Applying →   |
-| Saturn                | semi-sextile ⚺   | Imum Coeli            | 1.61° | Applying →   |
-| Saturn                | quintile Q       | Juno                  | 0.58° | Separating ← |
-| Saturn                | trine △          | Vesta                 | 3.37° | Applying →   |
-| Saturn                | square □         | Eris                  | 3.92° | Applying →   |
-| Saturn                | trine △          | Haumea                | 4.81° | Separating ← |
-| Saturn                | sextile ⚹        | Ixion                 | 1.19° | Separating ← |
-| Saturn                | sextile ⚹        | Quaoar                | 2.56° | Separating ← |
-| Saturn                | sextile ⚹        | Interpolated Lilith   | 3.96° | Separating ← |
-| Saturn                | quincunx ⚻       | Interpolated Perigee  | 0.53° | Applying →   |
-| Saturn                | opposition ☍     | White Moon            | 4.92° | Separating ← |
-| Saturn                | sextile ⚹        | Cupido                | 2.90° | Applying →   |
-| Saturn                | trine △          | Zeus                  | 4.51° | Separating ← |
-| Saturn                | quincunx ⚻       | Kronos                | 0.38° | Separating ← |
-| Uranus                | semi-sextile ⚺   | Mean North Lunar Node | 1.05° | Applying →   |
-| Uranus                | semi-sextile ⚺   | True North Lunar Node | 0.53° | Separating ← |
-| Uranus                | sextile ⚹        | Ascendant             | 0.92° | Applying →   |
-| Uranus                | sesquiquadrate ⚼ | Medium Coeli          | 1.83° | Applying →   |
-| Uranus                | trine △          | Descendant            | 0.92° | Applying →   |
-| Uranus                | semi-square ∠    | Imum Coeli            | 1.83° | Applying →   |
-| Uranus                | quincunx ⚻       | Mean South Lunar Node | 1.05° | Applying →   |
-| Uranus                | quincunx ⚻       | True South Lunar Node | 0.53° | Separating ← |
-| Uranus                | opposition ☍     | Pholus                | 1.25° | Separating ← |
-| Uranus                | biquintile bQ    | Ceres                 | 0.98° | Separating ← |
-| Uranus                | opposition ☍     | Pallas                | 0.51° | Separating ← |
-| Uranus                | sextile ⚹        | Juno                  | 3.36° | Separating ← |
-| Uranus                | trine △          | Sedna                 | 4.81° | Separating ← |
-| Uranus                | trine △          | Makemake              | 2.24° | Applying →   |
-| Uranus                | semi-square ∠    | Ixion                 | 0.96° | Separating ← |
-| Uranus                | biquintile bQ    | Orcus                 | 1.90° | Applying →   |
-| Uranus                | square □         | Pars Amoris           | 2.25° | Separating ← |
-| Uranus                | trine △          | Pars Fidei            | 1.48° | Separating ← |
-| Uranus                | biquintile bQ    | Mean Priapus          | 1.75° | Applying →   |
-| Neptune               | sextile ⚹        | Pluto                 | 2.21° | Separating ← |
-| Neptune               | biquintile bQ    | Medium Coeli          | 1.15° | Separating ← |
-| Neptune               | semi-square ∠    | Mean Lilith           | 1.23° | Separating ← |
-| Neptune               | opposition ☍     | Pholus                | 4.77° | Applying →   |
-| Neptune               | quincunx ⚻       | Ceres                 | 0.95° | Separating ← |
-| Neptune               | opposition ☍     | Pallas                | 5.51° | Applying →   |
-| Neptune               | sextile ⚹        | Juno                  | 2.67° | Applying →   |
-| Neptune               | trine △          | Vesta                 | 5.38° | Separating ← |
-| Neptune               | square □         | Eris                  | 4.83° | Separating ← |
-| Neptune               | trine △          | Sedna                 | 1.21° | Applying →   |
-| Neptune               | quincunx ⚻       | Orcus                 | 1.92° | Applying →   |
-| Neptune               | sextile ⚹        | Pars Spiritus         | 0.39° | Separating ← |
-| Neptune               | square □         | Pars Amoris           | 3.78° | Applying →   |
-| Neptune               | trine △          | Pars Fidei            | 4.55° | Applying →   |
-| Neptune               | quincunx ⚻       | Vertex                | 1.30° | Applying →   |
-| Neptune               | semi-sextile ⚺   | Anti Vertex           | 1.30° | Applying →   |
-| Neptune               | sesquiquadrate ⚼ | Mean Priapus          | 1.23° | Separating ← |
-| Neptune               | square □         | Apollon               | 1.06° | Separating ← |
-| Neptune               | trine △          | Admetos               | 2.20° | Separating ← |
-| Neptune               | opposition ☍     | Vulkanus              | 2.58° | Separating ← |
-| Pluto                 | trine △          | Chiron                | 4.91° | Separating ← |
-| Pluto                 | square □         | Medium Coeli          | 4.94° | Separating ← |
-| Pluto                 | square □         | Imum Coeli            | 4.94° | Separating ← |
-| Pluto                 | square □         | Ceres                 | 1.26° | Applying →   |
-| Pluto                 | conjunction ☌    | Juno                  | 4.88° | Applying →   |
-| Pluto                 | opposition ☍     | Vesta                 | 3.17° | Separating ← |
-| Pluto                 | opposition ☍     | Sedna                 | 3.43° | Applying →   |
-| Pluto                 | quintile Q       | Makemake              | 1.52° | Separating ← |
-| Pluto                 | square □         | Orcus                 | 4.13° | Applying →   |
-| Pluto                 | conjunction ☌    | Pars Spiritus         | 1.82° | Applying →   |
-| Pluto                 | biquintile bQ    | Interpolated Perigee  | 0.01° | Separating ← |
-| Pluto                 | conjunction ☌    | Cupido                | 3.64° | Applying →   |
-| Pluto                 | biquintile bQ    | Kronos                | 0.92° | Separating ← |
-| Pluto                 | semi-sextile ⚺   | Apollon               | 1.15° | Applying →   |
-| Pluto                 | opposition ☍     | Admetos               | 0.02° | Applying →   |
-| Pluto                 | trine △          | Vulkanus              | 0.37° | Separating ← |
-| Mean North Lunar Node | square □         | Ascendant             | 1.97° | Applying →   |
-| Mean North Lunar Node | square □         | Descendant            | 1.97° | Applying →   |
-| Mean North Lunar Node | quincunx ⚻       | Pholus                | 0.20° | Separating ← |
-| Mean North Lunar Node | opposition ☍     | Ceres                 | 5.93° | Separating ← |
-| Mean North Lunar Node | quincunx ⚻       | Pallas                | 0.54° | Applying →   |
-| Mean North Lunar Node | square □         | Juno                  | 2.31° | Separating ← |
-| Mean North Lunar Node | square □         | Sedna                 | 3.76° | Separating ← |
-| Mean North Lunar Node | opposition ☍     | Orcus                 | 3.05° | Separating ← |
-| Mean North Lunar Node | quintile Q       | Quaoar                | 1.71° | Applying →   |
-| Mean North Lunar Node | square □         | Pars Spiritus         | 5.36° | Separating ← |
-| Mean North Lunar Node | trine △          | Pars Amoris           | 1.20° | Separating ← |
-| Mean North Lunar Node | square □         | Pars Fidei            | 0.43° | Separating ← |
-| Mean North Lunar Node | trine △          | Vertex                | 3.67° | Separating ← |
-| Mean North Lunar Node | sextile ⚹        | Anti Vertex           | 3.67° | Separating ← |
-| Mean North Lunar Node | quintile Q       | Interpolated Lilith   | 0.31° | Applying →   |
-| Mean North Lunar Node | sesquiquadrate ⚼ | Interpolated Perigee  | 1.81° | Applying →   |
-| Mean North Lunar Node | trine △          | Hades                 | 2.13° | Separating ← |
-| Mean North Lunar Node | sesquiquadrate ⚼ | Kronos                | 0.89° | Applying →   |
-| True North Lunar Node | square □         | Ascendant             | 1.45° | Applying →   |
-| True North Lunar Node | square □         | Descendant            | 1.45° | Applying →   |
-| True North Lunar Node | quincunx ⚻       | Pholus                | 0.73° | Separating ← |
-| True North Lunar Node | quincunx ⚻       | Pallas                | 0.02° | Applying →   |
-| True North Lunar Node | square □         | Juno                  | 2.83° | Separating ← |
-| True North Lunar Node | quintile Q       | Eris                  | 1.67° | Applying →   |
-| True North Lunar Node | square □         | Sedna                 | 4.28° | Separating ← |
-| True North Lunar Node | opposition ☍     | Orcus                 | 3.57° | Separating ← |
-| True North Lunar Node | quintile Q       | Quaoar                | 1.19° | Applying →   |
-| True North Lunar Node | square □         | Pars Spiritus         | 5.89° | Separating ← |
-| True North Lunar Node | trine △          | Pars Amoris           | 1.72° | Separating ← |
-| True North Lunar Node | square □         | Pars Fidei            | 0.95° | Separating ← |
-| True North Lunar Node | trine △          | Vertex                | 4.20° | Separating ← |
-| True North Lunar Node | sextile ⚹        | Anti Vertex           | 4.20° | Separating ← |
-| True North Lunar Node | quintile Q       | Interpolated Lilith   | 0.21° | Separating ← |
-| True North Lunar Node | sesquiquadrate ⚼ | Interpolated Perigee  | 1.28° | Applying →   |
-| True North Lunar Node | trine △          | Hades                 | 2.66° | Separating ← |
-| True North Lunar Node | sesquiquadrate ⚼ | Kronos                | 0.37° | Applying →   |
-| Chiron                | semi-sextile ⚺   | Medium Coeli          | 0.03° | Separating ← |
-| Chiron                | quincunx ⚻       | Imum Coeli            | 0.03° | Separating ← |
-| Chiron                | quincunx ⚻       | True Lilith           | 1.87° | Separating ← |
-| Chiron                | sextile ⚹        | Vesta                 | 1.73° | Applying →   |
-| Chiron                | square □         | Eris                  | 2.28° | Separating ← |
-| Chiron                | semi-square ∠    | Makemake              | 0.38° | Separating ← |
-| Chiron                | trine △          | Ixion                 | 2.82° | Applying →   |
-| Chiron                | trine △          | Quaoar                | 4.20° | Applying →   |
-| Chiron                | quintile Q       | Pars Fidei            | 0.33° | Applying →   |
-| Chiron                | trine △          | Interpolated Lilith   | 5.60° | Separating ← |
-| Chiron                | semi-sextile ⚺   | True Priapus          | 1.87° | Separating ← |
-| Chiron                | semi-sextile ⚺   | Interpolated Perigee  | 1.10° | Separating ← |
-| Chiron                | trine △          | Cupido                | 1.26° | Separating ← |
-| Chiron                | sextile ⚹        | Admetos               | 4.92° | Separating ← |
-| Chiron                | conjunction ☌    | Vulkanus              | 4.54° | Separating ← |
-| Ascendant             | square □         | Mean South Lunar Node | 1.97° | Applying →   |
-| Ascendant             | square □         | True South Lunar Node | 1.45° | Applying →   |
-| Ascendant             | trine △          | Pholus                | 2.17° | Applying →   |
-| Ascendant             | trine △          | Pallas                | 1.43° | Applying →   |
-| Ascendant             | conjunction ☌    | Juno                  | 4.28° | Applying →   |
-| Ascendant             | opposition ☍     | Sedna                 | 5.73° | Applying →   |
-| Ascendant             | sextile ⚹        | Makemake              | 1.32° | Separating ← |
-| Ascendant             | square □         | Orcus                 | 5.02° | Applying →   |
-| Ascendant             | opposition ☍     | Pars Fidei            | 2.40° | Applying →   |
-| Ascendant             | biquintile bQ    | Vertex                | 0.36° | Separating ← |
-| Ascendant             | sesquiquadrate ⚼ | Interpolated Perigee  | 0.16° | Applying →   |
-| Ascendant             | biquintile bQ    | Hades                 | 1.90° | Separating ← |
-| Ascendant             | sesquiquadrate ⚼ | Kronos                | 1.08° | Applying →   |
-| Medium Coeli          | trine △          | True Lilith           | 1.90° | Separating ← |
-| Medium Coeli          | square □         | Vesta                 | 1.76° | Separating ← |
-| Medium Coeli          | trine △          | Eris                  | 2.31° | Separating ← |
-| Medium Coeli          | square □         | Ixion                 | 2.79° | Applying →   |
-| Medium Coeli          | square □         | Quaoar                | 4.16° | Applying →   |
-| Medium Coeli          | square □         | Interpolated Lilith   | 5.57° | Applying →   |
-| Medium Coeli          | sextile ⚹        | True Priapus          | 1.90° | Separating ← |
-| Medium Coeli          | sextile ⚹        | Interpolated Perigee  | 1.07° | Applying →   |
-| Medium Coeli          | square □         | Cupido                | 1.29° | Separating ← |
-| Medium Coeli          | sextile ⚹        | Kronos                | 1.98° | Applying →   |
-| Medium Coeli          | square □         | Admetos               | 4.95° | Separating ← |
-| Descendant            | square □         | Mean South Lunar Node | 1.97° | Applying →   |
-| Descendant            | square □         | True South Lunar Node | 1.45° | Applying →   |
-| Descendant            | sextile ⚹        | Pholus                | 2.17° | Applying →   |
-| Descendant            | sextile ⚹        | Pallas                | 1.43° | Applying →   |
-| Descendant            | opposition ☍     | Juno                  | 4.28° | Applying →   |
-| Descendant            | conjunction ☌    | Sedna                 | 5.73° | Applying →   |
-| Descendant            | trine △          | Makemake              | 1.32° | Separating ← |
-| Descendant            | square □         | Orcus                 | 5.02° | Applying →   |
-| Descendant            | conjunction ☌    | Pars Fidei            | 2.40° | Applying →   |
-| Descendant            | biquintile bQ    | Anti Vertex           | 0.36° | Separating ← |
-| Descendant            | semi-square ∠    | Interpolated Perigee  | 0.16° | Applying →   |
-| Descendant            | semi-square ∠    | Kronos                | 1.08° | Applying →   |
-| Imum Coeli            | sextile ⚹        | True Lilith           | 1.90° | Separating ← |
-| Imum Coeli            | square □         | Vesta                 | 1.76° | Separating ← |
-| Imum Coeli            | sextile ⚹        | Eris                  | 2.31° | Separating ← |
-| Imum Coeli            | biquintile bQ    | Haumea                | 0.41° | Applying →   |
-| Imum Coeli            | square □         | Ixion                 | 2.79° | Applying →   |
-| Imum Coeli            | square □         | Quaoar                | 4.16° | Applying →   |
-| Imum Coeli            | square □         | Interpolated Lilith   | 5.57° | Applying →   |
-| Imum Coeli            | trine △          | True Priapus          | 1.90° | Separating ← |
-| Imum Coeli            | trine △          | Interpolated Perigee  | 1.07° | Applying →   |
-| Imum Coeli            | square □         | Cupido                | 1.29° | Separating ← |
-| Imum Coeli            | biquintile bQ    | Zeus                  | 0.12° | Applying →   |
-| Imum Coeli            | trine △          | Kronos                | 1.98° | Applying →   |
-| Imum Coeli            | square □         | Admetos               | 4.95° | Separating ← |
-| Imum Coeli            | biquintile bQ    | Vulkanus              | 1.43° | Applying →   |
-| Mean Lilith           | sextile ⚹        | Haumea                | 2.67° | Separating ← |
-| Mean Lilith           | square □         | Makemake              | 5.51° | Applying →   |
-| Mean Lilith           | conjunction ☌    | Quaoar                | 4.91° | Separating ← |
-| Mean Lilith           | semi-sextile ⚺   | Pars Fortunae         | 0.51° | Separating ← |
-| Mean Lilith           | conjunction ☌    | Interpolated Lilith   | 3.51° | Applying →   |
-| Mean Lilith           | trine △          | White Moon            | 2.56° | Applying →   |
-| Mean Lilith           | sextile ⚹        | Zeus                  | 2.96° | Separating ← |
-| Mean Lilith           | semi-square ∠    | Apollon               | 0.17° | Separating ← |
-| Mean Lilith           | sesquiquadrate ⚼ | Vulkanus              | 1.35° | Applying →   |
-| Mean Lilith           | semi-sextile ⚺   | Poseidon              | 0.31° | Separating ← |
-| Mean South Lunar Node | semi-sextile ⚺   | Pholus                | 0.20° | Separating ← |
-| Mean South Lunar Node | conjunction ☌    | Ceres                 | 5.93° | Separating ← |
-| Mean South Lunar Node | semi-sextile ⚺   | Pallas                | 0.54° | Applying →   |
-| Mean South Lunar Node | square □         | Juno                  | 2.31° | Separating ← |
-| Mean South Lunar Node | square □         | Sedna                 | 3.76° | Separating ← |
-| Mean South Lunar Node | conjunction ☌    | Orcus                 | 3.05° | Separating ← |
-| Mean South Lunar Node | square □         | Pars Spiritus         | 5.36° | Separating ← |
-| Mean South Lunar Node | sextile ⚹        | Pars Amoris           | 1.20° | Separating ← |
-| Mean South Lunar Node | square □         | Pars Fidei            | 0.43° | Separating ← |
-| Mean South Lunar Node | sextile ⚹        | Vertex                | 3.67° | Separating ← |
-| Mean South Lunar Node | trine △          | Anti Vertex           | 3.67° | Separating ← |
-| Mean South Lunar Node | semi-square ∠    | Interpolated Perigee  | 1.81° | Applying →   |
-| Mean South Lunar Node | sextile ⚹        | Hades                 | 2.13° | Separating ← |
-| Mean South Lunar Node | semi-square ∠    | Kronos                | 0.89° | Applying →   |
-| True South Lunar Node | semi-sextile ⚺   | Pholus                | 0.73° | Separating ← |
-| True South Lunar Node | semi-sextile ⚺   | Pallas                | 0.02° | Applying →   |
-| True South Lunar Node | square □         | Juno                  | 2.83° | Separating ← |
-| True South Lunar Node | square □         | Sedna                 | 4.28° | Separating ← |
-| True South Lunar Node | conjunction ☌    | Orcus                 | 3.57° | Separating ← |
-| True South Lunar Node | square □         | Pars Spiritus         | 5.89° | Separating ← |
-| True South Lunar Node | sextile ⚹        | Pars Amoris           | 1.72° | Separating ← |
-| True South Lunar Node | square □         | Pars Fidei            | 0.95° | Separating ← |
-| True South Lunar Node | sextile ⚹        | Vertex                | 4.20° | Separating ← |
-| True South Lunar Node | trine △          | Anti Vertex           | 4.20° | Separating ← |
-| True South Lunar Node | semi-square ∠    | Interpolated Perigee  | 1.28° | Applying →   |
-| True South Lunar Node | sextile ⚹        | Hades                 | 2.66° | Separating ← |
-| True South Lunar Node | semi-square ∠    | Kronos                | 0.37° | Applying →   |
-| True Lilith           | trine △          | Ceres                 | 4.30° | Applying →   |
-| True Lilith           | quincunx ⚻       | Vesta                 | 0.13° | Separating ← |
-| True Lilith           | trine △          | Eris                  | 0.42° | Applying →   |
-| True Lilith           | biquintile bQ    | Sedna                 | 0.47° | Applying →   |
-| True Lilith           | opposition ☍     | Interpolated Perigee  | 2.97° | Separating ← |
-| True Lilith           | semi-sextile ⚺   | Cupido                | 0.60° | Separating ← |
-| True Lilith           | opposition ☍     | Kronos                | 3.88° | Separating ← |
-| True Lilith           | sextile ⚹        | Apollon               | 4.19° | Applying →   |
-| Pholus                | conjunction ☌    | Pallas                | 0.74° | Applying →   |
-| Pholus                | trine △          | Juno                  | 2.11° | Applying →   |
-| Pholus                | sextile ⚹        | Sedna                 | 3.56° | Applying →   |
-| Pholus                | sextile ⚹        | Makemake              | 3.49° | Separating ← |
-| Pholus                | sesquiquadrate ⚼ | Ixion                 | 0.29° | Separating ← |
-| Pholus                | sesquiquadrate ⚼ | Quaoar                | 1.08° | Applying →   |
-| Pholus                | trine △          | Pars Spiritus         | 5.16° | Applying →   |
-| Pholus                | square □         | Pars Amoris           | 0.99° | Applying →   |
-| Pholus                | sextile ⚹        | Pars Fidei            | 0.22° | Applying →   |
-| Pholus                | semi-sextile ⚺   | Hades                 | 1.93° | Applying →   |
-| Pholus                | square □         | Apollon               | 5.83° | Applying →   |
-| Ceres                 | square □         | Juno                  | 3.62° | Separating ← |
-| Ceres                 | square □         | Vesta                 | 4.43° | Applying →   |
-| Ceres                 | trine △          | Eris                  | 3.88° | Applying →   |
-| Ceres                 | square □         | Sedna                 | 2.17° | Separating ← |
-| Ceres                 | conjunction ☌    | Orcus                 | 2.88° | Separating ← |
-| Ceres                 | square □         | Pars Spiritus         | 0.56° | Separating ← |
-| Ceres                 | sextile ⚹        | Pars Amoris           | 4.73° | Separating ← |
-| Ceres                 | square □         | Pars Fidei            | 5.50° | Separating ← |
-| Ceres                 | sextile ⚹        | Vertex                | 2.25° | Separating ← |
-| Ceres                 | trine △          | Anti Vertex           | 2.25° | Separating ← |
-| Ceres                 | sextile ⚹        | True Priapus          | 4.30° | Applying →   |
-| Ceres                 | square □         | Cupido                | 4.90° | Applying →   |
-| Ceres                 | sextile ⚹        | Hades                 | 3.79° | Separating ← |
-| Ceres                 | sextile ⚹        | Apollon               | 0.11° | Applying →   |
-| Ceres                 | square □         | Admetos               | 1.24° | Applying →   |
-| Ceres                 | semi-sextile ⚺   | Vulkanus              | 1.63° | Applying →   |
-| Pallas                | trine △          | Juno                  | 2.85° | Applying →   |
-| Pallas                | sextile ⚹        | Sedna                 | 4.30° | Applying →   |
-| Pallas                | sextile ⚹        | Makemake              | 2.75° | Separating ← |
-| Pallas                | sesquiquadrate ⚼ | Ixion                 | 0.45° | Applying →   |
-| Pallas                | sesquiquadrate ⚼ | Quaoar                | 1.83° | Applying →   |
-| Pallas                | trine △          | Pars Spiritus         | 5.90° | Applying →   |
-| Pallas                | square □         | Pars Amoris           | 1.73° | Applying →   |
-| Pallas                | sextile ⚹        | Pars Fidei            | 0.97° | Applying →   |
-| Juno                  | opposition ☍     | Sedna                 | 1.45° | Applying →   |
-| Juno                  | semi-square ∠    | Haumea                | 1.23° | Applying →   |
-| Juno                  | square □         | Orcus                 | 0.74° | Applying →   |
-| Juno                  | conjunction ☌    | Pars Spiritus         | 3.06° | Applying →   |
-| Juno                  | semi-sextile ⚺   | Pars Amoris           | 1.11° | Separating ← |
-| Juno                  | opposition ☍     | Pars Fidei            | 1.88° | Separating ← |
-| Juno                  | quincunx ⚻       | Vertex                | 1.36° | Applying →   |
-| Juno                  | semi-sextile ⚺   | Anti Vertex           | 1.36° | Applying →   |
-| Juno                  | biquintile bQ    | True Priapus          | 1.92° | Applying →   |
-| Juno                  | quincunx ⚻       | Hades                 | 0.17° | Separating ← |
-| Juno                  | semi-square ∠    | Zeus                  | 0.93° | Applying →   |
-| Juno                  | opposition ☍     | Admetos               | 4.86° | Applying →   |
-| Juno                  | trine △          | Vulkanus              | 5.24° | Applying →   |
-| Vesta                 | semi-sextile ⚺   | Eris                  | 0.55° | Separating ← |
-| Vesta                 | opposition ☍     | Ixion                 | 4.56° | Applying →   |
-| Vesta                 | opposition ☍     | Quaoar                | 5.93° | Applying →   |
-| Vesta                 | opposition ☍     | Pars Spiritus         | 4.99° | Separating ← |
-| Vesta                 | semi-sextile ⚺   | True Priapus          | 0.13° | Separating ← |
-| Vesta                 | opposition ☍     | Cupido                | 0.47° | Applying →   |
-| Vesta                 | biquintile bQ    | Apollon               | 1.68° | Applying →   |
-| Vesta                 | conjunction ☌    | Admetos               | 3.19° | Separating ← |
-| Vesta                 | sextile ⚹        | Vulkanus              | 2.81° | Separating ← |
-| Eris                  | sesquiquadrate ⚼ | Makemake              | 1.90° | Separating ← |
-| Eris                  | biquintile bQ    | Ixion                 | 0.89° | Separating ← |
-| Eris                  | biquintile bQ    | Quaoar                | 0.48° | Applying →   |
-| Eris                  | biquintile bQ    | Interpolated Lilith   | 1.88° | Separating ← |
-| Eris                  | sextile ⚹        | True Priapus          | 0.42° | Applying →   |
-| Eris                  | sextile ⚹        | Interpolated Perigee  | 3.39° | Separating ← |
-| Eris                  | quincunx ⚻       | Cupido                | 1.02° | Applying →   |
-| Eris                  | sextile ⚹        | Kronos                | 4.30° | Separating ← |
-| Eris                  | opposition ☍     | Apollon               | 3.77° | Applying →   |
-| Eris                  | square □         | Vulkanus              | 2.26° | Applying →   |
-| Sedna                 | sesquiquadrate ⚼ | Haumea                | 0.23° | Applying →   |
-| Sedna                 | square □         | Orcus                 | 0.71° | Applying →   |
-| Sedna                 | opposition ☍     | Pars Spiritus         | 1.60° | Applying →   |
-| Sedna                 | conjunction ☌    | Pars Fidei            | 3.33° | Separating ← |
-| Sedna                 | semi-sextile ⚺   | Vertex                | 0.09° | Separating ← |
-| Sedna                 | quincunx ⚻       | Anti Vertex           | 0.09° | Separating ← |
-| Sedna                 | semi-sextile ⚺   | Hades                 | 1.63° | Applying →   |
-| Sedna                 | sesquiquadrate ⚼ | Zeus                  | 0.52° | Applying →   |
-| Sedna                 | conjunction ☌    | Admetos               | 3.41° | Separating ← |
-| Sedna                 | sextile ⚹        | Vulkanus              | 3.79° | Separating ← |
-| Haumea                | sextile ⚹        | Ixion                 | 3.62° | Separating ← |
-| Haumea                | semi-square ∠    | Orcus                 | 0.48° | Applying →   |
-| Haumea                | sextile ⚹        | Quaoar                | 2.25° | Separating ← |
-| Haumea                | semi-square ∠    | Pars Spiritus         | 1.83° | Applying →   |
-| Haumea                | sextile ⚹        | Interpolated Lilith   | 0.85° | Applying →   |
-| Haumea                | trine △          | Mean Priapus          | 2.67° | Separating ← |
-| Haumea                | square □         | Interpolated Perigee  | 5.34° | Applying →   |
-| Haumea                | sextile ⚹        | White Moon            | 0.11° | Separating ← |
-| Haumea                | conjunction ☌    | Zeus                  | 0.29° | Separating ← |
-| Haumea                | square □         | Kronos                | 4.43° | Static =     |
-| Haumea                | quintile Q       | Vulkanus              | 1.02° | Static =     |
-| Makemake              | trine △          | Pars Fidei            | 3.72° | Applying →   |
-| Makemake              | square □         | Mean Priapus          | 5.51° | Applying →   |
-| Makemake              | quintile Q       | Interpolated Perigee  | 1.51° | Applying →   |
-| Makemake              | square □         | Hades                 | 5.42° | Applying →   |
-| Makemake              | quintile Q       | Kronos                | 0.60° | Separating ← |
-| Ixion                 | conjunction ☌    | Quaoar                | 1.37° | Static =     |
-| Ixion                 | semi-square ∠    | Pars Amoris           | 1.28° | Separating ← |
-| Ixion                 | conjunction ☌    | Interpolated Lilith   | 2.77° | Separating ← |
-| Ixion                 | quincunx ⚻       | Interpolated Perigee  | 1.72° | Applying →   |
-| Ixion                 | trine △          | White Moon            | 3.73° | Separating ← |
-| Ixion                 | conjunction ☌    | Cupido                | 4.09° | Applying →   |
-| Ixion                 | sextile ⚹        | Zeus                  | 3.33° | Separating ← |
-| Ixion                 | quincunx ⚻       | Kronos                | 0.81° | Applying →   |
-| Orcus                 | square □         | Pars Spiritus         | 2.31° | Applying →   |
-| Orcus                 | sextile ⚹        | Pars Amoris           | 1.86° | Separating ← |
-| Orcus                 | square □         | Pars Fidei            | 2.62° | Separating ← |
-| Orcus                 | sextile ⚹        | Vertex                | 0.62° | Applying →   |
-| Orcus                 | trine △          | Anti Vertex           | 0.62° | Applying →   |
-| Orcus                 | quintile Q       | Mean Priapus          | 0.15° | Separating ← |
-| Orcus                 | sextile ⚹        | Hades                 | 0.92° | Separating ← |
-| Orcus                 | semi-square ∠    | Zeus                  | 0.19° | Applying →   |
-| Orcus                 | sextile ⚹        | Apollon               | 2.99° | Applying →   |
-| Orcus                 | square □         | Admetos               | 4.12° | Applying →   |
-| Quaoar                | semi-square ∠    | Pars Amoris           | 0.09° | Applying →   |
-| Quaoar                | conjunction ☌    | Interpolated Lilith   | 1.40° | Separating ← |
-| Quaoar                | opposition ☍     | Mean Priapus          | 4.91° | Separating ← |
-| Quaoar                | trine △          | White Moon            | 2.36° | Separating ← |
-| Quaoar                | conjunction ☌    | Cupido                | 5.46° | Applying →   |
-| Quaoar                | sextile ⚹        | Zeus                  | 1.95° | Separating ← |
-| Pars Fortunae         | quincunx ⚻       | Mean Priapus          | 0.51° | Separating ← |
-| Pars Fortunae         | square □         | White Moon            | 2.05° | Applying →   |
-| Pars Fortunae         | conjunction ☌    | Poseidon              | 0.20° | Separating ← |
-| Pars Spiritus         | opposition ☍     | Pars Fidei            | 4.94° | Static =     |
-| Pars Spiritus         | quincunx ⚻       | Vertex                | 1.69° | Static =     |
-| Pars Spiritus         | semi-sextile ⚺   | Anti Vertex           | 1.69° | Static =     |
-| Pars Spiritus         | biquintile bQ    | True Priapus          | 1.14° | Separating ← |
-| Pars Spiritus         | biquintile bQ    | Interpolated Perigee  | 1.83° | Separating ← |
-| Pars Spiritus         | conjunction ☌    | Cupido                | 5.46° | Applying →   |
-| Pars Spiritus         | semi-sextile ⚺   | Apollon               | 0.67° | Separating ← |
-| Pars Spiritus         | opposition ☍     | Admetos               | 1.81° | Separating ← |
-| Pars Spiritus         | trine △          | Vulkanus              | 2.19° | Separating ← |
-| Pars Amoris           | quincunx ⚻       | Pars Fidei            | 0.77° | Static =     |
-| Pars Amoris           | trine △          | Vertex                | 2.48° | Static =     |
-| Pars Amoris           | sextile ⚹        | Anti Vertex           | 2.48° | Static =     |
-| Pars Amoris           | semi-square ∠    | Interpolated Lilith   | 1.49° | Separating ← |
-| Pars Amoris           | quintile Q       | White Moon            | 0.55° | Applying →   |
-| Pars Amoris           | trine △          | Hades                 | 0.94° | Separating ← |
-| Pars Amoris           | conjunction ☌    | Apollon               | 4.84° | Separating ← |
-| Pars Amoris           | biquintile bQ    | Admetos               | 0.03° | Applying →   |
-| Pars Fidei            | semi-sextile ⚺   | Hades                 | 1.71° | Separating ← |
-| Pars Fidei            | semi-square ∠    | Kronos                | 1.32° | Applying →   |
-| Vertex                | semi-square ∠    | White Moon            | 0.03° | Applying →   |
-| Vertex                | conjunction ☌    | Hades                 | 1.54° | Applying →   |
-| Vertex                | trine △          | Apollon               | 2.36° | Separating ← |
-| Anti Vertex           | sesquiquadrate ⚼ | White Moon            | 0.03° | Applying →   |
-| Anti Vertex           | opposition ☍     | Hades                 | 1.54° | Applying →   |
-| Anti Vertex           | sextile ⚹        | Apollon               | 2.36° | Separating ← |
-| Interpolated Lilith   | opposition ☍     | Mean Priapus          | 3.51° | Applying →   |
-| Interpolated Lilith   | trine △          | White Moon            | 0.96° | Applying →   |
-| Interpolated Lilith   | sextile ⚹        | Zeus                  | 0.55° | Applying →   |
-| Mean Priapus          | sextile ⚹        | White Moon            | 2.56° | Applying →   |
-| Mean Priapus          | trine △          | Zeus                  | 2.96° | Separating ← |
-| Mean Priapus          | sesquiquadrate ⚼ | Apollon               | 0.17° | Separating ← |
-| Mean Priapus          | semi-square ∠    | Vulkanus              | 1.35° | Applying →   |
-| Mean Priapus          | quincunx ⚻       | Poseidon              | 0.31° | Separating ← |
-| True Priapus          | conjunction ☌    | Interpolated Perigee  | 2.97° | Separating ← |
-| True Priapus          | quincunx ⚻       | Cupido                | 0.60° | Separating ← |
-| True Priapus          | conjunction ☌    | Kronos                | 3.88° | Separating ← |
-| True Priapus          | trine △          | Apollon               | 4.19° | Applying →   |
-| Interpolated Perigee  | square □         | Zeus                  | 5.05° | Applying →   |
-| Interpolated Perigee  | conjunction ☌    | Kronos                | 0.91° | Applying →   |
-| White Moon            | semi-square ∠    | Hades                 | 1.51° | Separating ← |
-| White Moon            | sextile ⚹        | Zeus                  | 0.40° | Separating ← |
-| White Moon            | quintile Q       | Admetos               | 0.53° | Applying →   |
-| White Moon            | square □         | Poseidon              | 2.25° | Applying →   |
-| Cupido                | opposition ☍     | Admetos               | 3.66° | Applying →   |
-| Cupido                | trine △          | Vulkanus              | 3.28° | Applying →   |
-| Hades                 | trine △          | Apollon               | 3.90° | Applying →   |
-| Zeus                  | square □         | Kronos                | 4.14° | Applying →   |
-| Zeus                  | quintile Q       | Vulkanus              | 1.31° | Separating ← |
-| Apollon               | quincunx ⚻       | Admetos               | 1.13° | Static =     |
-| Apollon               | square □         | Vulkanus              | 1.52° | Separating ← |
-| Admetos               | sextile ⚹        | Vulkanus              | 0.38° | Separating ← |
+| Sun                   | opposition ☍     | Saturn                | 5.35° | Applying →   |
+| Sun                   | conjunction ☌    | Chiron                | 1.47° | Applying →   |
+| Sun                   | square □         | Ceres                 | 1.75° | Separating ← |
+| Sun                   | sextile ⚹        | Pallas                | 1.20° | Separating ← |
+| Sun                   | opposition ☍     | Juno                  | 5.77° | Separating ← |
+| Sun                   | sextile ⚹        | Haumea                | 1.29° | Separating ← |
+| Sun                   | trine △          | Ixion                 | 4.80° | Separating ← |
+| Sun                   | trine △          | Quaoar                | 3.21° | Separating ← |
+| Sun                   | conjunction ☌    | Pars Fidei            | 0.03° | Applying →   |
+| Sun                   | semi-sextile ⚺   | Vertex                | 1.85° | Separating ← |
+| Sun                   | quincunx ⚻       | Anti Vertex           | 1.85° | Separating ← |
+| Sun                   | sextile ⚹        | Zeus                  | 1.72° | Separating ← |
+| Sun                   | quintile Q       | Admetos               | 1.00° | Separating ← |
+| Sun                   | square □         | Poseidon              | 0.62° | Applying →   |
+| Moon                  | square □         | Venus                 | 0.67° | Applying →   |
+| Moon                  | square □         | Mars                  | 0.76° | Separating ← |
+| Moon                  | sextile ⚹        | Saturn                | 0.74° | Separating ← |
+| Moon                  | semi-square ∠    | Mean North Lunar Node | 1.18° | Separating ← |
+| Moon                  | semi-square ∠    | True North Lunar Node | 0.69° | Separating ← |
+| Moon                  | trine △          | Chiron                | 4.61° | Separating ← |
+| Moon                  | sesquiquadrate ⚼ | Mean South Lunar Node | 1.18° | Separating ← |
+| Moon                  | sesquiquadrate ⚼ | True South Lunar Node | 0.69° | Separating ← |
+| Moon                  | sesquiquadrate ⚼ | Eris                  | 1.80° | Separating ← |
+| Moon                  | square □         | Makemake              | 0.91° | Applying →   |
+| Moon                  | square □         | Pars Spiritus         | 3.10° | Applying →   |
+| Moon                  | semi-sextile ⚺   | Interpolated Lilith   | 1.35° | Applying →   |
+| Moon                  | biquintile bQ    | Mean Priapus          | 1.00° | Separating ← |
+| Moon                  | sesquiquadrate ⚼ | Interpolated Perigee  | 1.16° | Separating ← |
+| Mercury               | sesquiquadrate ⚼ | Uranus                | 0.82° | Applying →   |
+| Mercury               | biquintile bQ    | Mean North Lunar Node | 0.87° | Separating ← |
+| Mercury               | biquintile bQ    | True North Lunar Node | 0.37° | Separating ← |
+| Mercury               | square □         | Medium Coeli          | 3.55° | Applying →   |
+| Mercury               | square □         | Imum Coeli            | 3.55° | Applying →   |
+| Mercury               | sesquiquadrate ⚼ | Mean Lilith           | 0.68° | Separating ← |
+| Mercury               | trine △          | True Lilith           | 5.72° | Separating ← |
+| Mercury               | sextile ⚹        | Ceres                 | 1.48° | Applying →   |
+| Mercury               | semi-sextile ⚺   | Haumea                | 1.93° | Applying →   |
+| Mercury               | square □         | Ixion                 | 1.57° | Separating ← |
+| Mercury               | square □         | Quaoar                | 0.02° | Applying →   |
+| Mercury               | square □         | Pars Fortunae         | 5.40° | Separating ← |
+| Mercury               | opposition ☍     | Pars Amoris           | 4.73° | Separating ← |
+| Mercury               | conjunction ☌    | Vertex                | 1.38° | Applying →   |
+| Mercury               | opposition ☍     | Anti Vertex           | 1.38° | Applying →   |
+| Mercury               | semi-square ∠    | Mean Priapus          | 0.68° | Separating ← |
+| Mercury               | square □         | Cupido                | 5.30° | Separating ← |
+| Mercury               | semi-sextile ⚺   | Zeus                  | 1.51° | Applying →   |
+| Mercury               | sextile ⚹        | Kronos                | 2.73° | Separating ← |
+| Mercury               | sextile ⚹        | Poseidon              | 3.85° | Applying →   |
+| Venus                 | conjunction ☌    | Mars                  | 1.43° | Applying →   |
+| Venus                 | quincunx ⚻       | Saturn                | 1.41° | Separating ← |
+| Venus                 | trine △          | Uranus                | 5.83° | Applying →   |
+| Venus                 | quintile Q       | Pluto                 | 0.27° | Applying →   |
+| Venus                 | sesquiquadrate ⚼ | Mean North Lunar Node | 1.86° | Separating ← |
+| Venus                 | sesquiquadrate ⚼ | True North Lunar Node | 1.36° | Separating ← |
+| Venus                 | trine △          | Mean Lilith           | 4.33° | Applying →   |
+| Venus                 | semi-square ∠    | Mean South Lunar Node | 1.86° | Separating ← |
+| Venus                 | semi-square ∠    | True South Lunar Node | 1.36° | Separating ← |
+| Venus                 | trine △          | True Lilith           | 4.26° | Applying →   |
+| Venus                 | conjunction ☌    | Makemake              | 0.24° | Applying →   |
+| Venus                 | conjunction ☌    | Pars Spiritus         | 2.43° | Applying →   |
+| Venus                 | trine △          | Interpolated Lilith   | 0.68° | Applying →   |
+| Venus                 | sextile ⚹        | Mean Priapus          | 4.33° | Applying →   |
+| Venus                 | sextile ⚹        | True Priapus          | 4.26° | Applying →   |
+| Venus                 | semi-square ∠    | Interpolated Perigee  | 1.83° | Applying →   |
+| Venus                 | square □         | Hades                 | 5.61° | Applying →   |
+| Venus                 | quintile Q       | Kronos                | 0.72° | Separating ← |
+| Mars                  | quincunx ⚻       | Saturn                | 0.02° | Applying →   |
+| Mars                  | quintile Q       | Pluto                 | 1.70° | Applying →   |
+| Mars                  | sesquiquadrate ⚼ | Mean North Lunar Node | 0.43° | Separating ← |
+| Mars                  | sesquiquadrate ⚼ | True North Lunar Node | 0.07° | Applying →   |
+| Mars                  | trine △          | Mean Lilith           | 5.76° | Applying →   |
+| Mars                  | semi-square ∠    | Mean South Lunar Node | 0.43° | Separating ← |
+| Mars                  | semi-square ∠    | True South Lunar Node | 0.07° | Applying →   |
+| Mars                  | trine △          | True Lilith           | 2.83° | Applying →   |
+| Mars                  | sesquiquadrate ⚼ | Eris                  | 1.04° | Separating ← |
+| Mars                  | conjunction ☌    | Makemake              | 1.67° | Applying →   |
+| Mars                  | conjunction ☌    | Pars Spiritus         | 3.86° | Applying →   |
+| Mars                  | trine △          | Interpolated Lilith   | 2.11° | Applying →   |
+| Mars                  | sextile ⚹        | True Priapus          | 2.83° | Applying →   |
+| Mars                  | semi-square ∠    | Interpolated Perigee  | 0.40° | Separating ← |
+| Mars                  | quintile Q       | Kronos                | 0.71° | Applying →   |
+| Mars                  | sextile ⚹        | Poseidon              | 4.71° | Separating ← |
+| Jupiter               | biquintile bQ    | Uranus                | 1.50° | Separating ← |
+| Jupiter               | square □         | Pluto                 | 1.06° | Separating ← |
+| Jupiter               | quincunx ⚻       | Mean North Lunar Node | 0.19° | Separating ← |
+| Jupiter               | quincunx ⚻       | True North Lunar Node | 0.30° | Applying →   |
+| Jupiter               | biquintile bQ    | Ascendant             | 1.18° | Separating ← |
+| Jupiter               | square □         | Medium Coeli          | 3.13° | Separating ← |
+| Jupiter               | square □         | Imum Coeli            | 3.13° | Separating ← |
+| Jupiter               | semi-sextile ⚺   | Mean South Lunar Node | 0.19° | Separating ← |
+| Jupiter               | semi-sextile ⚺   | True South Lunar Node | 0.30° | Applying →   |
+| Jupiter               | trine △          | Eris                  | 0.81° | Separating ← |
+| Jupiter               | square □         | Ixion                 | 5.10° | Applying →   |
+| Jupiter               | square □         | Pars Fortunae         | 1.27° | Applying →   |
+| Jupiter               | opposition ☍     | Pars Amoris           | 1.95° | Applying →   |
+| Jupiter               | semi-sextile ⚺   | Interpolated Perigee  | 0.16° | Applying →   |
+| Jupiter               | semi-sextile ⚺   | White Moon            | 0.77° | Separating ← |
+| Jupiter               | square □         | Cupido                | 1.38° | Applying →   |
+| Jupiter               | sextile ⚹        | Kronos                | 3.95° | Applying →   |
+| Jupiter               | sextile ⚹        | Apollon               | 4.19° | Separating ← |
+| Jupiter               | square □         | Admetos               | 3.10° | Separating ← |
+| Jupiter               | quintile Q       | Poseidon              | 1.47° | Separating ← |
+| Saturn                | opposition ☍     | Chiron                | 3.88° | Applying →   |
+| Saturn                | quintile Q       | Medium Coeli          | 0.12° | Applying →   |
+| Saturn                | quintile Q       | Eris                  | 1.94° | Separating ← |
+| Saturn                | quincunx ⚻       | Makemake              | 1.65° | Separating ← |
+| Saturn                | quintile Q       | Ixion                 | 1.85° | Separating ← |
+| Saturn                | opposition ☍     | Pars Fidei            | 5.32° | Applying →   |
+| Saturn                | sesquiquadrate ⚼ | White Moon            | 1.03° | Applying →   |
+| Saturn                | quintile Q       | Cupido                | 1.87° | Applying →   |
+| Saturn                | square □         | Poseidon              | 4.73° | Applying →   |
+| Uranus                | conjunction ☌    | Neptune               | 3.88° | Separating ← |
+| Uranus                | conjunction ☌    | Ascendant             | 2.69° | Separating ← |
+| Uranus                | opposition ☍     | Descendant            | 2.69° | Separating ← |
+| Uranus                | conjunction ☌    | Mean Lilith           | 1.50° | Applying →   |
+| Uranus                | trine △          | Sedna                 | 0.92° | Separating ← |
+| Uranus                | trine △          | Makemake              | 5.59° | Applying →   |
+| Uranus                | quincunx ⚻       | Orcus                 | 0.72° | Separating ← |
+| Uranus                | semi-square ∠    | Quaoar                | 0.80° | Applying →   |
+| Uranus                | trine △          | Pars Spiritus         | 3.40° | Applying →   |
+| Uranus                | sesquiquadrate ⚼ | Vertex                | 0.56° | Separating ← |
+| Uranus                | semi-square ∠    | Anti Vertex           | 0.56° | Separating ← |
+| Uranus                | conjunction ☌    | Interpolated Lilith   | 5.15° | Applying →   |
+| Uranus                | opposition ☍     | Mean Priapus          | 1.50° | Applying →   |
+| Uranus                | quincunx ⚻       | Hades                 | 0.22° | Applying →   |
+| Uranus                | square □         | Apollon               | 3.31° | Separating ← |
+| Uranus                | trine △          | Admetos               | 4.41° | Separating ← |
+| Uranus                | opposition ☍     | Vulkanus              | 4.74° | Separating ← |
+| Uranus                | quintile Q       | Poseidon              | 0.03° | Separating ← |
+| Neptune               | sextile ⚹        | Pluto                 | 2.57° | Separating ← |
+| Neptune               | conjunction ☌    | Mean North Lunar Node | 3.44° | Applying →   |
+| Neptune               | conjunction ☌    | True North Lunar Node | 3.93° | Separating ← |
+| Neptune               | conjunction ☌    | Ascendant             | 1.19° | Applying →   |
+| Neptune               | opposition ☍     | Descendant            | 1.19° | Applying →   |
+| Neptune               | conjunction ☌    | Mean Lilith           | 5.37° | Applying →   |
+| Neptune               | opposition ☍     | Mean South Lunar Node | 3.44° | Applying →   |
+| Neptune               | opposition ☍     | True South Lunar Node | 3.93° | Separating ← |
+| Neptune               | square □         | Eris                  | 2.82° | Separating ← |
+| Neptune               | trine △          | Sedna                 | 2.95° | Applying →   |
+| Neptune               | trine △          | Pars Fortunae         | 4.90° | Separating ← |
+| Neptune               | opposition ☍     | Mean Priapus          | 5.37° | Applying →   |
+| Neptune               | opposition ☍     | Interpolated Perigee  | 3.47° | Separating ← |
+| Neptune               | trine △          | White Moon            | 2.85° | Separating ← |
+| Neptune               | biquintile bQ    | Hades                 | 1.91° | Separating ← |
+| Neptune               | square □         | Apollon               | 0.56° | Applying →   |
+| Neptune               | trine △          | Admetos               | 0.53° | Separating ← |
+| Neptune               | opposition ☍     | Vulkanus              | 0.87° | Separating ← |
+| Pluto                 | sextile ⚹        | Mean North Lunar Node | 0.87° | Applying →   |
+| Pluto                 | sextile ⚹        | True North Lunar Node | 1.36° | Separating ← |
+| Pluto                 | sextile ⚹        | Ascendant             | 3.75° | Applying →   |
+| Pluto                 | conjunction ☌    | Medium Coeli          | 4.19° | Separating ← |
+| Pluto                 | trine △          | Descendant            | 3.75° | Applying →   |
+| Pluto                 | opposition ☍     | Imum Coeli            | 4.19° | Separating ← |
+| Pluto                 | trine △          | Mean South Lunar Node | 0.87° | Applying →   |
+| Pluto                 | trine △          | True South Lunar Node | 1.36° | Separating ← |
+| Pluto                 | semi-square ∠    | True Lilith           | 1.54° | Applying →   |
+| Pluto                 | trine △          | Pholus                | 4.81° | Separating ← |
+| Pluto                 | trine △          | Vesta                 | 4.80° | Separating ← |
+| Pluto                 | quincunx ⚻       | Eris                  | 0.25° | Separating ← |
+| Pluto                 | opposition ☍     | Sedna                 | 5.52° | Applying →   |
+| Pluto                 | quintile Q       | Makemake              | 0.03° | Applying →   |
+| Pluto                 | square □         | Orcus                 | 5.73° | Applying →   |
+| Pluto                 | opposition ☍     | Pars Fortunae         | 2.34° | Separating ← |
+| Pluto                 | square □         | Pars Amoris           | 3.01° | Separating ← |
+| Pluto                 | sesquiquadrate ⚼ | True Priapus          | 1.54° | Applying →   |
+| Pluto                 | trine △          | Interpolated Perigee  | 0.90° | Separating ← |
+| Pluto                 | sextile ⚹        | White Moon            | 0.29° | Separating ← |
+| Pluto                 | conjunction ☌    | Cupido                | 2.44° | Static =     |
+| Pluto                 | biquintile bQ    | Kronos                | 0.99° | Applying →   |
+| Pluto                 | opposition ☍     | Admetos               | 2.04° | Applying →   |
+| Pluto                 | trine △          | Vulkanus              | 1.70° | Applying →   |
+| Mean North Lunar Node | conjunction ☌    | Ascendant             | 4.62° | Applying →   |
+| Mean North Lunar Node | sextile ⚹        | Medium Coeli          | 3.32° | Separating ← |
+| Mean North Lunar Node | opposition ☍     | Descendant            | 4.62° | Applying →   |
+| Mean North Lunar Node | trine △          | Imum Coeli            | 3.32° | Separating ← |
+| Mean North Lunar Node | opposition ☍     | Pholus                | 3.94° | Separating ← |
+| Mean North Lunar Node | conjunction ☌    | Juno                  | 4.32° | Applying →   |
+| Mean North Lunar Node | opposition ☍     | Vesta                 | 3.93° | Separating ← |
+| Mean North Lunar Node | square □         | Eris                  | 0.62° | Applying →   |
+| Mean North Lunar Node | trine △          | Pars Fortunae         | 1.46° | Separating ← |
+| Mean North Lunar Node | opposition ☍     | Interpolated Perigee  | 0.03° | Separating ← |
+| Mean North Lunar Node | trine △          | White Moon            | 0.58° | Applying →   |
+| Mean North Lunar Node | sextile ⚹        | Cupido                | 1.57° | Separating ← |
+| Mean North Lunar Node | biquintile bQ    | Hades                 | 1.53° | Applying →   |
+| Mean North Lunar Node | square □         | Apollon               | 4.00° | Applying →   |
+| Mean North Lunar Node | trine △          | Admetos               | 2.91° | Applying →   |
+| Mean North Lunar Node | opposition ☍     | Vulkanus              | 2.57° | Applying →   |
+| True North Lunar Node | conjunction ☌    | Ascendant             | 5.12° | Applying →   |
+| True North Lunar Node | sextile ⚹        | Medium Coeli          | 2.83° | Separating ← |
+| True North Lunar Node | opposition ☍     | Descendant            | 5.12° | Applying →   |
+| True North Lunar Node | trine △          | Imum Coeli            | 2.83° | Separating ← |
+| True North Lunar Node | opposition ☍     | Pholus                | 3.45° | Separating ← |
+| True North Lunar Node | conjunction ☌    | Juno                  | 3.83° | Applying →   |
+| True North Lunar Node | opposition ☍     | Vesta                 | 3.43° | Separating ← |
+| True North Lunar Node | square □         | Eris                  | 1.11° | Separating ← |
+| True North Lunar Node | sesquiquadrate ⚼ | Makemake              | 1.61° | Separating ← |
+| True North Lunar Node | sextile ⚹        | Ixion                 | 4.80° | Applying →   |
+| True North Lunar Node | trine △          | Pars Fortunae         | 0.97° | Applying →   |
+| True North Lunar Node | semi-sextile ⚺   | Pars Amoris           | 1.64° | Applying →   |
+| True North Lunar Node | biquintile bQ    | Vertex                | 1.75° | Applying →   |
+| True North Lunar Node | opposition ☍     | Interpolated Perigee  | 0.46° | Applying →   |
+| True North Lunar Node | trine △          | White Moon            | 1.08° | Applying →   |
+| True North Lunar Node | sextile ⚹        | Cupido                | 1.08° | Applying →   |
+| True North Lunar Node | square □         | Apollon               | 4.49° | Separating ← |
+| True North Lunar Node | trine △          | Admetos               | 3.40° | Separating ← |
+| True North Lunar Node | opposition ☍     | Vulkanus              | 3.06° | Separating ← |
+| Chiron                | quincunx ⚻       | True Lilith           | 1.02° | Separating ← |
+| Chiron                | square □         | Ceres                 | 3.22° | Applying →   |
+| Chiron                | sextile ⚹        | Pallas                | 2.68° | Applying →   |
+| Chiron                | sextile ⚹        | Haumea                | 2.77° | Separating ← |
+| Chiron                | trine △          | Quaoar                | 4.68° | Separating ← |
+| Chiron                | quintile Q       | Pars Fortunae         | 1.89° | Applying →   |
+| Chiron                | conjunction ☌    | Pars Fidei            | 1.45° | Separating ← |
+| Chiron                | semi-sextile ⚺   | True Priapus          | 1.02° | Separating ← |
+| Chiron                | sextile ⚹        | Zeus                  | 3.19° | Separating ← |
+| Chiron                | square □         | Poseidon              | 0.85° | Separating ← |
+| Ascendant             | conjunction ☌    | Mean Lilith           | 4.19° | Separating ← |
+| Ascendant             | opposition ☍     | Mean South Lunar Node | 4.62° | Applying →   |
+| Ascendant             | opposition ☍     | True South Lunar Node | 5.12° | Applying →   |
+| Ascendant             | square □         | Eris                  | 4.01° | Applying →   |
+| Ascendant             | trine △          | Sedna                 | 1.77° | Separating ← |
+| Ascendant             | quincunx ⚻       | Orcus                 | 1.97° | Separating ← |
+| Ascendant             | opposition ☍     | Mean Priapus          | 4.19° | Separating ← |
+| Ascendant             | opposition ☍     | Interpolated Perigee  | 4.65° | Applying →   |
+| Ascendant             | trine △          | White Moon            | 4.04° | Applying →   |
+| Ascendant             | square □         | Apollon               | 0.62° | Applying →   |
+| Ascendant             | trine △          | Admetos               | 1.72° | Applying →   |
+| Ascendant             | opposition ☍     | Vulkanus              | 2.05° | Applying →   |
+| Medium Coeli          | trine △          | Mean South Lunar Node | 3.32° | Separating ← |
+| Medium Coeli          | trine △          | True South Lunar Node | 2.83° | Separating ← |
+| Medium Coeli          | trine △          | Pholus                | 0.62° | Applying →   |
+| Medium Coeli          | sextile ⚹        | Juno                  | 1.00° | Applying →   |
+| Medium Coeli          | trine △          | Vesta                 | 0.60° | Applying →   |
+| Medium Coeli          | conjunction ☌    | Ixion                 | 1.97° | Applying →   |
+| Medium Coeli          | conjunction ☌    | Quaoar                | 3.56° | Applying →   |
+| Medium Coeli          | opposition ☍     | Pars Fortunae         | 1.86° | Separating ← |
+| Medium Coeli          | square □         | Pars Amoris           | 1.19° | Separating ← |
+| Medium Coeli          | square □         | Vertex                | 4.92° | Applying →   |
+| Medium Coeli          | square □         | Anti Vertex           | 4.92° | Applying →   |
+| Medium Coeli          | semi-square ∠    | Interpolated Lilith   | 0.79° | Separating ← |
+| Medium Coeli          | trine △          | Interpolated Perigee  | 3.29° | Separating ← |
+| Medium Coeli          | sextile ⚹        | White Moon            | 3.91° | Separating ← |
+| Medium Coeli          | conjunction ☌    | Cupido                | 1.75° | Separating ← |
+| Medium Coeli          | quincunx ⚻       | Kronos                | 0.82° | Applying →   |
+| Medium Coeli          | trine △          | Vulkanus              | 5.89° | Separating ← |
+| Descendant            | opposition ☍     | Mean Lilith           | 4.19° | Separating ← |
+| Descendant            | conjunction ☌    | Mean South Lunar Node | 4.62° | Applying →   |
+| Descendant            | conjunction ☌    | True South Lunar Node | 5.12° | Applying →   |
+| Descendant            | quintile Q       | Pallas                | 1.52° | Applying →   |
+| Descendant            | square □         | Eris                  | 4.01° | Applying →   |
+| Descendant            | sextile ⚹        | Sedna                 | 1.77° | Separating ← |
+| Descendant            | quintile Q       | Haumea                | 1.43° | Applying →   |
+| Descendant            | semi-sextile ⚺   | Orcus                 | 1.97° | Separating ← |
+| Descendant            | biquintile bQ    | Pars Amoris           | 0.76° | Applying →   |
+| Descendant            | conjunction ☌    | Mean Priapus          | 4.19° | Separating ← |
+| Descendant            | conjunction ☌    | Interpolated Perigee  | 4.65° | Applying →   |
+| Descendant            | sextile ⚹        | White Moon            | 4.04° | Applying →   |
+| Descendant            | quintile Q       | Zeus                  | 1.00° | Applying →   |
+| Descendant            | square □         | Apollon               | 0.62° | Applying →   |
+| Descendant            | sextile ⚹        | Admetos               | 1.72° | Applying →   |
+| Descendant            | conjunction ☌    | Vulkanus              | 2.05° | Applying →   |
+| Imum Coeli            | sextile ⚹        | Mean South Lunar Node | 3.32° | Separating ← |
+| Imum Coeli            | sextile ⚹        | True South Lunar Node | 2.83° | Separating ← |
+| Imum Coeli            | sextile ⚹        | Pholus                | 0.62° | Applying →   |
+| Imum Coeli            | trine △          | Pallas                | 5.57° | Applying →   |
+| Imum Coeli            | trine △          | Juno                  | 1.00° | Applying →   |
+| Imum Coeli            | sextile ⚹        | Vesta                 | 0.60° | Applying →   |
+| Imum Coeli            | trine △          | Haumea                | 5.48° | Applying →   |
+| Imum Coeli            | opposition ☍     | Ixion                 | 1.97° | Applying →   |
+| Imum Coeli            | opposition ☍     | Quaoar                | 3.56° | Applying →   |
+| Imum Coeli            | conjunction ☌    | Pars Fortunae         | 1.86° | Separating ← |
+| Imum Coeli            | square □         | Pars Amoris           | 1.19° | Separating ← |
+| Imum Coeli            | square □         | Vertex                | 4.92° | Applying →   |
+| Imum Coeli            | square □         | Anti Vertex           | 4.92° | Applying →   |
+| Imum Coeli            | sesquiquadrate ⚼ | Interpolated Lilith   | 0.79° | Separating ← |
+| Imum Coeli            | sextile ⚹        | Interpolated Perigee  | 3.29° | Separating ← |
+| Imum Coeli            | trine △          | White Moon            | 3.91° | Separating ← |
+| Imum Coeli            | opposition ☍     | Cupido                | 1.75° | Separating ← |
+| Imum Coeli            | trine △          | Zeus                  | 5.06° | Applying →   |
+| Imum Coeli            | semi-sextile ⚺   | Kronos                | 0.82° | Applying →   |
+| Imum Coeli            | biquintile bQ    | Apollon               | 1.32° | Separating ← |
+| Mean Lilith           | quintile Q       | Ceres                 | 0.84° | Applying →   |
+| Mean Lilith           | trine △          | Sedna                 | 2.42° | Applying →   |
+| Mean Lilith           | trine △          | Makemake              | 4.09° | Separating ← |
+| Mean Lilith           | semi-square ∠    | Ixion                 | 0.89° | Separating ← |
+| Mean Lilith           | semi-square ∠    | Quaoar                | 0.70° | Applying →   |
+| Mean Lilith           | trine △          | Pars Spiritus         | 1.90° | Separating ← |
+| Mean Lilith           | conjunction ☌    | Interpolated Lilith   | 3.66° | Separating ← |
+| Mean Lilith           | quincunx ⚻       | Hades                 | 1.28° | Applying →   |
+| Mean Lilith           | square □         | Apollon               | 4.81° | Applying →   |
+| Mean Lilith           | trine △          | Admetos               | 5.90° | Applying →   |
+| Mean Lilith           | quintile Q       | Poseidon              | 1.53° | Applying →   |
+| Mean South Lunar Node | conjunction ☌    | Pholus                | 3.94° | Separating ← |
+| Mean South Lunar Node | opposition ☍     | Juno                  | 4.32° | Applying →   |
+| Mean South Lunar Node | conjunction ☌    | Vesta                 | 3.93° | Separating ← |
+| Mean South Lunar Node | square □         | Eris                  | 0.62° | Applying →   |
+| Mean South Lunar Node | trine △          | Ixion                 | 5.29° | Separating ← |
+| Mean South Lunar Node | sextile ⚹        | Pars Fortunae         | 1.46° | Separating ← |
+| Mean South Lunar Node | conjunction ☌    | Interpolated Perigee  | 0.03° | Separating ← |
+| Mean South Lunar Node | sextile ⚹        | White Moon            | 0.58° | Applying →   |
+| Mean South Lunar Node | trine △          | Cupido                | 1.57° | Separating ← |
+| Mean South Lunar Node | square □         | Apollon               | 4.00° | Applying →   |
+| Mean South Lunar Node | sextile ⚹        | Admetos               | 2.91° | Applying →   |
+| Mean South Lunar Node | conjunction ☌    | Vulkanus              | 2.57° | Applying →   |
+| True South Lunar Node | conjunction ☌    | Pholus                | 3.45° | Separating ← |
+| True South Lunar Node | opposition ☍     | Juno                  | 3.83° | Applying →   |
+| True South Lunar Node | conjunction ☌    | Vesta                 | 3.43° | Separating ← |
+| True South Lunar Node | square □         | Eris                  | 1.11° | Separating ← |
+| True South Lunar Node | semi-square ∠    | Makemake              | 1.61° | Separating ← |
+| True South Lunar Node | trine △          | Ixion                 | 4.80° | Applying →   |
+| True South Lunar Node | sextile ⚹        | Pars Fortunae         | 0.97° | Applying →   |
+| True South Lunar Node | quincunx ⚻       | Pars Amoris           | 1.64° | Applying →   |
+| True South Lunar Node | biquintile bQ    | Anti Vertex           | 1.75° | Applying →   |
+| True South Lunar Node | conjunction ☌    | Interpolated Perigee  | 0.46° | Applying →   |
+| True South Lunar Node | sextile ⚹        | White Moon            | 1.08° | Applying →   |
+| True South Lunar Node | trine △          | Cupido                | 1.08° | Applying →   |
+| True South Lunar Node | square □         | Apollon               | 4.49° | Separating ← |
+| True South Lunar Node | sextile ⚹        | Admetos               | 3.40° | Separating ← |
+| True South Lunar Node | conjunction ☌    | Vulkanus              | 3.06° | Separating ← |
+| True Lilith           | sextile ⚹        | Ceres                 | 4.25° | Separating ← |
+| True Lilith           | square □         | Pallas                | 3.70° | Separating ← |
+| True Lilith           | square □         | Haumea                | 3.79° | Separating ← |
+| True Lilith           | trine △          | Makemake              | 4.51° | Applying →   |
+| True Lilith           | trine △          | Vertex                | 4.35° | Separating ← |
+| True Lilith           | sextile ⚹        | Anti Vertex           | 4.35° | Separating ← |
+| True Lilith           | conjunction ☌    | Interpolated Lilith   | 4.94° | Applying →   |
+| True Lilith           | square □         | Zeus                  | 4.21° | Separating ← |
+| True Lilith           | sesquiquadrate ⚼ | Admetos               | 0.50° | Separating ← |
+| True Lilith           | sextile ⚹        | Poseidon              | 1.87° | Separating ← |
+| Pholus                | square □         | Ceres                 | 4.40° | Separating ← |
+| Pholus                | sextile ⚹        | Pallas                | 4.95° | Separating ← |
+| Pholus                | opposition ☍     | Juno                  | 0.38° | Applying →   |
+| Pholus                | conjunction ☌    | Vesta                 | 0.02° | Applying →   |
+| Pholus                | square □         | Eris                  | 4.56° | Separating ← |
+| Pholus                | quintile Q       | Sedna                 | 1.66° | Applying →   |
+| Pholus                | sextile ⚹        | Haumea                | 4.86° | Applying →   |
+| Pholus                | semi-square ∠    | Makemake              | 1.85° | Separating ← |
+| Pholus                | trine △          | Ixion                 | 1.35° | Applying →   |
+| Pholus                | trine △          | Quaoar                | 2.94° | Applying →   |
+| Pholus                | sextile ⚹        | Pars Fortunae         | 2.48° | Separating ← |
+| Pholus                | semi-square ∠    | Pars Spiritus         | 0.34° | Applying →   |
+| Pholus                | quincunx ⚻       | Pars Amoris           | 1.81° | Separating ← |
+| Pholus                | biquintile bQ    | Anti Vertex           | 1.70° | Separating ← |
+| Pholus                | conjunction ☌    | Interpolated Perigee  | 3.92° | Applying →   |
+| Pholus                | sextile ⚹        | White Moon            | 4.53° | Applying →   |
+| Pholus                | trine △          | Cupido                | 2.37° | Separating ← |
+| Pholus                | sextile ⚹        | Zeus                  | 4.43° | Applying →   |
+| Pholus                | semi-sextile ⚺   | Kronos                | 0.19° | Applying →   |
+| Ceres                 | semi-sextile ⚺   | Pallas                | 0.55° | Separating ← |
+| Ceres                 | square □         | Juno                  | 4.02° | Separating ← |
+| Ceres                 | square □         | Vesta                 | 4.42° | Applying →   |
+| Ceres                 | semi-sextile ⚺   | Haumea                | 0.46° | Applying →   |
+| Ceres                 | semi-sextile ⚺   | Quaoar                | 1.46° | Separating ← |
+| Ceres                 | square □         | Pars Fidei            | 1.78° | Applying →   |
+| Ceres                 | sextile ⚹        | Vertex                | 0.10° | Separating ← |
+| Ceres                 | trine △          | Anti Vertex           | 0.10° | Separating ← |
+| Ceres                 | trine △          | True Priapus          | 4.25° | Separating ← |
+| Ceres                 | sesquiquadrate ⚼ | Hades                 | 0.87° | Separating ← |
+| Ceres                 | semi-sextile ⚺   | Zeus                  | 0.03° | Applying →   |
+| Ceres                 | trine △          | Kronos                | 4.21° | Separating ← |
+| Ceres                 | conjunction ☌    | Poseidon              | 2.37° | Applying →   |
+| Pallas                | trine △          | Juno                  | 4.57° | Separating ← |
+| Pallas                | sextile ⚹        | Vesta                 | 4.97° | Applying →   |
+| Pallas                | sesquiquadrate ⚼ | Sedna                 | 0.28° | Separating ← |
+| Pallas                | conjunction ☌    | Haumea                | 0.09° | Separating ← |
+| Pallas                | sextile ⚹        | Ixion                 | 3.60° | Separating ← |
+| Pallas                | semi-square ∠    | Orcus                 | 0.49° | Separating ← |
+| Pallas                | sextile ⚹        | Quaoar                | 2.01° | Separating ← |
+| Pallas                | biquintile bQ    | Pars Amoris           | 0.76° | Separating ← |
+| Pallas                | sextile ⚹        | Pars Fidei            | 1.23° | Applying →   |
+| Pallas                | semi-sextile ⚺   | Vertex                | 0.65° | Separating ← |
+| Pallas                | quincunx ⚻       | Anti Vertex           | 0.65° | Separating ← |
+| Pallas                | square □         | True Priapus          | 3.70° | Separating ← |
+| Pallas                | conjunction ☌    | Zeus                  | 0.52° | Separating ← |
+| Pallas                | square □         | Kronos                | 4.75° | Separating ← |
+| Pallas                | quintile Q       | Vulkanus              | 0.54° | Applying →   |
+| Pallas                | semi-sextile ⚺   | Poseidon              | 1.83° | Applying →   |
+| Juno                  | opposition ☍     | Vesta                 | 0.40° | Applying →   |
+| Juno                  | square □         | Eris                  | 4.94° | Applying →   |
+| Juno                  | trine △          | Haumea                | 4.48° | Separating ← |
+| Juno                  | sextile ⚹        | Ixion                 | 0.97° | Separating ← |
+| Juno                  | sextile ⚹        | Quaoar                | 2.56° | Separating ← |
+| Juno                  | trine △          | Pars Fortunae         | 2.86° | Applying →   |
+| Juno                  | sesquiquadrate ⚼ | Pars Spiritus         | 0.04° | Applying →   |
+| Juno                  | opposition ☍     | Pars Fidei            | 5.80° | Separating ← |
+| Juno                  | opposition ☍     | Interpolated Perigee  | 4.29° | Applying →   |
+| Juno                  | trine △          | White Moon            | 4.91° | Applying →   |
+| Juno                  | sextile ⚹        | Cupido                | 2.75° | Applying →   |
+| Juno                  | trine △          | Zeus                  | 4.06° | Separating ← |
+| Juno                  | quincunx ⚻       | Kronos                | 0.18° | Applying →   |
+| Vesta                 | square □         | Eris                  | 4.54° | Separating ← |
+| Vesta                 | quintile Q       | Sedna                 | 1.68° | Applying →   |
+| Vesta                 | sextile ⚹        | Haumea                | 4.87° | Applying →   |
+| Vesta                 | semi-square ∠    | Makemake              | 1.83° | Separating ← |
+| Vesta                 | trine △          | Ixion                 | 1.37° | Applying →   |
+| Vesta                 | trine △          | Quaoar                | 2.96° | Applying →   |
+| Vesta                 | sextile ⚹        | Pars Fortunae         | 2.46° | Separating ← |
+| Vesta                 | semi-square ∠    | Pars Spiritus         | 0.36° | Applying →   |
+| Vesta                 | quincunx ⚻       | Pars Amoris           | 1.79° | Separating ← |
+| Vesta                 | biquintile bQ    | Anti Vertex           | 1.68° | Separating ← |
+| Vesta                 | conjunction ☌    | Interpolated Perigee  | 3.90° | Applying →   |
+| Vesta                 | sextile ⚹        | White Moon            | 4.51° | Separating ← |
+| Vesta                 | trine △          | Cupido                | 2.35° | Separating ← |
+| Vesta                 | sextile ⚹        | Zeus                  | 4.45° | Applying →   |
+| Vesta                 | semi-sextile ⚺   | Kronos                | 0.21° | Applying →   |
+| Eris                  | biquintile bQ    | Ixion                 | 0.09° | Separating ← |
+| Eris                  | trine △          | Orcus                 | 5.98° | Applying →   |
+| Eris                  | biquintile bQ    | Quaoar                | 1.50° | Applying →   |
+| Eris                  | sextile ⚹        | Pars Amoris           | 2.75° | Separating ← |
+| Eris                  | quintile Q       | True Priapus          | 1.21° | Separating ← |
+| Eris                  | square □         | Interpolated Perigee  | 0.65° | Separating ← |
+| Eris                  | quincunx ⚻       | White Moon            | 0.03° | Separating ← |
+| Eris                  | sextile ⚹        | Kronos                | 4.76° | Separating ← |
+| Eris                  | opposition ☍     | Apollon               | 3.38° | Applying →   |
+| Eris                  | square □         | Vulkanus              | 1.95° | Applying →   |
+| Sedna                 | sesquiquadrate ⚼ | Haumea                | 0.19° | Separating ← |
+| Sedna                 | square □         | Orcus                 | 0.21° | Applying →   |
+| Sedna                 | trine △          | Pars Spiritus         | 4.32° | Separating ← |
+| Sedna                 | sextile ⚹        | Mean Priapus          | 2.42° | Applying →   |
+| Sedna                 | trine △          | White Moon            | 5.81° | Separating ← |
+| Sedna                 | semi-sextile ⚺   | Hades                 | 1.14° | Applying →   |
+| Sedna                 | sesquiquadrate ⚼ | Zeus                  | 0.23° | Applying →   |
+| Sedna                 | conjunction ☌    | Admetos               | 3.48° | Separating ← |
+| Sedna                 | sextile ⚹        | Vulkanus              | 3.82° | Separating ← |
+| Haumea                | sextile ⚹        | Ixion                 | 3.51° | Separating ← |
+| Haumea                | semi-square ∠    | Orcus                 | 0.40° | Applying →   |
+| Haumea                | sextile ⚹        | Quaoar                | 1.91° | Separating ← |
+| Haumea                | biquintile bQ    | Pars Amoris           | 0.66° | Separating ← |
+| Haumea                | sextile ⚹        | Pars Fidei            | 1.32° | Applying →   |
+| Haumea                | semi-sextile ⚺   | Vertex                | 0.56° | Separating ← |
+| Haumea                | quincunx ⚻       | Anti Vertex           | 0.56° | Separating ← |
+| Haumea                | square □         | True Priapus          | 3.79° | Separating ← |
+| Haumea                | conjunction ☌    | Zeus                  | 0.42° | Separating ← |
+| Haumea                | square □         | Kronos                | 4.66° | Static =     |
+| Haumea                | quintile Q       | Vulkanus              | 0.63° | Static =     |
+| Haumea                | semi-sextile ⚺   | Poseidon              | 1.92° | Applying →   |
+| Makemake              | conjunction ☌    | Pars Spiritus         | 2.19° | Applying →   |
+| Makemake              | trine △          | Interpolated Lilith   | 0.43° | Applying →   |
+| Makemake              | sextile ⚹        | Mean Priapus          | 4.09° | Separating ← |
+| Makemake              | sextile ⚹        | True Priapus          | 4.51° | Applying →   |
+| Makemake              | square □         | Hades                 | 5.37° | Applying →   |
+| Makemake              | quintile Q       | Kronos                | 0.96° | Separating ← |
+| Ixion                 | conjunction ☌    | Quaoar                | 1.59° | Static =     |
+| Ixion                 | opposition ☍     | Pars Fortunae         | 3.83° | Applying →   |
+| Ixion                 | square □         | Pars Amoris           | 3.16° | Applying →   |
+| Ixion                 | trine △          | Pars Fidei            | 4.83° | Separating ← |
+| Ixion                 | square □         | Vertex                | 2.95° | Separating ← |
+| Ixion                 | square □         | Anti Vertex           | 2.95° | Separating ← |
+| Ixion                 | sesquiquadrate ⚼ | Mean Priapus          | 0.89° | Separating ← |
+| Ixion                 | biquintile bQ    | True Priapus          | 1.30° | Separating ← |
+| Ixion                 | trine △          | Interpolated Perigee  | 5.27° | Applying →   |
+| Ixion                 | conjunction ☌    | Cupido                | 3.72° | Applying →   |
+| Ixion                 | sextile ⚹        | Zeus                  | 3.08° | Separating ← |
+| Ixion                 | quincunx ⚻       | Kronos                | 1.16° | Applying →   |
+| Orcus                 | biquintile bQ    | Interpolated Lilith   | 0.13° | Applying →   |
+| Orcus                 | sextile ⚹        | Hades                 | 0.93° | Separating ← |
+| Orcus                 | semi-square ∠    | Zeus                  | 0.02° | Separating ← |
+| Orcus                 | sextile ⚹        | Apollon               | 2.60° | Applying →   |
+| Orcus                 | square □         | Admetos               | 3.69° | Applying →   |
+| Quaoar                | opposition ☍     | Pars Fortunae         | 5.42° | Applying →   |
+| Quaoar                | square □         | Pars Amoris           | 4.75° | Applying →   |
+| Quaoar                | trine △          | Pars Fidei            | 3.23° | Separating ← |
+| Quaoar                | square □         | Vertex                | 1.36° | Separating ← |
+| Quaoar                | square □         | Anti Vertex           | 1.36° | Separating ← |
+| Quaoar                | sesquiquadrate ⚼ | Mean Priapus          | 0.70° | Applying →   |
+| Quaoar                | biquintile bQ    | True Priapus          | 0.29° | Applying →   |
+| Quaoar                | conjunction ☌    | Cupido                | 5.32° | Applying →   |
+| Quaoar                | sextile ⚹        | Zeus                  | 1.49° | Separating ← |
+| Pars Fortunae         | square □         | Pars Amoris           | 0.67° | Static =     |
+| Pars Fortunae         | sesquiquadrate ⚼ | Interpolated Lilith   | 1.07° | Separating ← |
+| Pars Fortunae         | sextile ⚹        | Interpolated Perigee  | 1.44° | Applying →   |
+| Pars Fortunae         | trine △          | White Moon            | 2.05° | Applying →   |
+| Pars Fortunae         | opposition ☍     | Cupido                | 0.11° | Applying →   |
+| Pars Fortunae         | biquintile bQ    | Apollon               | 0.54° | Separating ← |
+| Pars Fortunae         | conjunction ☌    | Admetos               | 4.37° | Applying →   |
+| Pars Fortunae         | sextile ⚹        | Vulkanus              | 4.04° | Applying →   |
+| Pars Spiritus         | trine △          | Interpolated Lilith   | 1.75° | Applying →   |
+| Pars Spiritus         | sextile ⚹        | Mean Priapus          | 1.90° | Separating ← |
+| Pars Spiritus         | quintile Q       | Cupido                | 0.29° | Applying →   |
+| Pars Spiritus         | square □         | Hades                 | 3.19° | Separating ← |
+| Pars Amoris           | semi-square ∠    | Interpolated Lilith   | 0.40° | Separating ← |
+| Pars Amoris           | square □         | Cupido                | 0.56° | Separating ← |
+| Pars Amoris           | biquintile bQ    | Zeus                  | 0.24° | Separating ← |
+| Pars Amoris           | trine △          | Kronos                | 2.00° | Separating ← |
+| Pars Amoris           | square □         | Admetos               | 5.04° | Applying →   |
+| Pars Amoris           | biquintile bQ    | Vulkanus              | 1.29° | Separating ← |
+| Pars Fidei            | semi-sextile ⚺   | Vertex                | 1.88° | Static =     |
+| Pars Fidei            | quincunx ⚻       | Anti Vertex           | 1.88° | Static =     |
+| Pars Fidei            | sextile ⚹        | Zeus                  | 1.74° | Applying →   |
+| Pars Fidei            | quintile Q       | Admetos               | 1.03° | Applying →   |
+| Pars Fidei            | square □         | Poseidon              | 0.60° | Separating ← |
+| Vertex                | sextile ⚹        | True Priapus          | 4.35° | Separating ← |
+| Vertex                | semi-sextile ⚺   | Zeus                  | 0.13° | Separating ← |
+| Vertex                | sextile ⚹        | Kronos                | 4.11° | Applying →   |
+| Vertex                | sextile ⚹        | Poseidon              | 2.47° | Separating ← |
+| Anti Vertex           | trine △          | True Priapus          | 4.35° | Separating ← |
+| Anti Vertex           | quincunx ⚻       | Zeus                  | 0.13° | Separating ← |
+| Anti Vertex           | trine △          | Kronos                | 4.11° | Applying →   |
+| Anti Vertex           | trine △          | Poseidon              | 2.47° | Separating ← |
+| Interpolated Lilith   | opposition ☍     | Mean Priapus          | 3.66° | Separating ← |
+| Interpolated Lilith   | opposition ☍     | True Priapus          | 4.94° | Applying →   |
+| Interpolated Lilith   | semi-square ∠    | Cupido                | 0.96° | Separating ← |
+| Mean Priapus          | semi-sextile ⚺   | Hades                 | 1.28° | Applying →   |
+| Mean Priapus          | square □         | Apollon               | 4.81° | Applying →   |
+| True Priapus          | square □         | Zeus                  | 4.21° | Separating ← |
+| True Priapus          | semi-square ∠    | Admetos               | 0.50° | Separating ← |
+| True Priapus          | trine △          | Poseidon              | 1.87° | Separating ← |
+| Interpolated Perigee  | sextile ⚹        | White Moon            | 0.61° | Separating ← |
+| Interpolated Perigee  | trine △          | Cupido                | 1.54° | Applying →   |
+| Interpolated Perigee  | square □         | Apollon               | 4.03° | Separating ← |
+| Interpolated Perigee  | sextile ⚹        | Admetos               | 2.94° | Separating ← |
+| Interpolated Perigee  | conjunction ☌    | Vulkanus              | 2.60° | Separating ← |
+| White Moon            | sextile ⚹        | Cupido                | 2.16° | Applying →   |
+| White Moon            | square □         | Kronos                | 4.72° | Applying →   |
+| White Moon            | trine △          | Admetos               | 2.32° | Separating ← |
+| White Moon            | sextile ⚹        | Vulkanus              | 1.99° | Separating ← |
+| Cupido                | opposition ☍     | Admetos               | 4.48° | Applying →   |
+| Cupido                | trine △          | Vulkanus              | 4.14° | Applying →   |
+| Hades                 | trine △          | Apollon               | 3.53° | Applying →   |
+| Zeus                  | square □         | Kronos                | 4.24° | Applying →   |
+| Zeus                  | quintile Q       | Vulkanus              | 1.05° | Separating ← |
+| Apollon               | quincunx ⚻       | Admetos               | 1.09° | Static =     |
+| Apollon               | square □         | Vulkanus              | 1.43° | Separating ← |
+| Admetos               | sextile ⚹        | Vulkanus              | 0.34° | Separating ← |
 +-----------------------+------------------+-----------------------+-------+--------------+

--- a/tests/fixtures/solar_return_report.txt
+++ b/tests/fixtures/solar_return_report.txt
@@ -1,5 +1,5 @@
 =====================================================
-Sample Natal Subject Solar Return — Solar Return 1990
+Sample Natal Subject Solar Return — Solar Return 1991
 =====================================================
 
 +Solar Return Chart — Birth Data-------------------------+
@@ -12,8 +12,8 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Latitude           | 53.4084°                          |
 | Longitude          | -2.9916°                          |
 | Timezone           | Europe/London                     |
-| Day of Week        | Saturday                          |
-| ISO Local Datetime | 1990-07-21T14:44:59+01:00         |
+| Day of Week        | Sunday                            |
+| ISO Local Datetime | 1991-07-21T20:33:06+01:00         |
 | Diurnality         | Diurnal                           |
 +--------------------+-----------------------------------+
 
@@ -23,85 +23,78 @@ Sample Natal Subject Solar Return — Solar Return 1990
 | Zodiac Type         | Tropical            |
 | Houses System       | Placidus            |
 | Perspective Type    | Apparent Geocentric |
-| Julian Day          | 2448094.072905      |
+| Julian Day          | 2448459.314653      |
 | Active Points Count | 14                  |
 +---------------------+---------------------+
 
 +Solar Return Chart Celestial Points--------+--------------+------------+---------+-----+------+---------------+
 | Point                 | Sign   | Position | Speed        | Motion     | Decl.   | OOB | Ret. | House         |
 +-----------------------+--------+----------+--------------+------------+---------+-----+------+---------------+
-| Ascendant             | Sco ♏ | 5.82°    | +245.7250°/d | -          | N/A     | -   | -    | First House   |
-| Medium Coeli          | Leo ♌ | 19.91°   | +367.6364°/d | -          | N/A     | -   | -    | Tenth House   |
-| Sun                   | Can ♋ | 28.54°   | +0.9551°/d   | Average    | +20.45° | -   | -    | Ninth House   |
-| Moon                  | Can ♋ | 21.21°   | +14.4024°/d  | Average    | +23.21° | -   | -    | Ninth House   |
-| Mercury               | Leo ♌ | 17.61°   | +1.6910°/d   | Fast       | +16.88° | -   | -    | Ninth House   |
-| Venus                 | Can ♋ | 1.71°    | +1.2038°/d   | Average    | +22.74° | -   | -    | Eighth House  |
-| Mars                  | Tau ♉ | 5.97°    | +0.6554°/d   | Fast       | +11.57° | -   | -    | Seventh House |
-| Jupiter               | Can ♋ | 23.91°   | +0.2240°/d   | Fast       | +21.56° | -   | -    | Ninth House   |
-| Saturn                | Cap ♑ | 21.52°   | -0.0732°/d   | Retrograde | -21.66° | -   | R    | Third House   |
-| Uranus                | Cap ♑ | 6.74°    | -0.0366°/d   | Retrograde | -23.60° | Y   | R    | Second House  |
-| Neptune               | Cap ♑ | 12.76°   | -0.0257°/d   | Retrograde | -21.96° | -   | R    | Third House   |
-| Pluto                 | Sco ♏ | 14.97°   | -0.0025°/d   | Retrograde | -1.42°  | -   | R    | First House   |
-| True North Lunar Node | Aqu ♒ | 7.26°    | -0.0080°/d   | -          | -18.46° | -   | R    | Third House   |
-| Chiron                | Can ♋ | 19.88°   | +0.1071°/d   | -          | +15.79° | -   | -    | Ninth House   |
+| Ascendant             | Cap ♑ | 13.82°   | +409.8309°/d | -          | N/A     | -   | -    | First House   |
+| Medium Coeli          | Sco ♏ | 21.77°   | +355.0355°/d | -          | N/A     | -   | -    | Tenth House   |
+| Sun                   | Can ♋ | 28.54°   | +0.9545°/d   | Average    | +20.45° | -   | -    | Seventh House |
+| Moon                  | Sag ♐ | 4.63°    | +11.9554°/d  | Average    | -24.70° | Y   | -    | Tenth House   |
+| Mercury               | Leo ♌ | 25.32°   | +1.1015°/d   | Slow       | +12.70° | -   | -    | Seventh House |
+| Venus                 | Vir ♍ | 5.30°    | +0.3635°/d   | Slow       | +7.49°  | -   | -    | Seventh House |
+| Mars                  | Vir ♍ | 3.87°    | +0.6178°/d   | Average    | +11.07° | -   | -    | Seventh House |
+| Jupiter               | Leo ♌ | 18.64°   | +0.2120°/d   | Fast       | +15.95° | -   | -    | Seventh House |
+| Saturn                | Aqu ♒ | 3.89°    | -0.0738°/d   | Retrograde | -19.74° | -   | R    | First House   |
+| Uranus                | Cap ♑ | 11.13°   | -0.0379°/d   | Retrograde | -23.35° | -   | R    | Twelfth House |
+| Neptune               | Cap ♑ | 15.01°   | -0.0261°/d   | Retrograde | -21.79° | -   | R    | First House   |
+| Pluto                 | Sco ♏ | 17.58°   | -0.0040°/d   | Retrograde | -2.43°  | -   | R    | Ninth House   |
+| True North Lunar Node | Cap ♑ | 18.94°   | +0.0160°/d   | -          | -22.10° | -   | -    | First House   |
+| Chiron                | Leo ♌ | 0.02°    | +0.1160°/d   | -          | +13.98° | -   | -    | Seventh House |
 +-----------------------+--------+----------+--------------+------------+---------+-----+------+---------------+
 
 +Solar Return Chart Houses (Placidus)+-------------------+
 | House          | Sign   | Position | Absolute Position |
 +----------------+--------+----------+-------------------+
-| First House    | Sco ♏ | 5.82°    | 215.82°           |
-| Second House   | Sag ♐ | 3.70°    | 243.70°           |
-| Third House    | Cap ♑ | 9.78°    | 279.78°           |
-| Fourth House   | Aqu ♒ | 19.91°   | 319.91°           |
-| Fifth House    | Pis ♓ | 23.00°   | 353.00°           |
-| Sixth House    | Ari ♈ | 17.47°   | 17.47°            |
-| Seventh House  | Tau ♉ | 5.82°    | 35.82°            |
-| Eighth House   | Gem ♊ | 3.70°    | 63.70°            |
-| Ninth House    | Can ♋ | 9.78°    | 99.78°            |
-| Tenth House    | Leo ♌ | 19.91°   | 139.91°           |
-| Eleventh House | Vir ♍ | 23.00°   | 173.00°           |
-| Twelfth House  | Lib ♎ | 17.47°   | 197.47°           |
+| First House    | Cap ♑ | 13.82°   | 283.82°           |
+| Second House   | Pis ♓ | 11.22°   | 341.22°           |
+| Third House    | Ari ♈ | 25.80°   | 25.80°            |
+| Fourth House   | Tau ♉ | 21.77°   | 51.77°            |
+| Fifth House    | Gem ♊ | 10.03°   | 70.03°            |
+| Sixth House    | Gem ♊ | 25.97°   | 85.97°            |
+| Seventh House  | Can ♋ | 13.82°   | 103.82°           |
+| Eighth House   | Vir ♍ | 11.22°   | 161.22°           |
+| Ninth House    | Lib ♎ | 25.80°   | 205.80°           |
+| Tenth House    | Sco ♏ | 21.77°   | 231.77°           |
+| Eleventh House | Sag ♐ | 10.03°   | 250.03°           |
+| Twelfth House  | Sag ♐ | 25.97°   | 265.97°           |
 +----------------+--------+----------+-------------------+
 
-+Lunar Phase--------------+--------------------+
-| Lunar Phase Information | Value              |
-+-------------------------+--------------------+
-| Phase Name              | Waning Crescent 🌘 |
-| Sun-Moon Angle          | 352.67°            |
-| Lunation Day            | 28                 |
-+-------------------------+--------------------+
++Lunar Phase--------------+-------------------+
+| Lunar Phase Information | Value             |
++-------------------------+-------------------+
+| Phase Name              | Waxing Gibbous 🌔 |
+| Sun-Moon Angle          | 126.09°           |
+| Lunation Day            | 10                |
++-------------------------+-------------------+
 
 +Element Distribution-----------+
 | Element  | Count | Percentage |
 +----------+-------+------------+
-| Fire 🔥  | 3.0   | 18%        |
-| Earth 🌍 | 3.5   | 21%        |
-| Air 💨   | 0.5   | 3%         |
-| Water 💧 | 9.6   | 58%        |
+| Fire 🔥  | 5.1   | 31%        |
+| Earth 🌍 | 6.5   | 39%        |
+| Air 💨   | 1.0   | 6%         |
+| Water 💧 | 4.0   | 24%        |
 | Total    | 16.6  | 100%       |
 +----------+-------+------------+
 
 +Quality Distribution-----------+
 | Quality  | Count | Percentage |
 +----------+-------+------------+
-| Cardinal | 9.1   | 55%        |
-| Fixed    | 7.5   | 45%        |
-| Mutable  | 0.0   | 0%         |
+| Cardinal | 5.5   | 33%        |
+| Fixed    | 6.1   | 37%        |
+| Mutable  | 5.0   | 30%        |
 | Total    | 16.6  | 100%       |
 +----------+-------+------------+
 
-+Angularities------------+----------+
-| Point   | Angle        | Distance |
-+---------+--------------+----------+
-| Mars    | Descendant   | 0.15°    |
-| Mercury | Medium Coeli | 2.30°    |
-+---------+--------------+----------+
-
-+Stelliums------+-----------------------------+
-| House | Count | Points                      |
-+-------+-------+-----------------------------+
-| 9     | 4     | Sun, Moon, Mercury, Jupiter |
-+-------+-------+-----------------------------+
++Stelliums------+------------------------------------+
+| House | Count | Points                             |
++-------+-------+------------------------------------+
+| 7     | 5     | Sun, Mercury, Venus, Mars, Jupiter |
++-------+-------+------------------------------------+
 
 +Active Celestial Points-----+
 | #  | Active Point          |
@@ -135,17 +128,15 @@ Sample Natal Subject Solar Return — Solar Return 1990
 +Aspects----------------+---------------+-----------------------+-------+--------------+
 | Point 1               | Aspect        | Point 2               | Orb   | Movement     |
 +-----------------------+---------------+-----------------------+-------+--------------+
-| Moon                  | conjunction ☌ | Jupiter               | 2.70° | Applying →   |
-| Moon                  | opposition ☍  | Saturn                | 0.31° | Applying →   |
-| Moon                  | conjunction ☌ | Chiron                | 1.33° | Separating ← |
-| Mercury               | square □      | Pluto                 | 2.63° | Separating ← |
-| Mercury               | conjunction ☌ | Medium Coeli          | 2.30° | Separating ← |
-| Mars                  | trine △       | Uranus                | 0.77° | Applying →   |
-| Mars                  | square □      | True North Lunar Node | 1.30° | Applying →   |
-| Mars                  | opposition ☍  | Ascendant             | 0.15° | Applying →   |
-| Jupiter               | opposition ☍  | Saturn                | 2.40° | Separating ← |
-| Saturn                | opposition ☍  | Chiron                | 1.64° | Applying →   |
-| Uranus                | sextile ⚹     | Ascendant             | 0.92° | Applying →   |
-| Neptune               | sextile ⚹     | Pluto                 | 2.21° | Separating ← |
-| True North Lunar Node | square □      | Ascendant             | 1.45° | Applying →   |
+| Sun                   | conjunction ☌ | Chiron                | 1.47° | Applying →   |
+| Moon                  | square □      | Venus                 | 0.67° | Applying →   |
+| Moon                  | square □      | Mars                  | 0.76° | Separating ← |
+| Moon                  | sextile ⚹     | Saturn                | 0.74° | Separating ← |
+| Venus                 | conjunction ☌ | Mars                  | 1.43° | Applying →   |
+| Jupiter               | square □      | Pluto                 | 1.06° | Separating ← |
+| Uranus                | conjunction ☌ | Ascendant             | 2.69° | Separating ← |
+| Neptune               | sextile ⚹     | Pluto                 | 2.57° | Separating ← |
+| Neptune               | conjunction ☌ | Ascendant             | 1.19° | Applying →   |
+| Pluto                 | sextile ⚹     | True North Lunar Node | 1.36° | Separating ← |
+| True North Lunar Node | sextile ⚹     | Medium Coeli          | 2.83° | Separating ← |
 +-----------------------+---------------+-----------------------+-------+--------------+


### PR DESCRIPTION
## The return that would not step forward

The instant of a return reported by the factory could not be fed back as the seed for the search of the next one: asking for the solar return *after* `2022-06-10T08:46:33Z` — the instant just received for 2022 — gave 2022 again. Backwards it worked. A client walking the sequence of returns with "next" stood still; solar, lunar, heliocentric and node, all alike.

### Why

Instants are reported truncated to the whole second (the chart is rebuilt from an integer `seconds` field, and the class docstring declares it). The exact crossing therefore lies in `[T, T+1s)`: a fraction of a second **after** the value in the caller's hands. Seeding the forward search from there, the ephemeris returned — correctly, for a primitive — the same crossing, just ahead of the seed. Backwards the truncated seed falls before the crossing and steps over it: hence the asymmetry.

`libephemeris` is not at fault: a body immediately before its target *must* have its first crossing at the current instant. The blame was the factory's, which reports to the second and compared at full precision.

### What changes

The order between a seed and a return is decided **at the resolution the factory reports with**: forward starts from the whole second after the seed; backwards from the seed's own whole second — the backend's backward searches are strictly past, so a crossing inside that second (reported at that second, hence not "before") stays excluded and one in the second before is found. A single helper, `_search_start_jd`, behind the three `*_from_iso_formatted_time` entry points; the solar/lunar search from a Julian Day lives in `_next_return_from_jd`, and the by-date wrapper hands it its **inclusive** midnight ("the first return of this date" includes a return in the first second of the date).

The contract, pinned for every type in `tests/core/test_planetary_return_roundtrip.py` (24 tests):

```
next(reported(N))      == N + 1
previous(reported(N))  == N − 1
previous(next(r))      == r          exact, instant for instant
```

plus a walk of 5 steps forward and 5 back that touches every return once and comes back home; sub-second seeds ordered at the reporting resolution in both directions (`previous` from the second after a reported instant finds exactly that one — for the Moon, the node and every heliocentric planet the backend resolves, Mercury–Saturn); the seed normalised to UTC before truncating (a `+14:00` at the range edge does not overflow); the clean refusal (`KerykeionException`) at the edges of the civil range. It is the mirror image of `test_back_is_one_cycle_earlier`, which seeded only in the direction the truncation favoured.

**What the solvers do not do on their own.** The heliocentric solvers converge at 0.001″ — six seconds of Pluto's motion, two of Uranus', one of Chiron's — and seeded one second past a crossing they returned it as the answer (the same crossing, reported one second later). Backwards the Sun solver has a ~90 ms dead band and skipped a year. The factory therefore holds every ISO search to the contract (`_settled`): the heliocentric crossing is settled to the millisecond by bisection around the solver's answer; a crossing inside the second before a backward seed is searched explicitly (Sun/Moon on longitude, node on lunar latitude, heliocentrics on heliocentric longitude); a result that has not passed the seed's second restarts from an hour past it. The contract holds and the suite pins it for Sun, Moon, nodes and the heliocentric bodies from Mercury to Pluto plus Chiron (twenty consecutive solar returns found from the second after, dead band included). Outside the contract only the heliocentric search for nodes and Lilith remains, which are not heliocentric bodies. Residual limit of the ephemeris: a crossing within a tenth of a millisecond of a whole second cannot be told from one on that second and is treated as such — the case that matters, the natal instant (a crossing by construction), is handled: `previous` seeded with it finds the cycle before birth. The heliocentric instants settle onto the crossing: for the slow bodies the reported second changes in about half the cases, up to the solver's tolerance (2 s Uranus, 4 s Neptune, 9 s Pluto).

Nothing reported changes. The by-date and by-year wrappers stay the same in effect (their midnight seeds never share a second with a return). The only visible consequence: a seed *inside* the same second as a crossing selects the following return — a search seeded from the natal instant itself returns the first birthday instead of the moment of birth. Four report fixtures that pinned that degenerate chart (the natal under another title, `1990-07-21T14:44:59` for someone born at 14:45:00) are regenerated with `poe regenerate:reports:output`.

### Two calendar facts, pinned beside it

They are the reason a consumer identifies a return by its instant and never by a period: born on 1 January, the 2024 solar return falls on 1 January and the next on 31 December **of the same year**; a lunar return on 2 August 2026 and the next on the 29th.

### Review

CodeRabbit, five findings resolved: the by-date wrapper keeps the midnight seed inclusive; the seed normalises to UTC before stepping; the "second after, backwards" case pinned for Mercury–Saturn too; ASCII dashes and raw regex. Two rounds of adversarial reviewers plus two post-fix passes (a root on the seed was being accepted → `previous` from the natal instant gave a return one second before birth; the arc changed sign at the antipode → an opposition mistaken for a return; both fixed and pinned): the backward rule `floor(t) − 1 s` excluded a crossing in the second before the seed → seed = the seed's own second; the slow heliocentric bodies stood still (solver tolerance > 1 s) and the Sun skipped a year in the dead band → settling by bisection + `_settled` post-condition; the claim "Chiron/Pholus/Uranians without a crossing" was a wrong measurement and is gone; minimum between two node passages ~12.4 days (measured 12.38–14.66); stale docstrings and the `site/docs` page updated.

### Verification

- `tests/core/`: green (libephemeris backend, medium tier); `test_planetary_return_roundtrip.py` 35 tests.
- `ruff check` clean on the touched files; `pyright` 0 errors on `factory.py`. The file was not `ruff format`-compliant before this PR and was not reformatted, to keep the diff on point.

@coderabbitai review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfuQJxRJuAVoWFU76wW1wE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ISO return searches in both directions, including whole-second boundary cases and solver recovery.
  * Enhanced heliocentric return accuracy and handling of supported bodies.
  * Added clearer errors for ephemeris-range limits and invalid UTC civil-time ranges.
  * Preserved expected behavior for unsupported heliocentric node and Lilith searches.

* **Documentation**
  * Clarified timestamp interpretation, inclusive search behavior, precision limits, and supported heliocentric bodies.
  * Added examples for finding subsequent returns using reported UTC timestamps.

* **Tests**
  * Expanded coverage for repeated returns, backward searches, natal seeds, and multiple returns within one calendar period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
