### PR TITLE
feat(events): sign periods and retrograde periods, clipped to a range — 6.0.0a92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@
   before the range or a retrograde that outlives it is reported honestly
   instead of being invisible — the state at the range start is read in the
   same ephemeris session (same zodiac frame) as the scan that follows it,
-  with a one-second probe before the range so a boundary sitting exactly on
-  the start is recognised (a stay entered on the start is not clipped; a
-  station on the start decides the motion state).
+  with a one-second probe past either bound so a boundary sitting exactly on
+  a range edge is recognised (a stay entered on the start, or left on the
+  end, is not clipped there; a station on the start decides the motion
+  state, one on the end closes the span).
   See `release_notes/v6.0.0a92.md`.
 - **Chiron stations, opt-in.** `RetrogradeStationFactory` accepts `"Chiron"`
   in `planets`; the default set (and its baselines) is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
   each clipped bound (`start_clipped` / `end_clipped`), so a stay that began
   before the range or a retrograde that outlives it is reported honestly
   instead of being invisible — the state at the range start is read in the
-  same ephemeris session (same zodiac frame) as the scan that follows it.
+  same ephemeris session (same zodiac frame) as the scan that follows it,
+  with a one-second probe before the range so a boundary sitting exactly on
+  the start is recognised (a stay entered on the start is not clipped; a
+  station on the start decides the motion state).
   See `release_notes/v6.0.0a92.md`.
 - **Chiron stations, opt-in.** `RetrogradeStationFactory` accepts `"Chiron"`
   in `planets`; the default set (and its baselines) is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [6.0.0a92] - 2026-08-29
+
+### Added
+
+- **Sign periods and retrograde periods.** Two range queries that answer
+  "where is every planet, and who is retrograde, across these dates" without
+  the caller stitching events together:
+  `SignIngressFactory.sign_periods_from_iso_range` / `_from_julian_day` return
+  contiguous, non-overlapping sign stays per planet (`SignPeriodModel`, in
+  `SignPeriodsCollectionModel`), and
+  `RetrogradeStationFactory.retrograde_periods_from_iso_range` /
+  `_from_julian_day` return retrograde spans (`RetrogradePeriodModel`, in
+  `RetrogradePeriodsCollectionModel`). Both are clipped to the range and flag
+  each clipped bound (`start_clipped` / `end_clipped`), so a stay that began
+  before the range or a retrograde that outlives it is reported honestly
+  instead of being invisible — the state at the range start is read in the
+  same ephemeris session (same zodiac frame) as the scan that follows it.
+  See `release_notes/v6.0.0a92.md`.
+- **Chiron stations, opt-in.** `RetrogradeStationFactory` accepts `"Chiron"`
+  in `planets`; the default set (and its baselines) is unchanged.
+
+### Changed
+
+- `SignIngressFactory.from_iso_range` parses its bounds through a shared
+  helper (`_iso_range_to_jd`); behaviour is unchanged.
+
 ## [6.0.0a91] - 2026-08-29
 
 Five defects that reached the screen of a downstream client as data that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@
   before the range or a retrograde that outlives it is reported honestly
   instead of being invisible — the state at the range start is read in the
   same ephemeris session (same zodiac frame) as the scan that follows it,
-  with a one-second probe past either bound so a boundary sitting exactly on
-  a range edge is recognised (a stay entered on the start, or left on the
+  with a probe a solver's resolution (50 ms) past either bound so a boundary
+  sitting exactly on a range edge is recognised (a stay entered on the start, or left on the
   end, is not clipped there; a station on the start decides the motion
   state, one on the end closes the span).
   See `release_notes/v6.0.0a92.md`.

--- a/kerykeion/__init__.py
+++ b/kerykeion/__init__.py
@@ -87,11 +87,15 @@ from .lunations import LunationFinderFactory, LunationModel, LunationsCollection
 from .retrograde_stations import (
     RetrogradeStationFactory,
     StationModel,
+    RetrogradePeriodModel,
+    RetrogradePeriodsCollectionModel,
     RetrogradeStationsCollectionModel,
 )
 from .sign_ingresses import (
     SignIngressFactory,
     IngressModel,
+    SignPeriodModel,
+    SignPeriodsCollectionModel,
     SignIngressesCollectionModel,
 )
 from .mundane_aspects import (
@@ -228,9 +232,13 @@ __all__ = [
     "LunationsCollectionModel",
     "RetrogradeStationFactory",
     "StationModel",
+    "RetrogradePeriodModel",
+    "RetrogradePeriodsCollectionModel",
     "RetrogradeStationsCollectionModel",
     "SignIngressFactory",
     "IngressModel",
+    "SignPeriodModel",
+    "SignPeriodsCollectionModel",
     "SignIngressesCollectionModel",
     "MundaneAspectFactory",
     "MundaneAspectModel",

--- a/kerykeion/retrograde_stations/__init__.py
+++ b/kerykeion/retrograde_stations/__init__.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
-"""Retrograde/direct station finder: motion-reversal moments over a range."""
+"""Retrograde/direct station finder: motion-reversal moments over a range, and
+the retrograde spans they delimit."""
 
 from .factory import (
     RetrogradeStationFactory,
     StationModel,
     RetrogradeStationsCollectionModel,
+    RetrogradePeriodModel,
+    RetrogradePeriodsCollectionModel,
 )
 
 __all__ = [
     "RetrogradeStationFactory",
     "RetrogradeStationsCollectionModel",
     "StationModel",
+    "RetrogradePeriodModel",
+    "RetrogradePeriodsCollectionModel",
 ]

--- a/kerykeion/retrograde_stations/__init__.py
+++ b/kerykeion/retrograde_stations/__init__.py
@@ -11,9 +11,9 @@ from .factory import (
 )
 
 __all__ = [
+    "RetrogradePeriodModel",
+    "RetrogradePeriodsCollectionModel",
     "RetrogradeStationFactory",
     "RetrogradeStationsCollectionModel",
     "StationModel",
-    "RetrogradePeriodModel",
-    "RetrogradePeriodsCollectionModel",
 ]

--- a/kerykeion/retrograde_stations/factory.py
+++ b/kerykeion/retrograde_stations/factory.py
@@ -65,12 +65,15 @@ _BISECTION_ITERS = 30
 # Backstop on samples per scan (~38,000 years at the 7-day step). Ranges that
 # would exceed it are rejected explicitly rather than silently truncated.
 _MAX_SAMPLES = 2_000_000
-# A station within one second of a range bound IS that bound: at the start it
-# decides the initial motion state deterministically (instead of the sign of
-# a speed that is numerically ~0 there), at the end it closes the span
-# unclipped. One second is far coarser than the bisection (milliseconds) and
-# far finer than any real retrograde span.
-_EDGE_TOL_DAYS = 1.0 / 86400.0
+# A station within the solver's own resolution of a range bound IS that bound:
+# at the start it decides the initial motion state deterministically (instead
+# of the sign of a speed that is numerically ~0 there), at the end it closes
+# the span unclipped. A twentieth of a second is far coarser than the
+# bisection's error (a 7-day bracket halved 30 times: well under a
+# millisecond) and twenty times finer than the second the ISO output
+# resolves — it absorbs the solver's error and nothing else: a station half
+# a second inside the range is a real station and stays one.
+_EDGE_TOL_DAYS = 0.05 / 86400.0
 
 
 def _to_utc_naive(dt: datetime) -> datetime:
@@ -200,12 +203,12 @@ class RetrogradePeriodsCollectionModel(SubscriptableBaseModel):
 def _scan_edges(
     name: str, body: int, start_jd: float, end_jd: float, iflag: int, found: List[StationModel]
 ) -> List[StationModel]:
-    """Stations within the second just outside either bound — typically an
+    """Stations within ``_EDGE_TOL_DAYS`` just outside either bound — an
     instant this very factory reported, which bisection may leave a hair to
     either side of the true zero — so the fold can treat them as sitting on
     the bound. Scanned apart from the range so the in-range brackets, hence
     the in-range instants, stay exactly those of :meth:`from_julian_day`. At
-    the very edge of the ephemeris that second does not exist and the bound
+    the very edge of the ephemeris that sliver does not exist and the bound
     stands. A station the range scan already holds is not reported twice."""
     edges: List[StationModel] = []
     before, after = start_jd - _EDGE_TOL_DAYS, end_jd + _EDGE_TOL_DAYS
@@ -240,8 +243,8 @@ def _fold_retrograde_periods(
         )
 
     ordered = sorted(stations, key=lambda s: s.julian_day)
-    # A station within a second of the range start overrides the speed
-    # snapshot: the motion BEFORE an SR is direct, before an SD it is
+    # A station within the solver's resolution of the range start overrides
+    # the speed snapshot: the motion BEFORE an SR is direct, before an SD it is
     # retrograde. Such a station is the range start itself (the scan may place
     # it a hair to either side).
     on_start = 0
@@ -249,9 +252,9 @@ def _fold_retrograde_periods(
         retro_at_start = ordered[0].station_type == "SD"
         ordered[0] = ordered[0].model_copy(update={"julian_day": start_jd})
         on_start = 1
-    # Likewise a station within a second of the range end is the range end
-    # itself: an SD there closes the open span unclipped, an SR there opens
-    # nothing that this range can see.
+    # Likewise a station within the solver's resolution of the range end is
+    # the range end itself: an SD there closes the open span unclipped, an SR
+    # there opens nothing that this range can see.
     if len(ordered) > on_start and abs(ordered[-1].julian_day - end_jd) <= _EDGE_TOL_DAYS:
         ordered[-1] = ordered[-1].model_copy(update={"julian_day": end_jd})
 
@@ -440,12 +443,14 @@ class RetrogradeStationFactory:
         there; the in-range stations open (SR) and close (SD) the spans; spans
         touching an edge are clipped and flagged — unless a station sits on
         that edge (say, an instant this factory reported), which then opens or
-        closes the span there unclipped. The in-range instants are exactly
-        those :meth:`from_julian_day` reports for the same range. Beyond a
-        one-second probe past either bound (to catch such a station), nothing
-        is searched outside the range, so a span open at the edge does not
-        tell where its real station is. An empty or inverted range yields
-        none; a span is as short as the range makes it.
+        closes the span there unclipped. "On the edge" means within the
+        solver's own resolution (a twentieth of a second, ten times the
+        bisection's error): a station half a second inside the range is a
+        real station. The in-range instants are exactly those
+        :meth:`from_julian_day` reports for the same range. Beyond that sliver
+        past either bound, nothing is searched outside the range, so a span
+        open at the edge does not tell where its real station is. An empty or
+        inverted range yields none; a span is as short as the range makes it.
 
         Raises:
             KerykeionException: as :meth:`from_julian_day`, and when the
@@ -471,11 +476,12 @@ class RetrogradeStationFactory:
             with ephemeris_session(zodiac_type=zodiac_type, sidereal_mode=sidereal_mode) as iflag:
                 for name, body in bodies:
                     retro_at_start = _speed(start_jd, body) < 0.0
-                    # The range scan, then one second beyond either bound: a
-                    # station sitting on the range start is bracketed and
-                    # found, and the fold's edge rule decides the initial state
-                    # from it rather than from a speed that is numerically ~0
-                    # there; one on the range end closes its span unclipped.
+                    # The range scan, then a solver's resolution beyond either
+                    # bound: a station sitting on the range start is bracketed
+                    # and found, and the fold's edge rule decides the initial
+                    # state from it rather than from a speed that is
+                    # numerically ~0 there; one on the range end closes its
+                    # span unclipped.
                     stations = RetrogradeStationFactory._scan_planet(name, body, start_jd, end_jd, iflag)
                     stations += _scan_edges(name, body, start_jd, end_jd, iflag, stations)
                     periods.extend(_fold_retrograde_periods(name, retro_at_start, stations, start_jd, end_jd))

--- a/kerykeion/retrograde_stations/factory.py
+++ b/kerykeion/retrograde_stations/factory.py
@@ -51,6 +51,9 @@ _STATION_PLANETS: List[tuple[str, int]] = [
 ]
 
 _PLANET_IDS = {name: pid for name, pid in _STATION_PLANETS}
+# Chiron stations too; opt-in (``planets=[..., "Chiron"]``) so the default
+# output — and its baselines — stay the seven classical/modern planets.
+_PLANET_IDS["Chiron"] = POINT_NUMBER_MAP["Chiron"]
 
 # Sampling step (days). Stations of the same planet are ≥ ~3 weeks apart (even
 # Mercury), so a week-long step still never brackets two stations — the speed
@@ -62,6 +65,10 @@ _BISECTION_ITERS = 30
 # Backstop on samples per scan (~38,000 years at the 7-day step). Ranges that
 # would exceed it are rejected explicitly rather than silently truncated.
 _MAX_SAMPLES = 2_000_000
+# A station within one second of the range start decides the initial motion
+# state deterministically, instead of leaving it to the sign of a speed that
+# is numerically ~0 there.
+_EDGE_TOL_DAYS = 1.0 / 86400.0
 
 
 def _to_utc_naive(dt: datetime) -> datetime:
@@ -161,6 +168,79 @@ class RetrogradeStationsCollectionModel(SubscriptableBaseModel):
     start_jd: float
     end_jd: float
     stations: List[StationModel]
+
+
+class RetrogradePeriodModel(SubscriptableBaseModel):
+    """One span of retrograde motion, clipped to the requested range.
+
+    ``start`` is a retrograde station (or the range start, flagged), ``end`` a
+    direct station (or the range end, flagged). Periods carry no sign: station
+    instants are zodiac-independent.
+    """
+
+    planet: str = Field(description="Planet name (kerykeion AstrologicalPoint vocabulary)")
+    start_jd: float = Field(description="Julian Day (UT) the retrograde motion begins (clipped to the range start)")
+    end_jd: float = Field(description="Julian Day (UT) the retrograde motion ends (clipped to the range end)")
+    start: str = Field(description="ISO 8601 UTC of start_jd")
+    end: str = Field(description="ISO 8601 UTC of end_jd")
+    start_clipped: bool = Field(description="True when the planet was already retrograde at the range start")
+    end_clipped: bool = Field(description="True when the planet is still retrograde at the range end")
+
+
+class RetrogradePeriodsCollectionModel(SubscriptableBaseModel):
+    """Retrograde spans of every requested planet across a Julian Day range."""
+
+    start_jd: float
+    end_jd: float
+    periods: List[RetrogradePeriodModel]
+
+
+def _fold_retrograde_periods(
+    name: str, retro_at_start: bool, stations: List[StationModel], start_jd: float, end_jd: float
+) -> List[RetrogradePeriodModel]:
+    """Turn the motion state at the range start plus the in-range stations into
+    retrograde spans: SR opens, SD closes, the edges clip."""
+
+    def period(a: float, b: float, a_clipped: bool, b_clipped: bool) -> RetrogradePeriodModel:
+        return RetrogradePeriodModel(
+            planet=name,
+            start_jd=a,
+            end_jd=b,
+            start=_jd_to_iso(a),
+            end=_jd_to_iso(b),
+            start_clipped=a_clipped,
+            end_clipped=b_clipped,
+        )
+
+    ordered = sorted(stations, key=lambda s: s.julian_day)
+    # A station on the range's first second overrides the speed snapshot: the
+    # motion BEFORE an SR is direct, before an SD it is retrograde. Such a
+    # station is the range start itself (the scan may place it a hair before).
+    if ordered and abs(ordered[0].julian_day - start_jd) <= _EDGE_TOL_DAYS:
+        retro_at_start = ordered[0].station_type == "SD"
+        ordered[0] = ordered[0].model_copy(update={"julian_day": start_jd})
+
+    out: List[RetrogradePeriodModel] = []
+    open_jd: Optional[float] = start_jd if retro_at_start else None
+    open_clipped = retro_at_start
+    for station in ordered:
+        if station.station_type == "SR":
+            if open_jd is not None:
+                raise KerykeionException(
+                    f"{name}: retrograde station at JD {station.julian_day:.5f} while already retrograde."
+                )
+            open_jd, open_clipped = station.julian_day, False
+        else:
+            if open_jd is None:
+                raise KerykeionException(
+                    f"{name}: direct station at JD {station.julian_day:.5f} while not retrograde."
+                )
+            if station.julian_day - open_jd > _EDGE_TOL_DAYS:
+                out.append(period(open_jd, station.julian_day, open_clipped, False))
+            open_jd = None
+    if open_jd is not None and end_jd - open_jd > _EDGE_TOL_DAYS:
+        out.append(period(open_jd, end_jd, open_clipped, True))
+    return out
 
 
 # =============================================================================
@@ -283,6 +363,84 @@ class RetrogradeStationFactory:
             end_jd=end_jd,
             stations=stations,
         )
+
+    @staticmethod
+    def retrograde_periods_from_iso_range(
+        start_date: str,
+        end_date: str,
+        planets: Optional[List[str]] = None,
+        zodiac_type: ZodiacType = "Tropical",
+        sidereal_mode: Optional[SiderealMode] = None,
+    ) -> RetrogradePeriodsCollectionModel:
+        """Retrograde spans between two ISO date(time) strings (treated as UTC).
+
+        Same arguments as :meth:`from_iso_range`; ``"Chiron"`` is accepted on
+        request.
+        """
+        try:
+            start_dt = _to_utc_naive(datetime.fromisoformat(start_date))
+            end_dt = _to_utc_naive(datetime.fromisoformat(end_date))
+        except (ValueError, TypeError) as exc:
+            raise KerykeionException(
+                f"Invalid ISO date/datetime for station range "
+                f"(start_date={start_date!r}, end_date={end_date!r}): {exc}"
+            ) from exc
+        if is_iso_date_only(end_date):
+            end_dt = end_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+        return RetrogradeStationFactory.retrograde_periods_from_julian_day(
+            datetime_to_julian(start_dt), datetime_to_julian(end_dt), planets, zodiac_type, sidereal_mode
+        )
+
+    @staticmethod
+    def retrograde_periods_from_julian_day(
+        start_jd: float,
+        end_jd: float,
+        planets: Optional[List[str]] = None,
+        zodiac_type: ZodiacType = "Tropical",
+        sidereal_mode: Optional[SiderealMode] = None,
+    ) -> RetrogradePeriodsCollectionModel:
+        """Retrograde spans of each planet across ``[start_jd, end_jd]``, clipped to it.
+
+        The motion state at the range start is read from the longitudinal speed
+        there; the in-range stations open (SR) and close (SD) the spans; spans
+        touching an edge are clipped and flagged. Nothing is searched outside
+        the range, so a span open at the edge does not tell where its real
+        station is. An empty or inverted range yields none.
+
+        Raises:
+            KerykeionException: as :meth:`from_julian_day`, and when the
+                stations do not alternate (SR while retrograde, SD while direct).
+            ValueError: as :meth:`from_julian_day`.
+        """
+        validate_julian_bounds(start_jd, end_jd)
+        if planets is not None:
+            invalid = sorted(set(planets) - set(_PLANET_IDS))
+            if invalid:
+                raise ValueError(
+                    f"Unknown or non-stationing planets: {', '.join(invalid)}. "
+                    f"Valid: {', '.join(_PLANET_IDS)}"
+                )
+            bodies = [(name, _PLANET_IDS[name]) for name in dict.fromkeys(planets)]
+        else:
+            bodies = list(_STATION_PLANETS)
+        _validate_zodiac(zodiac_type, sidereal_mode)
+
+        periods: List[RetrogradePeriodModel] = []
+        if end_jd > start_jd and bodies:
+            _ensure_scannable(start_jd, end_jd)
+            with ephemeris_session(zodiac_type=zodiac_type, sidereal_mode=sidereal_mode) as iflag:
+                for name, body in bodies:
+                    retro_at_start = _speed(start_jd, body) < 0.0
+                    # Start the scan one second early: a station sitting on the
+                    # range start is then bracketed and found, and the fold's
+                    # edge rule decides the initial state from it rather than
+                    # from a speed that is numerically ~0 there.
+                    stations = RetrogradeStationFactory._scan_planet(
+                        name, body, start_jd - _EDGE_TOL_DAYS, end_jd, iflag
+                    )
+                    periods.extend(_fold_retrograde_periods(name, retro_at_start, stations, start_jd, end_jd))
+
+        return RetrogradePeriodsCollectionModel(start_jd=start_jd, end_jd=end_jd, periods=periods)
 
     @staticmethod
     def _scan_planet(

--- a/kerykeion/retrograde_stations/factory.py
+++ b/kerykeion/retrograde_stations/factory.py
@@ -247,14 +247,19 @@ def _fold_retrograde_periods(
     # the speed snapshot: the motion BEFORE an SR is direct, before an SD it is
     # retrograde. Such a station is the range start itself (the scan may place
     # it a hair to either side).
-    on_start = 0
-    if ordered and abs(ordered[0].julian_day - start_jd) <= _EDGE_TOL_DAYS:
-        retro_at_start = ordered[0].station_type == "SD"
-        ordered[0] = ordered[0].model_copy(update={"julian_day": start_jd})
-        on_start = 1
     # Likewise a station within the solver's resolution of the range end is
     # the range end itself: an SD there closes the open span unclipped, an SR
-    # there opens nothing that this range can see.
+    # there opens nothing that this range can see. A station within reach of
+    # BOTH bounds (a range shorter than the tolerance, straddling it) goes to
+    # the bound that keeps the motion the range does contain: an SR opens at
+    # the start, an SD closes at the end.
+    on_start = 0
+    if ordered and abs(ordered[0].julian_day - start_jd) <= _EDGE_TOL_DAYS:
+        near_end_too = len(ordered) == 1 and abs(ordered[0].julian_day - end_jd) <= _EDGE_TOL_DAYS
+        if not (near_end_too and ordered[0].station_type == "SD"):
+            retro_at_start = ordered[0].station_type == "SD"
+            ordered[0] = ordered[0].model_copy(update={"julian_day": start_jd})
+            on_start = 1
     if len(ordered) > on_start and abs(ordered[-1].julian_day - end_jd) <= _EDGE_TOL_DAYS:
         ordered[-1] = ordered[-1].model_copy(update={"julian_day": end_jd})
 

--- a/kerykeion/retrograde_stations/factory.py
+++ b/kerykeion/retrograde_stations/factory.py
@@ -195,6 +195,17 @@ class RetrogradePeriodsCollectionModel(SubscriptableBaseModel):
     periods: List[RetrogradePeriodModel]
 
 
+def _probe_start(start_jd: float, body: int) -> float:
+    """``start_jd`` minus the one-second boundary probe, or ``start_jd`` itself
+    when that second lies before the ephemeris begins."""
+    probe = start_jd - _EDGE_TOL_DAYS
+    try:
+        _speed(probe, body)
+    except KerykeionException:
+        return start_jd
+    return probe
+
+
 def _fold_retrograde_periods(
     name: str, retro_at_start: bool, stations: List[StationModel], start_jd: float, end_jd: float
 ) -> List[RetrogradePeriodModel]:
@@ -403,9 +414,10 @@ class RetrogradeStationFactory:
 
         The motion state at the range start is read from the longitudinal speed
         there; the in-range stations open (SR) and close (SD) the spans; spans
-        touching an edge are clipped and flagged. Nothing is searched outside
-        the range, so a span open at the edge does not tell where its real
-        station is. An empty or inverted range yields none.
+        touching an edge are clipped and flagged. Beyond a one-second probe
+        before the range start (to catch a station sitting on it), nothing is
+        searched outside the range, so a span open at the edge does not tell
+        where its real station is. An empty or inverted range yields none.
 
         Raises:
             KerykeionException: as :meth:`from_julian_day`, and when the
@@ -434,9 +446,11 @@ class RetrogradeStationFactory:
                     # Start the scan one second early: a station sitting on the
                     # range start is then bracketed and found, and the fold's
                     # edge rule decides the initial state from it rather than
-                    # from a speed that is numerically ~0 there.
+                    # from a speed that is numerically ~0 there. At the very
+                    # edge of the ephemeris that second does not exist: then
+                    # the scan starts on the range and the snapshot decides.
                     stations = RetrogradeStationFactory._scan_planet(
-                        name, body, start_jd - _EDGE_TOL_DAYS, end_jd, iflag
+                        name, body, _probe_start(start_jd, body), end_jd, iflag
                     )
                     periods.extend(_fold_retrograde_periods(name, retro_at_start, stations, start_jd, end_jd))
 

--- a/kerykeion/retrograde_stations/factory.py
+++ b/kerykeion/retrograde_stations/factory.py
@@ -65,9 +65,11 @@ _BISECTION_ITERS = 30
 # Backstop on samples per scan (~38,000 years at the 7-day step). Ranges that
 # would exceed it are rejected explicitly rather than silently truncated.
 _MAX_SAMPLES = 2_000_000
-# A station within one second of the range start decides the initial motion
-# state deterministically, instead of leaving it to the sign of a speed that
-# is numerically ~0 there.
+# A station within one second of a range bound IS that bound: at the start it
+# decides the initial motion state deterministically (instead of the sign of
+# a speed that is numerically ~0 there), at the end it closes the span
+# unclipped. One second is far coarser than the bisection (milliseconds) and
+# far finer than any real retrograde span.
 _EDGE_TOL_DAYS = 1.0 / 86400.0
 
 
@@ -195,22 +197,36 @@ class RetrogradePeriodsCollectionModel(SubscriptableBaseModel):
     periods: List[RetrogradePeriodModel]
 
 
-def _probe_start(start_jd: float, body: int) -> float:
-    """``start_jd`` minus the one-second boundary probe, or ``start_jd`` itself
-    when that second lies before the ephemeris begins."""
-    probe = start_jd - _EDGE_TOL_DAYS
-    try:
-        _speed(probe, body)
-    except KerykeionException:
-        return start_jd
-    return probe
+def _scan_edges(
+    name: str, body: int, start_jd: float, end_jd: float, iflag: int, found: List[StationModel]
+) -> List[StationModel]:
+    """Stations within the second just outside either bound — typically an
+    instant this very factory reported, which bisection may leave a hair to
+    either side of the true zero — so the fold can treat them as sitting on
+    the bound. Scanned apart from the range so the in-range brackets, hence
+    the in-range instants, stay exactly those of :meth:`from_julian_day`. At
+    the very edge of the ephemeris that second does not exist and the bound
+    stands. A station the range scan already holds is not reported twice."""
+    edges: List[StationModel] = []
+    before, after = start_jd - _EDGE_TOL_DAYS, end_jd + _EDGE_TOL_DAYS
+    for a, b, probe in ((before, start_jd, before), (end_jd, after, after)):
+        try:
+            _speed(probe, body)
+        except KerykeionException:
+            continue
+        for station in RetrogradeStationFactory._scan_planet(name, body, a, b, iflag):
+            if all(abs(station.julian_day - known.julian_day) > _EDGE_TOL_DAYS for known in found):
+                edges.append(station)
+    return edges
 
 
 def _fold_retrograde_periods(
     name: str, retro_at_start: bool, stations: List[StationModel], start_jd: float, end_jd: float
 ) -> List[RetrogradePeriodModel]:
-    """Turn the motion state at the range start plus the in-range stations into
-    retrograde spans: SR opens, SD closes, the edges clip."""
+    """Turn the motion state at the range start plus the scanned stations into
+    retrograde spans: SR opens, SD closes, the edges clip — unless a station
+    sits on the edge, which then opens or closes the span unclipped. Only an
+    empty span is dropped; a span is as short as the range makes it."""
 
     def period(a: float, b: float, a_clipped: bool, b_clipped: bool) -> RetrogradePeriodModel:
         return RetrogradePeriodModel(
@@ -224,12 +240,20 @@ def _fold_retrograde_periods(
         )
 
     ordered = sorted(stations, key=lambda s: s.julian_day)
-    # A station on the range's first second overrides the speed snapshot: the
-    # motion BEFORE an SR is direct, before an SD it is retrograde. Such a
-    # station is the range start itself (the scan may place it a hair before).
+    # A station within a second of the range start overrides the speed
+    # snapshot: the motion BEFORE an SR is direct, before an SD it is
+    # retrograde. Such a station is the range start itself (the scan may place
+    # it a hair to either side).
+    on_start = 0
     if ordered and abs(ordered[0].julian_day - start_jd) <= _EDGE_TOL_DAYS:
         retro_at_start = ordered[0].station_type == "SD"
         ordered[0] = ordered[0].model_copy(update={"julian_day": start_jd})
+        on_start = 1
+    # Likewise a station within a second of the range end is the range end
+    # itself: an SD there closes the open span unclipped, an SR there opens
+    # nothing that this range can see.
+    if len(ordered) > on_start and abs(ordered[-1].julian_day - end_jd) <= _EDGE_TOL_DAYS:
+        ordered[-1] = ordered[-1].model_copy(update={"julian_day": end_jd})
 
     out: List[RetrogradePeriodModel] = []
     open_jd: Optional[float] = start_jd if retro_at_start else None
@@ -246,10 +270,10 @@ def _fold_retrograde_periods(
                 raise KerykeionException(
                     f"{name}: direct station at JD {station.julian_day:.5f} while not retrograde."
                 )
-            if station.julian_day - open_jd > _EDGE_TOL_DAYS:
+            if station.julian_day > open_jd:
                 out.append(period(open_jd, station.julian_day, open_clipped, False))
             open_jd = None
-    if open_jd is not None and end_jd - open_jd > _EDGE_TOL_DAYS:
+    if open_jd is not None and end_jd > open_jd:
         out.append(period(open_jd, end_jd, open_clipped, True))
     return out
 
@@ -414,10 +438,14 @@ class RetrogradeStationFactory:
 
         The motion state at the range start is read from the longitudinal speed
         there; the in-range stations open (SR) and close (SD) the spans; spans
-        touching an edge are clipped and flagged. Beyond a one-second probe
-        before the range start (to catch a station sitting on it), nothing is
-        searched outside the range, so a span open at the edge does not tell
-        where its real station is. An empty or inverted range yields none.
+        touching an edge are clipped and flagged — unless a station sits on
+        that edge (say, an instant this factory reported), which then opens or
+        closes the span there unclipped. The in-range instants are exactly
+        those :meth:`from_julian_day` reports for the same range. Beyond a
+        one-second probe past either bound (to catch such a station), nothing
+        is searched outside the range, so a span open at the edge does not
+        tell where its real station is. An empty or inverted range yields
+        none; a span is as short as the range makes it.
 
         Raises:
             KerykeionException: as :meth:`from_julian_day`, and when the
@@ -443,15 +471,13 @@ class RetrogradeStationFactory:
             with ephemeris_session(zodiac_type=zodiac_type, sidereal_mode=sidereal_mode) as iflag:
                 for name, body in bodies:
                     retro_at_start = _speed(start_jd, body) < 0.0
-                    # Start the scan one second early: a station sitting on the
-                    # range start is then bracketed and found, and the fold's
-                    # edge rule decides the initial state from it rather than
-                    # from a speed that is numerically ~0 there. At the very
-                    # edge of the ephemeris that second does not exist: then
-                    # the scan starts on the range and the snapshot decides.
-                    stations = RetrogradeStationFactory._scan_planet(
-                        name, body, _probe_start(start_jd, body), end_jd, iflag
-                    )
+                    # The range scan, then one second beyond either bound: a
+                    # station sitting on the range start is bracketed and
+                    # found, and the fold's edge rule decides the initial state
+                    # from it rather than from a speed that is numerically ~0
+                    # there; one on the range end closes its span unclipped.
+                    stations = RetrogradeStationFactory._scan_planet(name, body, start_jd, end_jd, iflag)
+                    stations += _scan_edges(name, body, start_jd, end_jd, iflag, stations)
                     periods.extend(_fold_retrograde_periods(name, retro_at_start, stations, start_jd, end_jd))
 
         return RetrogradePeriodsCollectionModel(start_jd=start_jd, end_jd=end_jd, periods=periods)

--- a/kerykeion/schemas/__init__.py
+++ b/kerykeion/schemas/__init__.py
@@ -161,8 +161,12 @@ _FEATURE_MODEL_HOMES = {
     "LunationsCollectionModel": "kerykeion.lunations.factory",
     "StationModel": "kerykeion.retrograde_stations.factory",
     "RetrogradeStationsCollectionModel": "kerykeion.retrograde_stations.factory",
+    "RetrogradePeriodModel": "kerykeion.retrograde_stations.factory",
+    "RetrogradePeriodsCollectionModel": "kerykeion.retrograde_stations.factory",
     "IngressModel": "kerykeion.sign_ingresses.factory",
     "SignIngressesCollectionModel": "kerykeion.sign_ingresses.factory",
+    "SignPeriodModel": "kerykeion.sign_ingresses.factory",
+    "SignPeriodsCollectionModel": "kerykeion.sign_ingresses.factory",
     "MundaneAspectModel": "kerykeion.mundane_aspects.factory",
     "MundaneAspectsCollectionModel": "kerykeion.mundane_aspects.factory",
     "MidpointModel": "kerykeion.midpoints.factory",
@@ -192,8 +196,15 @@ if TYPE_CHECKING:  # static analyzers see the lazy re-exports as plain imports
     from kerykeion.retrograde_stations.factory import (
         StationModel,
         RetrogradeStationsCollectionModel,
+        RetrogradePeriodModel,
+        RetrogradePeriodsCollectionModel,
     )
-    from kerykeion.sign_ingresses.factory import IngressModel, SignIngressesCollectionModel
+    from kerykeion.sign_ingresses.factory import (
+        IngressModel,
+        SignIngressesCollectionModel,
+        SignPeriodModel,
+        SignPeriodsCollectionModel,
+    )
     from kerykeion.mundane_aspects.factory import MundaneAspectModel, MundaneAspectsCollectionModel
     from kerykeion.midpoints.factory import MidpointModel, MidpointAspectModel
     from kerykeion.secondary_progressions.factory import (
@@ -368,8 +379,12 @@ __all__ = [
     "LunationsCollectionModel",
     "StationModel",
     "RetrogradeStationsCollectionModel",
+    "RetrogradePeriodModel",
+    "RetrogradePeriodsCollectionModel",
     "IngressModel",
     "SignIngressesCollectionModel",
+    "SignPeriodModel",
+    "SignPeriodsCollectionModel",
     "MundaneAspectModel",
     "MundaneAspectsCollectionModel",
     "MidpointModel",

--- a/kerykeion/sign_ingresses/__init__.py
+++ b/kerykeion/sign_ingresses/__init__.py
@@ -12,8 +12,8 @@ from .factory import (
 
 __all__ = [
     "IngressModel",
-    "SignIngressesCollectionModel",
     "SignIngressFactory",
+    "SignIngressesCollectionModel",
     "SignPeriodModel",
     "SignPeriodsCollectionModel",
 ]

--- a/kerykeion/sign_ingresses/__init__.py
+++ b/kerykeion/sign_ingresses/__init__.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
-"""Sign ingress finder: zodiac sign boundary crossings over a range."""
+"""Sign ingress finder: zodiac sign boundary crossings over a range, and the
+sign stays they delimit."""
 
 from .factory import (
     SignIngressFactory,
     IngressModel,
     SignIngressesCollectionModel,
+    SignPeriodModel,
+    SignPeriodsCollectionModel,
 )
 
 __all__ = [
     "IngressModel",
     "SignIngressesCollectionModel",
     "SignIngressFactory",
+    "SignPeriodModel",
+    "SignPeriodsCollectionModel",
 ]

--- a/kerykeion/sign_ingresses/factory.py
+++ b/kerykeion/sign_ingresses/factory.py
@@ -297,18 +297,34 @@ class SignPeriodsCollectionModel(SubscriptableBaseModel):
     periods: List[SignPeriodModel]
 
 
+# An ingress within one second of a range bound IS that bound: the stay it
+# opens or closes meets the bound unclipped, and no hair-thin stay is emitted
+# on the far side of it. One second is far coarser than the bisection (which
+# resolves a crossing to milliseconds) and far finer than any real stay.
 _EDGE_TOL_DAYS = 1.0 / 86400.0
 
 
-def _entered_at_start(start_jd: float, body: int, iflag: int, sign0: int) -> bool:
-    """True when the sign read at ``start_jd`` was entered on that very
-    instant — the range starts on an ingress — so the first stay is not a
-    clipped one. Probes one second before the range; at the very edge of the
-    ephemeris that second does not exist and the stay counts as clipped."""
-    try:
-        return int(_lon(start_jd - _EDGE_TOL_DAYS, body, iflag) // 30) != sign0
-    except KerykeionException:
-        return False
+def _scan_edges(
+    name: str, body: int, start_jd: float, end_jd: float, iflag: int, tropical: bool, found: List[IngressModel]
+) -> List[IngressModel]:
+    """Crossings within the second just outside either bound — typically a
+    root this very factory produced, which bisection may leave a hair to either
+    side of the true instant — so the fold can treat them as sitting on the
+    bound. Scanned apart from the range so the in-range brackets, hence the
+    in-range instants, stay exactly those of :meth:`from_julian_day`. At the
+    very edge of the ephemeris that second does not exist and the bound
+    stands. A crossing the range scan already holds is not reported twice."""
+    edges: List[IngressModel] = []
+    before, after = start_jd - _EDGE_TOL_DAYS, end_jd + _EDGE_TOL_DAYS
+    for a, b, probe in ((before, start_jd, before), (end_jd, after, after)):
+        try:
+            _lon(probe, body, iflag)
+        except KerykeionException:
+            continue
+        for ingress in SignIngressFactory._scan_planet(name, body, a, b, iflag, tropical):
+            if all(abs(ingress.julian_day - known.julian_day) > _EDGE_TOL_DAYS for known in found):
+                edges.append(ingress)
+    return edges
 
 
 def _fold_sign_periods(
@@ -317,12 +333,13 @@ def _fold_sign_periods(
     ingresses: List[IngressModel],
     start_jd: float,
     end_jd: float,
-    entered_at_start: bool = False,
 ) -> List[SignPeriodModel]:
-    """Turn the sign at the range start plus the in-range ingresses into
-    contiguous stays: open at ``start_jd`` (clipped, unless the range starts
-    on the ingress itself), hand over at each ingress, close the last at
-    ``end_jd`` (clipped)."""
+    """Turn the sign at the range start plus the scanned ingresses into
+    contiguous stays: open at ``start_jd``, hand over at each ingress, close
+    the last at ``end_jd``. A stay that reaches a bound is clipped — unless an
+    ingress sits on that bound (within ``_EDGE_TOL_DAYS``, the scan's edge
+    probe): then the bound is the ingress, the stay opens or closes there
+    unclipped, and whatever lies beyond belongs to the neighbouring range."""
 
     def period(sign_num: int, a: float, b: float, a_clipped: bool, b_clipped: bool) -> SignPeriodModel:
         return SignPeriodModel(
@@ -338,14 +355,19 @@ def _fold_sign_periods(
         )
 
     out: List[SignPeriodModel] = []
-    cur_sign, cur_start, cur_clipped = sign0, start_jd, not entered_at_start
+    cur_sign, cur_start, cur_clipped = sign0, start_jd, True
     for ingress in sorted(ingresses, key=lambda i: i.julian_day):
-        if ingress.julian_day <= cur_start:
-            # An ingress on the very first sample: the snapshot already reads
-            # the entered sign, so the stay it would close is empty — and the
-            # stay that starts here was entered on the range start, not before.
+        if not out and cur_start == start_jd and ingress.julian_day <= start_jd + _EDGE_TOL_DAYS:
+            # On the range start: the entered sign opens the range, unclipped.
+            # The snapshot may read either side of the crossing — it does not
+            # matter, the ingress decides.
             cur_sign, cur_clipped = ingress.sign_num, False
             continue
+        if ingress.julian_day >= end_jd - _EDGE_TOL_DAYS:
+            # On the range end: the current stay closes there, unclipped; the
+            # entered sign is the next range's business.
+            out.append(period(cur_sign, cur_start, end_jd, cur_clipped, False))
+            return out
         out.append(period(cur_sign, cur_start, ingress.julian_day, cur_clipped, False))
         cur_sign, cur_start, cur_clipped = ingress.sign_num, ingress.julian_day, False
     out.append(period(cur_sign, cur_start, end_jd, cur_clipped, True))
@@ -476,6 +498,13 @@ class SignIngressFactory:
         sidereal stays with sidereal ingress instants. Per planet the periods
         are contiguous and ordered; an empty or inverted range yields none.
 
+        The in-range instants are exactly those :meth:`from_julian_day` reports
+        for the same range. The scan also looks one second beyond either bound:
+        a range that starts or ends on an ingress — say, on an instant this
+        factory reported — opens or closes the stay there unclipped instead of
+        emitting a hair-thin stay on the wrong side of the crossing. Beyond
+        that second nothing is searched outside the range.
+
         Raises:
             KerykeionException / ValueError: as :meth:`from_julian_day`.
         """
@@ -491,16 +520,8 @@ class SignIngressFactory:
                 for name, body in bodies:
                     sign0 = int(_lon(start_jd, body, iflag) // 30)
                     ingresses = SignIngressFactory._scan_planet(name, body, start_jd, end_jd, iflag, tropical)
-                    periods.extend(
-                        _fold_sign_periods(
-                            name,
-                            sign0,
-                            ingresses,
-                            start_jd,
-                            end_jd,
-                            entered_at_start=_entered_at_start(start_jd, body, iflag, sign0),
-                        )
-                    )
+                    ingresses += _scan_edges(name, body, start_jd, end_jd, iflag, tropical, ingresses)
+                    periods.extend(_fold_sign_periods(name, sign0, ingresses, start_jd, end_jd))
 
         return SignPeriodsCollectionModel(start_jd=start_jd, end_jd=end_jd, periods=periods)
 

--- a/kerykeion/sign_ingresses/factory.py
+++ b/kerykeion/sign_ingresses/factory.py
@@ -297,23 +297,26 @@ class SignPeriodsCollectionModel(SubscriptableBaseModel):
     periods: List[SignPeriodModel]
 
 
-# An ingress within one second of a range bound IS that bound: the stay it
-# opens or closes meets the bound unclipped, and no hair-thin stay is emitted
-# on the far side of it. One second is far coarser than the bisection (which
-# resolves a crossing to milliseconds) and far finer than any real stay.
-_EDGE_TOL_DAYS = 1.0 / 86400.0
+# An ingress within the solver's own resolution of a range bound IS that bound:
+# the stay it opens or closes meets the bound unclipped, and no hair-thin stay
+# is emitted on the far side of it. A twentieth of a second is ten times the
+# widest bisection error (a 7-day bracket halved 27 times: ~2 ms) and still
+# twenty times finer than the second the ISO output resolves — so it absorbs
+# the solver's error and nothing else: a crossing half a second inside the
+# range is a real boundary and stays one.
+_EDGE_TOL_DAYS = 0.05 / 86400.0
 
 
 def _scan_edges(
     name: str, body: int, start_jd: float, end_jd: float, iflag: int, tropical: bool, found: List[IngressModel]
 ) -> List[IngressModel]:
-    """Crossings within the second just outside either bound — typically a
-    root this very factory produced, which bisection may leave a hair to either
-    side of the true instant — so the fold can treat them as sitting on the
-    bound. Scanned apart from the range so the in-range brackets, hence the
-    in-range instants, stay exactly those of :meth:`from_julian_day`. At the
-    very edge of the ephemeris that second does not exist and the bound
-    stands. A crossing the range scan already holds is not reported twice."""
+    """Crossings within ``_EDGE_TOL_DAYS`` just outside either bound — a root
+    this very factory produced, which bisection may leave a hair to either side
+    of the true instant — so the fold can treat them as sitting on the bound.
+    Scanned apart from the range so the in-range brackets, hence the in-range
+    instants, stay exactly those of :meth:`from_julian_day`. At the very edge
+    of the ephemeris that sliver does not exist and the bound stands. A
+    crossing the range scan already holds is not reported twice."""
     edges: List[IngressModel] = []
     before, after = start_jd - _EDGE_TOL_DAYS, end_jd + _EDGE_TOL_DAYS
     for a, b, probe in ((before, start_jd, before), (end_jd, after, after)):
@@ -337,9 +340,11 @@ def _fold_sign_periods(
     """Turn the sign at the range start plus the scanned ingresses into
     contiguous stays: open at ``start_jd``, hand over at each ingress, close
     the last at ``end_jd``. A stay that reaches a bound is clipped — unless an
-    ingress sits on that bound (within ``_EDGE_TOL_DAYS``, the scan's edge
-    probe): then the bound is the ingress, the stay opens or closes there
-    unclipped, and whatever lies beyond belongs to the neighbouring range."""
+    ingress sits on that bound (within ``_EDGE_TOL_DAYS``, the solver's own
+    resolution): then the bound is the ingress, the stay opens or closes there
+    unclipped, and whatever lies beyond belongs to the neighbouring range. An
+    ingress farther inside the range than that is a real boundary, however
+    close to the bound."""
 
     def period(sign_num: int, a: float, b: float, a_clipped: bool, b_clipped: bool) -> SignPeriodModel:
         return SignPeriodModel(
@@ -499,11 +504,14 @@ class SignIngressFactory:
         are contiguous and ordered; an empty or inverted range yields none.
 
         The in-range instants are exactly those :meth:`from_julian_day` reports
-        for the same range. The scan also looks one second beyond either bound:
-        a range that starts or ends on an ingress — say, on an instant this
-        factory reported — opens or closes the stay there unclipped instead of
-        emitting a hair-thin stay on the wrong side of the crossing. Beyond
-        that second nothing is searched outside the range.
+        for the same range. The scan also looks a solver's resolution (a
+        twentieth of a second) beyond either bound: a range that starts or ends
+        on an ingress — on an instant this factory reported, which bisection
+        leaves a few milliseconds off the true crossing — opens or closes the
+        stay there unclipped instead of emitting a hair-thin stay on the wrong
+        side of the crossing. An ingress any farther from a bound, inside or
+        outside the range, is what it is: a boundary or not in range. Beyond
+        that sliver nothing is searched outside the range.
 
         Raises:
             KerykeionException / ValueError: as :meth:`from_julian_day`.

--- a/kerykeion/sign_ingresses/factory.py
+++ b/kerykeion/sign_ingresses/factory.py
@@ -297,12 +297,32 @@ class SignPeriodsCollectionModel(SubscriptableBaseModel):
     periods: List[SignPeriodModel]
 
 
+_EDGE_TOL_DAYS = 1.0 / 86400.0
+
+
+def _entered_at_start(start_jd: float, body: int, iflag: int, sign0: int) -> bool:
+    """True when the sign read at ``start_jd`` was entered on that very
+    instant — the range starts on an ingress — so the first stay is not a
+    clipped one. Probes one second before the range; at the very edge of the
+    ephemeris that second does not exist and the stay counts as clipped."""
+    try:
+        return int(_lon(start_jd - _EDGE_TOL_DAYS, body, iflag) // 30) != sign0
+    except KerykeionException:
+        return False
+
+
 def _fold_sign_periods(
-    name: str, sign0: int, ingresses: List[IngressModel], start_jd: float, end_jd: float
+    name: str,
+    sign0: int,
+    ingresses: List[IngressModel],
+    start_jd: float,
+    end_jd: float,
+    entered_at_start: bool = False,
 ) -> List[SignPeriodModel]:
     """Turn the sign at the range start plus the in-range ingresses into
-    contiguous stays: open at ``start_jd`` (clipped), hand over at each
-    ingress, close the last at ``end_jd`` (clipped)."""
+    contiguous stays: open at ``start_jd`` (clipped, unless the range starts
+    on the ingress itself), hand over at each ingress, close the last at
+    ``end_jd`` (clipped)."""
 
     def period(sign_num: int, a: float, b: float, a_clipped: bool, b_clipped: bool) -> SignPeriodModel:
         return SignPeriodModel(
@@ -318,12 +338,13 @@ def _fold_sign_periods(
         )
 
     out: List[SignPeriodModel] = []
-    cur_sign, cur_start, cur_clipped = sign0, start_jd, True
+    cur_sign, cur_start, cur_clipped = sign0, start_jd, not entered_at_start
     for ingress in sorted(ingresses, key=lambda i: i.julian_day):
         if ingress.julian_day <= cur_start:
             # An ingress on the very first sample: the snapshot already reads
-            # the entered sign, so the stay it would close is empty.
-            cur_sign = ingress.sign_num
+            # the entered sign, so the stay it would close is empty — and the
+            # stay that starts here was entered on the range start, not before.
+            cur_sign, cur_clipped = ingress.sign_num, False
             continue
         out.append(period(cur_sign, cur_start, ingress.julian_day, cur_clipped, False))
         cur_sign, cur_start, cur_clipped = ingress.sign_num, ingress.julian_day, False
@@ -470,7 +491,16 @@ class SignIngressFactory:
                 for name, body in bodies:
                     sign0 = int(_lon(start_jd, body, iflag) // 30)
                     ingresses = SignIngressFactory._scan_planet(name, body, start_jd, end_jd, iflag, tropical)
-                    periods.extend(_fold_sign_periods(name, sign0, ingresses, start_jd, end_jd))
+                    periods.extend(
+                        _fold_sign_periods(
+                            name,
+                            sign0,
+                            ingresses,
+                            start_jd,
+                            end_jd,
+                            entered_at_start=_entered_at_start(start_jd, body, iflag, sign0),
+                        )
+                    )
 
         return SignPeriodsCollectionModel(start_jd=start_jd, end_jd=end_jd, periods=periods)
 

--- a/kerykeion/sign_ingresses/factory.py
+++ b/kerykeion/sign_ingresses/factory.py
@@ -142,6 +142,45 @@ def _lon(jd: float, body: int, iflag: int) -> float:
         ) from exc
 
 
+def _iso_range_to_jd(start_date: str, end_date: str) -> tuple[float, float]:
+    """ISO date(time) strings (treated as UTC) → Julian Day bounds.
+
+    A date-only end means "through the end of that UTC day".
+    """
+    try:
+        start_dt = _to_utc_naive(datetime.fromisoformat(start_date))
+        end_dt = _to_utc_naive(datetime.fromisoformat(end_date))
+    except (ValueError, TypeError) as exc:
+        # Wrap the bare datetime error as the library's own exception, so a
+        # caller catching KerykeionException around this entry point is not
+        # broken by a malformed ISO start_date/end_date. Same contract as
+        # LunationFinderFactory.from_iso_range.
+        raise KerykeionException(
+            f"Invalid ISO date/datetime for ingress range "
+            f"(start_date={start_date!r}, end_date={end_date!r}): {exc}"
+        ) from exc
+    # Parse as a date so every valid datetime separator remains exact.
+    if is_iso_date_only(end_date):
+        end_dt = end_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return datetime_to_julian(start_dt), datetime_to_julian(end_dt)
+
+
+def _resolve_bodies(planets: Optional[List[str]]) -> List[tuple[str, int]]:
+    """Requested planet names → (name, id) pairs; ``None`` = the default set."""
+    # None = default set; an explicit empty list = scan nothing.
+    if planets is None:
+        return list(_INGRESS_PLANETS)
+    invalid = sorted(set(planets) - set(_PLANET_IDS))
+    if invalid:
+        raise ValueError(
+            f"Unknown planets: {', '.join(invalid)}. "
+            f"Valid: {', '.join(_PLANET_IDS)}"
+        )
+    # Deduplicate (preserve order): duplicates would repeat the scan and
+    # emit every event multiple times.
+    return [(name, _PLANET_IDS[name]) for name in dict.fromkeys(planets)]
+
+
 def _sign_name(sign_num: int) -> str:
     """Zodiac sign name for an index (0=Aries), via the shared degree helper."""
     return get_kerykeion_point_from_degree(
@@ -230,6 +269,68 @@ class SignIngressesCollectionModel(SubscriptableBaseModel):
     ingresses: List[IngressModel]
 
 
+class SignPeriodModel(SubscriptableBaseModel):
+    """One stay of a planet in a sign, clipped to the requested range.
+
+    Consecutive periods of the same planet are contiguous (``end`` of one is
+    the ``start`` of the next — the ingress instant) and together cover the
+    whole range. The clip flags say whether a bound is the range edge rather
+    than a real ingress.
+    """
+
+    planet: str = Field(description="Planet name (kerykeion AstrologicalPoint vocabulary)")
+    sign: str = Field(description="Sign the planet is in")
+    sign_num: int = Field(description="Sign number (0=Aries)")
+    start_jd: float = Field(description="Julian Day (UT) the stay begins (clipped to the range start)")
+    end_jd: float = Field(description="Julian Day (UT) the stay ends (clipped to the range end)")
+    start: str = Field(description="ISO 8601 UTC of start_jd")
+    end: str = Field(description="ISO 8601 UTC of end_jd")
+    start_clipped: bool = Field(description="True when the sign was entered before the range")
+    end_clipped: bool = Field(description="True when the sign is left after the range")
+
+
+class SignPeriodsCollectionModel(SubscriptableBaseModel):
+    """Sign stays of every requested planet across a Julian Day range."""
+
+    start_jd: float
+    end_jd: float
+    periods: List[SignPeriodModel]
+
+
+def _fold_sign_periods(
+    name: str, sign0: int, ingresses: List[IngressModel], start_jd: float, end_jd: float
+) -> List[SignPeriodModel]:
+    """Turn the sign at the range start plus the in-range ingresses into
+    contiguous stays: open at ``start_jd`` (clipped), hand over at each
+    ingress, close the last at ``end_jd`` (clipped)."""
+
+    def period(sign_num: int, a: float, b: float, a_clipped: bool, b_clipped: bool) -> SignPeriodModel:
+        return SignPeriodModel(
+            planet=name,
+            sign=_sign_name(sign_num),
+            sign_num=sign_num % 12,
+            start_jd=a,
+            end_jd=b,
+            start=_jd_to_iso(a),
+            end=_jd_to_iso(b),
+            start_clipped=a_clipped,
+            end_clipped=b_clipped,
+        )
+
+    out: List[SignPeriodModel] = []
+    cur_sign, cur_start, cur_clipped = sign0, start_jd, True
+    for ingress in sorted(ingresses, key=lambda i: i.julian_day):
+        if ingress.julian_day <= cur_start:
+            # An ingress on the very first sample: the snapshot already reads
+            # the entered sign, so the stay it would close is empty.
+            cur_sign = ingress.sign_num
+            continue
+        out.append(period(cur_sign, cur_start, ingress.julian_day, cur_clipped, False))
+        cur_sign, cur_start, cur_clipped = ingress.sign_num, ingress.julian_day, False
+    out.append(period(cur_sign, cur_start, end_jd, cur_clipped, True))
+    return out
+
+
 # =============================================================================
 # FACTORY
 # =============================================================================
@@ -265,23 +366,7 @@ class SignIngressFactory:
                 is ``None`` on every sidereal ingress.
             sidereal_mode: Ayanamsha when ``zodiac_type='Sidereal'``.
         """
-        try:
-            start_dt = _to_utc_naive(datetime.fromisoformat(start_date))
-            end_dt = _to_utc_naive(datetime.fromisoformat(end_date))
-        except (ValueError, TypeError) as exc:
-            # Wrap the bare datetime error as the library's own exception, so a
-            # caller catching KerykeionException around this entry point is not
-            # broken by a malformed ISO start_date/end_date. Same contract as
-            # LunationFinderFactory.from_iso_range.
-            raise KerykeionException(
-                f"Invalid ISO date/datetime for ingress range "
-                f"(start_date={start_date!r}, end_date={end_date!r}): {exc}"
-            ) from exc
-        # Parse as a date so every valid datetime separator remains exact.
-        if is_iso_date_only(end_date):
-            end_dt = end_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
-        start_jd = datetime_to_julian(start_dt)
-        end_jd = datetime_to_julian(end_dt)
+        start_jd, end_jd = _iso_range_to_jd(start_date, end_date)
         return SignIngressFactory.from_julian_day(start_jd, end_jd, planets, zodiac_type, sidereal_mode)
 
     @staticmethod
@@ -312,21 +397,7 @@ class SignIngressFactory:
                 non-finite, or the range is too large to scan.
         """
         validate_julian_bounds(start_jd, end_jd)
-
-        # None = default set; an explicit empty list = scan nothing.
-        if planets is not None:
-            invalid = sorted(set(planets) - set(_PLANET_IDS))
-            if invalid:
-                raise ValueError(
-                    f"Unknown planets: {', '.join(invalid)}. "
-                    f"Valid: {', '.join(_PLANET_IDS)}"
-                )
-            # Deduplicate (preserve order): duplicates would repeat the scan and
-            # emit every event multiple times.
-            bodies = [(name, _PLANET_IDS[name]) for name in dict.fromkeys(planets)]
-        else:
-            bodies = list(_INGRESS_PLANETS)
-
+        bodies = _resolve_bodies(planets)
         _validate_zodiac(zodiac_type, sidereal_mode)
         # season_marker is meaningful ONLY in the tropical frame: the Sun
         # crossing a SIDEREAL cardinal boundary is not the equinox/solstice.
@@ -351,6 +422,57 @@ class SignIngressFactory:
             end_jd=end_jd,
             ingresses=ingresses,
         )
+
+    @staticmethod
+    def sign_periods_from_iso_range(
+        start_date: str,
+        end_date: str,
+        planets: Optional[List[str]] = None,
+        zodiac_type: ZodiacType = "Tropical",
+        sidereal_mode: Optional[SiderealMode] = None,
+    ) -> SignPeriodsCollectionModel:
+        """Where each planet is, sign by sign, between two ISO date(time) strings.
+
+        Same arguments as :meth:`from_iso_range`. The Moon is opt-in here too
+        (``planets=[..., "Moon"]``).
+        """
+        start_jd, end_jd = _iso_range_to_jd(start_date, end_date)
+        return SignIngressFactory.sign_periods_from_julian_day(start_jd, end_jd, planets, zodiac_type, sidereal_mode)
+
+    @staticmethod
+    def sign_periods_from_julian_day(
+        start_jd: float,
+        end_jd: float,
+        planets: Optional[List[str]] = None,
+        zodiac_type: ZodiacType = "Tropical",
+        sidereal_mode: Optional[SiderealMode] = None,
+    ) -> SignPeriodsCollectionModel:
+        """Sign stays of each planet across ``[start_jd, end_jd]``, clipped to it.
+
+        The sign at the range start is read in the same ephemeris session (same
+        zodiac frame) as the ingress scan, so the first period and the
+        ingresses that follow it can never disagree — a sidereal request gets
+        sidereal stays with sidereal ingress instants. Per planet the periods
+        are contiguous and ordered; an empty or inverted range yields none.
+
+        Raises:
+            KerykeionException / ValueError: as :meth:`from_julian_day`.
+        """
+        validate_julian_bounds(start_jd, end_jd)
+        bodies = _resolve_bodies(planets)
+        _validate_zodiac(zodiac_type, sidereal_mode)
+        tropical = zodiac_type != "Sidereal"
+
+        periods: List[SignPeriodModel] = []
+        if end_jd > start_jd and bodies:
+            _ensure_scannable(start_jd, end_jd, bodies)
+            with ephemeris_session(zodiac_type=zodiac_type, sidereal_mode=sidereal_mode) as iflag:
+                for name, body in bodies:
+                    sign0 = int(_lon(start_jd, body, iflag) // 30)
+                    ingresses = SignIngressFactory._scan_planet(name, body, start_jd, end_jd, iflag, tropical)
+                    periods.extend(_fold_sign_periods(name, sign0, ingresses, start_jd, end_jd))
+
+        return SignPeriodsCollectionModel(start_jd=start_jd, end_jd=end_jd, periods=periods)
 
     @staticmethod
     def _scan_planet(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kerykeion"
-version = "6.0.0a91"
+version = "6.0.0a92"
 authors = [
     { name = "Giacomo Battaglia", email = "kerykeion.astrology@gmail.com" }
 ]

--- a/release_notes/v6.0.0a92.md
+++ b/release_notes/v6.0.0a92.md
@@ -29,18 +29,20 @@ the ingresses that follow it, because both come from one frame and one lock.
 `RetrogradePeriodModel` spans: a retrograde station opens one, a direct
 station closes it, and the range edges clip — a planet already retrograde on
 the 1st is reported from the 1st with `start_clipped=True`, one still
-retrograde on the 31st with `end_clipped=True`. Beyond the one-second probe
+retrograde on the 31st with `end_clipped=True`. Beyond the edge probe
 described below, nothing is searched outside the range: a clipped bound says
 *where the range cut it*, not where the real station is. Stations that do not
 alternate raise loudly.
 
-The edges are decided deterministically: the scan looks one second beyond
-either bound, so a station sitting on the range start is bracketed and found,
-and it — not the sign of a speed that is numerically ~0 there — sets the
-initial state; a station sitting on the range end closes its span unclipped.
-Both matter when the bounds are instants this library reported, which
-bisection leaves a hair to either side of the true zero. A span is as short
-as the range makes it: only an empty one is dropped. Periods carry no sign: station instants are zodiac-independent.
+The edges are decided deterministically: the scan looks a solver's resolution
+(50 ms — ten times the bisection's error, twenty times finer than the second
+the ISO strings resolve) beyond either bound, so a station sitting on the
+range start is bracketed and found, and it — not the sign of a speed that is
+numerically ~0 there — sets the initial state; a station sitting on the range
+end closes its span unclipped. Both matter when the bounds are instants this
+library reported, which bisection leaves a hair to either side of the true
+zero. A station any farther from a bound is a real station, however close.
+A span is as short as the range makes it: only an empty one is dropped. Periods carry no sign: station instants are zodiac-independent.
 
 ## Chiron, opt-in
 
@@ -59,6 +61,7 @@ string); March 2025 with Venus open at the start and Mercury from its station;
 the range edges bounded by the library's own instants — the Sun's Aries
 ingress of every year 2019–2027 as the range start and as the range end,
 every Mercury direct station of 2020–2025 as the range end, a station on the
-range start — and a half-second range inside a retrograde; Chiron opt-in and
+range start — bounds half a second off an ingress or a station (real
+boundaries, not edges) and a half-second range inside a retrograde; Chiron opt-in and
 luminaries still rejected; identical span times under a sidereal zodiac.
 12 613 green on the branch head.

--- a/release_notes/v6.0.0a92.md
+++ b/release_notes/v6.0.0a92.md
@@ -34,10 +34,13 @@ described below, nothing is searched outside the range: a clipped bound says
 *where the range cut it*, not where the real station is. Stations that do not
 alternate raise loudly.
 
-The edge is decided deterministically: the scan starts one second before the
-range, so a station sitting on the range start is bracketed and found, and
-it — not the sign of a speed that is numerically ~0 there — sets the initial
-state. Periods carry no sign: station instants are zodiac-independent.
+The edges are decided deterministically: the scan looks one second beyond
+either bound, so a station sitting on the range start is bracketed and found,
+and it — not the sign of a speed that is numerically ~0 there — sets the
+initial state; a station sitting on the range end closes its span unclipped.
+Both matter when the bounds are instants this library reported, which
+bisection leaves a hair to either side of the true zero. A span is as short
+as the range makes it: only an empty one is dropped. Periods carry no sign: station instants are zodiac-independent.
 
 ## Chiron, opt-in
 

--- a/release_notes/v6.0.0a92.md
+++ b/release_notes/v6.0.0a92.md
@@ -56,5 +56,9 @@ to the ingress instants; the Moon's 13–14 stays per month with boundaries
 within one second of the void-of-course ends (the two finders refine
 differently — Newton vs bisection — so equality is by tolerance, never by
 string); March 2025 with Venus open at the start and Mercury from its station;
-a station on the range start; Chiron opt-in and luminaries still rejected;
-identical span times under a sidereal zodiac.
+the range edges bounded by the library's own instants — the Sun's Aries
+ingress of every year 2019–2027 as the range start and as the range end,
+every Mercury direct station of 2020–2025 as the range end, a station on the
+range start — and a half-second range inside a retrograde; Chiron opt-in and
+luminaries still rejected; identical span times under a sidereal zodiac.
+12 613 green on the branch head.

--- a/release_notes/v6.0.0a92.md
+++ b/release_notes/v6.0.0a92.md
@@ -1,0 +1,56 @@
+# v6.0.0a92 — Where every planet is, and who is retrograde
+
+Two questions an astrological calendar asks every month, and that the event
+finders alone cannot answer: *in which sign is Jupiter on the 1st?* and *is
+Saturn retrograde right now?* The ingress and station finders report what
+*changes* inside a range; a planet that neither ingresses nor stations in a
+month left no trace. This release adds the stays and the spans themselves.
+
+---
+
+## Sign periods
+
+`SignIngressFactory.sign_periods_from_iso_range(start, end, planets=None, zodiac_type, sidereal_mode)`
+returns, per planet, the contiguous list of `SignPeriodModel` covering the
+whole range: the first stay opens at the range start (`start_clipped=True`),
+each ingress hands over to the next stay (`end` of one is the `start` of the
+next — the ingress instant, to the same bisection), and the last stay closes
+at the range end (`end_clipped=True`). The Moon is opt-in, as for ingresses.
+
+The sign at the range start is read *inside the same ephemeris session* as
+the scan, with the session's `iflag`. That is the whole reason this lives in
+the library rather than in a caller: a sidereal request yields sidereal stays
+with sidereal ingress instants, and the first stay can never disagree with
+the ingresses that follow it, because both come from one frame and one lock.
+
+## Retrograde periods
+
+`RetrogradeStationFactory.retrograde_periods_from_iso_range(...)` returns
+`RetrogradePeriodModel` spans: a retrograde station opens one, a direct
+station closes it, and the range edges clip — a planet already retrograde on
+the 1st is reported from the 1st with `start_clipped=True`, one still
+retrograde on the 31st with `end_clipped=True`. Nothing is searched outside
+the range: a clipped bound says *where the range cut it*, not where the real
+station is. Stations that do not alternate raise loudly.
+
+The edge is decided deterministically: the scan starts one second before the
+range, so a station sitting on the range start is bracketed and found, and
+it — not the sign of a speed that is numerically ~0 there — sets the initial
+state. Periods carry no sign: station instants are zodiac-independent.
+
+## Chiron, opt-in
+
+`"Chiron"` is now accepted by the station finder and by the retrograde
+periods; the default set stays Mercury..Pluto, so existing outputs and
+baselines are byte-identical.
+
+## Tests
+
+Sun stays around the 2026 equinox (`Pis` → `Ari` on 20 March; `Aqu` → `Pis`
+on 14 March under LAHIRI); contiguity and clip flags; stay boundaries equal
+to the ingress instants; the Moon's 13–14 stays per month with boundaries
+within one second of the void-of-course ends (the two finders refine
+differently — Newton vs bisection — so equality is by tolerance, never by
+string); March 2025 with Venus open at the start and Mercury from its station;
+a station on the range start; Chiron opt-in and luminaries still rejected;
+identical span times under a sidereal zodiac.

--- a/release_notes/v6.0.0a92.md
+++ b/release_notes/v6.0.0a92.md
@@ -64,4 +64,4 @@ every Mercury direct station of 2020–2025 as the range end, a station on the
 range start — bounds half a second off an ingress or a station (real
 boundaries, not edges) and a half-second range inside a retrograde; Chiron opt-in and
 luminaries still rejected; identical span times under a sidereal zodiac.
-12 613 green on the branch head.
+12 616 green on the branch head.

--- a/release_notes/v6.0.0a92.md
+++ b/release_notes/v6.0.0a92.md
@@ -29,9 +29,10 @@ the ingresses that follow it, because both come from one frame and one lock.
 `RetrogradePeriodModel` spans: a retrograde station opens one, a direct
 station closes it, and the range edges clip — a planet already retrograde on
 the 1st is reported from the 1st with `start_clipped=True`, one still
-retrograde on the 31st with `end_clipped=True`. Nothing is searched outside
-the range: a clipped bound says *where the range cut it*, not where the real
-station is. Stations that do not alternate raise loudly.
+retrograde on the 31st with `end_clipped=True`. Beyond the one-second probe
+described below, nothing is searched outside the range: a clipped bound says
+*where the range cut it*, not where the real station is. Stations that do not
+alternate raise loudly.
 
 The edge is decided deterministically: the scan starts one second before the
 range, so a station sitting on the range start is bracketed and found, and

--- a/skills/kerykeion/SKILL.md
+++ b/skills/kerykeion/SKILL.md
@@ -21,7 +21,7 @@ license: AGPL-3.0
 
 # Using Kerykeion
 
-Verified against **kerykeion 6.0.0a91**, Python 3.12+.
+Verified against **kerykeion 6.0.0a92**, Python 3.12+.
 
 Kerykeion is a Python astrology library. Everything goes through **factories**:
 you never construct models by hand. Factories return **Pydantic models** whose

--- a/skills/kerykeion/references/api-index.md
+++ b/skills/kerykeion/references/api-index.md
@@ -236,6 +236,8 @@ answer "where is X documented?"; the domain file is always the richer source.
 | `resolve_subject_local_now` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
 | `RetrogradeStationFactory` | factory | `references/mundane-events.md` |
 | `RetrogradeStationsCollectionModel` | model | `references/mundane-events.md` |
+| `RetrogradePeriodModel` | model | `references/mundane-events.md` |
+| `RetrogradePeriodsCollectionModel` | model | `references/mundane-events.md` |
 | `ReturnType` | literal — `kerykeion.schemas` | `references/predictive.md` |
 | `ROYAL_FIXED_STARS` | subpackage import — `kerykeion.settings.config_constants` | `references/subjects.md` |
 | `safe_timezone` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
@@ -247,6 +249,8 @@ answer "where is X documented?"; the domain file is always the richer source.
 | `Sign` | literal — `kerykeion.schemas` | `references/subjects.md` |
 | `SIGN_CODES` | literal — `kerykeion.schemas` | `references/zodiac-houses-perspectives.md` |
 | `SignIngressesCollectionModel` | model | `references/mundane-events.md` |
+| `SignPeriodModel` | model | `references/mundane-events.md` |
+| `SignPeriodsCollectionModel` | model | `references/mundane-events.md` |
 | `SignIngressFactory` | factory | `references/mundane-events.md` |
 | `SignNumbers` | literal — `kerykeion.schemas` | `references/subjects.md` |
 | `single_chart_data_to_context` | subpackage import — `kerykeion.context` | `references/reports-and-ai-context.md` |

--- a/skills/kerykeion/references/mundane-events.md
+++ b/skills/kerykeion/references/mundane-events.md
@@ -121,14 +121,15 @@ Pluto` (Sun/Moon never station and are not accepted). `StationModel`: `planet`,
 
 ### Retrograde periods (a92)
 
-`RetrogradeStationFactory.retrograde_periods_from_iso_range(start, end, planets=None, zodiac_type, sidereal_mode)`
+`RetrogradeStationFactory.retrograde_periods_from_iso_range(start, end, planets=None, zodiac_type="Tropical", sidereal_mode=None)`
 / `retrograde_periods_from_julian_day(...)` → `RetrogradePeriodsCollectionModel`
 (`start_jd`, `end_jd`, `periods`). Each `RetrogradePeriodModel` is one retrograde
 span clipped to the range: `planet`, `start_jd`, `end_jd`, `start`, `end`,
 `start_clipped`, `end_clipped`. The motion state at the range start comes from
-the speed there (a station on the first second decides it deterministically);
-SR opens a span, SD closes it; clipped bounds are flagged and nothing is
-searched outside the range. `"Chiron"` is accepted opt-in by both the station
+the speed there, refined by a one-second probe before the range so a station
+sitting on the range start decides it deterministically; SR opens a span, SD
+closes it; clipped bounds are flagged, and beyond that probe nothing is
+searched outside the range — returned periods stay clipped to it. `"Chiron"` is accepted opt-in by both the station
 finder and the periods (default set unchanged).
 
 ## SignIngressFactory
@@ -372,11 +373,11 @@ hours in `references/calendars-hours-moon.md`.
 
 ### Sign periods (a92)
 
-`SignIngressFactory.sign_periods_from_iso_range(start, end, planets=None, zodiac_type, sidereal_mode)`
+`SignIngressFactory.sign_periods_from_iso_range(start, end, planets=None, zodiac_type="Tropical", sidereal_mode=None)`
 / `sign_periods_from_julian_day(...)` → `SignPeriodsCollectionModel` (`start_jd`,
 `end_jd`, `periods`). Per planet, contiguous `SignPeriodModel` stays covering
 the whole range: `planet`, `sign`, `sign_num`, `start_jd`, `end_jd`, `start`,
 `end`, `start_clipped`, `end_clipped`. The sign at the range start is read in
 the same ephemeris session (same frame) as the ingress scan, so stays and
-ingresses never disagree — a sidereal request yields sidereal stays. The Moon
+ingresses never disagree — a sidereal request yields sidereal stays. A range that starts exactly on an ingress opens an unclipped stay (a one-second probe before the range tells). The Moon
 is opt-in, as for ingresses.

--- a/skills/kerykeion/references/mundane-events.md
+++ b/skills/kerykeion/references/mundane-events.md
@@ -119,6 +119,18 @@ Pluto` (Sun/Moon never station and are not accepted). `StationModel`: `planet`,
 `station_type` (`"SR"` = turns retrograde, `"SD"` = turns direct),
 `julian_day`, `iso_utc`, `sign`, `sign_num`, `degree`, `ecliptic_longitude`.
 
+### Retrograde periods (a92)
+
+`RetrogradeStationFactory.retrograde_periods_from_iso_range(start, end, planets=None, zodiac_type, sidereal_mode)`
+/ `retrograde_periods_from_julian_day(...)` → `RetrogradePeriodsCollectionModel`
+(`start_jd`, `end_jd`, `periods`). Each `RetrogradePeriodModel` is one retrograde
+span clipped to the range: `planet`, `start_jd`, `end_jd`, `start`, `end`,
+`start_clipped`, `end_clipped`. The motion state at the range start comes from
+the speed there (a station on the first second decides it deterministically);
+SR opens a span, SD closes it; clipped bounds are flagged and nothing is
+searched outside the range. `"Chiron"` is accepted opt-in by both the station
+finder and the periods (default set unchanged).
+
 ## SignIngressFactory
 
 Static; same pair of entry points with `planets=None` →
@@ -357,3 +369,14 @@ Cross-references: subjects in `references/subjects.md`; provenance in
 `references/backends-and-provenance.md`; sidereal modes in
 `references/zodiac-houses-perspectives.md`; VoC Moon / sun times / planetary
 hours in `references/calendars-hours-moon.md`.
+
+### Sign periods (a92)
+
+`SignIngressFactory.sign_periods_from_iso_range(start, end, planets=None, zodiac_type, sidereal_mode)`
+/ `sign_periods_from_julian_day(...)` → `SignPeriodsCollectionModel` (`start_jd`,
+`end_jd`, `periods`). Per planet, contiguous `SignPeriodModel` stays covering
+the whole range: `planet`, `sign`, `sign_num`, `start_jd`, `end_jd`, `start`,
+`end`, `start_clipped`, `end_clipped`. The sign at the range start is read in
+the same ephemeris session (same frame) as the ingress scan, so stays and
+ingresses never disagree — a sidereal request yields sidereal stays. The Moon
+is opt-in, as for ingresses.

--- a/skills/kerykeion/references/mundane-events.md
+++ b/skills/kerykeion/references/mundane-events.md
@@ -126,10 +126,11 @@ Pluto` (Sun/Moon never station and are not accepted). `StationModel`: `planet`,
 (`start_jd`, `end_jd`, `periods`). Each `RetrogradePeriodModel` is one retrograde
 span clipped to the range: `planet`, `start_jd`, `end_jd`, `start`, `end`,
 `start_clipped`, `end_clipped`. The motion state at the range start comes from
-the speed there, refined by a one-second probe before the range so a station
-sitting on the range start decides it deterministically; SR opens a span, SD
-closes it; clipped bounds are flagged, and beyond that probe nothing is
-searched outside the range — returned periods stay clipped to it. `"Chiron"` is accepted opt-in by both the station
+the speed there, refined by a one-second probe past either bound so a station
+sitting on the range start decides it deterministically and one sitting on the
+range end closes the span unclipped; SR opens a span, SD closes it; clipped
+bounds are flagged, and beyond that probe nothing is searched outside the
+range — returned periods stay clipped to it. `"Chiron"` is accepted opt-in by both the station
 finder and the periods (default set unchanged).
 
 ## SignIngressFactory
@@ -379,5 +380,5 @@ hours in `references/calendars-hours-moon.md`.
 the whole range: `planet`, `sign`, `sign_num`, `start_jd`, `end_jd`, `start`,
 `end`, `start_clipped`, `end_clipped`. The sign at the range start is read in
 the same ephemeris session (same frame) as the ingress scan, so stays and
-ingresses never disagree — a sidereal request yields sidereal stays. A range that starts exactly on an ingress opens an unclipped stay (a one-second probe before the range tells). The Moon
+ingresses never disagree — a sidereal request yields sidereal stays. A range that starts or ends exactly on an ingress opens or closes the stay there, unclipped (the scan looks one second beyond either bound). The Moon
 is opt-in, as for ingresses.

--- a/skills/kerykeion/references/mundane-events.md
+++ b/skills/kerykeion/references/mundane-events.md
@@ -126,11 +126,11 @@ Pluto` (Sun/Moon never station and are not accepted). `StationModel`: `planet`,
 (`start_jd`, `end_jd`, `periods`). Each `RetrogradePeriodModel` is one retrograde
 span clipped to the range: `planet`, `start_jd`, `end_jd`, `start`, `end`,
 `start_clipped`, `end_clipped`. The motion state at the range start comes from
-the speed there, refined by a one-second probe past either bound so a station
-sitting on the range start decides it deterministically and one sitting on the
-range end closes the span unclipped; SR opens a span, SD closes it; clipped
-bounds are flagged, and beyond that probe nothing is searched outside the
-range — returned periods stay clipped to it. `"Chiron"` is accepted opt-in by both the station
+the speed there, refined by a probe a solver's resolution (50 ms) past either
+bound so a station sitting on the range start decides it deterministically and
+one sitting on the range end closes the span unclipped — a station any farther
+in is a real station; SR opens a span, SD closes it; clipped bounds are
+flagged, and beyond that probe nothing is searched outside the range — returned periods stay clipped to it. `"Chiron"` is accepted opt-in by both the station
 finder and the periods (default set unchanged).
 
 ## SignIngressFactory
@@ -380,5 +380,5 @@ hours in `references/calendars-hours-moon.md`.
 the whole range: `planet`, `sign`, `sign_num`, `start_jd`, `end_jd`, `start`,
 `end`, `start_clipped`, `end_clipped`. The sign at the range start is read in
 the same ephemeris session (same frame) as the ingress scan, so stays and
-ingresses never disagree — a sidereal request yields sidereal stays. A range that starts or ends exactly on an ingress opens or closes the stay there, unclipped (the scan looks one second beyond either bound). The Moon
+ingresses never disagree — a sidereal request yields sidereal stays. A range that starts or ends exactly on an ingress opens or closes the stay there, unclipped (the scan looks a solver's resolution — 50 ms — beyond either bound; an ingress any farther in is a real boundary). The Moon
 is opt-in, as for ingresses.

--- a/skills/kerykeion/references/traditional.md
+++ b/skills/kerykeion/references/traditional.md
@@ -24,7 +24,7 @@ zodiacal_releasing,horary,primary_directions,receptions}/factory.py`, plus
 
 ## Frame prerequisites and refusals
 
-Each factory validates its own prerequisites and raises `KerykeionException`. Verified in 6.0.0a91:
+Each factory validates its own prerequisites and raises `KerykeionException`. Verified in 6.0.0a92:
 
 | Factory | Heliocentric / barycentric / selenocentric / planetocentric subject | Midpoint composite subject |
 |---|---|---|

--- a/tests/core/test_retrograde_periods.py
+++ b/tests/core/test_retrograde_periods.py
@@ -90,7 +90,10 @@ class TestEdges:
         sr = next(s for s in stations if s.station_type == "SR")
         sd = next(s for s in stations if s.station_type == "SD")
         half = 0.5 / 86400.0
-        periods = lambda a, b: RetrogradeStationFactory.retrograde_periods_from_julian_day(a, b, ["Mercury"]).periods
+
+        def periods(a, b):
+            return RetrogradeStationFactory.retrograde_periods_from_julian_day(a, b, ["Mercury"]).periods
+
         starting_before = periods(sr.julian_day - half, sr.julian_day + 10)
         assert [(p.start_clipped, p.end_clipped) for p in starting_before] == [(False, True)]
         assert 0 < starting_before[0].start_jd - (sr.julian_day - half) < 2 * half
@@ -101,6 +104,28 @@ class TestEdges:
         ending_after = periods(sd.julian_day - 10, sd.julian_day + half)
         assert [(p.start_clipped, p.end_clipped) for p in ending_after] == [(True, False)]
         assert 0 < (sd.julian_day + half) - ending_after[0].end_jd < 2 * half
+
+    def test_a_range_shorter_than_the_tolerance_straddling_a_station_keeps_its_motion(self):
+        # 40 ms around a station: the station is within the solver's resolution
+        # of BOTH bounds. It goes to the bound that keeps the motion the range
+        # contains — an SD to the end (retrograde until it), an SR to the start
+        # (retrograde from it) — never to a bound that empties the span.
+        stations = RetrogradeStationFactory.from_iso_range("2020-06-01", "2020-07-31", ["Mercury"]).stations
+        sr = next(s for s in stations if s.station_type == "SR")
+        sd = next(s for s in stations if s.station_type == "SD")
+        tick = 0.02 / 86400.0
+        around_sd = RetrogradeStationFactory.retrograde_periods_from_julian_day(
+            sd.julian_day - tick, sd.julian_day + tick, ["Mercury"]
+        )
+        assert [(p.start_jd, p.end_jd, p.start_clipped, p.end_clipped) for p in around_sd.periods] == [
+            (sd.julian_day - tick, sd.julian_day + tick, True, False)
+        ]
+        around_sr = RetrogradeStationFactory.retrograde_periods_from_julian_day(
+            sr.julian_day - tick, sr.julian_day + tick, ["Mercury"]
+        )
+        assert [(p.start_jd, p.end_jd, p.start_clipped, p.end_clipped) for p in around_sr.periods] == [
+            (sr.julian_day - tick, sr.julian_day + tick, False, True)
+        ]
 
     def test_a_sub_second_range_inside_retrograde_motion_is_one_span(self):
         # Mercury is retrograde from 15 March to 7 April 2025: half a second of

--- a/tests/core/test_retrograde_periods.py
+++ b/tests/core/test_retrograde_periods.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Tests for RetrogradeStationFactory.retrograde_periods_*: retrograde spans clipped to a range."""
+
+from datetime import datetime
+
+import pytest
+
+from kerykeion.retrograde_stations import RetrogradeStationFactory
+from kerykeion.utilities import datetime_to_julian
+
+ONE_SECOND = 1.0 / 86400.0
+
+
+class TestMarch2025:
+    """Venus is already retrograde on 5 March 2025; Mercury turns on the 15th; both run past the 31st."""
+
+    def test_venus_open_at_the_start_and_mercury_from_its_station(self):
+        res = RetrogradeStationFactory.retrograde_periods_from_iso_range("2025-03-05", "2025-03-31")
+        by_planet = {p.planet: p for p in res.periods}
+        assert set(by_planet) == {"Venus", "Mercury"}, [p.planet for p in res.periods]
+        venus, mercury = by_planet["Venus"], by_planet["Mercury"]
+        assert venus.start_clipped and venus.end_clipped
+        assert venus.start_jd == res.start_jd and venus.end_jd == res.end_jd
+        assert not mercury.start_clipped and mercury.end_clipped
+        assert mercury.start.startswith("2025-03-15")
+        assert mercury.end_jd == res.end_jd
+
+    def test_span_starts_are_the_retrograde_stations(self):
+        periods = RetrogradeStationFactory.retrograde_periods_from_iso_range("2025-01-01", "2025-12-31").periods
+        stations = RetrogradeStationFactory.from_iso_range("2025-01-01", "2025-12-31").stations
+        # The period scan starts one second before the range (edge rule), so
+        # its brackets differ from the station scan's and the bisected instants
+        # agree to well under a second — never compare the floats for equality.
+        sr = [(s.planet, s.julian_day) for s in stations if s.station_type == "SR"]
+        sd = [(s.planet, s.julian_day) for s in stations if s.station_type == "SD"]
+
+        def near(planet: str, jd: float, pool: list) -> bool:
+            return any(p == planet and abs(j - jd) <= ONE_SECOND for p, j in pool)
+
+        for p in periods:
+            if not p.start_clipped:
+                assert near(p.planet, p.start_jd, sr), (p.planet, p.start)
+            if not p.end_clipped:
+                assert near(p.planet, p.end_jd, sd), (p.planet, p.end)
+            assert p.start_jd < p.end_jd
+
+    def test_spans_never_overlap_per_planet(self):
+        periods = RetrogradeStationFactory.retrograde_periods_from_iso_range("2024-01-01", "2025-12-31").periods
+        for planet in {p.planet for p in periods}:
+            spans = sorted((p for p in periods if p.planet == planet), key=lambda p: p.start_jd)
+            for a, b in zip(spans, spans[1:]):
+                assert a.end_jd <= b.start_jd
+
+
+class TestEdges:
+    def test_a_quiet_month_for_a_direct_planet_yields_nothing(self):
+        # Mars is direct throughout April 2025 (its retrograde ended 24 Feb 2025).
+        res = RetrogradeStationFactory.retrograde_periods_from_iso_range("2025-04-01", "2025-04-30", ["Mars"])
+        assert res.periods == []
+
+    def test_a_station_on_the_range_start_opens_the_span_unclipped(self):
+        stations = RetrogradeStationFactory.from_iso_range("2025-03-01", "2025-03-31", ["Mercury"]).stations
+        sr = next(s for s in stations if s.station_type == "SR")
+        res = RetrogradeStationFactory.retrograde_periods_from_julian_day(sr.julian_day, sr.julian_day + 20, ["Mercury"])
+        assert len(res.periods) == 1
+        period = res.periods[0]
+        assert abs(period.start_jd - sr.julian_day) <= ONE_SECOND
+        assert not period.start_clipped
+        assert period.end_clipped
+
+    def test_chiron_is_opt_in_and_luminaries_stay_rejected(self):
+        res = RetrogradeStationFactory.retrograde_periods_from_iso_range("2025-01-01", "2025-12-31", ["Chiron"])
+        assert res.periods and all(p.planet == "Chiron" for p in res.periods)
+        default = RetrogradeStationFactory.retrograde_periods_from_iso_range("2025-01-01", "2025-12-31")
+        assert "Chiron" not in {p.planet for p in default.periods}
+        with pytest.raises(ValueError):
+            RetrogradeStationFactory.retrograde_periods_from_iso_range("2025-01-01", "2025-12-31", ["Sun"])
+
+    def test_times_are_identical_under_a_sidereal_zodiac(self):
+        tropical = RetrogradeStationFactory.retrograde_periods_from_iso_range("2025-03-05", "2025-03-31")
+        sidereal = RetrogradeStationFactory.retrograde_periods_from_iso_range(
+            "2025-03-05", "2025-03-31", zodiac_type="Sidereal", sidereal_mode="LAHIRI"
+        )
+        assert [(p.planet, p.start_jd, p.end_jd) for p in tropical.periods] == [
+            (p.planet, p.start_jd, p.end_jd) for p in sidereal.periods
+        ]
+
+    def test_empty_range_yields_nothing(self):
+        jd = datetime_to_julian(datetime(2025, 3, 10))
+        assert RetrogradeStationFactory.retrograde_periods_from_julian_day(jd, jd).periods == []

--- a/tests/core/test_retrograde_periods.py
+++ b/tests/core/test_retrograde_periods.py
@@ -28,9 +28,9 @@ class TestMarch2025:
     def test_span_starts_are_the_retrograde_stations(self):
         periods = RetrogradeStationFactory.retrograde_periods_from_iso_range("2025-01-01", "2025-12-31").periods
         stations = RetrogradeStationFactory.from_iso_range("2025-01-01", "2025-12-31").stations
-        # The period scan starts one second before the range (edge rule), so
-        # its brackets differ from the station scan's and the bisected instants
-        # agree to well under a second — never compare the floats for equality.
+        # The in-range brackets are the station scan's own, so the instants
+        # agree exactly; only a station snapped onto a range bound (edge rule)
+        # moves, by under a second.
         sr = [(s.planet, s.julian_day) for s in stations if s.station_type == "SR"]
         sd = [(s.planet, s.julian_day) for s in stations if s.station_type == "SD"]
 
@@ -67,6 +67,31 @@ class TestEdges:
         assert abs(period.start_jd - sr.julian_day) <= ONE_SECOND
         assert not period.start_clipped
         assert period.end_clipped
+
+    def test_a_station_on_the_range_end_closes_the_span_unclipped(self):
+        # Every Mercury direct station of 2020-2025 as the range end: the
+        # bisected instant may sit a hair on the retrograde side of the true
+        # zero, which must not turn the closing station into a clipped edge.
+        stations = RetrogradeStationFactory.from_iso_range("2020-01-01", "2025-12-31", ["Mercury"]).stations
+        direct = [s for s in stations if s.station_type == "SD"]
+        assert len(direct) >= 15
+        for sd in direct:
+            res = RetrogradeStationFactory.retrograde_periods_from_julian_day(
+                sd.julian_day - 10, sd.julian_day, ["Mercury"]
+            )
+            assert [(p.start_clipped, p.end_clipped) for p in res.periods] == [(True, False)], sd.julian_day
+            assert res.periods[0].end_jd == sd.julian_day
+
+    def test_a_sub_second_range_inside_retrograde_motion_is_one_span(self):
+        # Mercury is retrograde from 15 March to 7 April 2025: half a second of
+        # it is still a retrograde span, clipped at both ends — not nothing.
+        jd = datetime_to_julian(datetime(2025, 3, 20, 12))
+        end = jd + ONE_SECOND / 2
+        res = RetrogradeStationFactory.retrograde_periods_from_julian_day(jd, end, ["Mercury"])
+        assert len(res.periods) == 1
+        period = res.periods[0]
+        assert (period.start_jd, period.end_jd) == (jd, end)
+        assert period.start_clipped and period.end_clipped
 
     def test_chiron_is_opt_in_and_luminaries_stay_rejected(self):
         res = RetrogradeStationFactory.retrograde_periods_from_iso_range("2025-01-01", "2025-12-31", ["Chiron"])

--- a/tests/core/test_retrograde_periods.py
+++ b/tests/core/test_retrograde_periods.py
@@ -30,7 +30,7 @@ class TestMarch2025:
         stations = RetrogradeStationFactory.from_iso_range("2025-01-01", "2025-12-31").stations
         # The in-range brackets are the station scan's own, so the instants
         # agree exactly; only a station snapped onto a range bound (edge rule)
-        # moves, by under a second.
+        # moves, by the solver's own few milliseconds.
         sr = [(s.planet, s.julian_day) for s in stations if s.station_type == "SR"]
         sd = [(s.planet, s.julian_day) for s in stations if s.station_type == "SD"]
 
@@ -81,6 +81,26 @@ class TestEdges:
             )
             assert [(p.start_clipped, p.end_clipped) for p in res.periods] == [(True, False)], sd.julian_day
             assert res.periods[0].end_jd == sd.julian_day
+
+    def test_a_bound_half_a_second_off_the_station_keeps_the_real_station(self):
+        # Half a second is far beyond the solver's resolution: the station is
+        # then a real station inside the range, or simply outside it — never a
+        # bound. Mercury, June-July 2020 (SR 18 June, SD 12 July).
+        stations = RetrogradeStationFactory.from_iso_range("2020-06-01", "2020-07-31", ["Mercury"]).stations
+        sr = next(s for s in stations if s.station_type == "SR")
+        sd = next(s for s in stations if s.station_type == "SD")
+        half = 0.5 / 86400.0
+        periods = lambda a, b: RetrogradeStationFactory.retrograde_periods_from_julian_day(a, b, ["Mercury"]).periods
+        starting_before = periods(sr.julian_day - half, sr.julian_day + 10)
+        assert [(p.start_clipped, p.end_clipped) for p in starting_before] == [(False, True)]
+        assert 0 < starting_before[0].start_jd - (sr.julian_day - half) < 2 * half
+        starting_after = periods(sr.julian_day + half, sr.julian_day + 10)
+        assert [(p.start_clipped, p.end_clipped) for p in starting_after] == [(True, True)]
+        ending_before = periods(sd.julian_day - 10, sd.julian_day - half)
+        assert [(p.start_clipped, p.end_clipped) for p in ending_before] == [(True, True)]
+        ending_after = periods(sd.julian_day - 10, sd.julian_day + half)
+        assert [(p.start_clipped, p.end_clipped) for p in ending_after] == [(True, False)]
+        assert 0 < (sd.julian_day + half) - ending_after[0].end_jd < 2 * half
 
     def test_a_sub_second_range_inside_retrograde_motion_is_one_span(self):
         # Mercury is retrograde from 15 March to 7 April 2025: half a second of

--- a/tests/core/test_sign_periods.py
+++ b/tests/core/test_sign_periods.py
@@ -97,20 +97,31 @@ class TestFrameAndEdges:
             assert all(a.end_jd == b.start_jd for a, b in zip(stays, stays[1:]))
 
 
-class TestRangeStartingOnAnIngress:
-    """A range that begins on the ingress instant opens the entered sign unclipped."""
+class TestRangeBoundsOnAnIngress:
+    """A range that begins or ends on an ingress instant — the instant this
+    factory reported, which bisection leaves a hair to either side of the true
+    crossing — opens or closes the stay there: unclipped, and whole (no
+    hair-thin stay on the wrong side of the crossing)."""
 
-    def test_first_stay_is_not_clipped_when_the_range_starts_on_the_ingress(self):
-        aries = next(
-            x for x in SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31", ["Sun"]).ingresses if x.sign == "Ari"
-        )
+    @staticmethod
+    def _aries_ingress(year: int):
+        found = SignIngressFactory.from_iso_range(f"{year}-03-15", f"{year}-03-25", ["Sun"]).ingresses
+        return next(x for x in found if x.sign == "Ari")
+
+    @pytest.mark.parametrize("year", range(2019, 2028))
+    def test_first_stay_is_not_clipped_when_the_range_starts_on_the_ingress(self, year):
+        aries = self._aries_ingress(year)
         res = SignIngressFactory.sign_periods_from_julian_day(aries.julian_day, aries.julian_day + 10, ["Sun"])
-        assert [p.sign for p in res.periods] == ["Ari"]
-        first = res.periods[0]
-        assert first.start_jd == aries.julian_day
-        assert not first.start_clipped
-        assert first.end_clipped
+        assert [(p.sign, p.start_clipped, p.end_clipped) for p in res.periods] == [("Ari", False, True)]
+        assert res.periods[0].start_jd == aries.julian_day
 
-    def test_first_stay_is_clipped_when_the_range_starts_mid_sign(self):
+    @pytest.mark.parametrize("year", range(2019, 2028))
+    def test_last_stay_is_not_clipped_when_the_range_ends_on_the_ingress(self, year):
+        aries = self._aries_ingress(year)
+        res = SignIngressFactory.sign_periods_from_julian_day(aries.julian_day - 10, aries.julian_day, ["Sun"])
+        assert [(p.sign, p.start_clipped, p.end_clipped) for p in res.periods] == [("Pis", True, False)]
+        assert res.periods[0].end_jd == aries.julian_day
+
+    def test_stays_are_clipped_when_the_range_cuts_mid_sign(self):
         res = SignIngressFactory.sign_periods_from_iso_range("2026-03-01", "2026-03-10", ["Sun"])
-        assert res.periods[0].start_clipped
+        assert [(p.sign, p.start_clipped, p.end_clipped) for p in res.periods] == [("Pis", True, True)]

--- a/tests/core/test_sign_periods.py
+++ b/tests/core/test_sign_periods.py
@@ -95,3 +95,22 @@ class TestFrameAndEdges:
             stays = [p for p in res.periods if p.planet == planet]
             assert stays[0].start_clipped and stays[-1].end_clipped
             assert all(a.end_jd == b.start_jd for a, b in zip(stays, stays[1:]))
+
+
+class TestRangeStartingOnAnIngress:
+    """A range that begins on the ingress instant opens the entered sign unclipped."""
+
+    def test_first_stay_is_not_clipped_when_the_range_starts_on_the_ingress(self):
+        aries = next(
+            x for x in SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31", ["Sun"]).ingresses if x.sign == "Ari"
+        )
+        res = SignIngressFactory.sign_periods_from_julian_day(aries.julian_day, aries.julian_day + 10, ["Sun"])
+        assert [p.sign for p in res.periods] == ["Ari"]
+        first = res.periods[0]
+        assert first.start_jd == aries.julian_day
+        assert not first.start_clipped
+        assert first.end_clipped
+
+    def test_first_stay_is_clipped_when_the_range_starts_mid_sign(self):
+        res = SignIngressFactory.sign_periods_from_iso_range("2026-03-01", "2026-03-10", ["Sun"])
+        assert res.periods[0].start_clipped

--- a/tests/core/test_sign_periods.py
+++ b/tests/core/test_sign_periods.py
@@ -128,17 +128,25 @@ class TestRangeBoundsOnAnIngress:
         # bound. Only the bisection's own millisecond error is absorbed.
         aries = self._aries_ingress(2026)
         half = 0.5 / 86400.0
-        starting_before = SignIngressFactory.sign_periods_from_julian_day(aries.julian_day - half, aries.julian_day + 10, ["Sun"])
+        starting_before = SignIngressFactory.sign_periods_from_julian_day(
+            aries.julian_day - half, aries.julian_day + 10, ["Sun"]
+        )
         assert [(p.sign, p.start_clipped, p.end_clipped) for p in starting_before.periods] == [
             ("Pis", True, False),
             ("Ari", False, True),
         ]
         assert 0 < starting_before.periods[0].end_jd - starting_before.periods[0].start_jd < 2 * half
-        starting_after = SignIngressFactory.sign_periods_from_julian_day(aries.julian_day + half, aries.julian_day + 10, ["Sun"])
+        starting_after = SignIngressFactory.sign_periods_from_julian_day(
+            aries.julian_day + half, aries.julian_day + 10, ["Sun"]
+        )
         assert [(p.sign, p.start_clipped, p.end_clipped) for p in starting_after.periods] == [("Ari", True, True)]
-        ending_before = SignIngressFactory.sign_periods_from_julian_day(aries.julian_day - 10, aries.julian_day - half, ["Sun"])
+        ending_before = SignIngressFactory.sign_periods_from_julian_day(
+            aries.julian_day - 10, aries.julian_day - half, ["Sun"]
+        )
         assert [(p.sign, p.start_clipped, p.end_clipped) for p in ending_before.periods] == [("Pis", True, True)]
-        ending_after = SignIngressFactory.sign_periods_from_julian_day(aries.julian_day - 10, aries.julian_day + half, ["Sun"])
+        ending_after = SignIngressFactory.sign_periods_from_julian_day(
+            aries.julian_day - 10, aries.julian_day + half, ["Sun"]
+        )
         assert [(p.sign, p.start_clipped, p.end_clipped) for p in ending_after.periods] == [
             ("Pis", True, False),
             ("Ari", False, True),

--- a/tests/core/test_sign_periods.py
+++ b/tests/core/test_sign_periods.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""Tests for SignIngressFactory.sign_periods_*: contiguous sign stays clipped to a range."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from kerykeion.schemas.exceptions import KerykeionException
+from kerykeion.sign_ingresses import SignIngressFactory
+from kerykeion.void_of_course_moon import VoidOfCourseMoonFactory
+from kerykeion.utilities import datetime_to_julian
+
+ONE_SECOND = 1.0 / 86400.0
+
+
+def _jd(iso: str) -> float:
+    dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return datetime_to_julian(dt)
+
+
+class TestSunMarch2026:
+    """The Sun's March equinox is an exact anchor: Pisces until 2026-03-20, then Aries."""
+
+    def test_two_contiguous_stays_around_the_equinox(self):
+        res = SignIngressFactory.sign_periods_from_iso_range("2026-03-01", "2026-03-31", ["Sun"])
+        assert [p.sign for p in res.periods] == ["Pis", "Ari"]
+        pisces, aries = res.periods
+        assert pisces.start_jd == res.start_jd and pisces.start_clipped
+        assert aries.end_jd == res.end_jd and aries.end_clipped
+        assert not pisces.end_clipped and not aries.start_clipped
+        assert pisces.end_jd == aries.start_jd
+        assert aries.start.startswith("2026-03-20")
+        assert pisces.start == "2026-03-01T00:00:00Z"
+
+    def test_boundaries_are_the_ingress_instants(self):
+        periods = SignIngressFactory.sign_periods_from_iso_range("2026-01-01", "2026-12-31", ["Sun"]).periods
+        ingresses = SignIngressFactory.from_iso_range("2026-01-01", "2026-12-31", ["Sun"]).ingresses
+        assert len(periods) == len(ingresses) + 1
+        for period, ingress in zip(periods[1:], ingresses):
+            assert period.start_jd == ingress.julian_day
+            assert period.sign == ingress.sign
+            assert period.sign_num == ingress.sign_num
+        for a, b in zip(periods, periods[1:]):
+            assert a.end_jd == b.start_jd
+            assert a.sign != b.sign
+
+
+class TestMoon:
+    def test_a_month_holds_thirteen_or_fourteen_stays(self):
+        res = SignIngressFactory.sign_periods_from_iso_range("2026-09-01", "2026-09-30", ["Moon"])
+        assert 13 <= len(res.periods) <= 15
+        for a, b in zip(res.periods, res.periods[1:]):
+            assert a.end_jd == b.start_jd
+            assert b.sign_num == (a.sign_num + 1) % 12
+
+    def test_boundaries_agree_with_the_void_of_course_ends_within_a_second(self):
+        periods = SignIngressFactory.sign_periods_from_iso_range("2026-09-01", "2026-09-30", ["Moon"]).periods
+        windows = VoidOfCourseMoonFactory.from_iso_range("2026-09-01", "2026-09-30").windows
+        void_ends = [_jd(w.void_end if isinstance(w.void_end, str) else w.void_end.isoformat()) for w in windows]
+        starts = [p.start_jd for p in periods[1:]]
+        assert starts, "expected in-range Moon ingresses"
+        for start in starts:
+            assert min(abs(start - v) for v in void_ends) <= ONE_SECOND
+
+
+class TestFrameAndEdges:
+    def test_sidereal_lahiri_shifts_the_stays_by_one_sign(self):
+        res = SignIngressFactory.sign_periods_from_iso_range(
+            "2026-03-01", "2026-03-31", ["Sun"], zodiac_type="Sidereal", sidereal_mode="LAHIRI"
+        )
+        assert [p.sign for p in res.periods] == ["Aqu", "Pis"]
+        assert res.periods[1].start.startswith("2026-03-14")
+
+    def test_sidereal_requires_a_mode(self):
+        with pytest.raises(KerykeionException):
+            SignIngressFactory.sign_periods_from_iso_range("2026-03-01", "2026-03-31", ["Sun"], zodiac_type="Sidereal")
+
+    def test_empty_and_inverted_ranges_yield_nothing(self):
+        jd = datetime_to_julian(datetime(2026, 3, 10))
+        assert SignIngressFactory.sign_periods_from_julian_day(jd, jd, ["Sun"]).periods == []
+        assert SignIngressFactory.sign_periods_from_julian_day(jd, jd - 5, ["Sun"]).periods == []
+
+    def test_unknown_planet_is_rejected(self):
+        with pytest.raises(ValueError):
+            SignIngressFactory.sign_periods_from_iso_range("2026-03-01", "2026-03-31", ["Ceres"])
+
+    def test_default_set_excludes_the_moon(self):
+        res = SignIngressFactory.sign_periods_from_iso_range("2026-03-01", "2026-03-05")
+        planets = {p.planet for p in res.periods}
+        assert "Moon" not in planets and "Sun" in planets and "Pluto" in planets
+        # Every planet: first stay clipped at the start, last at the end, contiguous between.
+        for planet in planets:
+            stays = [p for p in res.periods if p.planet == planet]
+            assert stays[0].start_clipped and stays[-1].end_clipped
+            assert all(a.end_jd == b.start_jd for a, b in zip(stays, stays[1:]))

--- a/tests/core/test_sign_periods.py
+++ b/tests/core/test_sign_periods.py
@@ -122,6 +122,29 @@ class TestRangeBoundsOnAnIngress:
         assert [(p.sign, p.start_clipped, p.end_clipped) for p in res.periods] == [("Pis", True, False)]
         assert res.periods[0].end_jd == aries.julian_day
 
+    def test_a_bound_half_a_second_off_the_ingress_keeps_the_real_boundary(self):
+        # Half a second is far beyond the solver's resolution: the crossing is
+        # then a real boundary inside the range, or simply outside it — never a
+        # bound. Only the bisection's own millisecond error is absorbed.
+        aries = self._aries_ingress(2026)
+        half = 0.5 / 86400.0
+        starting_before = SignIngressFactory.sign_periods_from_julian_day(aries.julian_day - half, aries.julian_day + 10, ["Sun"])
+        assert [(p.sign, p.start_clipped, p.end_clipped) for p in starting_before.periods] == [
+            ("Pis", True, False),
+            ("Ari", False, True),
+        ]
+        assert 0 < starting_before.periods[0].end_jd - starting_before.periods[0].start_jd < 2 * half
+        starting_after = SignIngressFactory.sign_periods_from_julian_day(aries.julian_day + half, aries.julian_day + 10, ["Sun"])
+        assert [(p.sign, p.start_clipped, p.end_clipped) for p in starting_after.periods] == [("Ari", True, True)]
+        ending_before = SignIngressFactory.sign_periods_from_julian_day(aries.julian_day - 10, aries.julian_day - half, ["Sun"])
+        assert [(p.sign, p.start_clipped, p.end_clipped) for p in ending_before.periods] == [("Pis", True, True)]
+        ending_after = SignIngressFactory.sign_periods_from_julian_day(aries.julian_day - 10, aries.julian_day + half, ["Sun"])
+        assert [(p.sign, p.start_clipped, p.end_clipped) for p in ending_after.periods] == [
+            ("Pis", True, False),
+            ("Ari", False, True),
+        ]
+        assert 0 < ending_after.periods[1].end_jd - ending_after.periods[1].start_jd < 2 * half
+
     def test_stays_are_clipped_when_the_range_cuts_mid_sign(self):
         res = SignIngressFactory.sign_periods_from_iso_range("2026-03-01", "2026-03-10", ["Sun"])
         assert [(p.sign, p.start_clipped, p.end_clipped) for p in res.periods] == [("Pis", True, True)]

--- a/uv.lock
+++ b/uv.lock
@@ -297,7 +297,7 @@ wheels = [
 
 [[package]]
 name = "kerykeion"
-version = "6.0.0a91"
+version = "6.0.0a92"
 source = { editable = "." }
 dependencies = [
     { name = "libephemeris" },


### PR DESCRIPTION
## What

Two range queries that answer *where is every planet, and who is retrograde, across these dates* without the caller stitching events together — the ingress and station finders report what changes inside a range, and a planet that neither ingresses nor stations in a month leaves no trace.

- `SignIngressFactory.sign_periods_from_iso_range` / `sign_periods_from_julian_day` → `SignPeriodsCollectionModel`: per planet, contiguous `SignPeriodModel` stays covering the whole range, clipped at the edges and flagged (`start_clipped` / `end_clipped`), handed over at each ingress to the same bisected instant. The sign at the range start is read inside the same ephemeris session — same `iflag`, same frame — as the scan, so a sidereal request yields sidereal stays that cannot disagree with the ingresses that follow them. The Moon is opt-in, as for ingresses.
- `RetrogradeStationFactory.retrograde_periods_from_iso_range` / `retrograde_periods_from_julian_day` → `RetrogradePeriodsCollectionModel`: retrograde spans opened by an SR and closed by an SD, clipped and flagged at the range edges; nothing is searched outside the range. The scan starts one second before the range so a station sitting on the range start is bracketed and decides the initial state deterministically. Non-alternating stations raise.
- `"Chiron"` accepted by the station finder and the periods, opt-in; the default set and its baselines are byte-identical.

Release plumbing for **6.0.0a92**: version, changelog, `release_notes/v6.0.0a92.md`, the skill's verified-against pin, models exported from the feature packages, `kerykeion` and `kerykeion.schemas`, and documented in the skill references.

## Why in the library

The start-of-range snapshot must share the scan's session and flag (sessions do not nest), which only the factories own; the invariant "first stay agrees with the following ingresses" is only testable where both live; and the periods are generally useful beyond one consumer. Downstream: the Astrologer API's `/advanced/astro-calendar` gains `sign_periods` and `retrograde_periods` (companion PR), which Astrologer Studio's Planets view reads.

## Tests

`tests/core/test_sign_periods.py`, `tests/core/test_retrograde_periods.py`: the Sun's stays around the 2026 equinox (Pisces → Aries on 20 March; Aquarius → Pisces on 14 March under Lahiri), contiguity and clip flags, boundaries equal to the ingress instants, the Moon's 13–14 stays a month with boundaries within a second of the void-of-course ends (Newton vs bisection: tolerance, never string equality), March 2025 with Venus open at the start and Mercury from its station, a station on the range start, Chiron opt-in and luminaries rejected, identical span times under a sidereal zodiac, empty and inverted ranges. Full suite green (12 455 passed) on top of a91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dhW174jxS6d66geUxu5jV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added APIs for querying planetary sign periods and retrograde periods over ISO or Julian date ranges.
  * Results include clipped-bound indicators and precise handling of events at range edges.
  * Added optional Chiron calculations while preserving the default planet set.
  * Exposed new period models through public package and schema interfaces.

* **Documentation**
  * Added documentation for period queries and range behavior.
  * Updated the release version to 6.0.0a92.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->