### PR TITLE
docs(audit): full documentation audit aligned to a92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,7 +688,7 @@ drawing changed except the words of the lunar phase.
   stored a86 composite re-rendered on a87 can read a planet in the opposite
   house; the two are distinguishable because a87 records `house_anchor`.
 
-## [6.0.0a86]
+## [6.0.0a86] - 2026-08-21
 
 ### Fixed
 
@@ -954,6 +954,12 @@ drawing changed except the words of the lunar phase.
   genuinely has its referent — Mercury at its August 1990 station (with Uranus
   out of bounds), a Longyearbyen chart whose Placidus request could not be
   honoured, a sidereal Lahiri chart, and a synastry pair. Runs offline.
+
+## [6.0.0a85] - 2026-08-12
+
+No library changes on this branch. The a85 release carried optional tooling
+that lives on a separate, unmerged branch; `kerykeion.__all__` and every
+Pydantic schema are exactly what a84 shipped, and no calculation changed.
 
 ## 6.0.0a84 - 2026-08-12
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ Thank you for your interest in contributing to Kerykeion! Contributions of all k
 
    The suite auto-detects the range of the installed ephemeris kernel and
    skips tests that need a wider one, so a plain run is green out of the box —
-   on a default install that means the `medium` tier, with the extended-tier
+   a fresh install bundles the base DE440s kernel (1849-2150), so on a default
+   install that means the `base` tier, with the medium- and extended-tier
    subjects skipped rather than run. To actually exercise the full range,
    install the DE441 kernel and set the environment variable the
    `regenerate:*` tasks set for themselves:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,24 @@ Thank you for your interest in contributing to Kerykeion! Contributions of all k
 4. Make your changes, add tests if applicable, and ensure the test suite passes:
 
    ```bash
-   uv run pytest
+   uv run poe test:core
    ```
 
+   Use the poe task rather than a bare `uv run pytest`: `-m 'not online'` is not
+   in `addopts`, so a plain run also fires the GeoNames network tests and fails
+   without an account. `uv run pytest tests/core -m 'not online'` is equivalent.
+
    The suite auto-detects the range of the installed ephemeris kernel and
-   skips tests that need a wider one, so a plain run is green out of the box.
-   With the full-range DE441 kernel installed you can force everything with
-   `uv run pytest --tier=extended`.
+   skips tests that need a wider one, so a plain run is green out of the box —
+   on a default install that means the `medium` tier, with the extended-tier
+   subjects skipped rather than run. To actually exercise the full range,
+   install the DE441 kernel and set the environment variable the
+   `regenerate:*` tasks set for themselves:
+
+   ```bash
+   uv run python -c "import libephemeris; libephemeris.download_leb_for_tier('extended')"
+   LIBEPHEMERIS_PRECISION=extended uv run poe test:extended
+   ```
 
 5. Push your branch and open a Pull Request against the `main` branch.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,10 +77,12 @@ uv run pytest tests/ --collect-only -q -m 'not online' | tail -1
 
 `test:extended` and `test:all` both run `pytest tests/ -m 'not online'` and set
 **no** `LIBEPHEMERIS_PRECISION`. `tests/conftest.py` probes the ephemeris kernel
-that is actually loaded and picks the widest tier it can serve — on a default
-install that is `medium`, so the extended-tier subjects (500 BC through 1492)
-are **skipped with a reason**, not run and not failed. The task name says which
-tier is being asked for; the installed kernel decides which one you get.
+that is actually loaded and picks the widest tier it can serve — a fresh install
+bundles the base DE440s kernel (1849-2150), so on a default install that is
+`base`, and the medium-tier (1550-1848, 2200) and extended-tier (500 BC through
+1492) subjects are **skipped with a reason**, not run and not failed. The task
+name says which tier is being asked for; the installed kernel decides which one
+you get.
 
 To really run the extended tier, install the full-range kernel and ask for it:
 
@@ -143,9 +145,12 @@ uv run poe regenerate:docs-charts
 #### Documentation gates
 
 `poe docs:check` fails on an export in `kerykeion.__all__` that no user-facing
-page documents. `poe docs:snippets` executes every ` ```python ` block in every
-Markdown file in the repository; `poe docs:snippets:skill` is the focused run
-over `skills/kerykeion/` alone. `poe regenerate:docs-charts` rewrites
+page documents. `poe docs:snippets` executes every ` ```python ` block in
+`README.md`, `kerykeion/llms.txt`, `site/docs`, `site/examples` and
+`skills/kerykeion/` — release notes and other top-level Markdown files are
+skipped by default; `--all` scans every Markdown file in the tree, ignored
+virtual environments and worktrees included. `poe docs:snippets:skill` is the
+focused run over `skills/kerykeion/` alone. `poe regenerate:docs-charts` rewrites
 `docs/charts/` — the SVGs the README embeds **by raw URL**, so they must be
 regenerated whenever the chart renderer changes or the README shows charts the
 library no longer draws.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,7 +45,7 @@ Kerykeion uses [poethepoet](https://github.com/nat-n/poethepoet) as a task runne
 Tests are organized in 4 tiers (each tier includes the previous):
 
 ```bash
-# Core tests (fastest, ~4,600 tests, excludes heavy parametrized suites)
+# Core tests (fastest — excludes the 5 heavy parametrized suites)
 uv run poe test:core
 
 # Base tier (DE440s range: 1849-2150)
@@ -68,7 +68,30 @@ uv run pytest tests/core/test_aspects.py
 
 # Run tests with verbose output (useful for debugging)
 uv run pytest tests/core/test_aspects.py -s -vvv
+
+# How many tests each command collects, without running them
+uv run pytest tests/ --collect-only -q -m 'not online' | tail -1
 ```
+
+#### The tier is auto-detected, and `LIBEPHEMERIS_PRECISION` is what widens it
+
+`test:extended` and `test:all` both run `pytest tests/ -m 'not online'` and set
+**no** `LIBEPHEMERIS_PRECISION`. `tests/conftest.py` probes the ephemeris kernel
+that is actually loaded and picks the widest tier it can serve — on a default
+install that is `medium`, so the extended-tier subjects (500 BC through 1492)
+are **skipped with a reason**, not run and not failed. The task name says which
+tier is being asked for; the installed kernel decides which one you get.
+
+To really run the extended tier, install the full-range kernel and ask for it:
+
+```bash
+uv run python -c "import libephemeris; libephemeris.download_leb_for_tier('extended')"
+LIBEPHEMERIS_PRECISION=extended uv run poe test:extended
+```
+
+The `regenerate:*` tasks and `test:gates:extended` set
+`LIBEPHEMERIS_PRECISION=extended` themselves — baselines must be regenerated on
+the full-range kernel or the long-range subjects are silently dropped.
 
 ### Code Quality
 ```bash
@@ -112,60 +135,92 @@ uv run poe docs:check
 # always run standalone — no import prelude, no shared page context — even in
 # the default docs:snippets run. Focused version:
 uv run poe docs:snippets:skill
+
+# Regenerate the README's showcase charts (docs/charts/)
+uv run poe regenerate:docs-charts
 ```
+
+#### Documentation gates
+
+`poe docs:check` fails on an export in `kerykeion.__all__` that no user-facing
+page documents. `poe docs:snippets` executes every ` ```python ` block in every
+Markdown file in the repository; `poe docs:snippets:skill` is the focused run
+over `skills/kerykeion/` alone. `poe regenerate:docs-charts` rewrites
+`docs/charts/` — the SVGs the README embeds **by raw URL**, so they must be
+regenerated whenever the chart renderer changes or the README shows charts the
+library no longer draws.
+
+### No CI — every gate is local
+
+This project deliberately runs **no** GitHub Actions. `.github/` holds only
+`FUNDING.yml`. Every gate lives in `pyproject.toml` as a poe task and is run
+locally before a push or a release: `poe check`, `poe quality`, `poe test:core`,
+`poe docs:check`, `poe docs:snippets`, `poe build:smoke`. Do not add a workflow
+file.
 
 ## 📁 Project Structure
 
 ```
 kerykeion/
-├── kerykeion/                       # Main package
-│   ├── __init__.py                  # Public API exports
-│   ├── astrological_subject_factory.py  # Core subject creation
-│   ├── chart_data_factory.py        # Chart data computation
-│   ├── composite_subject_factory.py # Composite/Davison charts
-│   ├── ephemeris_backend.py         # Backend abstraction (libephemeris/swisseph)
-│   ├── ephemeris_data_factory.py    # Time-series ephemeris
-│   ├── planetary_return_factory.py  # Solar/Lunar returns
-│   ├── relationship_score_factory.py # Compatibility scoring
-│   ├── relocated_chart_factory.py   # Relocated charts
-│   ├── transits_time_range_factory.py # Transit tracking
-│   ├── context_serializer.py        # AI/LLM XML export
-│   ├── report.py                    # Text reports
-│   ├── utilities.py                 # Zodiac math helpers
-│   ├── aspects/                     # Aspect detection
-│   ├── astro_cartography/           # ACG lines
-│   ├── charts/                      # SVG chart rendering
-│   ├── dignities/                   # Essential dignities
-│   ├── dominants/                   # Planet/sign/element/quality scoring
-│   ├── eclipses/                    # Eclipse search
-│   ├── fixed_stars/                 # Dynamic star discovery
-│   ├── heliacal/                    # Heliacal risings/settings
-│   ├── house_comparison/            # Synastry house overlay
-│   ├── lunations/                   # Lunar phase event search
-│   ├── midpoints/                   # Cosmobiology midpoints
-│   ├── moon_phase_details/          # Lunar phase context
-│   ├── mundane_aspects/             # Exact transiting aspects
-│   ├── occultations/                # Lunar occultations
-│   ├── planetary_hours/             # Chaldean planetary hours
-│   ├── planetary_nodes/             # Nodes & apsides
-│   ├── planetary_phenomena/         # Elongation/station/etc
-│   ├── primary_directions/          # Placidus semi-arc
-│   ├── retrograde_stations/         # Retrograde/direct station search
-│   ├── schemas/                     # Pydantic models & types
-│   ├── secondary_progressions/      # Progressions & solar arc
-│   ├── settings/                    # Configuration & constants
-│   ├── sign_ingresses/              # Zodiac sign-boundary search
-│   ├── sun_times/                   # Sunrise/sunset/twilight
-│   ├── vedic/                       # Nakshatra support
-│   ├── void_of_course_moon/         # Void-of-course state/windows
-│   └── zodiacal_releasing/          # Hellenistic time-lord periods
-├── tests/core/                      # Test suite (74 files)
-├── examples/                        # Usage examples
-├── site/docs/                       # Documentation source (markdown)
-├── skills/kerykeion/                # Cross-platform AI Agent Skill (agentskills.io)
-├── release_notes/                   # Selective longer release notes
-├── pyproject.toml                   # Project configuration
-├── uv.lock                          # Dependency lock file
+├── kerykeion/                   # Main package — every module below is a package
+│   ├── __init__.py              # Public API exports (__all__)
+│   ├── aspects/                 # Natal, synastry and transit aspect detection
+│   ├── astro_cartography/       # Astro-cartography (ACG) lines
+│   ├── astrological_subject/    # AstrologicalSubjectFactory — the core subject
+│   ├── chart_data/              # ChartDataFactory — chart models with aspects and distributions
+│   ├── charts/                  # SVG chart rendering (natal, synastry, transit, composite, return)
+│   ├── composite_subject/       # Composite (midpoint) and Davison charts
+│   ├── context/                 # Serialization of the models into semantic XML for AI consumption
+│   ├── dignities/               # Essential dignities for traditional evaluation
+│   ├── dominants/               # Planet/sign/element/quality scoring
+│   ├── eclipses/                # Localized solar and lunar eclipse search
+│   ├── ephemeris_backend/       # Backend selection (libephemeris/swisseph) and the ephemeris lock
+│   ├── ephemeris_data/          # EphemerisDataFactory — time-series ephemeris
+│   ├── firdaria/                # Firdaria (Firdariyyat), the Persian time-lord technique
+│   ├── fixed_stars/             # Dynamic fixed-star discovery and catalog
+│   ├── geonames/                # GeoNames city/timezone lookup (the only networked module)
+│   ├── heliacal/                # Heliacal risings and settings
+│   ├── horary/                  # Horary significators and considerations before judgment
+│   ├── house_comparison/        # Bidirectional synastry house overlay
+│   ├── lunations/               # New/quarter/full moon moments over a range
+│   ├── midpoints/               # Cosmobiology midpoints
+│   ├── moon_phase_details/      # Lunar phase context and upcoming phases
+│   ├── motion/                  # Per-point motion state (retrograde, stationary, slow, fast)
+│   ├── mundane_aspects/         # Exact transiting-to-transiting aspects
+│   ├── occultations/            # Lunar occultations
+│   ├── planetary_hours/         # Chaldean planetary hours
+│   ├── planetary_nodes/         # Planetary nodes and apsides
+│   ├── planetary_phenomena/     # Elongation, phase, station and other observational data
+│   ├── planetary_returns/       # Solar and lunar returns
+│   ├── predictive/              # Shared helpers for the predictive techniques
+│   ├── primary_directions/      # Placidus semi-arc primary directions
+│   ├── profections/             # Annual profections, the Hellenistic year-lord technique
+│   ├── receptions/              # Mutual receptions between classical planets
+│   ├── relationship_score/      # Compatibility scoring (Ciro Discepolo method)
+│   ├── relocated_chart/         # Relocated charts: natal positions, recomputed houses
+│   ├── report/                  # Plain-text reports
+│   ├── retrograde_stations/     # Retrograde/direct stations and retrograde spans
+│   ├── schemas/                 # Canonical home of all public models, literals and settings
+│   ├── secondary_progressions/  # Secondary progressions and solar arc
+│   ├── settings/                # Global configuration, chart defaults, translations
+│   ├── sign_ingresses/          # Zodiac sign-boundary crossings and sign stays
+│   ├── sun_times/               # Sunrise, sunset, solar noon and the twilights
+│   ├── swisseph_setup/          # Fetches the Swiss Ephemeris data files (optional backend)
+│   ├── transits/                # TransitsTimeRangeFactory — transits over a period
+│   ├── utilities/               # Zodiac/house lookups, Julian-day and angle math, tz resolution
+│   ├── vedic/                   # Nakshatra calculations
+│   ├── void_of_course_moon/     # Void-of-course Moon state and windows
+│   └── zodiacal_releasing/      # Zodiacal releasing (aphesis) time-lord periods
+├── tests/core/                  # Test suite (102 files — see TEST.md)
+├── tests/data/, tests/fixtures/ # Golden baselines: SVGs, positions, aspects, report snapshots
+├── examples/                    # Runnable usage examples (see examples/README.md)
+├── scripts/                     # Developer tooling and gates (see scripts/README.md)
+├── site/docs/                   # Documentation source (markdown)
+├── skills/kerykeion/            # Cross-platform AI Agent Skill (agentskills.io)
+├── release_notes/               # Selective longer release notes
+├── docs/charts/                 # The README's showcase SVGs (regenerate:docs-charts)
+├── pyproject.toml               # Project configuration and every poe task
+├── uv.lock                      # Dependency lock file
 └── README.md
 ```
 
@@ -249,11 +304,16 @@ uv sync --dev
 
 **Issue: Tests failing**
 ```bash
-# Run tests with verbose output
-uv run pytest -v
+# Run the fast tier with verbose output. Prefer this over a bare `uv run pytest`:
+# `-m 'not online'` is NOT in addopts, so a plain run also fires the GeoNames
+# network tests and fails without an account.
+uv run poe test:core -v
 
-# Run specific test with debugging
-uv run pytest tests/test_specific.py -s -vvv
+# Or, if you want pytest directly, deselect the online tests yourself
+uv run pytest tests/core -m 'not online' -v
+
+# Run a specific test with debugging (tests live under tests/core/)
+uv run pytest tests/core/test_aspects.py -s -vvv
 ```
 
 ## 📊 Code Style Guidelines

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -44,8 +44,9 @@ See [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md).
   distribution, including the commercial edition.
 - **Runtime backend.** The default ephemeris backend, `libephemeris`, is licensed
   **AGPL-3.0-only** and is authored by the same maintainer. Both the AGPL edition
-  and the commercial edition may use it; the commercial edition requires a
-  separate commercial license for `libephemeris` as well. The optional Swiss
+  and the commercial edition may use it; the commercial grant for Kerykeion
+  includes a commercial license for `libephemeris` as well (see
+  [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md)). The optional Swiss
   Ephemeris backend (`pyswisseph`) is never used on the default path and requires
   a separate license from Astrodienst AG for closed use.
 

--- a/MANDATORY_EVOLUTIONS.md
+++ b/MANDATORY_EVOLUTIONS.md
@@ -10,87 +10,66 @@ Status legend: 🔴 not started · 🟡 in progress · 🟢 done · 🔵 optiona
 
 ---
 
-## 1. 🔴 Migrate timezone handling from `pytz` to `zoneinfo`
+## 1. 🟢 DONE — Migrate timezone handling from `pytz` to `zoneinfo`
 
-**Why (limitation being removed).** `pytz` compiles only the *explicit* IANA DST
-transitions, which end around 2037. Beyond the last compiled transition it
-**freezes** the offset at the last known entry instead of applying the zone's
-perpetual POSIX rule. For a birth/event date past ~2037 in a DST zone (e.g. a
-summer 2038+ `America/New_York` chart) the resolved instant can be off by one
-hour (Moon ≈ 0.55°, angles up to ~15°). The ephemeris range reaches 2650, so
-future charts are in scope. `zoneinfo` (stdlib ≥ 3.9) reads the TZif POSIX
-footer and extrapolates future DST correctly.
-
-Documented meanwhile as a "Known limitation" in `CHANGELOG.md`.
-
-**Secondary benefits.** Removes the `pytz` API footguns the codebase currently
-works around: mandatory `tz.localize()` (never the `datetime(tzinfo=…)`
-constructor — it attaches the LMT offset), `tz.normalize()` after arithmetic,
-and `is_dst=` disambiguation. `zoneinfo` uses the standard PEP 495 `fold`
-attribute instead and handles wall-clock arithmetic natively.
-
-**Scope (files with pytz coupling — audit before starting).**
-- `kerykeion/astrological_subject_factory.py` — the core local↔UTC conversion,
-  DST fold handling via `is_dst`, `from_current_time`, partial-date defaults.
-- `kerykeion/ephemeris_data_factory.py` — per-step localize/`astimezone`.
-- `kerykeion/moon_phase_details/factory.py` — the `tzinfo.normalize(...)` call
-  for solar-noon offset.
-- `kerykeion/relocated_chart_factory.py`, `kerykeion/utilities.py` (`safe_timezone`),
-  and any `import pytz` / `.localize(` / `.normalize(` / `is_dst` site
-  (`grep -rn "pytz\|localize\|normalize\|is_dst" kerykeion/`).
-- `pyproject.toml` — drop the `pytz` dependency (add `tzdata` for platforms
-  without a system tz database, e.g. Windows).
-
-**Risk.** High. Rounds 16–17 built careful DST-fold handling on the pytz
-`is_dst` model; the fold/ambiguous/non-existent-time semantics must be
-re-expressed on PEP 495 `fold` with identical results. Extensive golden
-baselines (positions, houses, reports, SVG) encode current instants — most are
-pre-2037 and must stay byte-identical; only post-2037 DST-zone cases should
-change (and become correct).
-
-**Acceptance criteria.**
-- All existing tests pass; pre-2037 instants byte-identical (no baseline churn
-  except intentional post-2037 corrections).
-- New tests: a summer 2038+ chart in a DST zone resolves to the DST offset
-  (matching `zoneinfo`), spring-forward gap and fall-back fold still handled.
-- `import pytz` gone from `kerykeion/`; the CHANGELOG limitation note removed.
-- Quality gate green.
+**Shipped in 6.0.0a76 (2026-07-20).** `pytz` is gone from the package and
+`tzdata` is a hard runtime dependency; `grep -rn pytz kerykeion/ pyproject.toml`
+returns nothing. Charts past ~2037 (and before 1901-12-13) now get the zone's
+perpetual POSIX rule instead of a frozen offset. See the `6.0.0a76` CHANGELOG
+entry for the full account.
 
 ---
 
-## 2. 🔴 Canonical backend-error taxonomy + runtime name validation
+## 2. 🟡 Canonical backend-error taxonomy + runtime name validation
+
+**Status: partially done.** The individual sites were repaired one by one, but
+the canonical taxonomy the item asks for does not exist yet: nothing is exported
+from `kerykeion/ephemeris_backend/` beyond `POLAR_HOUSES_ERROR_TYPES`, and every
+module still resolves the backend error type for itself.
 
 **Why (limitation being removed).** The library repeatedly rediscovers, module
 by module, that the ephemeris backend does *not* raise `RuntimeError` for its
 failures (libephemeris raises an `Error` hierarchy — `CalculationError` /
 `EphemerisRangeError`, `DataNotFoundError` / `UnknownBodyError`, `ConfigurationError`;
-pyswisseph raises a generic `swisseph.Error`). Three modules independently
-learned this the hard way (`dominants/utils.py`, `lunations/lunation_factory.py`,
-and — fixed in round 23 — `moon_phase_details`, `void_of_course_moon`,
-`heliacal`). Each site resolves the backend error type ad hoc with
-`getattr(ephe, "Error", …)`. There is no single source of truth that also
-distinguishes the *range* / *data* / *config* subtrees, so "expected no-event"
-vs "hard failure" is re-derived everywhere and easy to get wrong (round 23's
-HIGH was exactly this: heliacal treating every backend error as "no event").
+pyswisseph raises a generic `swisseph.Error`). Several modules learned this the
+hard way (`dominants/utils.py`, `lunations/factory.py`, and — fixed in round 23 —
+`moon_phase_details`, `void_of_course_moon`, `heliacal`). There is no single
+source of truth that also distinguishes the *range* / *data* / *config* subtrees,
+so "expected no-event" vs "hard failure" is re-derived everywhere and easy to get
+wrong (round 23's HIGH was exactly this: heliacal treating every backend error as
+"no event").
 
-**Scope.**
-- Export a canonical tuple/enum from `kerykeion/ephemeris_backend.py`, e.g.
-  `BACKEND_ERROR_TYPES` (the base) plus distinguishable `BACKEND_RANGE_ERRORS`,
-  `BACKEND_DATA_ERRORS`, `BACKEND_CONFIG_ERRORS`, resolved once for the active
-  backend (swisseph collapses to the generic `Error` — document that these
-  cannot be told apart there). Include the *Skyfield* `EphemerisRangeError`
-  (libephemeris runs `heliacal_ut` through Skyfield, which raises its own
-  `ValueError` subclass — round 23 discovered this).
-- Migrate every ad-hoc `getattr(ephe, "Error", …)` handler and the remaining
-  dead `except RuntimeError` site (`sun_times/utils.py:368`, left untouched in
-  round 23 because no harm was reproduced) to the canonical types.
+**What is done.**
+- `kerykeion/void_of_course_moon/factory.py` resolves the hierarchy once through
+  `_resolve_backend_error_types()` and splits it into `_BACKEND_ERROR_TYPES` and
+  `_RANGE_ERROR_TYPES` — the shape the canonical export should take, but private
+  to that one module.
+- `dominants/utils.py` no longer keys on `RuntimeError`; it catches broadly with
+  a comment naming the reason.
+- Round 23 hard-validated the closed `PLANETS` set in heliacal `search_events`.
+
+**What is left (verified by grep today).**
+- **Five ad-hoc resolutions of the backend error type** to migrate onto one
+  canonical export: `moon_phase_details/factory.py:86`,
+  `moon_phase_details/utils.py:41`, `heliacal/factory.py:38`,
+  `void_of_course_moon/factory.py:28`, `planetary_returns/factory.py:98`.
+- **One `except RuntimeError` left on a backend call**: `sun_times/utils.py:465`
+  (the twilight `rise_trans` wrapper — it moved from `:368`, still untouched
+  because no harm has been reproduced).
+- **The canonical export itself.** From `kerykeion/ephemeris_backend/backend.py`,
+  e.g. `BACKEND_ERROR_TYPES` (the base) plus distinguishable
+  `BACKEND_RANGE_ERRORS`, `BACKEND_DATA_ERRORS`, `BACKEND_CONFIG_ERRORS`,
+  resolved once for the active backend (swisseph collapses to the generic
+  `Error` — document that these cannot be told apart there). Include the
+  *Skyfield* `EphemerisRangeError` (libephemeris runs `heliacal_ut` through
+  Skyfield, which raises its own `ValueError` subclass — round 23 discovered
+  this).
 - **Runtime validation of open `str` name parameters** at public entries whose
   type is only a `Literal` at static-check time (no runtime enforcement for
   API/JSON/form callers): aspects `active_points`, heliacal `planets` and the
   fixed-star-accepting `planet_name_or_star` (validate against the
   fixed-star catalog so a mistyped star yields "unknown body", not a misleading
-  "no event found"), `active_fixed_stars`. Round 23 hard-validated only the
-  closed `PLANETS` set in `search_events`; the star-accepting entries still
+  "no event found"), `active_fixed_stars`. The star-accepting entries still
   return a correct exception *type* but an imprecise message.
 
 **Risk.** Low–medium. Mostly mechanical, but the range/data/config split must
@@ -120,7 +99,8 @@ different chart with only scattered log lines to explain it:
   needs a missing planetary kernel (notably the **Sun**, which needs `sepl_18.se1`)
   falls back to its **geocentric** position — returned under the planetocentric
   label, ~62° off, with only a `logging.warning`. The fallback is deliberate and
-  logged (see the comment at `astrological_subject_factory.py` ~2386), but the
+  logged (see the planet-calculation branch in
+  `kerykeion/astrological_subject/factory.py`), but the
   point is not flagged as degraded on the returned model.
 - **Chiron / asteroids / TNOs** need `seas_18.se1`; **fixed stars** need
   `sefstars.txt`; **barycentric** perspectives need `sepl_*.se1`. These are
@@ -128,8 +108,8 @@ different chart with only scattered log lines to explain it:
 
 The `libephemeris` default backend and a fully-provisioned `swisseph` install are
 both correct — this is only the incomplete-swisseph state. The test suite
-`conftest.py` fail-fasts there, so it is invisible to CI but reachable by a real
-user immediately after `pip install kerykeion[swiss]`.
+`conftest.py` fail-fasts there, so no local gate sees it, yet it is reachable by
+a real user immediately after `pip install kerykeion[swiss]`.
 
 **Scope.**
 - Add a machine-readable degradation signal on the subject model (e.g. a

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <img src="https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/docs/charts/modern_default_natal.svg" width="540" alt="John Lennon - Natal Chart">
 </p>
 
-Kerykeion is a Python library for astrology. It computes planetary and house positions, detects aspects, and generates SVG charts, including birth, synastry, transit, and composite charts. You can also customize which planets to include in your calculations.
+Kerykeion is a Python library for astrology. It computes planetary and house positions, detects aspects, and generates SVG charts: birth, synastry, transit, solar and lunar return, progression and composite charts. You can also customize which planets to include in your calculations.
 
 The main goal of this project is to offer a clean, data-driven approach to astrology, making it accessible and programmable.
 
@@ -53,11 +53,14 @@ It is [open source](https://github.com/g-battaglia/Astrologer-API) and directly 
   - [Birth Chart](#birth-chart-1)
   - [Wheel Only Birth Chart (External)](#wheel-only-birth-chart-external)
   - [Synastry Chart](#synastry-chart-1)
+- [Output Options](#output-options)
   - [Change the Output Directory](#change-the-output-directory)
   - [Change Language](#change-language)
   - [Minified SVG](#minified-svg)
   - [SVG without CSS Variables](#svg-without-css-variables)
   - [Grid Only SVG](#grid-only-svg)
+  - [Machine-readable point metadata](#machine-readable-point-metadata)
+- [Chart Options](#chart-options)
 - [Classic Chart Style](#classic-chart-style)
   - [Classic Birth Chart](#classic-birth-chart)
   - [Classic Synastry Chart](#classic-synastry-chart)
@@ -71,14 +74,14 @@ It is [open source](https://github.com/g-battaglia/Astrologer-API) and directly 
 - [Example: Retrieving Aspects](#example-retrieving-aspects)
 - [Relationship Score](#relationship-score)
 - [House Comparison (Synastry Overlay)](#house-comparison-synastry-overlay)
-- [Element \& Quality Distribution Strategies](#element--quality-distribution-strategies)
+- [Element & Quality Distribution Strategies](#element--quality-distribution-strategies)
 - [Ayanamsa (Sidereal Modes)](#ayanamsa-sidereal-modes)
 - [House Systems](#house-systems)
 - [Perspective Type](#perspective-type)
 - [Themes](#themes)
 - [Alternative Initialization](#alternative-initialization)
 - [Arabic Parts (Lots)](#arabic-parts-lots)
-- [Lunar Nodes (Rahu \& Ketu)](#lunar-nodes-rahu--ketu)
+- [Lunar Nodes (Rahu & Ketu)](#lunar-nodes-rahu--ketu)
 - [Fixed Stars](#fixed-stars)
 - [JSON Support](#json-support)
 - [Moon Phase Details](#moon-phase-details)
@@ -89,6 +92,7 @@ It is [open source](https://github.com/g-battaglia/Astrologer-API) and directly 
   - [Lunation Finder](#lunation-finder)
   - [Retrograde Stations](#retrograde-stations)
   - [Sign Ingresses](#sign-ingresses)
+  - [Mundane Aspects](#mundane-aspects)
 - [V6 Advanced Features](#v6-advanced-features)
   - [Uranian / Hamburg School Planets](#uranian--hamburg-school-planets)
   - [Essential Dignities](#essential-dignities)
@@ -100,6 +104,7 @@ It is [open source](https://github.com/g-battaglia/Astrologer-API) and directly 
   - [Occultation Search](#occultation-search)
   - [Davison Composite Chart](#davison-composite-chart)
   - [Relocated Charts](#relocated-charts)
+  - [Motion State & Stations](#motion-state--stations)
   - [Declination & Out-of-Bounds Detection](#declination--out-of-bounds-detection)
   - [Barycentric & Planetocentric Perspectives](#barycentric--planetocentric-perspectives)
   - [Nutation Model](#nutation-model)
@@ -140,7 +145,7 @@ pip3 install kerykeion
 For more installation options and environment setup, see the [Getting Started guide](https://www.kerykeion.net/content/docs/).
 
 > **Note — supported date range.** The default ephemeris data bundled with a
-> fresh install covers the years **1849–2150** (JPL DE440s). Charts outside
+> fresh install covers the years **1850–2150** (JPL DE440s; upper bound exclusive, so through 2149-12-31). Charts outside
 > that range raise a `KerykeionException` until you install a wider data tier:
 >
 > ```text
@@ -153,9 +158,7 @@ For more installation options and environment setup, see the [Getting Started gu
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 subject = AstrologicalSubjectFactory.from_birth_data(
     name="Example Person",
@@ -206,13 +209,13 @@ john = AstrologicalSubjectFactory.from_birth_data(
 
 # Retrieve information about the Sun:
 print(john.sun.model_dump_json())
-# > {"name":"Sun","quality":"Cardinal","element":"Air","sign":"Lib","sign_num":6,"position":16.26789435029039,"abs_pos":196.2678943502904,"emoji":"♎️","point_type":"AstrologicalPoint","house":"Sixth_House","retrograde":false,"speed":0.9884519666546676,"declination":-6.39888585742412, ...}
-# (additional fields omitted: ecliptic_latitude, nakshatra*, gauquelin_sector, azimuth, altitude_above_horizon, is_out_of_bounds, ...)
+# > {"name":"Sun","quality":"Cardinal","element":"Air","sign":"Lib","sign_num":6,"position":16.2678943501,"abs_pos":196.2678943501,"emoji":"♎️","point_type":"AstrologicalPoint","house":"Sixth_House","retrograde":false,"speed":0.9884815716,"motion_state":"average","declination":-6.3988858578, ...}
+# (further fields: ecliptic_latitude, magnitude, source, precision_class, ephemeris_coverage_*_jd, the dignity fields (decan_*, term_ruler, essential_dignity, dignity_score), nakshatra*, gauquelin_sector, azimuth, altitude_above_horizon, is_out_of_bounds — the opt-in ones are null until their calculate_* flag is on)
 
 # Retrieve information about the first house:
 print(john.first_house.model_dump_json())
-# > {"name":"First_House","quality":"Cardinal","element":"Fire","sign":"Ari","sign_num":0,"position":19.72351854613349,"abs_pos":19.72351854613349,"emoji":"♈️","point_type":"House","house":null,"retrograde":null,"speed":886.503993869951, ...}
-# (additional fields omitted: declination, nakshatra*, gauquelin_sector, azimuth, altitude_above_horizon, is_out_of_bounds, ...)
+# > {"name":"First_House","quality":"Cardinal","element":"Fire","sign":"Ari","sign_num":0,"position":19.7235186504,"abs_pos":19.7235186504,"emoji":"♈️","point_type":"House","house":null,"retrograde":null,"speed":886.5070945745,"motion_state":null,"declination":null, ...}
+# (a house is a KerykeionPointModel too: the fields a cusp has no value for are null)
 
 # Retrieve the element of the Moon sign:
 print(john.moon.element)
@@ -236,6 +239,8 @@ print(john.is_diurnal)
 **To avoid GeoNames, provide longitude, latitude, and timezone and set `online=False`:**
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 john = AstrologicalSubjectFactory.from_birth_data(
     "John Lennon", 1940, 10, 9, 18, 30,
     city="Liverpool",
@@ -255,7 +260,7 @@ To generate a chart, use the `ChartDataFactory` to pre-compute chart data, then 
 
 **📖 Chart generation docs: [Charts Documentation](https://www.kerykeion.net/content/docs/charts)**
 
-The info panel in the bottom-left corner reports the chart's **diurnality** — whether the Sun stood above the horizon (`Diurnality: Diurnal`) or below it (`Diurnality: Nocturnal`). Two-wheel charts report both wheels, since each keeps its own, and drop the heading to fit (`Natal Nocturnal · Transit Diurnal`; a synastry names the two subjects). The line is omitted where it has no referent: any chart not cast from the Earth — a heliocentric one excludes the Sun (it is the centre body), and a Marscentric or Selenocentric one draws a Sun that is not the one measured, since `is_diurnal` comes from a tropical geocentric Sun — and a midpoint composite, which represents no single sky. A solar arc direction is omitted too: it keeps the nativity's instant, so its value answers for the birth chart rather than for the wheel drawn from it. Pass `show_diurnality=False` to `ChartDrawer` to leave it out entirely — the panel then keeps exactly the spacing it had before the line existed.
+The info panel in the bottom-left corner also reports the chart's **diurnality** — `Diurnal` when the Sun stood above the horizon, `Nocturnal` below it. `show_diurnality=False` leaves it out; [Chart Options](#chart-options) lists the charts on which the line is omitted because it has no referent.
 
 **Tip:**
 The optimized way to open the generated SVG files is with a web browser (e.g., Chrome, Firefox).
@@ -265,9 +270,7 @@ To improve compatibility across different applications, you can use the `remove_
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subject
 john = AstrologicalSubjectFactory.from_birth_data(
@@ -301,9 +304,7 @@ An "external" birth chart places the zodiac wheel on the outer ring, offering an
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subject
 birth_chart = AstrologicalSubjectFactory.from_birth_data(
@@ -333,9 +334,7 @@ Synastry charts overlay two individuals' planetary positions to analyze relation
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subjects
 first = AstrologicalSubjectFactory.from_birth_data(
@@ -374,9 +373,7 @@ Transit charts compare current planetary positions against a natal chart:
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subjects
 transit = AstrologicalSubjectFactory.from_birth_data(
@@ -415,10 +412,7 @@ Solar returns calculate the exact moment the Sun returns to its natal position e
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.planetary_returns.factory import PlanetaryReturnFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, PlanetaryReturnFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create natal subject
 john = AstrologicalSubjectFactory.from_birth_data(
@@ -458,10 +452,7 @@ solar_return_chart.save_svg(output_path=output_dir, filename="john-lennon-solar-
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.planetary_returns.factory import PlanetaryReturnFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, PlanetaryReturnFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create natal subject
 john = AstrologicalSubjectFactory.from_birth_data(
@@ -495,6 +486,22 @@ single_wheel_chart.save_svg(output_path=output_dir, filename="john-lennon-solar-
 
 **📖 Planetary return factory docs: [PlanetaryReturnFactory](https://www.kerykeion.net/content/docs/planetary_return_factory)**
 
+Return instants are reported to the whole second, and a reported instant can be handed back as the seed of the next search: `next_return_from_iso_formatted_time(reported, "Solar")` gives the *following* return, never the same one again, and `backwards=True` from the same seed gives the previous one. The same holds for lunar returns, heliocentric returns and lunar-node crossings.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, PlanetaryReturnFactory
+
+john = AstrologicalSubjectFactory.from_birth_data(
+    "John Lennon", 1940, 10, 9, 18, 30, lng=-2.9833, lat=53.4, tz_str="Europe/London", online=False,
+)
+returns = PlanetaryReturnFactory(john, lng=-2.9833, lat=53.4, tz_str="Europe/London", online=False)
+
+first = returns.next_return_from_iso_formatted_time("2022-06-01T00:00:00Z", "Solar")
+following = returns.next_return_from_iso_formatted_time(first.iso_formatted_utc_datetime, "Solar")
+print(first.iso_formatted_utc_datetime, following.iso_formatted_utc_datetime)
+# 2022-10-09T14:12:26+00:00 2023-10-09T20:04:25+00:00
+```
+
 ![John Lennon Solar Return Chart (Single Wheel)](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20Solar%20Return%20-%20SingleReturnChart%20Chart%20-%20Modern.svg)
 
 ### Lunar Return Chart
@@ -503,10 +510,7 @@ Lunar returns calculate when the Moon returns to its natal position (approximate
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.planetary_returns.factory import PlanetaryReturnFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, PlanetaryReturnFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create natal subject
 john = AstrologicalSubjectFactory.from_birth_data(
@@ -551,9 +555,7 @@ Composite charts create a single chart from two individuals' midpoints to repres
 
 ```python
 from pathlib import Path
-from kerykeion import CompositeSubjectFactory, AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, CompositeSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subjects (offline configuration)
 angelina = AstrologicalSubjectFactory.from_birth_data(
@@ -572,8 +574,10 @@ brad = AstrologicalSubjectFactory.from_birth_data(
     online=False,
 )
 
-# Step 2: Create composite subject
-factory = CompositeSubjectFactory(angelina, brad)
+# Step 2: Create composite subject. `house_anchor` picks the angle the composite
+# house ring is anchored on — "auto" (default), "ascendant" or "midheaven"; the
+# model reports the choice in composite_model.house_anchor and .house_frame.
+factory = CompositeSubjectFactory(angelina, brad, house_anchor="auto")
 composite_model = factory.get_midpoint_composite_subject_model()
 
 # Step 3: Pre-compute composite chart data
@@ -601,9 +605,7 @@ For _all_ the charts, you can generate a wheel-only chart by using the method `s
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subject
 birth_chart = AstrologicalSubjectFactory.from_birth_data(
@@ -631,9 +633,7 @@ birth_chart_svg.save_wheel_only_svg_file(output_path=output_dir, filename="john-
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subject
 birth_chart = AstrologicalSubjectFactory.from_birth_data(
@@ -663,9 +663,7 @@ birth_chart_svg.save_wheel_only_svg_file(
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subjects
 first = AstrologicalSubjectFactory.from_birth_data(
@@ -696,15 +694,17 @@ synastry_chart.save_wheel_only_svg_file(output_path=output_dir, filename="lennon
 
 ![John Lennon and Paul McCartney Synastry](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Synastry%20Chart%20-%20Modern%20Wheel%20Only.svg)
 
+## Output Options
+
+Every `ChartDrawer` — whatever the chart type or style — can be pointed at a folder, translated, minified, made self-contained, or reduced to its aspect grid.
+
 ### Change the Output Directory
 
 To save the SVG file in a custom location, specify the `output_path` parameter in `save_svg()`:
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subjects
 first = AstrologicalSubjectFactory.from_birth_data(
@@ -731,7 +731,7 @@ synastry_chart = ChartDrawer(chart_data=chart_data)
 output_dir = Path("charts_output")
 output_dir.mkdir(exist_ok=True)
 synastry_chart.save_svg(output_path=output_dir)
-print("Saved to", (output_dir / f"{synastry_chart.first_obj.name} - Synastry Chart.svg").resolve())
+print("Saved to", (output_dir / f"{synastry_chart.first_obj.name} - Synastry Chart - Modern.svg").resolve())
 ```
 
 ### Change Language
@@ -740,9 +740,7 @@ You can switch chart language by passing `chart_language` to the `ChartDrawer` c
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subject
 birth_chart = AstrologicalSubjectFactory.from_birth_data(
@@ -773,9 +771,7 @@ built-in strings:
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 birth_chart = AstrologicalSubjectFactory.from_birth_data(
     "John Lennon", 1940, 10, 9, 18, 30,
@@ -825,9 +821,7 @@ To generate a minified SVG, set `minify=True` in the `save_svg()` method:
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subject
 birth_chart = AstrologicalSubjectFactory.from_birth_data(
@@ -859,9 +853,7 @@ To generate an SVG without CSS variables, set `remove_css_variables=True` in the
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subject
 birth_chart = AstrologicalSubjectFactory.from_birth_data(
@@ -895,9 +887,7 @@ It's possible to generate a grid-only SVG, useful for creating a custom layout. 
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subjects
 birth_chart = AstrologicalSubjectFactory.from_birth_data(
@@ -926,7 +916,7 @@ output_dir.mkdir(exist_ok=True)
 aspect_grid_chart.save_aspect_grid_only_svg_file(output_path=output_dir, filename="lennon-mccartney-aspect-grid")
 ```
 
-![John Lennon — Aspect Grid](https://raw.githubusercontent.com/g-battaglia/kerykeion/main/tests/data/svg/John%20Lennon%20-%20Aspect%20Grid%20Only%20-%20Natal%20Chart%20-%20Aspect%20Grid%20Only.svg)
+![John Lennon — Aspect Grid](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Aspect%20Grid%20Only%20-%20Natal%20Chart%20-%20Aspect%20Grid%20Only.svg)
 
 ### Machine-readable point metadata
 
@@ -945,8 +935,8 @@ bounds, plus `kr:magnitude`, `kr:nearpoint` and `kr:orb` on fixed stars — and 
 chart-level analyses it takes part in: `kr:angularity` (one attribute listing
 every angle the point stands on, as `Ascendant:0.8991 Medium_Coeli:4.3156`,
 closest first) and `kr:stellium`. None of these are gated by a
-rendering option; the opt-in marks above only decide whether a reader sees them
-drawn. An attribute is **absent** when the model does not carry the value, so
+rendering option; the opt-in marks in [Chart Options](#chart-options) only decide
+whether a reader sees them drawn. An attribute is **absent** when the model does not carry the value, so
 silence means "this chart does not compute it" rather than zero or false — a
 heliocentric chart states no motion state, a midpoint composite none at all.
 Attribute names are lowercase letters with no separators (`motionstate`, not
@@ -955,32 +945,52 @@ and a name carrying an underscore would be dropped silently. See the
 [charts documentation](https://www.kerykeion.net/content/docs/charts) for the
 full table.
 
-## Classic Chart Style
+## Chart Options
 
-Since v6 the **modern** concentric-ring layout is the default chart style. The traditional **classic** wheel remains fully supported: set it at the instance level via `ChartDrawer(chart_data=..., style="classic")` or per-render via `save_svg(style="classic")`. Both styles work with all six themes.
+`ChartDrawer` takes its options at construction. `style` and `glyph_size` can also be overridden per render (`save_svg(style="classic")`); every other option is constructor-only. All of them apply to the full chart and to the wheel-only output alike.
 
-Available `style` values: `"modern"` (default) and `"classic"`.
+**Style.** Since v6 the **modern** concentric-ring layout is the default. The traditional **classic** wheel remains fully supported: `ChartDrawer(chart_data=..., style="classic")` or `save_svg(style="classic")`. Available `style` values: `"modern"` (default) and `"classic"`. Both styles work with all three themes — see [Themes](#themes) — or with no theme at all.
 
 Default filenames spell the style out: `save_svg()` writes `"{name} - {chart type} Chart - Modern.svg"`, and with `style="classic"` it writes `"... - Classic.svg"` (wheel-only output uses `" - Modern Wheel Only"` / `" - Classic Wheel Only"`).
 
-**Info-panel keyword arguments** (every chart type, both styles):
+**Every chart, both styles:**
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `show_diurnality` | `bool` | `True` | Print the chart's diurnality (Sun above or below the horizon) in the bottom-left info panel. Constructor only — there is no `save_svg()` override |
+| `theme` | `str \| None` | `"classic"` | `"classic"`, `"dark"` or `"black-and-white"`; `None` ships the CSS variables unthemed, for your own stylesheet. See [Themes](#themes) |
+| `chart_language` | `str` | `"EN"` | One of the ten chart languages; a `language_pack` dict supplies custom labels. See [Change Language](#change-language) |
+| `custom_title` | `str \| None` | `None` | Replace the generated chart title |
+| `transparent_background` | `bool` | `False` | Leave the page unpainted instead of filling it with the theme's paper colour. The wheel-only output paints its background too, so set this to lay the wheel over your own page |
+| `auto_size` | `bool` | `True` | Size the page to its contents; `padding` (default `20`, in px) is the margin left around them |
+| `show_diurnality` | `bool` | `True` | Print the chart's diurnality in the bottom-left info panel — `Diurnal` when the Sun stood above the horizon, `Nocturnal` below it. Two-wheel charts report both wheels (`Natal Nocturnal · Transit Diurnal`; a synastry names the two subjects). The line is omitted where it has no referent: any chart not cast from the Earth (a heliocentric chart has no Sun to point at; a Marscentric or Selenocentric one draws a Sun that is not the one measured), a midpoint composite (no single sky) and a solar arc direction (it keeps the nativity's instant). With `False` the panel keeps exactly the spacing it had before the line existed |
 
 **Modern-only keyword arguments** (ignored by the classic style):
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `show_zodiac_background_ring` | `bool` | `True` | Draw colored zodiac wedges as the outer zodiac annulus around the cusp ring |
-| `glyph_size` | `str` | `"medium"` | Size of the planet cluster — glyph, degrees, sign, minutes and ℞. `"small"` is the medium cluster at 90%; `"large"` draws the planet glyph at the classic style's own size — 24px single / 19.2px dual at the default page with the zodiac background ring active, for glyphs at optical weight 1.0 (the per-glyph map stays applied; with the ring off the whole modern wheel, cluster included, draws 1/0.92 larger at every size). On the dual rings parity belongs to the glyph alone: the reading follows the single wheel's ×1.248 progression, so the dual numerals never outgrow the single wheel's. Overridable per render |
+| `glyph_size` | `str` | `"medium"` | Size of the planet cluster — glyph, degrees, sign, minutes and ℞. `"medium"` is the default drawing; `"small"` is the same cluster at 90%; `"large"` draws the planet glyph at the classic style's own size (24px on a single wheel, 19.2px on a dual wheel, at the default page with the zodiac background ring on). On a single wheel the degrees and sign grow with the large glyph; on the dual rings only the glyph grows and the reading keeps the medium size. Overridable per render: `save_svg(glyph_size="large")` |
 
-**Dual-chart keyword arguments** (Synastry, Transit, Composite, Dual Return):
+<table>
+  <tr>
+    <td align="center"><strong>small</strong></td>
+    <td align="center"><strong>medium</strong> (default)</td>
+    <td align="center"><strong>large</strong></td>
+  </tr>
+  <tr>
+    <td><img src="https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Natal%20Chart%20-%20Modern%20Small.svg" width="250" alt="Modern natal chart with the small glyph size"></td>
+    <td><img src="https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Natal%20Chart%20-%20Modern.svg" width="250" alt="Modern natal chart with the default medium glyph size"></td>
+    <td><img src="https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Natal%20Chart%20-%20Modern%20Large.svg" width="250" alt="Modern natal chart with the large glyph size"></td>
+  </tr>
+</table>
+
+**Dual-chart keyword arguments** (Synastry, Transit, Dual Return, Progression — a composite is a single wheel):
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `double_chart_aspect_grid_type` | `str` | `"list"` | Aspect grid layout: `"list"` (compact vertical list) or `"table"` (traditional cross-reference grid) |
+| `show_house_position_comparison` | `bool` | `True` | Draw the house-comparison grid: where the second subject's points fall in the first subject's houses |
+| `show_cusp_position_comparison` | `bool` | `False` | Draw the cusp-comparison grid: where the second subject's house cusps fall in the first subject's houses |
 
 **Classic-only constructor arguments** (ignored by the modern style, which logs a warning when they are set):
 
@@ -1053,13 +1063,15 @@ referent, and none of them claims something its own sky does not have:
   </tr>
 </table>
 
+## Classic Chart Style
+
+Select the classic wheel with `style="classic"` (constructor or per render); its own options are listed under [Chart Options](#chart-options). The examples below render the same charts as above in the classic style.
+
 ### Classic Birth Chart
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 john = AstrologicalSubjectFactory.from_birth_data(
     "John Lennon", 1940, 10, 9, 18, 30,
@@ -1083,9 +1095,7 @@ chart.save_svg(output_path=output_dir, filename="john-lennon-classic", style="cl
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 john = AstrologicalSubjectFactory.from_birth_data(
     "John Lennon", 1940, 10, 9, 18, 30,
@@ -1116,9 +1126,7 @@ chart.save_svg(output_path=output_dir, filename="lennon-mccartney-synastry-class
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 john = AstrologicalSubjectFactory.from_birth_data(
     "John Lennon", 1940, 10, 9, 18, 30,
@@ -1150,9 +1158,7 @@ chart.save_svg(output_path=output_dir, filename="lennon-transit-classic", style=
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 john = AstrologicalSubjectFactory.from_birth_data(
     "John Lennon", 1940, 10, 9, 18, 30,
@@ -1237,7 +1243,7 @@ Technique results are accepted directly, each rendering its own report:
 ```python
 from kerykeion import AstrologicalSubjectFactory, FirdariaFactory, ReportGenerator
 
-subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, "Rome", "IT")
+subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
 ReportGenerator(FirdariaFactory.from_subject(subject, target_date="2026-06-04")).print_report()
 ```
 
@@ -1367,7 +1373,7 @@ print(dual_chart_result.aspects[0])
 ```python
 from kerykeion import AstrologicalSubjectFactory, AspectsFactory
 
-subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, "Rome", "IT")
+subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
 
 # Custom aspect set with explicit per-aspect orbs (a list of {name, orb} dicts):
 custom_aspects = [
@@ -1432,8 +1438,8 @@ print(f"Description: {result.score_description}")
 ```python
 from kerykeion import AstrologicalSubjectFactory, HouseComparisonFactory
 
-person_a = AstrologicalSubjectFactory.from_birth_data("Person A", 1990, 5, 15, 10, 30, "Rome", "IT")
-person_b = AstrologicalSubjectFactory.from_birth_data("Person B", 1992, 8, 23, 14, 45, "Milan", "IT")
+person_a = AstrologicalSubjectFactory.from_birth_data("Person A", 1990, 5, 15, 10, 30, lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
+person_b = AstrologicalSubjectFactory.from_birth_data("Person B", 1992, 8, 23, 14, 45, lng=9.19, lat=45.4642, tz_str="Europe/Rome", online=False)
 
 comparison = HouseComparisonFactory(person_a, person_b).get_house_comparison()
 for placement in comparison.first_points_in_second_houses:
@@ -1443,7 +1449,7 @@ for placement in comparison.first_points_in_second_houses:
 
 ## Element & Quality Distribution Strategies
 
-`ChartDataFactory` now offers two strategies for calculating element and modality totals. The default `"weighted"` mode leans on a curated map that emphasises core factors (for example `sun`, `moon`, and `ascendant` weight 2.0, angles such as `medium_coeli` 1.5, personal planets 1.5, social planets 1.0, outers 0.5, and minor bodies 0.3–0.8). Provide `distribution_method="pure_count"` when you want every active point to contribute equally.
+`ChartDataFactory` offers two strategies for calculating element and modality totals. The default `"weighted"` mode leans on a curated map that emphasises core factors (for example `sun`, `moon`, and `ascendant` weight 2.0, angles such as `medium_coeli` 1.5, personal planets 1.5, social planets 1.0, outers 0.5, and minor bodies 0.3–0.8). Provide `distribution_method="pure_count"` when you want every active point to contribute equally.
 
 You can refine the weighting without rebuilding the dictionary: pass lowercase point names to `custom_distribution_weights` and use `"__default__"` to override the fallback value applied to entries that are not listed explicitly.
 
@@ -1487,6 +1493,8 @@ All convenience helpers (`create_synastry_chart_data`, `create_transit_chart_dat
 By default, the zodiac type is **Tropical**. To use **Sidereal**, specify the sidereal mode:
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 johnny = AstrologicalSubjectFactory.from_birth_data(
     "Johnny Depp", 1963, 6, 9, 0, 0,
     lng=-87.1112,
@@ -1506,6 +1514,8 @@ Kerykeion supports **47 named sidereal modes** plus a **USER** mode for custom a
 **Custom ayanamsa (USER mode):**
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 custom = AstrologicalSubjectFactory.from_birth_data(
     "Custom Ayanamsa", 2000, 1, 1, 0, 0,
     lng=0.0, lat=51.5, tz_str="Etc/GMT", online=False,
@@ -1525,6 +1535,8 @@ custom = AstrologicalSubjectFactory.from_birth_data(
 By default, houses are calculated using **Placidus**. Configure a different house system as follows:
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 johnny = AstrologicalSubjectFactory.from_birth_data(
     "Johnny Depp", 1963, 6, 9, 0, 0,
     lng=-87.1112,
@@ -1541,11 +1553,15 @@ johnny = AstrologicalSubjectFactory.from_birth_data(
 
 All house systems available in the ephemeris backend are supported, including Gauquelin Sectors (see [Gauquelin Sectors](#gauquelin-sectors) below).
 
+Some systems crowd several cusps onto one longitude at extreme latitudes (Sunshine at 74° N puts the second through the sixth cusp on one degree). `subject.coincident_house_cusps` lists those groups of house numbers — the houses between them have no width, so no point can ever be in them — and is empty for every chart whose twelve cusps are twelve distinct points, which is every ordinary chart. Inside the polar circle a house system that is undefined there is substituted (Porphyry by default) and the substitution is recorded in `subject.polar_house_fallbacks`; `show_polar_fallback_note=True` prints it on the chart.
+
 ## Perspective Type
 
 By default, Kerykeion uses the **Apparent Geocentric** perspective (the most standard in astrology). Other perspectives (e.g., **Heliocentric**) can be set this way:
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 johnny = AstrologicalSubjectFactory.from_birth_data(
     "Johnny Depp", 1963, 6, 9, 0, 0,
     lng=-87.1112,
@@ -1595,9 +1611,7 @@ Here's an example of how to set the theme:
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subject
 dark_theme_subject = AstrologicalSubjectFactory.from_birth_data(
@@ -1611,15 +1625,13 @@ dark_theme_subject = AstrologicalSubjectFactory.from_birth_data(
 # Step 2: Pre-compute chart data
 chart_data = ChartDataFactory.create_natal_chart_data(dark_theme_subject)
 
-# Step 3: Create visualization with dark high contrast theme
+# Step 3: Create visualization with the dark theme
 dark_theme_natal_chart = ChartDrawer(chart_data=chart_data, theme="dark")
 
 output_dir = Path("charts_output")
 output_dir.mkdir(exist_ok=True)
 dark_theme_natal_chart.save_svg(output_path=output_dir, filename="john-lennon-natal-dark")
 ```
-
-![John Lennon](https://www.kerykeion.net/img/showcase/John%20Lennon%20-%20Dark%20-%20Natal%20Chart.svg)
 
 ## Alternative Initialization
 
@@ -1660,7 +1672,7 @@ from kerykeion import AstrologicalSubjectFactory
 from kerykeion.settings.config_constants import DEFAULT_ACTIVE_POINTS
 
 subject = AstrologicalSubjectFactory.from_birth_data(
-    "Jane", 1990, 6, 15, 12, 0, "Rome", "IT",
+    "Jane", 1990, 6, 15, 12, 0, lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False,
     active_points=DEFAULT_ACTIVE_POINTS + ["Pars_Fortunae", "Pars_Spiritus", "Pars_Amoris", "Pars_Fidei"],
 )
 print(subject.pars_fortunae.sign, subject.pars_fortunae.position)
@@ -1675,7 +1687,7 @@ Kerykeion supports both **True** and **Mean** Lunar Nodes:
 - **Mean North Lunar Node**: `"Mean_North_Lunar_Node"`
 - **Mean South Lunar Node**: `"Mean_South_Lunar_Node"`
 
-By default, only the **True** nodes are active in charts and aspect calculations. To include the Mean nodes (or customize which nodes appear), pass the `active_points` parameter to the `ChartDataFactory` methods.
+By default only the **True North** node is active in charts and aspect calculations (`True_North_Lunar_Node` is in the default active points; `True_South_Lunar_Node` is not). To include the South node or the Mean nodes, pass the `active_points` parameter to the `ChartDataFactory` methods.
 
 **📖 ChartDataFactory documentation: [ChartDataFactory Guide](https://www.kerykeion.net/content/docs/chart_data_factory)**
 
@@ -1683,9 +1695,7 @@ Example:
 
 ```python
 from pathlib import Path
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Step 1: Create subject
 subject = AstrologicalSubjectFactory.from_birth_data(
@@ -1696,7 +1706,7 @@ subject = AstrologicalSubjectFactory.from_birth_data(
     online=False,
 )
 
-# Step 2: Pre-compute chart data with custom active points including true nodes
+# Step 2: Pre-compute chart data with custom active points including the Mean nodes
 chart_data = ChartDataFactory.create_natal_chart_data(
     subject,
     active_points=[
@@ -1726,7 +1736,7 @@ chart = ChartDrawer(chart_data=chart_data)
 
 output_dir = Path("charts_output")
 output_dir.mkdir(exist_ok=True)
-chart.save_svg(output_path=output_dir, filename="johnny-depp-custom-points")
+chart.save_svg(output_path=output_dir, filename="john-lennon-mean-nodes")
 ```
 
 ## Fixed Stars
@@ -1742,7 +1752,7 @@ Fixed stars are **opt-in**: pass the names you want to `active_fixed_stars` when
 
 ```python
 from kerykeion import AstrologicalSubjectFactory
-from kerykeion.chart_data.factory import ChartDataFactory
+from kerykeion import ChartDataFactory
 
 subject = AstrologicalSubjectFactory.from_birth_data(
     "John Lennon", 1940, 10, 9, 18, 30,
@@ -1823,18 +1833,19 @@ ReportGenerator(overview).print_report()
 Moon Phase Overview — Tue, 01 Apr 2025 06:51:00 +0000
 =====================================================
 
-+Moon Summary--+--------------------+
-| Field        | Value              |
-+--------------+--------------------+
-| Phase Name   | Waxing Crescent 🌒 |
-| Major Phase  | New Moon           |
-| Stage        | Waxing             |
-| Illumination | 12%                |
-| Age (days)   | 3                  |
-| Lunar Cycle  | 11.068%            |
-| Sun Sign     | Ari                |
-| Moon Sign    | Tau                |
-+--------------+--------------------+
++Moon Summary------+--------------------+
+| Field            | Value              |
++------------------+--------------------+
+| Phase Name       | Waxing Crescent 🌒 |
+| Major Phase      | New Moon           |
+| Stage            | Waxing             |
+| Illumination     | 12%                |
+| Age (days)       | 3                  |
+| Age (exact days) | 2.8286             |
+| Lunar Cycle      | 11.068%            |
+| Sun Sign         | Ari                |
+| Moon Sign        | Tau                |
++------------------+--------------------+
 
 +Illumination Details-------+
 | Field            | Value  |
@@ -1905,13 +1916,13 @@ print(overview.model_dump_json(exclude_none=True, indent=2))
 
 ## Timing Factories
 
-Six lightweight factories that work directly from dates/locations (no full `AstrologicalSubject` is constructed). Times are returned as timezone-aware UTC datetimes.
+Seven lightweight factories that work directly from dates and locations — no `AstrologicalSubjectModel` is built. `SunTimesFactory` and `PlanetaryHoursFactory` return timezone-aware UTC datetimes; the event finders return ISO-8601 UTC strings with the Julian Day beside them.
 
 ### Sun Times
 
 `SunTimesFactory` returns sunrise / sunset / solar-noon / day-length for a civil date at a location, with polar day/night detection.
 
-**What the numbers mean.** Sunrise and sunset are the moment the Sun's apparent **upper limb** meets the horizon: the semidiameter is taken from the real Earth–Sun distance rather than a fixed 16′, and refraction from a standard atmosphere (1013.25 hPa, 15 °C), which puts the Sun's geometric centre near −0.83° at the event. The horizon is the level sea horizon at any elevation, which is the convention published rise/set tables use. Solar noon is the **meridian transit** — the instant the Sun is highest — not the midpoint of sunrise and sunset; the two agree only while the declination is stationary, and away from the solstices the midpoint drifts by up to a minute, more the higher the latitude. Because a transit is a meridian crossing rather than a horizon crossing, solar noon is reported on polar days too, when there is no rise/set pair at all.
+**What the numbers mean.** Sunrise and sunset are the moment the Sun's apparent **upper limb** meets the level sea horizon, with the real semidiameter and standard refraction (the Sun's centre is near −0.83° at the event). Solar noon is the **meridian transit** — the instant the Sun is highest — not the midpoint of sunrise and sunset, so it is reported on polar days too. The full conventions are in the [Sun Times docs](https://www.kerykeion.net/content/docs/sun_times_factory).
 
 **Sunrise is not `is_diurnal`.** `AstrologicalSubjectModel.is_diurnal` tests the Sun's **geometric centre** against the true horizon — no disc, no atmosphere — because that is the question a chart is cast from. Sunrise counts the Sun as risen as soon as its upper edge shows through the air, which happens earlier. The gap is real and grows towards the poles: about **3.3 min at the equator, 4.4 min at Rome, 8.2 min at Reykjavík and 10 min at Tromsø**. Both answers are right to their own question, and neither should ever be derived from the other.
 
@@ -1978,6 +1989,24 @@ for station in result.stations:
     print(station.iso_utc, station.planet, station.station_type)  # station_type: 'SR' (turns retrograde) / 'SD' (turns direct)
 ```
 
+`retrograde_periods_from_iso_range` turns the stations into spans — the intervals during which a planet is retrograde. A retrograde station opens a span and a direct station closes it; the range edges clip, so a planet already retrograde on the first day is reported from that day with `start_clipped=True`, and one still retrograde on the last day with `end_clipped=True`. `"Chiron"` is accepted opt-in by both finders; the Sun and Moon are rejected.
+
+```python
+from kerykeion import RetrogradeStationFactory
+
+periods = RetrogradeStationFactory.retrograde_periods_from_iso_range("2026-01-01", "2026-12-31")
+for period in periods.periods:
+    print(period.planet, period.start, "->", period.end, period.start_clipped, period.end_clipped)
+# Mercury 2026-02-26T06:48:10Z -> 2026-03-20T19:32:50Z False False
+# Mercury 2026-06-29T17:35:55Z -> 2026-07-23T22:57:51Z False False
+# ...
+
+# Opt in to Chiron (Mercury..Pluto is the default set):
+with_chiron = RetrogradeStationFactory.retrograde_periods_from_iso_range(
+    "2026-01-01", "2026-12-31", planets=["Mercury", "Chiron"]
+)
+```
+
 ### Sign Ingresses
 
 `SignIngressFactory` finds the moments planets cross from one zodiac sign into the next (Sun–Pluto by default; pass `planets=["Moon"]` to include the fast-moving Moon).
@@ -1990,9 +2019,38 @@ for ingress in result.ingresses:
     print(ingress.iso_utc, ingress.planet, "->", ingress.sign)
 ```
 
+`sign_periods_from_iso_range` answers the other question — *which sign is each planet in, and for how long*: per planet, the contiguous stays that cover the whole range. The first stay opens at the range start (`start_clipped=True`), each ingress hands over to the next stay (the `end` of one is the `start` of the next, to the same instant), and the last stay closes at the range end (`end_clipped=True`). A sidereal request yields sidereal stays with sidereal ingress instants. The Moon is opt-in here too.
+
+```python
+from kerykeion import SignIngressFactory
+
+stays = SignIngressFactory.sign_periods_from_iso_range("2026-03-01", "2026-03-31", planets=["Sun", "Mercury"])
+for stay in stays.periods:
+    print(stay.planet, stay.sign, stay.start, "->", stay.end, stay.start_clipped, stay.end_clipped)
+# Sun Pis 2026-03-01T00:00:00Z -> 2026-03-20T14:45:58Z True False
+# Sun Ari 2026-03-20T14:45:58Z -> 2026-04-01T00:00:00Z False True
+# Mercury Pis 2026-03-01T00:00:00Z -> 2026-04-01T00:00:00Z True True
+```
+
+### Mundane Aspects
+
+`MundaneAspectFactory` finds the exact moments two moving bodies form an aspect in the sky — no natal chart involved. Points are the Moon through Pluto, Chiron and the lunar nodes; aspects are the longitude aspects of the default set. ISO inputs without an offset are treated as UTC.
+
+```python
+from kerykeion import MundaneAspectFactory
+
+result = MundaneAspectFactory.from_iso_range(
+    "2026-01-01", "2026-01-31",
+    points=["Sun", "Moon", "Mars", "Jupiter"], aspects=["conjunction", "opposition"],
+)
+for hit in result.aspects[:3]:
+    print(hit.iso_utc, hit.point_a, hit.aspect, hit.point_b, hit.point_a_sign, hit.point_b_sign)
+# 2026-01-03T10:02:55Z Moon opposition Sun Can Cap
+```
+
 ## V6 Advanced Features
 
-Kerykeion v6 adds a suite of advanced astronomical and astrological calculation modules. All v6 features are optional opt-in — existing code works unchanged.
+Kerykeion v6 adds a suite of advanced astronomical and astrological calculation modules. Every module below is opt-in: nothing here changes the output of a chart that does not ask for it. (Code written for v5 needs the [migration guide](https://www.kerykeion.net/content/docs/migration) — several classes were renamed and some defaults changed.)
 
 ### Uranian / Hamburg School Planets
 
@@ -2034,9 +2092,11 @@ The nakshatras divide the *sidereal* zodiac. A sidereal chart supplies those
 longitudes itself; on a tropical chart they are rotated by `nakshatra_ayanamsa`
 (default `"LAHIRI"`) for the 27-fold division only, so the chart stays tropical
 and still names the nakshatra a Jyotish chart would name. Pass
-`nakshatra_ayanamsa=None` to get back the pre-v6 uncorrected values.
+`nakshatra_ayanamsa=None` to divide the tropical longitudes as they are (the uncorrected values, with a warning).
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 subject = AstrologicalSubjectFactory.from_birth_data(
     "Example", 1985, 4, 15, 8, 30,
     lng=11.25, lat=43.77, tz_str="Europe/Rome", online=False,
@@ -2192,6 +2252,8 @@ the phase (`"stationary_direct"`, SD). Where no second sample is available the
 generic `"stationary"` stands.
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 subject = AstrologicalSubjectFactory.from_birth_data(
     "Mercury Station", 1990, 8, 25, 12, 0,
     lng=-0.1276, lat=51.5074, tz_str="Europe/London", online=False,
@@ -2208,6 +2270,8 @@ print(f"Mercury: {subject.mercury.motion_state} at {subject.mercury.speed:.5f}°
 Equatorial declination and OOB detection for all celestial points.
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 subject = AstrologicalSubjectFactory.from_birth_data(
     "Example", 1985, 4, 15, 8, 30,
     lng=11.25, lat=43.77, tz_str="Europe/Rome", online=False,
@@ -2221,6 +2285,8 @@ print(f"Sun OOB: {subject.sun.is_out_of_bounds}")
 Solar system barycenter or any planet as the observer origin.
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 bary = AstrologicalSubjectFactory.from_birth_data(
     "Bary", 1985, 4, 15, 8, 30,
     lng=11.25, lat=43.77, tz_str="Europe/Rome", online=False,
@@ -2234,6 +2300,8 @@ print(f"Barycentric Sun: {bary.sun.abs_pos:.4f}")
 True/mean obliquity and nutation in longitude/obliquity.
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 subject = AstrologicalSubjectFactory.from_birth_data(
     "Example", 2000, 1, 1, 12, 0,
     lng=0, lat=0, tz_str="Etc/GMT", online=False,
@@ -2266,6 +2334,8 @@ for star in stars:
 36-sector system for statistical astrology research.
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 subject = AstrologicalSubjectFactory.from_birth_data(
     "Example", 1985, 4, 15, 8, 30,
     lng=11.25, lat=43.77, tz_str="Europe/Rome", online=False,
@@ -2280,6 +2350,8 @@ print(f"Mars Gauquelin sector: {subject.mars.gauquelin_sector:.2f}")
 Horizon coordinates for all celestial points.
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 subject = AstrologicalSubjectFactory.from_birth_data(
     "Example", 1985, 4, 15, 8, 30,
     lng=11.25, lat=43.77, tz_str="Europe/Rome", online=False,
@@ -2293,6 +2365,8 @@ print(f"Sun azimuth: {subject.sun.azimuth:.2f}, altitude: {subject.sun.altitude_
 Interpolated Lilith, Mean Priapus, and True Priapus (anti-Lilith points).
 
 ```python
+from kerykeion import AstrologicalSubjectFactory
+
 subject = AstrologicalSubjectFactory.from_birth_data(
     "Example", 1985, 4, 15, 8, 30,
     lng=11.25, lat=43.77, tz_str="Europe/Rome", online=False,
@@ -2361,9 +2435,7 @@ chart drawer) works transparently.
 ```python
 from pathlib import Path
 
-from kerykeion import AstrologicalSubjectFactory, SecondaryProgressionFactory
-from kerykeion.chart_data.factory import ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, SecondaryProgressionFactory, ChartDataFactory, ChartDrawer
 
 natal = AstrologicalSubjectFactory.from_birth_data(
     "Example", 1985, 4, 15, 8, 30,
@@ -2469,7 +2541,7 @@ for line in lines[:5]:
 ```python
 from kerykeion import AstrologicalSubjectFactory, DominantsFactory
 
-subject = AstrologicalSubjectFactory.from_birth_data("John Lennon", 1940, 10, 9, 18, 30, "Liverpool", "GB")
+subject = AstrologicalSubjectFactory.from_birth_data("John Lennon", 1940, 10, 9, 18, 30, lng=-2.9833, lat=53.4, tz_str="Europe/London", online=False)
 
 dominants = DominantsFactory.from_subject(subject, strategy="modern")
 print(dominants.dominant_planet, dominants.dominant_sign)
@@ -2486,7 +2558,7 @@ almuten = DominantsFactory.from_subject(subject, strategy="almuten_figuris", inc
 ```python
 from kerykeion import AstrologicalSubjectFactory, ZodiacalReleasingFactory
 
-subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, "Rome", "IT")
+subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
 zr = ZodiacalReleasingFactory.from_subject(subject, lot="fortune", levels=2, target_date="2026-06-04")
 print(zr.lot_sign, len(zr.periods), "top-level periods")
 ```
@@ -2498,7 +2570,7 @@ print(zr.lot_sign, len(zr.periods), "top-level periods")
 ```python
 from kerykeion import AstrologicalSubjectFactory, ProfectionsFactory
 
-subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, "Rome", "IT")
+subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
 profections = ProfectionsFactory.from_subject(subject, target_date="2026-06-04")
 print(f"Age {profections.current.age}: house {profections.current.house}, lord {profections.current.lord}")
 ```
@@ -2510,7 +2582,7 @@ print(f"Age {profections.current.age}: house {profections.current.house}, lord {
 ```python
 from kerykeion import AstrologicalSubjectFactory, FirdariaFactory
 
-subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, "Rome", "IT")
+subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
 firdaria = FirdariaFactory.from_subject(subject, target_date="2026-06-04")
 print(f"Current lord: {firdaria.current.lord}" if firdaria.current else "No current period")
 ```
@@ -2522,7 +2594,7 @@ print(f"Current lord: {firdaria.current.lord}" if firdaria.current else "No curr
 ```python
 from kerykeion import AstrologicalSubjectFactory, MutualReceptionsFactory
 
-subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, "Rome", "IT")
+subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
 receptions = MutualReceptionsFactory.from_subject(subject)
 for r in receptions.receptions:
     print(f"{r.first_planet} ↔ {r.second_planet} ({r.reception_type})")
@@ -2535,7 +2607,7 @@ for r in receptions.receptions:
 ```python
 from kerykeion import AstrologicalSubjectFactory, HoraryIndicatorsFactory
 
-subject = AstrologicalSubjectFactory.from_birth_data("Question", 2026, 6, 4, 15, 30, "Rome", "IT")
+subject = AstrologicalSubjectFactory.from_birth_data("Question", 2026, 6, 4, 15, 30, lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
 indicators = HoraryIndicatorsFactory.from_subject(subject)
 print(f"Querent ruler: {indicators.querent.ruler}, Quesited ruler: {indicators.quesited.ruler}")
 ```
@@ -2546,7 +2618,7 @@ print(f"Querent ruler: {indicators.querent.ruler}, Quesited ruler: {indicators.q
 - **Getting Started**: [kerykeion.net/docs](https://www.kerykeion.net/content/docs/)
 - **Examples Gallery**: [kerykeion.net/examples](https://www.kerykeion.net/content/examples/)
 - **API Reference**: [kerykeion.net/pydocs](https://www.kerykeion.net/pydocs/)
-- **Astrologer API Docs**: [kerykeion.net/astrologer-api](https://www.kerykeion.net/content/astrologer-api/)
+- **Astrologer API Docs**: [kerykeion.net/astrologer-api](https://www.kerykeion.net/content/docs/astrologer-api)
 - **Migration Guide (v4/v5 to v6)**: [Migration Guide](https://www.kerykeion.net/content/docs/migration)
 
 ## Projects built with Kerykeion
@@ -2561,7 +2633,10 @@ Clone the repository or download the ZIP via the GitHub interface.
 git clone https://github.com/g-battaglia/kerykeion.git
 cd kerykeion
 uv sync --dev
+uv run poe test:core   # the core suite; `uv run poe check` runs every gate
 ```
+
+The development workflow — test tiers, golden baselines, documentation gates (`poe docs:check`, `poe docs:snippets`), release steps — is described in [DEVELOPMENT.md](https://github.com/g-battaglia/kerykeion/blob/alpha/v6/DEVELOPMENT.md); the test suite in [TEST.md](https://github.com/g-battaglia/kerykeion/blob/alpha/v6/TEST.md). Every gate runs locally through `poe`; there is no CI.
 
 ## Using the Swiss Ephemeris Backend (Optional)
 
@@ -2629,6 +2704,8 @@ This project is covered under the AGPL-3.0 License. For detailed information, pl
 As a rule of thumb, if you use this library in a project, you should open-source that project under a compatible license. Alternatively, if you wish to keep your source closed, consider using the paid [Astrologer API](https://www.kerykeion.net/astrologer-api/subscribe), which is AGPL-3.0 compliant and also helps support the project.
 
 Since the Astrologer API is an external third-party service, using it does _not_ require your code to be open-source.
+
+The dual-licensing model (AGPL-3.0 for open source, a commercial license on request) is described in [LICENSING.md](https://github.com/g-battaglia/kerykeion/blob/alpha/v6/LICENSING.md) and [COMMERCIAL-LICENSE.md](https://github.com/g-battaglia/kerykeion/blob/alpha/v6/COMMERCIAL-LICENSE.md); both are marked as drafts.
 
 _This is not legal advice — see the [LICENSE](https://github.com/g-battaglia/kerykeion/blob/alpha/v6/LICENSE) file and consult legal counsel for guidance._
 

--- a/TEST.md
+++ b/TEST.md
@@ -8,9 +8,11 @@ Tests are run through **4 hierarchical tiers** (`core < base < medium < extended
 
 **The task name asks for a tier; the installed kernel decides which one you get.**
 `poe test:extended` and `poe test:all` are both plain `pytest tests/ -m 'not online'`
-and set no `LIBEPHEMERIS_PRECISION`, so on a default install the auto-detected tier
-is `medium` and the extended-tier subjects are skipped rather than run. To really
-run them, install the full-range kernel and set the variable:
+and set no `LIBEPHEMERIS_PRECISION`, so the tier is whatever the installed kernel
+can serve. A fresh install bundles the base DE440s kernel (1849-2150), so on a
+default install the auto-detected tier is `base` and the medium- and extended-tier
+subjects are skipped rather than run. To really run them, install the full-range
+kernel and set the variable:
 
 ```bash
 uv run python -c "import libephemeris; libephemeris.download_leb_for_tier('extended')"
@@ -389,7 +391,7 @@ SVG baseline files live in `tests/data/svg/` (354 files). Tests compare generate
 
 A few golden charts cast two millennia back differ STRUCTURALLY between the backends — an aspect falls in or out of orb. Those carry `@pytest.mark.reference_backend_only`, one at a time and with a reason.
 
-**Every baseline has a reader.** `tests/core/test_every_baseline_has_a_reader.py` fails if a stored baseline is compared by no test; twenty were, when it was written. It finds out by running every golden test with the comparison replaced by a recorder (`tests/data/golden_drive.py` — parametrized cases expanded, `setup_class` called, skips survived), plus the source lines that hand a name to a comparison; a name that is merely mentioned, in a docstring or an exemption table, is not a reader. On the default (medium) kernel the baselines of extended-tier subjects are exempt by tier, so a lost reader for one of them is invisible there; `poe check` therefore also runs `test:gates:extended`, the same gates under `LIBEPHEMERIS_PRECISION=extended`, where only what the backend cannot compute is exempt — and the run fails if the extended kernel it asked for is not the one installed.
+**Every baseline has a reader.** `tests/core/test_every_baseline_has_a_reader.py` fails if a stored baseline is compared by no test; twenty were, when it was written. It finds out by running every golden test with the comparison replaced by a recorder (`tests/data/golden_drive.py` — parametrized cases expanded, `setup_class` called, skips survived), plus the source lines that hand a name to a comparison; a name that is merely mentioned, in a docstring or an exemption table, is not a reader. On the default (base) kernel the baselines of medium- and extended-tier subjects are exempt by tier, so a lost reader for one of them is invisible there; `poe check` therefore also runs `test:gates:extended`, the same gates under `LIBEPHEMERIS_PRECISION=extended`, where only what the backend cannot compute is exempt — and the run fails if the extended kernel it asked for is not the one installed.
 
 **Golden charts are hermetic.** They are cast at coordinates frozen in `tests/data/golden_places.py`, never resolved through GeoNames — `from_birth_data` defaults to `online=True`, so the whole golden suite used to depend on what a remote service answered that minute. `tests/core/test_golden_charts_are_hermetic.py` fails if one reaches for the network: it drives every golden test in all five golden modules through the same driver with both GeoNames doors — the city lookup and the timezone-for-coordinates lookup — refused.
 

--- a/TEST.md
+++ b/TEST.md
@@ -2,9 +2,23 @@
 
 ## Overview
 
-Kerykeion's test suite lives in `tests/core/` with **74 test files** and parallel execution via `pytest-xdist` (`-n 8`).
+Kerykeion's test suite lives in `tests/core/` with **102 test files** and parallel execution via `pytest-xdist` (`-n auto`).
 
 Tests are run through **4 hierarchical tiers** (`core < base < medium < extended`). Without an explicit `--tier` option, the tier is auto-detected by probing the loaded ephemeris kernel, so a plain `pytest` run is green on any kernel; test cases for subjects outside the active tier are skipped (with a reason), not failed.
+
+**The task name asks for a tier; the installed kernel decides which one you get.**
+`poe test:extended` and `poe test:all` are both plain `pytest tests/ -m 'not online'`
+and set no `LIBEPHEMERIS_PRECISION`, so on a default install the auto-detected tier
+is `medium` and the extended-tier subjects are skipped rather than run. To really
+run them, install the full-range kernel and set the variable:
+
+```bash
+uv run python -c "import libephemeris; libephemeris.download_leb_for_tier('extended')"
+LIBEPHEMERIS_PRECISION=extended uv run poe test:extended
+```
+
+The `regenerate:*` tasks and `test:gates:extended` set
+`LIBEPHEMERIS_PRECISION=extended` for themselves.
 
 ---
 
@@ -12,8 +26,8 @@ Tests are run through **4 hierarchical tiers** (`core < base < medium < extended
 
 ```bash
 # Test — 4 tiers, each includes everything from the previous one
-poe test:core         # ~4,600 tests — every module, no exhaustive matrix
-poe test:base         # full suite (~11,000 collected) — exhaustive matrix, DE440s subjects (1849-2150)
+poe test:core         # ~7,500 tests — every module, no exhaustive matrix
+poe test:base         # full suite (~14,000 collected) — exhaustive matrix, DE440s subjects (1849-2150)
 poe test:medium       # full suite — adds DE440 subjects (1550-2650)
 poe test:extended     # full suite — all subjects, full ephemeris range
 
@@ -22,22 +36,41 @@ poe test:core:cov     # Coverage on core tier
 poe test:base:cov     # Coverage on base tier
 poe test:medium:cov   # Coverage on medium tier
 poe test:extended:cov # Coverage on extended tier (full)
+poe test:all:cov      # Alias of test:extended:cov, with an explicit --cov=kerykeion
 
-# Regenerate golden standards
-poe regenerate:svg        # SVG chart baselines (tests/data/svg/) — three scripts, then the eleven test-owned baselines via KERYKEION_REGEN_BASELINES
-poe regenerate:reports    # Report golden files (tests/fixtures/)
-poe regenerate:positions  # Expected positions & subjects (tests/data/expected_*.py)
-poe regenerate:aspects    # Expected aspects (tests/data/expected_*_aspects.py)
-poe regenerate:all        # All of the above
+# Backend-specific runs (same tests, different ephemeris engine)
+poe test:lib          # core tests forced on libephemeris
+poe test:swe          # core tests forced on swisseph (needs kerykeion[swiss])
+poe test:compare      # the two backends compared head to head
+
+# Regenerate golden standards — the full list
+poe regenerate:svg            # SVG chart baselines (tests/data/svg/) — three scripts, then the eleven test-owned baselines via KERYKEION_REGEN_BASELINES
+poe regenerate:reports        # Report golden files (tests/fixtures/)
+poe regenerate:positions      # Expected positions & subjects (tests/data/expected_*.py)
+poe regenerate:aspects        # Expected aspects (tests/data/expected_*_aspects.py)
+poe regenerate:configurations # House-system, sidereal-mode, perspective, return, composite, ephemeris and Arabic-part fixtures
+poe regenerate:docs-charts    # docs/charts/ — the README's showcase SVGs, embedded by raw URL
+poe regenerate:gallery-v6     # tests/data/v6_gallery/ and its index page
+poe regenerate:glyph-gallery  # The glyph poster and site/docs/chart-glyphs.md
+poe regenerate:glyph-widths   # charts/glyph_metrics.py — per-character widths (macOS only)
+poe regenerate:glyph-ink      # charts/glyph_ink_metrics.py — measured in a browser (interactive)
+poe regenerate:all            # Everything above except the two glyph-measurement tasks
 ```
+
+`regenerate:all` runs `regenerate:svg`, `regenerate:docs-charts`,
+`regenerate:gallery-v6`, `regenerate:glyph-gallery`, `regenerate:reports`,
+`regenerate:positions`, `regenerate:aspects` and `regenerate:configurations`.
+The two glyph-measurement tasks are excluded on purpose: one needs macOS system
+fonts, the other opens a browser.
 
 ---
 
 ## What Each Tier Tests
 
-### `test:core` (~7,100 tests)
+### `test:core` (~7,500 tests)
 
-Runs **92 of the 97 test files** in `tests/core/` (about 7,100 offline tests), one per
+Runs **97 of the 102 test files** in `tests/core/` — 7,517 offline tests at the
+time of writing; run `--collect-only` for today's figure — one per
 module/concern. This tier exercises representative paths across Kerykeion:
 subject creation, chart drawing, aspects, reports, composite subjects,
 planetary returns, ephemeris data, transits, relationship scores, context
@@ -52,7 +85,7 @@ It **excludes** the 5 exhaustive matrix files that generate thousands of paramet
 |---------------|-------------|
 | `test_houses_positions.py` | Every house system x temporal/geographic subject x cusp |
 | `test_planetary_positions.py` | Every planet x temporal/geographic subject |
-| `test_moon_phase_historical_verification.py` | 2,042 historical moon phase cases |
+| `test_moon_phase_historical_verification.py` | 365 historical syzygies from the AstroPixels tables |
 | `test_subject_factory_parametrized.py` | Every house system/sidereal mode/perspective x subjects |
 | `test_chart_parametrized.py` | Temporal/geographic x themes/house systems cross-products |
 
@@ -60,7 +93,7 @@ Use `test:core` for fast local development feedback.
 
 ### `test:base`
 
-Includes **all 74 test files** (core + the 5 matrix files above). The full suite always collects ~11,000 tests; the tier controls which temporal subjects actually run — cases for subjects outside the tier are skipped at runtime. `base` restricts temporal subjects to the **DE440s ephemeris** range (1849-2150, 11 subjects). This is the recommended local-validation tier — it catches regressions across the full matrix without requiring extended ephemeris files.
+Includes **all 102 test files** (core + the 5 matrix files above). The full suite always collects ~14,000 tests; the tier controls which temporal subjects actually run — cases for subjects outside the tier are skipped at runtime. `base` restricts temporal subjects to the **DE440s ephemeris** range (1849-2150, 11 subjects). This is the recommended local-validation tier — it catches regressions across the full matrix without requiring extended ephemeris files.
 
 ### `test:medium`
 
@@ -77,7 +110,7 @@ Runs everything with **all 25 temporal subjects** spanning from 500 BC to 2200 A
 ```
 tests/
 ├── conftest.py              # Tier filtering (auto-detected), parametrized fixtures, session subjects
-├── core/                    # All 74 test files (representative subset shown)
+├── core/                    # All 102 test files (representative subset shown)
 │   ├── conftest.py          # Session fixtures, SVG/report comparison helpers
 │   ├── test_arabic_parts.py
 │   ├── test_aspects.py
@@ -105,7 +138,7 @@ tests/
 │   ├── test_subject_factory_parametrized.py
 │   ├── test_transits.py
 │   ├── test_utilities.py
-│   └── ...                  # (74 files total — see Test Files Reference below)
+│   └── ...                  # (102 files total — see Test Files Reference below)
 ├── data/                    # Shared test data
 │   ├── compare_svg_lines.py          # SVG line-by-line comparison utility
 │   ├── expected_natal_aspects.py     # Golden natal aspect data
@@ -115,7 +148,7 @@ tests/
 │   ├── expected_arabic_parts.py
 │   ├── test_subjects_matrix.py       # Subject matrix: 25 temporal, 16 geographic
 │   ├── configurations/               # Settings override JSON files
-│   ├── svg/                           # 346 SVG baseline files
+│   ├── svg/                           # 354 SVG baseline files
 │   ├── golden_places.py              # frozen coordinates: golden charts never resolve a city online
 │   ├── compare_svg_lines.py          # THE SVG comparison; there is one
 │   └── regeneration_guard.py         # refuses to regenerate from another checkout's code
@@ -194,6 +227,17 @@ Latitude diversity from 66°S to 66°N, plus date-line coverage:
 | `test_chart_parametrized.py` | Temporal x themes cross-product, geographic x house systems, extreme latitude whole-sign, sidereal x theme combinations, house system synastry/transit |
 | `test_draw_planets.py` | Planet glyph positioning, retrograde markers, degree labels, planet grouping/overlap handling, edge cases (empty list, single planet, zero/359 degrees), SVG output structure, chart type variants, internal helpers |
 | `test_lunar_phase_svg.py` | All 8 standard moon phases match reference SVG sheet |
+| `test_glyph_system.py` | One declared glyph set: no hand-edit survives inside the generated `<symbol>` block, no symbol silently deleted, one weight and one colour per glyph |
+| `test_wheel_growth.py` | The modern wheel grows only on the two canvas shapes that have room for it, and stays byte-identical below that |
+| `test_modern_cusp_dimming.py` | A cusp line dims for exactly the span of the reading written across it — all of it or none |
+| `test_house_number_spread.py` | How far apart two house numbers are pushed when a quadrant system crowds four cusps into three degrees |
+| `test_house_sector_wedges.py` | The invisible clickable house wedge sits under the cusp line the reader sees, so a click near a cusp selects the right house |
+| `test_grid_point_labels.py` | The name a planet-grid row prints and the room it leaves — a translated name may not overrun the block beside it |
+| `test_diurnality_svg.py` | The info panel's diurnality line: neutral wording, and absent rather than guessed where it has no referent |
+| `test_optional_chart_marks.py` | The six opt-in marks (stations, out-of-bounds, separating dashes, relationship score, ayanamsa, polar fallback): off is genuinely off, on draws the mark |
+| `test_optional_mark_baselines.py` | The twenty optional-mark SVG baselines that nothing was comparing |
+| `test_translation_coverage.py` | Every label a chart can print exists in all ten language packs |
+| `test_glyph_playground.py` | The 264 diffs in `scripts/glyph_playground.html` round-trip to real renders |
 
 ### Reports
 
@@ -236,8 +280,14 @@ Latitude diversity from 66°S to 66°N, plus date-line coverage:
 | `test_arabic_parts.py` | Formula correctness (Pars Fortunae/Spiritus/Amoris/Fidei), day/night symmetry, result properties, auto-activation of dependencies, day/night detection (Sun altitude), geographic edge cases, sidereal mode, `is_diurnal` field, single-part-only activation |
 | `test_house_comparison.py` | Cusps/points in reciprocal houses, limited active points, HouseComparisonFactory end-to-end, malformed data handling |
 | `test_moon_phase_details_factory_mocked.py` | Moon phase details factory with mocked ephemeris backend, phase identification, illumination, upcoming phases, eclipses, integration test |
-| `test_moon_phase_historical_verification.py` | 2,042-case historical moon phase verification |
+| `test_moon_phase_historical_verification.py` | 365 historical syzygies (AstroPixels, 2001-2040) verified for angle, illumination and synodic month |
 | `test_v512_features.py` | Regression tests for v5.12 features (house cusp speeds, expanded fixed stars, sidereal modes, ayanamsa value) |
+| `test_profections.py` | Annual profections against the Lennon chart: one house per year, the sign on the profected cusp, the Lord of the Year, birthday boundaries |
+| `test_firdaria.py` | Firdaria invariants: the opening lord matches the chart's sect luminary, the 75-year cycle is contiguous, node periods carry no sub-periods |
+| `test_receptions_horary.py` | Mutual receptions, horary indicators, and the rulership lookups both build on |
+| `test_lunar_phase_windows.py` | The phase name is a window *centred* on the event it names, not a bin starting at it |
+| `test_point_and_chartdata_enrichments.py` | The v6 enrichments: per-point `motion_state`, star constellation, chart angularities and stelliums, progressed points, precise lunar age |
+| `test_timezone_correctness.py` | The civil-time layer: offsets outside the tz database's recorded range, spring-forward gaps and fall-back folds |
 
 ### v6 Advanced Features
 
@@ -290,6 +340,25 @@ Latitude diversity from 66°S to 66°N, plus date-line coverage:
 | `test_v5_migration_errors.py` | v5-to-v6 migration error messages |
 | `test_void_of_course_moon_factory.py` | Void-of-course Moon detection |
 | `test_zodiacal_releasing.py` | Zodiacal releasing (aphesis) periods |
+| `test_retrograde_periods.py` | `RetrogradeStationFactory.retrograde_periods_*` — retrograde spans clipped to a range |
+| `test_sign_periods.py` | `SignIngressFactory.sign_periods_*` — contiguous sign stays clipped to a range |
+| `test_planetary_return_roundtrip.py` | A reported return instant re-fed as the seed of the next search finds the *next* return, not the same one |
+| `test_polar_house_invariants.py` | What must still hold when a house system is undefined inside the polar circle |
+| `test_sun_times_anchors.py` | Sunrise, sunset and solar noon against two national observatories — hand-transcribed values no script may rewrite |
+| `test_sun_times_altitude_invariant.py` | The Sun-vs-horizon geometry re-measured as an angle by a second implementation, where near-polar clock comparisons stop being meaningful |
+| `test_ephemeris_provenance.py` | Source propagation and sealed-LEB coverage behaviour |
+
+### Gates
+
+These run in `poe check` / `poe quality` and fail on documentation and baseline
+rot rather than on a calculation.
+
+| File | What it covers |
+|------|----------------|
+| `test_agent_skill_contract.py` | `skills/kerykeion/` against version drift, license loss and dangling reference files — it is copied verbatim into third-party repos |
+| `test_every_baseline_has_a_reader.py` | A stored SVG baseline that no test compares. Twenty were unread when it was written |
+| `test_golden_charts_are_hermetic.py` | A golden chart asking GeoNames where it was cast; both network doors are refused for the whole golden suite |
+| `test_baseline_freshness.py` | A committed baseline missing an info-panel row the template now emits — how fifty-one baselines, eleven of them README images, were left behind |
 
 ---
 
@@ -312,7 +381,7 @@ Latitude diversity from 66°S to 66°N, plus date-line coverage:
 
 ### Golden-File Testing
 
-SVG baseline files live in `tests/data/svg/` (346 files). Tests compare generated SVGs through `compare_svg_file()` in `tests/data/compare_svg_lines.py`, which is the only such comparison in the repository.
+SVG baseline files live in `tests/data/svg/` (354 files). Tests compare generated SVGs through `compare_svg_file()` in `tests/data/compare_svg_lines.py`, which is the only such comparison in the repository.
 
 **Structure is fatal, on every backend.** Line count, the count of numbers in a line, and the line with its numbers blanked out must all match. A missing baseline fails and names `uv run poe regenerate:svg`. The extended parametrized matrix alone skips a combination whose baseline was never generated.
 
@@ -332,7 +401,7 @@ Report golden files live in `tests/fixtures/` (42 `.txt` files). The `assert_rep
 
 1. **Offline by default.** All subjects use `online=False, suppress_geonames_warning=True` with explicit `lat`, `lng`, `tz_str` coordinates. Only tests marked `@pytest.mark.online` require network access.
 
-2. **Parallel-safe.** No shared mutable state between tests. Session-scoped fixtures create immutable subjects. Tests are distributed across 8 workers by default.
+2. **Parallel-safe.** No shared mutable state between tests. Session-scoped fixtures create immutable subjects. Tests are distributed with `-n auto --dist loadgroup` (one worker per core) by default.
 
 3. **Tiered ephemeris.** Historical and future test subjects are stratified by the JPL ephemeris file required. Run `test:base` for fast validation and `test:extended` for full coverage.
 

--- a/docs/charts/marks_polar_modern.svg
+++ b/docs/charts/marks_polar_modern.svg
@@ -94,8 +94,8 @@
 <g kr:node='ModernHoroscope' font-family='Arial, Helvetica, Liberation Sans, sans-serif' transform='rotate(-90 50.0 50.0)'>
 <g kr:node='ZodiacBackgrounds'>
   <g kr:node='ZodiacSign' kr:sign='Ari' kr:signnumber='0'>
-  <path d='M 56.427474,99.585155 A 50.0,50.0 0 0,0 80.358933,89.728267 L 77.930218,86.550005 A 46.0,46.0 0 0,1 55.913276,95.618342 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 56.427474,99.585155 A 50.0,50.0 0 0,0 80.358933,89.728267 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 56.427474,99.585155 A 50.0,50.0 0 0,0 80.358933,89.728267 L 77.930218,86.550005 A 46.0,46.0 0 0,1 55.913276,95.618342 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 56.427474,99.585155 A 50.0,50.0 0 0,0 80.358933,89.728267 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-202.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(292.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Ari' />
@@ -103,8 +103,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Tau' kr:signnumber='1'>
-  <path d='M 80.358933,89.728267 A 50.0,50.0 0 0,0 96.155741,69.226222 L 92.463281,67.688124 A 46.0,46.0 0 0,1 77.930218,86.550005 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 80.358933,89.728267 A 50.0,50.0 0 0,0 96.155741,69.226222 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 80.358933,89.728267 A 50.0,50.0 0 0,0 96.155741,69.226222 L 92.463281,67.688124 A 46.0,46.0 0 0,1 77.930218,86.550005 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 80.358933,89.728267 A 50.0,50.0 0 0,0 96.155741,69.226222 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-232.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(322.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Tau' />
@@ -112,8 +112,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Gem' kr:signnumber='2'>
-  <path d='M 96.155741,69.226222 A 50.0,50.0 0 0,0 99.585155,43.572526 L 95.618342,44.086724 A 46.0,46.0 0 0,1 92.463281,67.688124 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 96.155741,69.226222 A 50.0,50.0 0 0,0 99.585155,43.572526 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 96.155741,69.226222 A 50.0,50.0 0 0,0 99.585155,43.572526 L 95.618342,44.086724 A 46.0,46.0 0 0,1 92.463281,67.688124 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 96.155741,69.226222 A 50.0,50.0 0 0,0 99.585155,43.572526 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-262.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(352.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Gem' />
@@ -121,8 +121,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Can' kr:signnumber='3'>
-  <path d='M 99.585155,43.572526 A 50.0,50.0 0 0,0 89.728267,19.641067 L 86.550005,22.069782 A 46.0,46.0 0 0,1 95.618342,44.086724 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.585155,43.572526 A 50.0,50.0 0 0,0 89.728267,19.641067 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 99.585155,43.572526 A 50.0,50.0 0 0,0 89.728267,19.641067 L 86.550005,22.069782 A 46.0,46.0 0 0,1 95.618342,44.086724 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.585155,43.572526 A 50.0,50.0 0 0,0 89.728267,19.641067 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-292.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(382.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Can' />
@@ -130,8 +130,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Leo' kr:signnumber='4'>
-  <path d='M 89.728267,19.641067 A 50.0,50.0 0 0,0 69.226222,3.844259 L 67.688124,7.536719 A 46.0,46.0 0 0,1 86.550005,22.069782 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 89.728267,19.641067 A 50.0,50.0 0 0,0 69.226222,3.844259 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 89.728267,19.641067 A 50.0,50.0 0 0,0 69.226222,3.844259 L 67.688124,7.536719 A 46.0,46.0 0 0,1 86.550005,22.069782 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 89.728267,19.641067 A 50.0,50.0 0 0,0 69.226222,3.844259 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-322.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(412.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Leo' />
@@ -139,8 +139,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Vir' kr:signnumber='5'>
-  <path d='M 69.226222,3.844259 A 50.0,50.0 0 0,0 43.572526,0.414845 L 44.086724,4.381658 A 46.0,46.0 0 0,1 67.688124,7.536719 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 69.226222,3.844259 A 50.0,50.0 0 0,0 43.572526,0.414845 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 69.226222,3.844259 A 50.0,50.0 0 0,0 43.572526,0.414845 L 44.086724,4.381658 A 46.0,46.0 0 0,1 67.688124,7.536719 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 69.226222,3.844259 A 50.0,50.0 0 0,0 43.572526,0.414845 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-352.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(442.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Vir' />
@@ -148,8 +148,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Lib' kr:signnumber='6'>
-  <path d='M 43.572526,0.414845 A 50.0,50.0 0 0,0 19.641067,10.271733 L 22.069782,13.449995 A 46.0,46.0 0 0,1 44.086724,4.381658 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 43.572526,0.414845 A 50.0,50.0 0 0,0 19.641067,10.271733 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 43.572526,0.414845 A 50.0,50.0 0 0,0 19.641067,10.271733 L 22.069782,13.449995 A 46.0,46.0 0 0,1 44.086724,4.381658 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 43.572526,0.414845 A 50.0,50.0 0 0,0 19.641067,10.271733 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-22.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(112.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Lib' />
@@ -157,8 +157,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sco' kr:signnumber='7'>
-  <path d='M 19.641067,10.271733 A 50.0,50.0 0 0,0 3.844259,30.773778 L 7.536719,32.311876 A 46.0,46.0 0 0,1 22.069782,13.449995 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 19.641067,10.271733 A 50.0,50.0 0 0,0 3.844259,30.773778 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 19.641067,10.271733 A 50.0,50.0 0 0,0 3.844259,30.773778 L 7.536719,32.311876 A 46.0,46.0 0 0,1 22.069782,13.449995 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 19.641067,10.271733 A 50.0,50.0 0 0,0 3.844259,30.773778 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-52.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(142.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sco' />
@@ -166,8 +166,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sag' kr:signnumber='8'>
-  <path d='M 3.844259,30.773778 A 50.0,50.0 0 0,0 0.414845,56.427474 L 4.381658,55.913276 A 46.0,46.0 0 0,1 7.536719,32.311876 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 3.844259,30.773778 A 50.0,50.0 0 0,0 0.414845,56.427474 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 3.844259,30.773778 A 50.0,50.0 0 0,0 0.414845,56.427474 L 4.381658,55.913276 A 46.0,46.0 0 0,1 7.536719,32.311876 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 3.844259,30.773778 A 50.0,50.0 0 0,0 0.414845,56.427474 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-82.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(172.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sag' />
@@ -175,8 +175,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Cap' kr:signnumber='9'>
-  <path d='M 0.414845,56.427474 A 50.0,50.0 0 0,0 10.271733,80.358933 L 13.449995,77.930218 A 46.0,46.0 0 0,1 4.381658,55.913276 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.414845,56.427474 A 50.0,50.0 0 0,0 10.271733,80.358933 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 0.414845,56.427474 A 50.0,50.0 0 0,0 10.271733,80.358933 L 13.449995,77.930218 A 46.0,46.0 0 0,1 4.381658,55.913276 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.414845,56.427474 A 50.0,50.0 0 0,0 10.271733,80.358933 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-112.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(202.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Cap' />
@@ -184,8 +184,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Aqu' kr:signnumber='10'>
-  <path d='M 10.271733,80.358933 A 50.0,50.0 0 0,0 30.773778,96.155741 L 32.311876,92.463281 A 46.0,46.0 0 0,1 13.449995,77.930218 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 10.271733,80.358933 A 50.0,50.0 0 0,0 30.773778,96.155741 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 10.271733,80.358933 A 50.0,50.0 0 0,0 30.773778,96.155741 L 32.311876,92.463281 A 46.0,46.0 0 0,1 13.449995,77.930218 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 10.271733,80.358933 A 50.0,50.0 0 0,0 30.773778,96.155741 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-142.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(232.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Aqu' />
@@ -193,8 +193,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Pis' kr:signnumber='11'>
-  <path d='M 30.773778,96.155741 A 50.0,50.0 0 0,0 56.427474,99.585155 L 55.913276,95.618342 A 46.0,46.0 0 0,1 32.311876,92.463281 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 30.773778,96.155741 A 50.0,50.0 0 0,0 56.427474,99.585155 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 30.773778,96.155741 A 50.0,50.0 0 0,0 56.427474,99.585155 L 55.913276,95.618342 A 46.0,46.0 0 0,1 32.311876,92.463281 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 30.773778,96.155741 A 50.0,50.0 0 0,0 56.427474,99.585155 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-172.385780 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(262.385780) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Pis' />
@@ -301,34 +301,34 @@
 </g>
 <g kr:node='PlanetRing'>
 <path d='M 5.347999999999999,50.0 A 44.652,44.652 0 1,1 94.652,50.0 A 44.652,44.652 0 1,1 5.347999999999999,50.0 M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 Z' fill='#f4f4f5' fill-rule='evenodd' stroke='#d4d4d8' stroke-width='0.25'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-26.004005 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='7.910' stroke='#81818d)' stroke-width='0.07' transform='rotate(-52.008009 50.0 50.0)'/>
-<line x1='50.0' y1='7.910' x2='50.0' y2='26.596' stroke='#81818d)' stroke-width='0.07' stroke-opacity='0.35' transform='rotate(-52.008009 50.0 50.0)'/>
-<line x1='50.0' y1='26.596' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.07' transform='rotate(-52.008009 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.6' transform='rotate(-78.012014 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.167' stroke='#81818d)' stroke-width='0.07' transform='rotate(-112.008009 50.0 50.0)'/>
-<line x1='50.0' y1='8.167' x2='50.0' y2='26.596' stroke='#81818d)' stroke-width='0.07' stroke-opacity='0.35' transform='rotate(-112.008009 50.0 50.0)'/>
-<line x1='50.0' y1='26.596' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.07' transform='rotate(-112.008009 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-146.004005 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-206.004005 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-232.008009 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#81818d)' stroke-width='0.6' transform='rotate(-258.012014 50.0 50.0)'/>
-<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-258.012014 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.6' transform='rotate(-258.012014 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.029' stroke='#81818d)' stroke-width='0.07' transform='rotate(-292.008009 50.0 50.0)'/>
-<line x1='50.0' y1='8.029' x2='50.0' y2='23.376' stroke='#81818d)' stroke-width='0.07' stroke-opacity='0.35' transform='rotate(-292.008009 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.07' transform='rotate(-292.008009 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-326.004005 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-26.004005 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='7.910' stroke='#81818d' stroke-width='0.07' transform='rotate(-52.008009 50.0 50.0)'/>
+<line x1='50.0' y1='7.910' x2='50.0' y2='26.596' stroke='#ccccd1' stroke-width='0.07' transform='rotate(-52.008009 50.0 50.0)'/>
+<line x1='50.0' y1='26.596' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.07' transform='rotate(-52.008009 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.6' transform='rotate(-78.012014 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.167' stroke='#81818d' stroke-width='0.07' transform='rotate(-112.008009 50.0 50.0)'/>
+<line x1='50.0' y1='8.167' x2='50.0' y2='26.596' stroke='#ccccd1' stroke-width='0.07' transform='rotate(-112.008009 50.0 50.0)'/>
+<line x1='50.0' y1='26.596' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.07' transform='rotate(-112.008009 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-146.004005 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-206.004005 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-232.008009 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#81818d' stroke-width='0.6' transform='rotate(-258.012014 50.0 50.0)'/>
+<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-258.012014 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.6' transform='rotate(-258.012014 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.029' stroke='#81818d' stroke-width='0.07' transform='rotate(-292.008009 50.0 50.0)'/>
+<line x1='50.0' y1='8.029' x2='50.0' y2='23.376' stroke='#ccccd1' stroke-width='0.07' transform='rotate(-292.008009 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.07' transform='rotate(-292.008009 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-326.004005 50.0 50.0)'/>
 <g kr:node='ChartPoint' kr:house='First_House' kr:sign='Vir' kr:absoluteposition='172.61421986038195' kr:signposition='22.61421986038195' kr:slug='Ascendant' kr:speed='125.541925' kr:cx='164.33152' kr:cy='290.00000000000006' transform='rotate(-0.000000 50.0 50.0)'>
   <g transform='translate(50.0 10.22) rotate(90.000000) scale(0.172368) translate(-12 -12)'>
     <use xlink:href='#Ascendant' kr:slug='Ascendant' kr:node='Glyph' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#7f3f00' font-weight='500' transform='rotate(90.000000 50.0 14.21) translate(0 0.2408)'>22º</text>
-  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#7f3f00' font-weight='500' transform='rotate(90.000000 50.0 21.89) translate(0 0.1968)'>36'</text>
@@ -341,7 +341,7 @@
     <use xlink:href='#Pluto' kr:slug='Pluto' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(142.788969 50.0 14.21) translate(0 0.2240)'>15º</text>
-  <g transform='translate(50.0 17.89) rotate(142.788969) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(142.788969) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Sco' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(142.788969 50.0 21.89) translate(0 0.2124)'>24'</text>
@@ -355,7 +355,7 @@
     <use xlink:href='#Uranus' kr:slug='Uranus' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(194.721756 50.0 14.21) translate(0 0.2240)'>8º</text>
-  <g transform='translate(50.0 17.89) rotate(194.721756) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(194.721756) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(194.721756 50.0 21.89) translate(0 0.1968)'>10'</text>
@@ -369,7 +369,7 @@
     <use xlink:href='#Neptune' kr:slug='Neptune' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(201.937421 50.0 14.21) translate(0 0.2240)'>13º</text>
-  <g transform='translate(50.0 17.89) rotate(201.937421) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(201.937421) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(201.937421 50.0 21.89) translate(0 0.1968)'>43'</text>
@@ -383,7 +383,7 @@
     <use xlink:href='#Saturn' kr:slug='Saturn' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(211.422598 50.0 14.21) translate(0 0.2408)'>24º</text>
-  <g transform='translate(50.0 17.89) rotate(211.422598) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(211.422598) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(211.422598 50.0 21.89) translate(0 0.2124)'>2'</text>
@@ -397,7 +397,7 @@
     <use xlink:href='#True_North_Lunar_Node' kr:slug='True_North_Lunar_Node' kr:node='Glyph' fill='#4c1541' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#4c1541' font-weight='500' transform='rotate(225.506523 50.0 14.21) translate(0 0.2240)'>8º</text>
-  <g transform='translate(50.0 17.89) rotate(225.506523) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(225.506523) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Aqu' fill='#4c1541' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#4c1541' font-weight='500' transform='rotate(225.506523 50.0 21.89) translate(0 0.2072)'>7'</text>
@@ -410,7 +410,7 @@
     <use xlink:href='#Moon' kr:slug='Moon' kr:node='Glyph' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#150052' font-weight='500' transform='rotate(261.631580 50.0 14.21) translate(0 0.2408)'>14º</text>
-  <g transform='translate(50.0 17.89) rotate(261.631580) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(261.631580) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Pis' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#150052' font-weight='500' transform='rotate(261.631580 50.0 21.89) translate(0 0.2124)'>14'</text>
@@ -423,7 +423,7 @@
     <use xlink:href='#Mars' kr:slug='Mars' kr:node='Glyph' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#540000' font-weight='500' transform='rotate(288.367174 50.0 14.21) translate(0 0.2240)'>10º</text>
-  <g transform='translate(50.0 17.89) rotate(288.367174) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(288.367174) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Ari' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#540000' font-weight='500' transform='rotate(288.367174 50.0 21.89) translate(0 0.1968)'>58'</text>
@@ -436,7 +436,7 @@
     <use xlink:href='#Venus' kr:slug='Venus' kr:node='Glyph' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#400052' font-weight='500' transform='rotate(326.065383 50.0 14.21) translate(0 0.2240)'>18º</text>
-  <g transform='translate(50.0 17.89) rotate(326.065383) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(326.065383) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#400052' font-weight='500' transform='rotate(326.065383 50.0 21.89) translate(0 0.1968)'>40'</text>
@@ -449,7 +449,7 @@
     <use xlink:href='#Mercury' kr:slug='Mercury' kr:node='Glyph' fill='#520800' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#520800' font-weight='500' transform='rotate(342.163266 50.0 14.21) translate(0 0.2240)'>5º</text>
-  <g transform='translate(50.0 17.89) rotate(342.163266) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(342.163266) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Gem' fill='#520800' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#520800' font-weight='500' transform='rotate(342.163266 50.0 21.89) translate(0 0.1968)'>32'</text>
@@ -462,7 +462,7 @@
     <use xlink:href='#Medium_Coeli' kr:slug='Medium_Coeli' kr:node='Glyph' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#a80000' font-weight='500' transform='rotate(348.782394 50.0 14.21) translate(0 0.2240)'>10º</text>
-  <g transform='translate(50.0 17.89) rotate(348.782394) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(348.782394) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Gem' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#a80000' font-weight='500' transform='rotate(348.782394 50.0 21.89) translate(0 0.1968)'>37'</text>
@@ -475,7 +475,7 @@
     <use xlink:href='#Sun' kr:slug='Sun' kr:node='Glyph' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#7e3e00' font-weight='500' transform='rotate(361.435744 50.0 14.21) translate(0 0.2408)'>24º</text>
-  <g transform='translate(50.0 17.89) rotate(361.435744) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(361.435744) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Gem' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#7e3e00' font-weight='500' transform='rotate(361.435744 50.0 21.89) translate(0 0.2124)'>2'</text>
@@ -488,7 +488,7 @@
     <use xlink:href='#Jupiter' kr:slug='Jupiter' kr:node='Glyph' fill='#47133d' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#47133d' font-weight='500' transform='rotate(380.025862 50.0 14.21) translate(0 0.2240)'>15º</text>
-  <g transform='translate(50.0 17.89) rotate(380.025862) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(380.025862) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Can' fill='#47133d' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#47133d' font-weight='500' transform='rotate(380.025862 50.0 21.89) translate(0 0.1968)'>52'</text>
@@ -501,7 +501,7 @@
     <use xlink:href='#Chiron' kr:slug='Chiron' kr:node='Glyph' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#505705' font-weight='500' transform='rotate(386.669217 50.0 14.21) translate(0 0.2240)'>16º</text>
-  <g transform='translate(50.0 17.89) rotate(386.669217) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(386.669217) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Can' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#505705' font-weight='500' transform='rotate(386.669217 50.0 21.89) translate(0 0.1968)'>3'</text>
@@ -512,29 +512,29 @@
 </g>
 <g kr:node='HouseRing'>
 <path d='M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 M 30.5,50.0 A 19.5,19.5 0 1,1 69.5,50.0 A 19.5,19.5 0 1,1 30.5,50.0 Z' fill='#e4e4e7' fill-rule='evenodd'/>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='1' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-13.002002 50.0 50.0) rotate(103.002002 50.0 29.25)'>1</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-26.004005 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-26.004005 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='2' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-39.006007 50.0 50.0) rotate(129.006007 50.0 29.25)'>2</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-52.008009 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-52.008009 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='3' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-65.010011 50.0 50.0) rotate(155.010011 50.0 29.25)'>3</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-78.012014 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-78.012014 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='4' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-95.010011 50.0 50.0) rotate(185.010011 50.0 29.25)'>4</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-112.008009 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-112.008009 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='5' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-129.006007 50.0 50.0) rotate(219.006007 50.0 29.25)'>5</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-146.004005 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-146.004005 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='6' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-163.002002 50.0 50.0) rotate(253.002002 50.0 29.25)'>6</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='7' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-193.002002 50.0 50.0) rotate(283.002002 50.0 29.25)'>7</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-206.004005 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-206.004005 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='8' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-219.006007 50.0 50.0) rotate(309.006007 50.0 29.25)'>8</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-232.008009 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-232.008009 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='9' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-245.010011 50.0 50.0) rotate(335.010011 50.0 29.25)'>9</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-258.012014 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-258.012014 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='10' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-275.010011 50.0 50.0) rotate(365.010011 50.0 29.25)'>10</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-292.008009 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-292.008009 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='11' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-309.006007 50.0 50.0) rotate(399.006007 50.0 29.25)'>11</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-326.004005 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-326.004005 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='12' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-343.002002 50.0 50.0) rotate(433.002002 50.0 29.25)'>12</text></g>
 </g>
 <g kr:node='HouseSector' kr:house='1'><path d='M 50.000000,0.000000 A 50.0,50.0 0 0,0 28.078302,5.061830 L 41.450538,32.474114 A 19.5,19.5 0 0,1 50.000000,30.500000 Z' fill='transparent' stroke='none' pointer-events='all'/></g>

--- a/docs/charts/marks_sidereal_modern.svg
+++ b/docs/charts/marks_sidereal_modern.svg
@@ -94,8 +94,8 @@
 <g kr:node='ModernHoroscope' font-family='Arial, Helvetica, Liberation Sans, sans-serif' transform='rotate(-90 50.0 50.0)'>
 <g kr:node='ZodiacBackgrounds'>
   <g kr:node='ZodiacSign' kr:sign='Ari' kr:signnumber='0'>
-  <path d='M 47.104854,0.083889 A 50.0,50.0 0 0,0 22.534674,8.218953 L 24.731901,11.561437 A 46.0,46.0 0 0,1 47.336466,4.077178 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 47.104854,0.083889 A 50.0,50.0 0 0,0 22.534674,8.218953 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 47.104854,0.083889 A 50.0,50.0 0 0,0 22.534674,8.218953 L 24.731901,11.561437 A 46.0,46.0 0 0,1 47.336466,4.077178 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 47.104854,0.083889 A 50.0,50.0 0 0,0 22.534674,8.218953 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-18.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(108.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Ari' />
@@ -103,8 +103,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Tau' kr:signnumber='1'>
-  <path d='M 22.534674,8.218953 A 50.0,50.0 0 0,0 5.323807,27.549215 L 8.897902,29.345277 A 46.0,46.0 0 0,1 24.731901,11.561437 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 22.534674,8.218953 A 50.0,50.0 0 0,0 5.323807,27.549215 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 22.534674,8.218953 A 50.0,50.0 0 0,0 5.323807,27.549215 L 8.897902,29.345277 A 46.0,46.0 0 0,1 24.731901,11.561437 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 22.534674,8.218953 A 50.0,50.0 0 0,0 5.323807,27.549215 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-48.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(138.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Tau' />
@@ -112,8 +112,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Gem' kr:signnumber='2'>
-  <path d='M 5.323807,27.549215 A 50.0,50.0 0 0,0 0.083889,52.895146 L 4.077178,52.663534 A 46.0,46.0 0 0,1 8.897902,29.345277 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 5.323807,27.549215 A 50.0,50.0 0 0,0 0.083889,52.895146 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 5.323807,27.549215 A 50.0,50.0 0 0,0 0.083889,52.895146 L 4.077178,52.663534 A 46.0,46.0 0 0,1 8.897902,29.345277 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 5.323807,27.549215 A 50.0,50.0 0 0,0 0.083889,52.895146 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-78.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(168.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Gem' />
@@ -121,8 +121,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Can' kr:signnumber='3'>
-  <path d='M 0.083889,52.895146 A 50.0,50.0 0 0,0 8.218953,77.465326 L 11.561437,75.268099 A 46.0,46.0 0 0,1 4.077178,52.663534 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.083889,52.895146 A 50.0,50.0 0 0,0 8.218953,77.465326 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 0.083889,52.895146 A 50.0,50.0 0 0,0 8.218953,77.465326 L 11.561437,75.268099 A 46.0,46.0 0 0,1 4.077178,52.663534 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.083889,52.895146 A 50.0,50.0 0 0,0 8.218953,77.465326 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-108.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(198.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Can' />
@@ -130,8 +130,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Leo' kr:signnumber='4'>
-  <path d='M 8.218953,77.465326 A 50.0,50.0 0 0,0 27.549215,94.676193 L 29.345277,91.102098 A 46.0,46.0 0 0,1 11.561437,75.268099 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 8.218953,77.465326 A 50.0,50.0 0 0,0 27.549215,94.676193 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 8.218953,77.465326 A 50.0,50.0 0 0,0 27.549215,94.676193 L 29.345277,91.102098 A 46.0,46.0 0 0,1 11.561437,75.268099 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 8.218953,77.465326 A 50.0,50.0 0 0,0 27.549215,94.676193 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-138.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(228.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Leo' />
@@ -139,8 +139,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Vir' kr:signnumber='5'>
-  <path d='M 27.549215,94.676193 A 50.0,50.0 0 0,0 52.895146,99.916111 L 52.663534,95.922822 A 46.0,46.0 0 0,1 29.345277,91.102098 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 27.549215,94.676193 A 50.0,50.0 0 0,0 52.895146,99.916111 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 27.549215,94.676193 A 50.0,50.0 0 0,0 52.895146,99.916111 L 52.663534,95.922822 A 46.0,46.0 0 0,1 29.345277,91.102098 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 27.549215,94.676193 A 50.0,50.0 0 0,0 52.895146,99.916111 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-168.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(258.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Vir' />
@@ -148,8 +148,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Lib' kr:signnumber='6'>
-  <path d='M 52.895146,99.916111 A 50.0,50.0 0 0,0 77.465326,91.781047 L 75.268099,88.438563 A 46.0,46.0 0 0,1 52.663534,95.922822 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 52.895146,99.916111 A 50.0,50.0 0 0,0 77.465326,91.781047 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 52.895146,99.916111 A 50.0,50.0 0 0,0 77.465326,91.781047 L 75.268099,88.438563 A 46.0,46.0 0 0,1 52.663534,95.922822 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 52.895146,99.916111 A 50.0,50.0 0 0,0 77.465326,91.781047 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-198.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(288.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Lib' />
@@ -157,8 +157,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sco' kr:signnumber='7'>
-  <path d='M 77.465326,91.781047 A 50.0,50.0 0 0,0 94.676193,72.450785 L 91.102098,70.654723 A 46.0,46.0 0 0,1 75.268099,88.438563 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 77.465326,91.781047 A 50.0,50.0 0 0,0 94.676193,72.450785 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 77.465326,91.781047 A 50.0,50.0 0 0,0 94.676193,72.450785 L 91.102098,70.654723 A 46.0,46.0 0 0,1 75.268099,88.438563 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 77.465326,91.781047 A 50.0,50.0 0 0,0 94.676193,72.450785 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-228.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(318.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sco' />
@@ -166,8 +166,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sag' kr:signnumber='8'>
-  <path d='M 94.676193,72.450785 A 50.0,50.0 0 0,0 99.916111,47.104854 L 95.922822,47.336466 A 46.0,46.0 0 0,1 91.102098,70.654723 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 94.676193,72.450785 A 50.0,50.0 0 0,0 99.916111,47.104854 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 94.676193,72.450785 A 50.0,50.0 0 0,0 99.916111,47.104854 L 95.922822,47.336466 A 46.0,46.0 0 0,1 91.102098,70.654723 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 94.676193,72.450785 A 50.0,50.0 0 0,0 99.916111,47.104854 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-258.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(348.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sag' />
@@ -175,8 +175,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Cap' kr:signnumber='9'>
-  <path d='M 99.916111,47.104854 A 50.0,50.0 0 0,0 91.781047,22.534674 L 88.438563,24.731901 A 46.0,46.0 0 0,1 95.922822,47.336466 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.916111,47.104854 A 50.0,50.0 0 0,0 91.781047,22.534674 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 99.916111,47.104854 A 50.0,50.0 0 0,0 91.781047,22.534674 L 88.438563,24.731901 A 46.0,46.0 0 0,1 95.922822,47.336466 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.916111,47.104854 A 50.0,50.0 0 0,0 91.781047,22.534674 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-288.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(378.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Cap' />
@@ -184,8 +184,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Aqu' kr:signnumber='10'>
-  <path d='M 91.781047,22.534674 A 50.0,50.0 0 0,0 72.450785,5.323807 L 70.654723,8.897902 A 46.0,46.0 0 0,1 88.438563,24.731901 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 91.781047,22.534674 A 50.0,50.0 0 0,0 72.450785,5.323807 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 91.781047,22.534674 A 50.0,50.0 0 0,0 72.450785,5.323807 L 70.654723,8.897902 A 46.0,46.0 0 0,1 88.438563,24.731901 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 91.781047,22.534674 A 50.0,50.0 0 0,0 72.450785,5.323807 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-318.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(408.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Aqu' />
@@ -193,8 +193,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Pis' kr:signnumber='11'>
-  <path d='M 72.450785,5.323807 A 50.0,50.0 0 0,0 47.104854,0.083889 L 47.336466,4.077178 A 46.0,46.0 0 0,1 70.654723,8.897902 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 72.450785,5.323807 A 50.0,50.0 0 0,0 47.104854,0.083889 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 72.450785,5.323807 A 50.0,50.0 0 0,0 47.104854,0.083889 L 47.336466,4.077178 A 46.0,46.0 0 0,1 70.654723,8.897902 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 72.450785,5.323807 A 50.0,50.0 0 0,0 47.104854,0.083889 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-348.319450 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(438.319450) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Pis' />
@@ -301,28 +301,28 @@
 </g>
 <g kr:node='PlanetRing'>
 <path d='M 5.347999999999999,50.0 A 44.652,44.652 0 1,1 94.652,50.0 A 44.652,44.652 0 1,1 5.347999999999999,50.0 M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 Z' fill='#f4f4f5' fill-rule='evenodd' stroke='#d4d4d8' stroke-width='0.25'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='ChartPoint' kr:house='First_House' kr:sign='Pis' kr:absoluteposition='356.6805503175564' kr:signposition='26.680550317556424' kr:slug='Ascendant' kr:speed='886.944154' kr:cx='164.33152' kr:cy='290.0' transform='rotate(-0.000000 50.0 50.0)'>
   <g transform='translate(50.0 10.22) rotate(90.000000) scale(0.172368) translate(-12 -12)'>
     <use xlink:href='#Ascendant' kr:slug='Ascendant' kr:node='Glyph' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#7f3f00' font-weight='500' transform='rotate(90.000000 50.0 14.21) translate(0 0.2240)'>26º</text>
-  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Pis' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#7f3f00' font-weight='500' transform='rotate(90.000000 50.0 21.89) translate(0 0.1968)'>40'</text>
@@ -335,7 +335,7 @@
     <use xlink:href='#Saturn' kr:slug='Saturn' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(110.648968 50.0 14.21) translate(0 0.2240)'>20º</text>
-  <g transform='translate(50.0 17.89) rotate(110.648968) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(110.648968) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Ari' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(110.648968 50.0 21.89) translate(0 0.2124)'>11'</text>
@@ -349,7 +349,7 @@
     <use xlink:href='#Jupiter' kr:slug='Jupiter' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(116.835659 50.0 14.21) translate(0 0.2240)'>20º</text>
-  <g transform='translate(50.0 17.89) rotate(116.835659) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(116.835659) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Ari' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(116.835659 50.0 21.89) translate(0 0.1968)'>39'</text>
@@ -363,7 +363,7 @@
     <use xlink:href='#Uranus' kr:slug='Uranus' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(125.840888 50.0 14.21) translate(0 0.2408)'>2º</text>
-  <g transform='translate(50.0 17.89) rotate(125.840888) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(125.840888) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(125.840888 50.0 21.89) translate(0 0.1968)'>31'</text>
@@ -372,38 +372,38 @@
 <g kr:node='Indicator' kr:slug='Uranus' kr:absoluteposition='32.521437910465735' transform='rotate(-35.840888 50.0 50.0)'>
   <path d='M 50.0 5.348 l 0 1.075' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
 </g>
-<g kr:node='ChartPoint' kr:house='Fifth_House' kr:sign='Can' kr:absoluteposition='97.5376388272794' kr:signposition='7.537638827279395' kr:slug='Chiron' kr:speed='0.052891' kr:declination='13.4146' kr:cx='370.423797894039' kr:cy='463.0138936247984' transform='rotate(-99.973270 50.0 50.0)'>
-  <g transform='translate(50.0 10.22) rotate(189.973270) scale(0.172368) translate(-12 -12)'>
+<g kr:node='ChartPoint' kr:house='Fifth_House' kr:sign='Can' kr:absoluteposition='97.5376388272794' kr:signposition='7.537638827279395' kr:slug='Chiron' kr:speed='0.052891' kr:declination='13.4146' kr:cx='370.6030804181587' kr:cy='462.98227173450493' transform='rotate(-100.032647 50.0 50.0)'>
+  <g transform='translate(50.0 10.22) rotate(190.032647) scale(0.172368) translate(-12 -12)'>
     <use xlink:href='#Chiron' kr:slug='Chiron' kr:node='Glyph' fill='#505705' />
   </g>
-  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#505705' font-weight='500' transform='rotate(189.973270 50.0 14.21) translate(0 0.2408)'>7º</text>
-  <g transform='translate(50.0 17.89) rotate(189.973270) scale(0.092781) translate(-16 -16)'>
+  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#505705' font-weight='500' transform='rotate(190.032647 50.0 14.21) translate(0 0.2408)'>7º</text>
+  <g transform='translate(50.0 17.89) rotate(190.032647) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Can' fill='#505705' />
   </g>
-  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#505705' font-weight='500' transform='rotate(189.973270 50.0 21.89) translate(0 0.1968)'>32'</text>
+  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#505705' font-weight='500' transform='rotate(190.032647 50.0 21.89) translate(0 0.1968)'>32'</text>
 </g>
 <g kr:node='Indicator' kr:slug='Chiron' kr:absoluteposition='97.5376388272794' transform='rotate(-100.857089 50.0 50.0)'>
-  <path d='M 50.0 5.348 l 0 1.075 A 43.652 43.652 0 0 1 50.6733294211 6.3531933414 L 50.6567476121 7.4280654471' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
+  <path d='M 50.0 5.348 l 0 1.075 A 43.652 43.652 0 0 1 50.6280967226 6.3525189901 L 50.6126288408 7.4274077028' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
 </g>
-<g kr:node='ChartPoint' kr:house='Fifth_House' kr:sign='Can' kr:absoluteposition='101.15750973379633' kr:signposition='11.157509733796331' kr:slug='Pluto' kr:motionstate='fast' kr:speed='0.011336' kr:declination='23.1195' kr:cx='386.5338929176597' kr:cy='459.39306855783144' transform='rotate(-105.360778 50.0 50.0)'>
-  <g transform='translate(50.0 10.22) rotate(195.360778) scale(0.18144) translate(-12 -12)'>
+<g kr:node='ChartPoint' kr:house='Fifth_House' kr:sign='Can' kr:absoluteposition='101.15750973379633' kr:signposition='11.157509733796331' kr:slug='Pluto' kr:motionstate='fast' kr:speed='0.011336' kr:declination='23.1195' kr:cx='386.35832142483036' kr:cy='459.4412018966536' transform='rotate(-105.301401 50.0 50.0)'>
+  <g transform='translate(50.0 10.22) rotate(195.301401) scale(0.18144) translate(-12 -12)'>
     <use xlink:href='#Pluto' kr:slug='Pluto' kr:node='Glyph' fill='#713f04' />
   </g>
-  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#713f04' font-weight='500' transform='rotate(195.360778 50.0 14.21) translate(0 0.2408)'>11º</text>
-  <g transform='translate(50.0 17.89) rotate(195.360778) scale(0.092781) translate(-16 -16)'>
+  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#713f04' font-weight='500' transform='rotate(195.301401 50.0 14.21) translate(0 0.2408)'>11º</text>
+  <g transform='translate(50.0 17.89) rotate(195.301401) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Can' fill='#713f04' />
   </g>
-  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#713f04' font-weight='500' transform='rotate(195.360778 50.0 21.89) translate(0 0.1968)'>9'</text>
+  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#713f04' font-weight='500' transform='rotate(195.301401 50.0 21.89) translate(0 0.1968)'>9'</text>
 </g>
 <g kr:node='Indicator' kr:slug='Pluto' kr:absoluteposition='101.15750973379633' transform='rotate(-104.476959 50.0 50.0)'>
-  <path d='M 50.0 5.348 l 0 1.075 A 43.652 43.652 0 0 0 49.3266705789 6.3531933414 L 49.3432523879 7.4280654471' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
+  <path d='M 50.0 5.348 l 0 1.075 A 43.652 43.652 0 0 0 49.3719032774 6.3525189901 L 49.3873711592 7.4274077028' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
 </g>
 <g kr:node='ChartPoint' kr:house='Sixth_House' kr:sign='Leo' kr:absoluteposition='130.1848390420978' kr:signposition='10.184839042097792' kr:slug='Venus' kr:motionstate='average' kr:speed='1.133683' kr:declination='10.5716' kr:cx='460.9317397678071' kr:cy='417.41636151704296' transform='rotate(-133.504289 50.0 50.0)' kr:stellium='6'>
   <g transform='translate(50.0 10.22) rotate(223.504289) scale(0.18144) translate(-12 -12)'>
     <use xlink:href='#Venus' kr:slug='Venus' kr:node='Glyph' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#400052' font-weight='500' transform='rotate(223.504289 50.0 14.21) translate(0 0.2240)'>10º</text>
-  <g transform='translate(50.0 17.89) rotate(223.504289) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(223.504289) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#400052' font-weight='500' transform='rotate(223.504289 50.0 21.89) translate(0 0.2124)'>11'</text>
@@ -416,7 +416,7 @@
     <use xlink:href='#Neptune' kr:slug='Neptune' kr:node='Glyph' fill='#06537f' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#06537f' font-weight='500' transform='rotate(246.318991 50.0 14.21) translate(0 0.2408)'>2º</text>
-  <g transform='translate(50.0 17.89) rotate(246.318991) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(246.318991) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#06537f' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#06537f' font-weight='500' transform='rotate(246.318991 50.0 21.89) translate(0 0.1968)'>59'</text>
@@ -429,7 +429,7 @@
     <use xlink:href='#Mars' kr:slug='Mars' kr:node='Glyph' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#540000' font-weight='500' transform='rotate(252.951402 50.0 14.21) translate(0 0.2240)'>9º</text>
-  <g transform='translate(50.0 17.89) rotate(252.951402) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(252.951402) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#540000' font-weight='500' transform='rotate(252.951402 50.0 21.89) translate(0 0.1968)'>37'</text>
@@ -442,7 +442,7 @@
     <use xlink:href='#True_North_Lunar_Node' kr:slug='True_North_Lunar_Node' kr:node='Glyph' fill='#4c1541' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#4c1541' font-weight='500' transform='rotate(261.257298 50.0 14.21) translate(0 0.2408)'>17º</text>
-  <g transform='translate(50.0 17.89) rotate(261.257298) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(261.257298) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#4c1541' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#4c1541' font-weight='500' transform='rotate(261.257298 50.0 21.89) translate(0 0.1968)'>59'</text>
@@ -455,7 +455,7 @@
     <use xlink:href='#Sun' kr:slug='Sun' kr:node='Glyph' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#7e3e00' font-weight='500' transform='rotate(266.612587 50.0 14.21) translate(0 0.2240)'>23º</text>
-  <g transform='translate(50.0 17.89) rotate(266.612587) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(266.612587) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#7e3e00' font-weight='500' transform='rotate(266.612587 50.0 21.89) translate(0 0.2124)'>14'</text>
@@ -468,7 +468,7 @@
     <use xlink:href='#Mercury' kr:slug='Mercury' kr:node='Glyph' fill='#520800' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#520800' font-weight='500' transform='rotate(288.847104 50.0 14.21) translate(0 0.2240)'>15º</text>
-  <g transform='translate(50.0 17.89) rotate(288.847104) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(288.847104) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#520800' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#520800' font-weight='500' transform='rotate(288.847104 50.0 21.89) translate(0 0.1968)'>31'</text>
@@ -481,7 +481,7 @@
     <use xlink:href='#Medium_Coeli' kr:slug='Medium_Coeli' kr:node='Glyph' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#a80000' font-weight='500' transform='rotate(347.347283 50.0 14.21) translate(0 0.2408)'>14º</text>
-  <g transform='translate(50.0 17.89) rotate(347.347283) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(347.347283) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Sag' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#a80000' font-weight='500' transform='rotate(347.347283 50.0 21.89) translate(0 0.2124)'>1'</text>
@@ -494,7 +494,7 @@
     <use xlink:href='#Moon' kr:slug='Moon' kr:node='Glyph' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#150052' font-weight='500' transform='rotate(373.835496 50.0 14.21) translate(0 0.2240)'>10º</text>
-  <g transform='translate(50.0 17.89) rotate(373.835496) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(373.835496) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#150052' font-weight='500' transform='rotate(373.835496 50.0 21.89) translate(0 0.1968)'>30'</text>
@@ -505,29 +505,29 @@
 </g>
 <g kr:node='HouseRing'>
 <path d='M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 M 30.5,50.0 A 19.5,19.5 0 1,1 69.5,50.0 A 19.5,19.5 0 1,1 30.5,50.0 Z' fill='#e4e4e7' fill-rule='evenodd'/>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='1' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-19.904366 50.0 50.0) rotate(109.904366 50.0 29.25)'>1</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='2' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-50.161212 50.0 50.0) rotate(140.161212 50.0 29.25)'>2</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='3' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-68.930487 50.0 50.0) rotate(158.930487 50.0 29.25)'>3</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='4' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-86.468184 50.0 50.0) rotate(176.468184 50.0 29.25)'>4</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='5' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-108.981980 50.0 50.0) rotate(198.981980 50.0 29.25)'>5</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='6' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-151.187437 50.0 50.0) rotate(241.187437 50.0 29.25)'>6</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='7' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-199.904366 50.0 50.0) rotate(289.904366 50.0 29.25)'>7</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='8' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-230.161212 50.0 50.0) rotate(320.161212 50.0 29.25)'>8</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='9' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-248.930487 50.0 50.0) rotate(338.930487 50.0 29.25)'>9</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='10' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-266.468184 50.0 50.0) rotate(356.468184 50.0 29.25)'>10</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='11' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-288.981980 50.0 50.0) rotate(378.981980 50.0 29.25)'>11</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='12' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-331.187437 50.0 50.0) rotate(421.187437 50.0 29.25)'>12</text></g>
 </g>
 <g kr:node='HouseSector' kr:house='1'><path d='M 50.000000,0.000000 A 50.0,50.0 0 0,0 17.988660,11.590702 L 37.515578,35.020374 A 19.5,19.5 0 0,1 50.000000,30.500000 Z' fill='transparent' stroke='none' pointer-events='all'/></g>

--- a/docs/charts/marks_synastry_modern.svg
+++ b/docs/charts/marks_synastry_modern.svg
@@ -85,8 +85,8 @@
 <g kr:node='ModernDualHoroscope' kr:charttype='Synastry' font-family='Arial, Helvetica, Liberation Sans, sans-serif' transform='rotate(-90 50.0 50.0)'>
 <g kr:node='ZodiacBackgrounds'>
   <g kr:node='ZodiacSign' kr:sign='Ari' kr:signnumber='0'>
-  <path d='M 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 L 41.783889,4.739692 A 46.0,46.0 0 0,1 65.514793,6.695368 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 L 41.783889,4.739692 A 46.0,46.0 0 0,1 65.514793,6.695368 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-355.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(445.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Ari' />
@@ -94,8 +94,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Tau' kr:signnumber='1'>
-  <path d='M 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 L 20.254485,14.911479 A 46.0,46.0 0 0,1 41.783889,4.739692 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 L 20.254485,14.911479 A 46.0,46.0 0 0,1 41.783889,4.739692 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-25.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(115.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Tau' />
@@ -103,8 +103,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Gem' kr:signnumber='2'>
-  <path d='M 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 L 6.695368,34.485207 A 46.0,46.0 0 0,1 20.254485,14.911479 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 L 6.695368,34.485207 A 46.0,46.0 0 0,1 20.254485,14.911479 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-55.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(145.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Gem' />
@@ -112,8 +112,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Can' kr:signnumber='3'>
-  <path d='M 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 L 4.739692,58.216111 A 46.0,46.0 0 0,1 6.695368,34.485207 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 L 4.739692,58.216111 A 46.0,46.0 0 0,1 6.695368,34.485207 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-85.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(175.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Can' />
@@ -121,8 +121,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Leo' kr:signnumber='4'>
-  <path d='M 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 L 14.911479,79.745515 A 46.0,46.0 0 0,1 4.739692,58.216111 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 L 14.911479,79.745515 A 46.0,46.0 0 0,1 4.739692,58.216111 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-115.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(205.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Leo' />
@@ -130,8 +130,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Vir' kr:signnumber='5'>
-  <path d='M 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 L 34.485207,93.304632 A 46.0,46.0 0 0,1 14.911479,79.745515 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 L 34.485207,93.304632 A 46.0,46.0 0 0,1 14.911479,79.745515 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-145.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(235.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Vir' />
@@ -139,8 +139,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Lib' kr:signnumber='6'>
-  <path d='M 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 L 58.216111,95.260308 A 46.0,46.0 0 0,1 34.485207,93.304632 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 L 58.216111,95.260308 A 46.0,46.0 0 0,1 34.485207,93.304632 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-175.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(265.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Lib' />
@@ -148,8 +148,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sco' kr:signnumber='7'>
-  <path d='M 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 L 79.745515,85.088521 A 46.0,46.0 0 0,1 58.216111,95.260308 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 L 79.745515,85.088521 A 46.0,46.0 0 0,1 58.216111,95.260308 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-205.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(295.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sco' />
@@ -157,8 +157,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sag' kr:signnumber='8'>
-  <path d='M 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 L 93.304632,65.514793 A 46.0,46.0 0 0,1 79.745515,85.088521 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 L 93.304632,65.514793 A 46.0,46.0 0 0,1 79.745515,85.088521 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-235.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(325.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sag' />
@@ -166,8 +166,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Cap' kr:signnumber='9'>
-  <path d='M 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 L 95.260308,41.783889 A 46.0,46.0 0 0,1 93.304632,65.514793 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 L 95.260308,41.783889 A 46.0,46.0 0 0,1 93.304632,65.514793 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-265.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(355.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Cap' />
@@ -175,8 +175,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Aqu' kr:signnumber='10'>
-  <path d='M 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 L 85.088521,20.254485 A 46.0,46.0 0 0,1 95.260308,41.783889 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 L 85.088521,20.254485 A 46.0,46.0 0 0,1 95.260308,41.783889 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-295.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(385.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Aqu' />
@@ -184,8 +184,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Pis' kr:signnumber='11'>
-  <path d='M 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 L 65.514793,6.695368 A 46.0,46.0 0 0,1 85.088521,20.254485 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 L 65.514793,6.695368 A 46.0,46.0 0 0,1 85.088521,20.254485 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-325.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(415.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Pis' />
@@ -292,27 +292,27 @@
 </g>
 <g kr:node='PlanetRing' kr:horoscope='1'>
 <path d='M 5.347999999999999,50.0 A 44.652,44.652 0 1,1 94.652,50.0 A 44.652,44.652 0 1,1 5.347999999999999,50.0 M 20.5,50.0 A 29.5,29.5 0 1,1 79.5,50.0 A 29.5,29.5 0 1,1 20.5,50.0 Z' fill='#e8e8ed' fill-rule='evenodd' stroke='#d4d4d8' stroke-width='0.25'/>
-<line x1='50.0' y1='6.5' x2='50.0' y2='20.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='6.500' x2='50.0' y2='6.663' stroke='#81818d)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
-<line x1='50.0' y1='6.663' x2='50.0' y2='18.430' stroke='#81818d)' stroke-width='0.07' stroke-opacity='0.35' transform='rotate(-39.808733 50.0 50.0)'/>
-<line x1='50.0' y1='18.430' x2='50.0' y2='20.500' stroke='#81818d)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
-<line x1='50.0' y1='6.500' x2='50.0' y2='6.597' stroke='#81818d)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
-<line x1='50.0' y1='6.597' x2='50.0' y2='20.500' stroke='#81818d)' stroke-width='0.07' stroke-opacity='0.35' transform='rotate(-60.513692 50.0 50.0)'/>
-<line x1='50.0' y1='6.5' x2='50.0' y2='20.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
-<line x1='50.0' y1='6.5' x2='50.0' y2='20.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
-<line x1='50.0' y1='6.5' x2='50.0' y2='20.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
-<line x1='50.0' y1='6.5' x2='50.0' y2='20.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
-<line x1='50.0' y1='6.5' x2='50.0' y2='20.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
-<line x1='50.0' y1='6.5' x2='50.0' y2='20.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
-<line x1='50.0' y1='6.5' x2='50.0' y2='20.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='6.5' x2='50.0' y2='20.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
-<line x1='50.0' y1='6.5' x2='50.0' y2='20.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='20.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='6.663' stroke='#81818d' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='6.663' x2='50.0' y2='18.430' stroke='#c4c4cb' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='18.430' x2='50.0' y2='20.500' stroke='#81818d' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='6.597' stroke='#81818d' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='6.597' x2='50.0' y2='20.500' stroke='#c4c4cb' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='20.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='20.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='20.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='20.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='20.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='20.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='20.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='20.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='20.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='ChartPoint' kr:house='Eighth_House' kr:sign='Tau' kr:absoluteposition='49.065465495848706' kr:signposition='19.065465495848706' kr:slug='Venus' kr:horoscope='1' kr:motionstate='average' kr:speed='1.162485' kr:declination='15.4905' kr:cx='179.8043423154209' kr:cy='380.09748214002184' transform='rotate(-29.354337 50.0 50.0)' kr:projectedhouse='First_House' kr:projectedhoroscope='0'>
   <g transform='translate(50.0 8.38) rotate(119.354337) scale(0.132) translate(-12 -12)'>
     <use xlink:href='#Venus' kr:slug='Venus' kr:node='Glyph' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#400052' font-weight='500' transform='rotate(119.354337 50.0 11.82) translate(0 0.2120)'>19º</text>
-  <g transform='translate(50.0 14.76) rotate(119.354337) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(119.354337) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#400052' font-weight='500' transform='rotate(119.354337 50.0 17.37) translate(0 0.1159)'>3'</text>
@@ -325,7 +325,7 @@
     <use xlink:href='#Uranus' kr:slug='Uranus' kr:node='Glyph' fill='#6f0766' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#6f0766' font-weight='500' transform='rotate(131.330567 50.0 11.82) translate(0 0.2279)'>1º</text>
-  <g transform='translate(50.0 14.76) rotate(131.330567) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(131.330567) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Gem' fill='#6f0766' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#6f0766' font-weight='500' transform='rotate(131.330567 50.0 17.37) translate(0 0.1159)'>58'</text>
@@ -338,7 +338,7 @@
     <use xlink:href='#Saturn' kr:slug='Saturn' kr:node='Glyph' fill='#124500' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#124500' font-weight='500' transform='rotate(136.435378 50.0 11.82) translate(0 0.2120)'>5º</text>
-  <g transform='translate(50.0 14.76) rotate(136.435378) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(136.435378) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Gem' fill='#124500' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#124500' font-weight='500' transform='rotate(136.435378 50.0 17.37) translate(0 0.1250)'>12'</text>
@@ -351,7 +351,7 @@
     <use xlink:href='#Mercury' kr:slug='Mercury' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#b03030' font-weight='500' transform='rotate(148.625322 50.0 11.82) translate(0 0.2120)'>18º</text>
-  <g transform='translate(50.0 14.76) rotate(148.625322) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(148.625322) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Gem' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#b03030' font-weight='500' transform='rotate(148.625322 50.0 17.37) translate(0 0.1159)'>20'</text>
@@ -365,7 +365,7 @@
     <use xlink:href='#Sun' kr:slug='Sun' kr:node='Glyph' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#7e3e00' font-weight='500' transform='rotate(156.957510 50.0 11.82) translate(0 0.2120)'>26º</text>
-  <g transform='translate(50.0 14.76) rotate(156.957510) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(156.957510) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Gem' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#7e3e00' font-weight='500' transform='rotate(156.957510 50.0 17.37) translate(0 0.1159)'>40'</text>
@@ -378,7 +378,7 @@
     <use xlink:href='#Jupiter' kr:slug='Jupiter' kr:node='Glyph' fill='#47133d' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#47133d' font-weight='500' transform='rotate(162.135986 50.0 11.82) translate(0 0.2279)'>1º</text>
-  <g transform='translate(50.0 14.76) rotate(162.135986) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(162.135986) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Can' fill='#47133d' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#47133d' font-weight='500' transform='rotate(162.135986 50.0 17.37) translate(0 0.1159)'>50'</text>
@@ -391,7 +391,7 @@
     <use xlink:href='#Medium_Coeli' kr:slug='Medium_Coeli' kr:node='Glyph' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#a80000' font-weight='500' transform='rotate(174.716060 50.0 11.82) translate(0 0.2279)'>14º</text>
-  <g transform='translate(50.0 14.76) rotate(174.716060) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(174.716060) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Can' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#a80000' font-weight='500' transform='rotate(174.716060 50.0 17.37) translate(0 0.1159)'>25'</text>
@@ -404,7 +404,7 @@
     <use xlink:href='#Mars' kr:slug='Mars' kr:node='Glyph' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#540000' font-weight='500' transform='rotate(191.880659 50.0 11.82) translate(0 0.2279)'>2º</text>
-  <g transform='translate(50.0 14.76) rotate(191.880659) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(191.880659) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#540000' font-weight='500' transform='rotate(191.880659 50.0 17.37) translate(0 0.1159)'>43'</text>
@@ -417,7 +417,7 @@
     <use xlink:href='#Pluto' kr:slug='Pluto' kr:node='Glyph' fill='#713f04' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#713f04' font-weight='500' transform='rotate(195.687975 50.0 11.82) translate(0 0.2279)'>4º</text>
-  <g transform='translate(50.0 14.76) rotate(195.687975) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(195.687975) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#713f04' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#713f04' font-weight='500' transform='rotate(195.687975 50.0 17.37) translate(0 0.1159)'>16'</text>
@@ -430,7 +430,7 @@
     <use xlink:href='#Chiron' kr:slug='Chiron' kr:node='Glyph' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#505705' font-weight='500' transform='rotate(202.446048 50.0 11.82) translate(0 0.2279)'>12º</text>
-  <g transform='translate(50.0 14.76) rotate(202.446048) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(202.446048) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#505705' font-weight='500' transform='rotate(202.446048 50.0 17.37) translate(0 0.1159)'>9'</text>
@@ -443,7 +443,7 @@
     <use xlink:href='#Moon' kr:slug='Moon' kr:node='Glyph' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#150052' font-weight='500' transform='rotate(208.489020 50.0 11.82) translate(0 0.2120)'>18º</text>
-  <g transform='translate(50.0 14.76) rotate(208.489020) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(208.489020) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#150052' font-weight='500' transform='rotate(208.489020 50.0 17.37) translate(0 0.1250)'>12'</text>
@@ -456,7 +456,7 @@
     <use xlink:href='#True_North_Lunar_Node' kr:slug='True_North_Lunar_Node' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#b03030' font-weight='500' transform='rotate(226.934542 50.0 11.82) translate(0 0.2120)'>6º</text>
-  <g transform='translate(50.0 14.76) rotate(226.934542) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(226.934542) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#b03030' font-weight='500' transform='rotate(226.934542 50.0 17.37) translate(0 0.1159)'>38'</text>
@@ -470,7 +470,7 @@
     <use xlink:href='#Neptune' kr:slug='Neptune' kr:node='Glyph' fill='#06537f' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#06537f' font-weight='500' transform='rotate(247.408384 50.0 11.82) translate(0 0.2279)'>27º</text>
-  <g transform='translate(50.0 14.76) rotate(247.408384) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(247.408384) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#06537f' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#06537f' font-weight='500' transform='rotate(247.408384 50.0 17.37) translate(0 0.1220)'>7'</text>
@@ -483,7 +483,7 @@
     <use xlink:href='#Ascendant' kr:slug='Ascendant' kr:node='Glyph' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='11.82' font-size='2.12' fill='#7f3f00' font-weight='500' transform='rotate(261.060032 50.0 11.82) translate(0 0.2120)'>10º</text>
-  <g transform='translate(50.0 14.76) rotate(261.060032) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 14.76) rotate(261.060032) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='17.37' font-size='1.22' fill='#7f3f00' font-weight='500' transform='rotate(261.060032 50.0 17.37) translate(0 0.1159)'>46'</text>
@@ -494,31 +494,31 @@
 </g>
 <g kr:node='PlanetRing' kr:horoscope='0'>
 <path d='M 20.5,50.0 A 29.5,29.5 0 1,1 79.5,50.0 A 29.5,29.5 0 1,1 20.5,50.0 M 34.5,50.0 A 15.5,15.5 0 1,1 65.5,50.0 A 15.5,15.5 0 1,1 34.5,50.0 Z' fill='#f4f4f5' fill-rule='evenodd' stroke='#d4d4d8' stroke-width='0.25'/>
-<line x1='50.0' y1='20.500' x2='50.0' y2='21.246' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='21.246' x2='50.0' y2='32.730' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='32.730' x2='50.0' y2='34.500' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='20.500' x2='50.0' y2='20.963' stroke='#81818d)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
-<line x1='50.0' y1='20.963' x2='50.0' y2='34.500' stroke='#81818d)' stroke-width='0.07' stroke-opacity='0.35' transform='rotate(-39.808733 50.0 50.0)'/>
-<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
-<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
-<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
-<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
-<line x1='50.0' y1='20.500' x2='50.0' y2='20.814' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
-<line x1='50.0' y1='20.814' x2='50.0' y2='32.730' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-180.000000 50.0 50.0)'/>
-<line x1='50.0' y1='32.730' x2='50.0' y2='34.500' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
-<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
-<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
-<line x1='50.0' y1='20.500' x2='50.0' y2='21.358' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='21.358' x2='50.0' y2='32.730' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='32.730' x2='50.0' y2='34.500' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
-<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='20.500' x2='50.0' y2='21.246' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='21.246' x2='50.0' y2='32.730' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='32.730' x2='50.0' y2='34.500' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='20.500' x2='50.0' y2='20.963' stroke='#81818d' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='20.963' x2='50.0' y2='34.500' stroke='#ccccd1' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='20.500' x2='50.0' y2='20.814' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='20.814' x2='50.0' y2='32.730' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='32.730' x2='50.0' y2='34.500' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='20.500' x2='50.0' y2='21.358' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='21.358' x2='50.0' y2='32.730' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='32.730' x2='50.0' y2='34.500' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='20.5' x2='50.0' y2='34.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='ChartPoint' kr:house='First_House' kr:sign='Ari' kr:absoluteposition='19.711128718293267' kr:signposition='19.711128718293267' kr:slug='Ascendant' kr:horoscope='0' kr:speed='886.944184' kr:cx='219.35487999999998' kr:cy='290.0' transform='rotate(-0.000000 50.0 50.0)' kr:projectedhouse='Seventh_House' kr:projectedhoroscope='1'>
   <g transform='translate(50.0 22.68) rotate(90.000000) scale(0.1254) translate(-12 -12)'>
     <use xlink:href='#Ascendant' kr:slug='Ascendant' kr:node='Glyph' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#7f3f00' font-weight='500' transform='rotate(90.000000 50.0 26.12) translate(0 0.2120)'>19º</text>
-  <g transform='translate(50.0 29.06) rotate(90.000000) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(90.000000) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Ari' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#7f3f00' font-weight='500' transform='rotate(90.000000 50.0 31.67) translate(0 0.1250)'>42'</text>
@@ -531,7 +531,7 @@
     <use xlink:href='#Saturn' kr:slug='Saturn' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#b03030' font-weight='500' transform='rotate(110.325020 50.0 26.12) translate(0 0.2120)'>13º</text>
-  <g transform='translate(50.0 29.06) rotate(110.325020) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(110.325020) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#b03030' font-weight='500' transform='rotate(110.325020 50.0 31.67) translate(0 0.1250)'>12'</text>
@@ -545,7 +545,7 @@
     <use xlink:href='#Jupiter' kr:slug='Jupiter' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#b03030' font-weight='500' transform='rotate(117.159607 50.0 26.12) translate(0 0.2120)'>13º</text>
-  <g transform='translate(50.0 29.06) rotate(117.159607) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(117.159607) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#b03030' font-weight='500' transform='rotate(117.159607 50.0 31.67) translate(0 0.1250)'>41'</text>
@@ -559,7 +559,7 @@
     <use xlink:href='#Uranus' kr:slug='Uranus' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#b03030' font-weight='500' transform='rotate(125.840888 50.0 26.12) translate(0 0.2120)'>25º</text>
-  <g transform='translate(50.0 29.06) rotate(125.840888) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(125.840888) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#b03030' font-weight='500' transform='rotate(125.840888 50.0 31.67) translate(0 0.1159)'>33'</text>
@@ -573,7 +573,7 @@
     <use xlink:href='#Chiron' kr:slug='Chiron' kr:node='Glyph' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#505705' font-weight='500' transform='rotate(189.503302 50.0 26.12) translate(0 0.2120)'>0º</text>
-  <g transform='translate(50.0 29.06) rotate(189.503302) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(189.503302) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#505705' font-weight='500' transform='rotate(189.503302 50.0 31.67) translate(0 0.1159)'>34'</text>
@@ -586,7 +586,7 @@
     <use xlink:href='#Pluto' kr:slug='Pluto' kr:node='Glyph' fill='#713f04' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#713f04' font-weight='500' transform='rotate(195.830746 50.0 26.12) translate(0 0.2279)'>4º</text>
-  <g transform='translate(50.0 29.06) rotate(195.830746) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(195.830746) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#713f04' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#713f04' font-weight='500' transform='rotate(195.830746 50.0 31.67) translate(0 0.1250)'>11'</text>
@@ -599,7 +599,7 @@
     <use xlink:href='#Venus' kr:slug='Venus' kr:node='Glyph' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#400052' font-weight='500' transform='rotate(223.504289 50.0 26.12) translate(0 0.2120)'>3º</text>
-  <g transform='translate(50.0 29.06) rotate(223.504289) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(223.504289) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#400052' font-weight='500' transform='rotate(223.504289 50.0 31.67) translate(0 0.1250)'>12'</text>
@@ -612,7 +612,7 @@
     <use xlink:href='#Neptune' kr:slug='Neptune' kr:node='Glyph' fill='#06537f' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#06537f' font-weight='500' transform='rotate(246.318991 50.0 26.12) translate(0 0.2120)'>26º</text>
-  <g transform='translate(50.0 29.06) rotate(246.318991) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(246.318991) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#06537f' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#06537f' font-weight='500' transform='rotate(246.318991 50.0 31.67) translate(0 0.1250)'>1'</text>
@@ -625,7 +625,7 @@
     <use xlink:href='#Mars' kr:slug='Mars' kr:node='Glyph' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#540000' font-weight='500' transform='rotate(252.951402 50.0 26.12) translate(0 0.2279)'>2º</text>
-  <g transform='translate(50.0 29.06) rotate(252.951402) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(252.951402) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#540000' font-weight='500' transform='rotate(252.951402 50.0 31.67) translate(0 0.1159)'>39'</text>
@@ -638,7 +638,7 @@
     <use xlink:href='#True_North_Lunar_Node' kr:slug='True_North_Lunar_Node' kr:node='Glyph' fill='#4c1541' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#4c1541' font-weight='500' transform='rotate(260.834460 50.0 26.12) translate(0 0.2279)'>11º</text>
-  <g transform='translate(50.0 29.06) rotate(260.834460) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(260.834460) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#4c1541' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#4c1541' font-weight='500' transform='rotate(260.834460 50.0 31.67) translate(0 0.1250)'>1'</text>
@@ -651,7 +651,7 @@
     <use xlink:href='#Sun' kr:slug='Sun' kr:node='Glyph' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#7e3e00' font-weight='500' transform='rotate(267.035424 50.0 26.12) translate(0 0.2120)'>16º</text>
-  <g transform='translate(50.0 29.06) rotate(267.035424) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(267.035424) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#7e3e00' font-weight='500' transform='rotate(267.035424 50.0 31.67) translate(0 0.1159)'>16'</text>
@@ -664,7 +664,7 @@
     <use xlink:href='#Mercury' kr:slug='Mercury' kr:node='Glyph' fill='#520800' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#520800' font-weight='500' transform='rotate(288.847104 50.0 26.12) translate(0 0.2120)'>8º</text>
-  <g transform='translate(50.0 29.06) rotate(288.847104) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(288.847104) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Sco' fill='#520800' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#520800' font-weight='500' transform='rotate(288.847104 50.0 31.67) translate(0 0.1159)'>33'</text>
@@ -677,7 +677,7 @@
     <use xlink:href='#Medium_Coeli' kr:slug='Medium_Coeli' kr:node='Glyph' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#a80000' font-weight='500' transform='rotate(347.347283 50.0 26.12) translate(0 0.2279)'>7º</text>
-  <g transform='translate(50.0 29.06) rotate(347.347283) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(347.347283) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#a80000' font-weight='500' transform='rotate(347.347283 50.0 31.67) translate(0 0.1159)'>3'</text>
@@ -690,7 +690,7 @@
     <use xlink:href='#Moon' kr:slug='Moon' kr:node='Glyph' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='26.12' font-size='2.12' fill='#150052' font-weight='500' transform='rotate(373.835496 50.0 26.12) translate(0 0.2120)'>3º</text>
-  <g transform='translate(50.0 29.06) rotate(373.835496) scale(0.0558) translate(-16 -16)'>
+  <g transform='translate(50.0 29.06) rotate(373.835496) scale(0.051336) translate(-16 -16)'>
     <use xlink:href='#Aqu' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='31.67' font-size='1.22' fill='#150052' font-weight='500' transform='rotate(373.835496 50.0 31.67) translate(0 0.1159)'>32'</text>
@@ -701,29 +701,29 @@
 </g>
 <g kr:node='HouseRing'>
 <path d='M 34.5,50.0 A 15.5,15.5 0 1,1 65.5,50.0 A 15.5,15.5 0 1,1 34.5,50.0 M 37.5,50.0 A 12.5,12.5 0 1,1 62.5,50.0 A 12.5,12.5 0 1,1 37.5,50.0 Z' fill='#e4e4e7' fill-rule='evenodd'/>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='1' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-19.904366 50.0 50.0) rotate(109.904366 50.0 36.0)'>1</text></g>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='2' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-50.161212 50.0 50.0) rotate(140.161212 50.0 36.0)'>2</text></g>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='3' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-68.930487 50.0 50.0) rotate(158.930487 50.0 36.0)'>3</text></g>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='4' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-86.468184 50.0 50.0) rotate(176.468184 50.0 36.0)'>4</text></g>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='5' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-108.981980 50.0 50.0) rotate(198.981980 50.0 36.0)'>5</text></g>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='6' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-151.187437 50.0 50.0) rotate(241.187437 50.0 36.0)'>6</text></g>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='7' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-199.904366 50.0 50.0) rotate(289.904366 50.0 36.0)'>7</text></g>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='8' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-230.161212 50.0 50.0) rotate(320.161212 50.0 36.0)'>8</text></g>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='9' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-248.930487 50.0 50.0) rotate(338.930487 50.0 36.0)'>9</text></g>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='10' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-266.468184 50.0 50.0) rotate(356.468184 50.0 36.0)'>10</text></g>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='11' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-288.981980 50.0 50.0) rotate(378.981980 50.0 36.0)'>11</text></g>
-<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='34.5' x2='50.0' y2='37.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='12' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='36.0' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-331.187437 50.0 50.0) rotate(421.187437 50.0 36.0)'>12</text></g>
 </g>
 <g kr:node='HouseSector' kr:house='1' kr:horoscope='0'><path d='M 50.000000,0.000000 A 50.0,50.0 0 0,0 17.988660,11.590702 L 41.997165,40.397676 A 12.5,12.5 0 0,1 50.000000,37.500000 Z' fill='transparent' stroke='none' pointer-events='all'/></g>

--- a/docs/charts/marks_wheel_modern.svg
+++ b/docs/charts/marks_wheel_modern.svg
@@ -94,8 +94,8 @@
 <g kr:node='ModernHoroscope' font-family='Arial, Helvetica, Liberation Sans, sans-serif' transform='rotate(-90 50.0 50.0)'>
 <g kr:node='ZodiacBackgrounds'>
   <g kr:node='ZodiacSign' kr:sign='Ari' kr:signnumber='0'>
-  <path d='M 22.091362,91.486238 A 50.0,50.0 0 0,0 46.573529,99.882455 L 46.847647,95.891858 A 46.0,46.0 0 0,1 24.324053,88.167339 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 22.091362,91.486238 A 50.0,50.0 0 0,0 46.573529,99.882455 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 22.091362,91.486238 A 50.0,50.0 0 0,0 46.573529,99.882455 L 46.847647,95.891858 A 46.0,46.0 0 0,1 24.324053,88.167339 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 22.091362,91.486238 A 50.0,50.0 0 0,0 46.573529,99.882455 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-161.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(251.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Ari' />
@@ -103,8 +103,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Tau' kr:signnumber='1'>
-  <path d='M 46.573529,99.882455 A 50.0,50.0 0 0,0 71.973816,94.912709 L 70.215911,91.319692 A 46.0,46.0 0 0,1 46.847647,95.891858 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 46.573529,99.882455 A 50.0,50.0 0 0,0 71.973816,94.912709 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 46.573529,99.882455 A 50.0,50.0 0 0,0 71.973816,94.912709 L 70.215911,91.319692 A 46.0,46.0 0 0,1 46.847647,95.891858 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 46.573529,99.882455 A 50.0,50.0 0 0,0 71.973816,94.912709 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-191.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(281.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Tau' />
@@ -112,8 +112,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Gem' kr:signnumber='2'>
-  <path d='M 71.973816,94.912709 A 50.0,50.0 0 0,0 91.486238,77.908638 L 88.167339,75.675947 A 46.0,46.0 0 0,1 70.215911,91.319692 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 71.973816,94.912709 A 50.0,50.0 0 0,0 91.486238,77.908638 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 71.973816,94.912709 A 50.0,50.0 0 0,0 91.486238,77.908638 L 88.167339,75.675947 A 46.0,46.0 0 0,1 70.215911,91.319692 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 71.973816,94.912709 A 50.0,50.0 0 0,0 91.486238,77.908638 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-221.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(311.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Gem' />
@@ -121,8 +121,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Can' kr:signnumber='3'>
-  <path d='M 91.486238,77.908638 A 50.0,50.0 0 0,0 99.882455,53.426471 L 95.891858,53.152353 A 46.0,46.0 0 0,1 88.167339,75.675947 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 91.486238,77.908638 A 50.0,50.0 0 0,0 99.882455,53.426471 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 91.486238,77.908638 A 50.0,50.0 0 0,0 99.882455,53.426471 L 95.891858,53.152353 A 46.0,46.0 0 0,1 88.167339,75.675947 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 91.486238,77.908638 A 50.0,50.0 0 0,0 99.882455,53.426471 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-251.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(341.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Can' />
@@ -130,8 +130,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Leo' kr:signnumber='4'>
-  <path d='M 99.882455,53.426471 A 50.0,50.0 0 0,0 94.912709,28.026184 L 91.319692,29.784089 A 46.0,46.0 0 0,1 95.891858,53.152353 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.882455,53.426471 A 50.0,50.0 0 0,0 94.912709,28.026184 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 99.882455,53.426471 A 50.0,50.0 0 0,0 94.912709,28.026184 L 91.319692,29.784089 A 46.0,46.0 0 0,1 95.891858,53.152353 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.882455,53.426471 A 50.0,50.0 0 0,0 94.912709,28.026184 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-281.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(371.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Leo' />
@@ -139,8 +139,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Vir' kr:signnumber='5'>
-  <path d='M 94.912709,28.026184 A 50.0,50.0 0 0,0 77.908638,8.513762 L 75.675947,11.832661 A 46.0,46.0 0 0,1 91.319692,29.784089 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 94.912709,28.026184 A 50.0,50.0 0 0,0 77.908638,8.513762 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 94.912709,28.026184 A 50.0,50.0 0 0,0 77.908638,8.513762 L 75.675947,11.832661 A 46.0,46.0 0 0,1 91.319692,29.784089 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 94.912709,28.026184 A 50.0,50.0 0 0,0 77.908638,8.513762 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-311.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(401.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Vir' />
@@ -148,8 +148,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Lib' kr:signnumber='6'>
-  <path d='M 77.908638,8.513762 A 50.0,50.0 0 0,0 53.426471,0.117545 L 53.152353,4.108142 A 46.0,46.0 0 0,1 75.675947,11.832661 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 77.908638,8.513762 A 50.0,50.0 0 0,0 53.426471,0.117545 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 77.908638,8.513762 A 50.0,50.0 0 0,0 53.426471,0.117545 L 53.152353,4.108142 A 46.0,46.0 0 0,1 75.675947,11.832661 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 77.908638,8.513762 A 50.0,50.0 0 0,0 53.426471,0.117545 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-341.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(431.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Lib' />
@@ -157,8 +157,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sco' kr:signnumber='7'>
-  <path d='M 53.426471,0.117545 A 50.0,50.0 0 0,0 28.026184,5.087291 L 29.784089,8.680308 A 46.0,46.0 0 0,1 53.152353,4.108142 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 53.426471,0.117545 A 50.0,50.0 0 0,0 28.026184,5.087291 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 53.426471,0.117545 A 50.0,50.0 0 0,0 28.026184,5.087291 L 29.784089,8.680308 A 46.0,46.0 0 0,1 53.152353,4.108142 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 53.426471,0.117545 A 50.0,50.0 0 0,0 28.026184,5.087291 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-11.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(101.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sco' />
@@ -166,8 +166,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sag' kr:signnumber='8'>
-  <path d='M 28.026184,5.087291 A 50.0,50.0 0 0,0 8.513762,22.091362 L 11.832661,24.324053 A 46.0,46.0 0 0,1 29.784089,8.680308 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 28.026184,5.087291 A 50.0,50.0 0 0,0 8.513762,22.091362 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 28.026184,5.087291 A 50.0,50.0 0 0,0 8.513762,22.091362 L 11.832661,24.324053 A 46.0,46.0 0 0,1 29.784089,8.680308 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 28.026184,5.087291 A 50.0,50.0 0 0,0 8.513762,22.091362 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-41.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(131.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sag' />
@@ -175,8 +175,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Cap' kr:signnumber='9'>
-  <path d='M 8.513762,22.091362 A 50.0,50.0 0 0,0 0.117545,46.573529 L 4.108142,46.847647 A 46.0,46.0 0 0,1 11.832661,24.324053 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 8.513762,22.091362 A 50.0,50.0 0 0,0 0.117545,46.573529 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 8.513762,22.091362 A 50.0,50.0 0 0,0 0.117545,46.573529 L 4.108142,46.847647 A 46.0,46.0 0 0,1 11.832661,24.324053 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 8.513762,22.091362 A 50.0,50.0 0 0,0 0.117545,46.573529 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-71.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(161.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Cap' />
@@ -184,8 +184,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Aqu' kr:signnumber='10'>
-  <path d='M 0.117545,46.573529 A 50.0,50.0 0 0,0 5.087291,71.973816 L 8.680308,70.215911 A 46.0,46.0 0 0,1 4.108142,46.847647 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.117545,46.573529 A 50.0,50.0 0 0,0 5.087291,71.973816 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 0.117545,46.573529 A 50.0,50.0 0 0,0 5.087291,71.973816 L 8.680308,70.215911 A 46.0,46.0 0 0,1 4.108142,46.847647 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.117545,46.573529 A 50.0,50.0 0 0,0 5.087291,71.973816 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-101.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(191.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Aqu' />
@@ -193,8 +193,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Pis' kr:signnumber='11'>
-  <path d='M 5.087291,71.973816 A 50.0,50.0 0 0,0 22.091362,91.486238 L 24.324053,88.167339 A 46.0,46.0 0 0,1 8.680308,70.215911 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 5.087291,71.973816 A 50.0,50.0 0 0,0 22.091362,91.486238 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 5.087291,71.973816 A 50.0,50.0 0 0,0 22.091362,91.486238 L 24.324053,88.167339 A 46.0,46.0 0 0,1 8.680308,70.215911 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 5.087291,71.973816 A 50.0,50.0 0 0,0 22.091362,91.486238 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-131.070474 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(221.070474) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Pis' />
@@ -301,43 +301,43 @@
 </g>
 <g kr:node='PlanetRing'>
 <path d='M 5.347999999999999,50.0 A 44.652,44.652 0 1,1 94.652,50.0 A 44.652,44.652 0 1,1 5.347999999999999,50.0 M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 Z' fill='#f4f4f5' fill-rule='evenodd' stroke='#d4d4d8' stroke-width='0.25'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-27.795281 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.029' stroke='#81818d)' stroke-width='0.07' transform='rotate(-62.878155 50.0 50.0)'/>
-<line x1='50.0' y1='8.029' x2='50.0' y2='26.596' stroke='#81818d)' stroke-width='0.07' stroke-opacity='0.35' transform='rotate(-62.878155 50.0 50.0)'/>
-<line x1='50.0' y1='26.596' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.07' transform='rotate(-62.878155 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.6' transform='rotate(-101.934256 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-135.315774 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-160.693997 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-207.795281 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-242.878155 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#81818d)' stroke-width='0.6' transform='rotate(-281.934256 50.0 50.0)'/>
-<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-281.934256 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.6' transform='rotate(-281.934256 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-315.315774 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-340.693997 50.0 50.0)'/>
-<g kr:node='ChartPoint' kr:house='First_House' kr:sign='Sco' kr:absoluteposition='213.92952631867698' kr:signposition='3.9295263186769773' kr:slug='Ascendant' kr:speed='252.012626' kr:cx='164.35491991594392' kr:cy='292.8671776673121' transform='rotate(-0.935196 50.0 50.0)'>
-  <g transform='translate(50.0 10.22) rotate(90.935196) scale(0.172368) translate(-12 -12)'>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-27.795281 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.029' stroke='#81818d' stroke-width='0.07' transform='rotate(-62.878155 50.0 50.0)'/>
+<line x1='50.0' y1='8.029' x2='50.0' y2='26.596' stroke='#ccccd1' stroke-width='0.07' transform='rotate(-62.878155 50.0 50.0)'/>
+<line x1='50.0' y1='26.596' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.07' transform='rotate(-62.878155 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.6' transform='rotate(-101.934256 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-135.315774 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-160.693997 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-207.795281 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-242.878155 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#81818d' stroke-width='0.6' transform='rotate(-281.934256 50.0 50.0)'/>
+<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-281.934256 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.6' transform='rotate(-281.934256 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-315.315774 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-340.693997 50.0 50.0)'/>
+<g kr:node='ChartPoint' kr:house='First_House' kr:sign='Sco' kr:absoluteposition='213.92952631867698' kr:signposition='3.9295263186769773' kr:slug='Ascendant' kr:speed='252.012626' kr:cx='164.35442391891772' kr:cy='292.83662980580016' transform='rotate(-0.925231 50.0 50.0)'>
+  <g transform='translate(50.0 10.22) rotate(90.925231) scale(0.172368) translate(-12 -12)'>
     <use xlink:href='#Ascendant' kr:slug='Ascendant' kr:node='Glyph' fill='#7f3f00' />
   </g>
-  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#7f3f00' font-weight='500' transform='rotate(90.935196 50.0 14.21) translate(0 0.2240)'>3º</text>
-  <g transform='translate(50.0 17.89) rotate(90.935196) scale(0.092781) translate(-16 -16)'>
+  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#7f3f00' font-weight='500' transform='rotate(90.925231 50.0 14.21) translate(0 0.2240)'>3º</text>
+  <g transform='translate(50.0 17.89) rotate(90.925231) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Sco' fill='#7f3f00' />
   </g>
-  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#7f3f00' font-weight='500' transform='rotate(90.935196 50.0 21.89) translate(0 0.1917)'>55'</text>
+  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#7f3f00' font-weight='500' transform='rotate(90.925231 50.0 21.89) translate(0 0.1917)'>55'</text>
 </g>
 <g kr:node='Indicator' kr:slug='Ascendant' kr:absoluteposition='213.92952631867698' transform='rotate(-0.000000 50.0 50.0)'>
-  <path d='M 50.0 5.348 l 0 1.075 A 43.652 43.652 0 0 0 49.2875327462 6.3538146637 L 49.3050783866 7.4286714683' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
+  <path d='M 50.0 5.348 l 0 1.075 A 43.652 43.652 0 0 0 49.2951236085 6.3536914130 L 49.3124823119 7.4285512529' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
 </g>
 <g kr:node='ChartPoint' kr:house='First_House' kr:sign='Sco' kr:absoluteposition='225.2305424393643' kr:signposition='15.230542439364314' kr:slug='Pluto' kr:motionstate='fast' kr:speed='0.017038' kr:declination='-1.8067' kr:cx='167.73752394888464' kr:cy='324.4246163413523' transform='rotate(-11.301016 50.0 50.0)'>
   <g transform='translate(50.0 10.22) rotate(101.301016) scale(0.18144) translate(-12 -12)'>
     <use xlink:href='#Pluto' kr:slug='Pluto' kr:node='Glyph' fill='#713f04' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#713f04' font-weight='500' transform='rotate(101.301016 50.0 14.21) translate(0 0.2240)'>15º</text>
-  <g transform='translate(50.0 17.89) rotate(101.301016) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(101.301016) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Sco' fill='#713f04' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#713f04' font-weight='500' transform='rotate(101.301016 50.0 21.89) translate(0 0.1968)'>13'</text>
@@ -345,12 +345,12 @@
 <g kr:node='Indicator' kr:slug='Pluto' kr:absoluteposition='225.2305424393643' transform='rotate(-11.301016 50.0 50.0)'>
   <path d='M 50.0 5.348 l 0 1.075' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
 </g>
-<g kr:node='ChartPoint' kr:house='Second_House' kr:sign='Cap' kr:absoluteposition='275.77082757415224' kr:signposition='5.770827574152236' kr:slug='Uranus' kr:retrograde='true' kr:motionstate='retrograde' kr:speed='-0.016482' kr:declination='-23.6431' kr:oob='true' kr:cx='254.84682206074208' kr:cy='443.6500932390068' transform='rotate(-61.004695 50.0 50.0)'>
+<g kr:node='ChartPoint' kr:house='Second_House' kr:sign='Cap' kr:absoluteposition='275.77082757415224' kr:signposition='5.770827574152236' kr:slug='Uranus' kr:retrograde='true' kr:motionstate='retrograde' kr:speed='-0.016482' kr:declination='-23.6431' kr:oob='true' kr:cx='254.84682206074237' kr:cy='443.65009323900694' transform='rotate(-61.004695 50.0 50.0)'>
   <g transform='translate(50.0 10.22) rotate(151.004695) scale(0.172368) translate(-12 -12)'>
     <use xlink:href='#Uranus' kr:slug='Uranus' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(151.004695 50.0 14.21) translate(0 0.2240)'>5º</text>
-  <g transform='translate(50.0 17.89) rotate(151.004695) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(151.004695) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(151.004695 50.0 21.89) translate(0 0.1968)'>46'</text>
@@ -359,12 +359,12 @@
 <g kr:node='Indicator' kr:slug='Uranus' kr:absoluteposition='275.77082757415224' transform='rotate(-61.841301 50.0 50.0)'>
   <path d='M 50.0 5.348 l 0 1.075 A 43.652 43.652 0 0 1 50.6373632609 6.3526533215 L 50.6216671758 7.4275387260' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
 </g>
-<g kr:node='ChartPoint' kr:house='Third_House' kr:sign='Cap' kr:absoluteposition='282.02398123455873' kr:signposition='12.023981234558732' kr:slug='Neptune' kr:retrograde='true' kr:motionstate='retrograde' kr:speed='-0.014909' kr:declination='-22.0459' kr:cx='275.8319585321326' kr:cy='453.5294386943478' transform='rotate(-68.575234 50.0 50.0)'>
+<g kr:node='ChartPoint' kr:house='Third_House' kr:sign='Cap' kr:absoluteposition='282.02398123455873' kr:signposition='12.023981234558732' kr:slug='Neptune' kr:retrograde='true' kr:motionstate='retrograde' kr:speed='-0.014909' kr:declination='-22.0459' kr:cx='275.8319585321327' kr:cy='453.52943869434785' transform='rotate(-68.575234 50.0 50.0)'>
   <g transform='translate(50.0 10.22) rotate(158.575234) scale(0.172368) translate(-12 -12)'>
     <use xlink:href='#Neptune' kr:slug='Neptune' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(158.575234 50.0 14.21) translate(0 0.2408)'>12º</text>
-  <g transform='translate(50.0 17.89) rotate(158.575234) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(158.575234) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(158.575234 50.0 21.89) translate(0 0.2124)'>1'</text>
@@ -373,12 +373,12 @@
 <g kr:node='Indicator' kr:slug='Neptune' kr:absoluteposition='282.02398123455873' transform='rotate(-68.094455 50.0 50.0)'>
   <path d='M 50.0 5.348 l 0 1.075' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
 </g>
-<g kr:node='ChartPoint' kr:house='Third_House' kr:sign='Cap' kr:absoluteposition='289.3607540393654' kr:signposition='19.360754039365418' kr:slug='Saturn' kr:retrograde='true' kr:motionstate='retrograde' kr:speed='-0.04407' kr:declination='-22.0307' kr:cx='296.8687477169276' kr:cy='460.29125033895417' transform='rotate(-75.787055 50.0 50.0)'>
+<g kr:node='ChartPoint' kr:house='Third_House' kr:sign='Cap' kr:absoluteposition='289.3607540393654' kr:signposition='19.360754039365418' kr:slug='Saturn' kr:retrograde='true' kr:motionstate='retrograde' kr:speed='-0.04407' kr:declination='-22.0307' kr:cx='296.8687477169278' kr:cy='460.2912503389543' transform='rotate(-75.787055 50.0 50.0)'>
   <g transform='translate(50.0 10.22) rotate(165.787055) scale(0.172368) translate(-12 -12)'>
     <use xlink:href='#Saturn' kr:slug='Saturn' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(165.787055 50.0 14.21) translate(0 0.2240)'>19º</text>
-  <g transform='translate(50.0 17.89) rotate(165.787055) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(165.787055) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(165.787055 50.0 21.89) translate(0 0.2124)'>21'</text>
@@ -392,7 +392,7 @@
     <use xlink:href='#True_North_Lunar_Node' kr:slug='True_North_Lunar_Node' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(183.093512 50.0 14.21) translate(0 0.2408)'>7º</text>
-  <g transform='translate(50.0 17.89) rotate(183.093512) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(183.093512) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Aqu' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(183.093512 50.0 21.89) translate(0 0.2124)'>1'</text>
@@ -406,7 +406,7 @@
     <use xlink:href='#Mars' kr:slug='Mars' kr:node='Glyph' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#540000' font-weight='500' transform='rotate(292.969605 50.0 14.21) translate(0 0.2240)'>26º</text>
-  <g transform='translate(50.0 17.89) rotate(292.969605) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(292.969605) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#540000' font-weight='500' transform='rotate(292.969605 50.0 21.89) translate(0 0.1968)'>53'</text>
@@ -419,7 +419,7 @@
     <use xlink:href='#Chiron' kr:slug='Chiron' kr:node='Glyph' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#505705' font-weight='500' transform='rotate(349.492359 50.0 14.21) translate(0 0.2240)'>23º</text>
-  <g transform='translate(50.0 17.89) rotate(349.492359) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(349.492359) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Can' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#505705' font-weight='500' transform='rotate(349.492359 50.0 21.89) translate(0 0.1968)'>25'</text>
@@ -432,7 +432,7 @@
     <use xlink:href='#Jupiter' kr:slug='Jupiter' kr:node='Glyph' fill='#47133d' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#47133d' font-weight='500' transform='rotate(357.570369 50.0 14.21) translate(0 0.2408)'>1º</text>
-  <g transform='translate(50.0 17.89) rotate(357.570369) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(357.570369) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#47133d' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#47133d' font-weight='500' transform='rotate(357.570369 50.0 21.89) translate(0 0.1968)'>29'</text>
@@ -445,7 +445,7 @@
     <use xlink:href='#Venus' kr:slug='Venus' kr:node='Glyph' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#400052' font-weight='500' transform='rotate(367.957383 50.0 14.21) translate(0 0.2408)'>14º</text>
-  <g transform='translate(50.0 17.89) rotate(367.957383) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(367.957383) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#400052' font-weight='500' transform='rotate(367.957383 50.0 21.89) translate(0 0.2072)'>7'</text>
@@ -458,7 +458,7 @@
     <use xlink:href='#Medium_Coeli' kr:slug='Medium_Coeli' kr:node='Glyph' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#a80000' font-weight='500' transform='rotate(374.172297 50.0 14.21) translate(0 0.2240)'>15º</text>
-  <g transform='translate(50.0 17.89) rotate(374.172297) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(374.172297) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#a80000' font-weight='500' transform='rotate(374.172297 50.0 21.89) translate(0 0.1968)'>51'</text>
@@ -471,7 +471,7 @@
     <use xlink:href='#Sun' kr:slug='Sun' kr:node='Glyph' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#7e3e00' font-weight='500' transform='rotate(388.065825 50.0 14.21) translate(0 0.2408)'>1º</text>
-  <g transform='translate(50.0 17.89) rotate(388.065825) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(388.065825) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#7e3e00' font-weight='500' transform='rotate(388.065825 50.0 21.89) translate(0 0.1968)'>59'</text>
@@ -484,7 +484,7 @@
     <use xlink:href='#Mercury' kr:slug='Mercury' kr:node='Glyph' fill='#8a5a12' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#8a5a12' font-weight='500' transform='rotate(409.637490 50.0 14.21) translate(0 0.2240)'>23º</text>
-  <g transform='translate(50.0 17.89) rotate(409.637490) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(409.637490) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#8a5a12' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#8a5a12' font-weight='500' transform='rotate(409.637490 50.0 21.89) translate(0 0.1968)'>34'</text>
@@ -493,45 +493,45 @@
 <g kr:node='Indicator' kr:slug='Mercury' kr:absoluteposition='173.5670165495044' transform='rotate(-319.637490 50.0 50.0)'>
   <path d='M 50.0 5.348 l 0 1.075' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
 </g>
-<g kr:node='ChartPoint' kr:house='Twelfth_House' kr:sign='Sco' kr:absoluteposition='210.54123811638087' kr:signposition='0.5412381163808675' kr:slug='Moon' kr:motionstate='average' kr:speed='12.181463' kr:declination='-16.5213' kr:cx='164.83141669700836' kr:cy='276.75680215607724' transform='rotate(-355.676516 50.0 50.0)' kr:angularity='Ascendant:3.3883'>
-  <g transform='translate(50.0 10.22) rotate(445.676516) scale(0.18144) translate(-12 -12)'>
+<g kr:node='ChartPoint' kr:house='Twelfth_House' kr:sign='Sco' kr:absoluteposition='210.54123811638087' kr:signposition='0.5412381163808675' kr:slug='Moon' kr:motionstate='average' kr:speed='12.181463' kr:declination='-16.5213' kr:cx='164.82911611745084' kr:cy='276.7872673032083' transform='rotate(-355.686480 50.0 50.0)' kr:angularity='Ascendant:3.3883'>
+  <g transform='translate(50.0 10.22) rotate(445.686480) scale(0.18144) translate(-12 -12)'>
     <use xlink:href='#Moon' kr:slug='Moon' kr:node='Glyph' fill='#150052' />
   </g>
-  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#150052' font-weight='500' transform='rotate(445.676516 50.0 14.21) translate(0 0.2240)'>0º</text>
-  <g transform='translate(50.0 17.89) rotate(445.676516) scale(0.092781) translate(-16 -16)'>
+  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#150052' font-weight='500' transform='rotate(445.686480 50.0 14.21) translate(0 0.2240)'>0º</text>
+  <g transform='translate(50.0 17.89) rotate(445.686480) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Sco' fill='#150052' />
   </g>
-  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#150052' font-weight='500' transform='rotate(445.676516 50.0 21.89) translate(0 0.1968)'>32'</text>
+  <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#150052' font-weight='500' transform='rotate(445.686480 50.0 21.89) translate(0 0.1968)'>32'</text>
 </g>
 <g kr:node='Indicator' kr:slug='Moon' kr:absoluteposition='210.54123811638087' transform='rotate(-356.611712 50.0 50.0)'>
-  <path d='M 50.0 5.348 l 0 1.075 A 43.652 43.652 0 0 1 50.7124672538 6.3538146637 L 50.6949216134 7.4286714683' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
+  <path d='M 50.0 5.348 l 0 1.075 A 43.652 43.652 0 0 1 50.7048763915 6.3536914130 L 50.6875176881 7.4285512529' fill='transparent' stroke='#8a8278' stroke-width='0.1'/>
 </g>
 </g>
 <g kr:node='HouseRing'>
 <path d='M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 M 30.5,50.0 A 19.5,19.5 0 1,1 69.5,50.0 A 19.5,19.5 0 1,1 30.5,50.0 Z' fill='#e4e4e7' fill-rule='evenodd'/>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='1' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-13.897640 50.0 50.0) rotate(103.897640 50.0 29.25)'>1</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-27.795281 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-27.795281 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='2' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-45.336718 50.0 50.0) rotate(135.336718 50.0 29.25)'>2</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-62.878155 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-62.878155 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='3' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-82.406206 50.0 50.0) rotate(172.406206 50.0 29.25)'>3</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-101.934256 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-101.934256 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='4' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-118.625015 50.0 50.0) rotate(208.625015 50.0 29.25)'>4</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-135.315774 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-135.315774 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='5' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-148.004885 50.0 50.0) rotate(238.004885 50.0 29.25)'>5</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-160.693997 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-160.693997 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='6' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-170.346998 50.0 50.0) rotate(260.346998 50.0 29.25)'>6</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='7' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-193.897640 50.0 50.0) rotate(283.897640 50.0 29.25)'>7</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-207.795281 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-207.795281 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='8' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-225.336718 50.0 50.0) rotate(315.336718 50.0 29.25)'>8</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-242.878155 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-242.878155 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='9' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-262.406206 50.0 50.0) rotate(352.406206 50.0 29.25)'>9</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-281.934256 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-281.934256 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='10' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-298.625015 50.0 50.0) rotate(388.625015 50.0 29.25)'>10</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-315.315774 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-315.315774 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='11' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-328.004885 50.0 50.0) rotate(418.004885 50.0 29.25)'>11</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-340.693997 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-340.693997 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='12' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-350.346998 50.0 50.0) rotate(440.346998 50.0 29.25)'>12</text></g>
 </g>
 <g kr:node='HouseSector' kr:house='1'><path d='M 50.000000,0.000000 A 50.0,50.0 0 0,0 26.684311,5.769031 L 40.906881,32.749922 A 19.5,19.5 0 0,1 50.000000,30.500000 Z' fill='transparent' stroke='none' pointer-events='all'/></g>

--- a/docs/charts/modern_black_and_white_natal.svg
+++ b/docs/charts/modern_black_and_white_natal.svg
@@ -301,28 +301,28 @@
 </g>
 <g kr:node='PlanetRing'>
 <path d='M 5.347999999999999,50.0 A 44.652,44.652 0 1,1 94.652,50.0 A 44.652,44.652 0 1,1 5.347999999999999,50.0 M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 Z' fill='#e8e8e8' fill-rule='evenodd' stroke='#a0a0a0' stroke-width='0.25'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#727272)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#727272)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#727272)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#727272)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#727272)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#727272)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#727272' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#bfbfbf' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#727272' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#727272' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#bfbfbf' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#727272' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#727272' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='ChartPoint' kr:house='First_House' kr:sign='Ari' kr:absoluteposition='19.711128718293267' kr:signposition='19.711128718293267' kr:slug='Ascendant' kr:speed='886.944184' kr:cx='164.33152' kr:cy='290.0' transform='rotate(-0.000000 50.0 50.0)'>
   <g transform='translate(50.0 10.22) rotate(90.000000) scale(0.172368) translate(-12 -12)'>
     <use xlink:href='#Ascendant' kr:slug='Ascendant' kr:node='Glyph' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#000000' font-weight='500' transform='rotate(90.000000 50.0 14.21) translate(0 0.2240)'>19º</text>
-  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Ari' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#000000' font-weight='500' transform='rotate(90.000000 50.0 21.89) translate(0 0.2124)'>42'</text>
@@ -335,7 +335,7 @@
     <use xlink:href='#Saturn' kr:slug='Saturn' kr:node='Glyph' fill='#444444' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#444444' font-weight='500' transform='rotate(110.648968 50.0 14.21) translate(0 0.2240)'>13º</text>
-  <g transform='translate(50.0 17.89) rotate(110.648968) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(110.648968) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#444444' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#444444' font-weight='500' transform='rotate(110.648968 50.0 21.89) translate(0 0.2124)'>12'</text>
@@ -349,7 +349,7 @@
     <use xlink:href='#Jupiter' kr:slug='Jupiter' kr:node='Glyph' fill='#444444' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#444444' font-weight='500' transform='rotate(116.835659 50.0 14.21) translate(0 0.2240)'>13º</text>
-  <g transform='translate(50.0 17.89) rotate(116.835659) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(116.835659) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#444444' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#444444' font-weight='500' transform='rotate(116.835659 50.0 21.89) translate(0 0.2124)'>41'</text>
@@ -363,7 +363,7 @@
     <use xlink:href='#Uranus' kr:slug='Uranus' kr:node='Glyph' fill='#444444' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#444444' font-weight='500' transform='rotate(125.840888 50.0 14.21) translate(0 0.2240)'>25º</text>
-  <g transform='translate(50.0 17.89) rotate(125.840888) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(125.840888) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#444444' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#444444' font-weight='500' transform='rotate(125.840888 50.0 21.89) translate(0 0.1968)'>33'</text>
@@ -377,7 +377,7 @@
     <use xlink:href='#Chiron' kr:slug='Chiron' kr:node='Glyph' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#000000' font-weight='500' transform='rotate(189.491565 50.0 14.21) translate(0 0.2240)'>0º</text>
-  <g transform='translate(50.0 17.89) rotate(189.491565) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(189.491565) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#000000' font-weight='500' transform='rotate(189.491565 50.0 21.89) translate(0 0.1968)'>34'</text>
@@ -390,7 +390,7 @@
     <use xlink:href='#Pluto' kr:slug='Pluto' kr:node='Glyph' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#000000' font-weight='500' transform='rotate(195.842483 50.0 14.21) translate(0 0.2408)'>4º</text>
-  <g transform='translate(50.0 17.89) rotate(195.842483) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(195.842483) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#000000' font-weight='500' transform='rotate(195.842483 50.0 21.89) translate(0 0.2124)'>11'</text>
@@ -403,7 +403,7 @@
     <use xlink:href='#Venus' kr:slug='Venus' kr:node='Glyph' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#000000' font-weight='500' transform='rotate(223.504289 50.0 14.21) translate(0 0.2240)'>3º</text>
-  <g transform='translate(50.0 17.89) rotate(223.504289) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(223.504289) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#000000' font-weight='500' transform='rotate(223.504289 50.0 21.89) translate(0 0.2124)'>12'</text>
@@ -416,7 +416,7 @@
     <use xlink:href='#Neptune' kr:slug='Neptune' kr:node='Glyph' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#000000' font-weight='500' transform='rotate(246.318991 50.0 14.21) translate(0 0.2240)'>26º</text>
-  <g transform='translate(50.0 17.89) rotate(246.318991) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(246.318991) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#000000' font-weight='500' transform='rotate(246.318991 50.0 21.89) translate(0 0.2124)'>1'</text>
@@ -429,7 +429,7 @@
     <use xlink:href='#Mars' kr:slug='Mars' kr:node='Glyph' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#000000' font-weight='500' transform='rotate(252.951402 50.0 14.21) translate(0 0.2408)'>2º</text>
-  <g transform='translate(50.0 17.89) rotate(252.951402) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(252.951402) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#000000' font-weight='500' transform='rotate(252.951402 50.0 21.89) translate(0 0.1968)'>39'</text>
@@ -442,7 +442,7 @@
     <use xlink:href='#True_North_Lunar_Node' kr:slug='True_North_Lunar_Node' kr:node='Glyph' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#000000' font-weight='500' transform='rotate(261.257298 50.0 14.21) translate(0 0.2408)'>11º</text>
-  <g transform='translate(50.0 17.89) rotate(261.257298) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(261.257298) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#000000' font-weight='500' transform='rotate(261.257298 50.0 21.89) translate(0 0.2124)'>1'</text>
@@ -455,7 +455,7 @@
     <use xlink:href='#Sun' kr:slug='Sun' kr:node='Glyph' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#000000' font-weight='500' transform='rotate(266.612587 50.0 14.21) translate(0 0.2240)'>16º</text>
-  <g transform='translate(50.0 17.89) rotate(266.612587) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(266.612587) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#000000' font-weight='500' transform='rotate(266.612587 50.0 21.89) translate(0 0.1968)'>16'</text>
@@ -468,7 +468,7 @@
     <use xlink:href='#Mercury' kr:slug='Mercury' kr:node='Glyph' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#000000' font-weight='500' transform='rotate(288.847104 50.0 14.21) translate(0 0.2240)'>8º</text>
-  <g transform='translate(50.0 17.89) rotate(288.847104) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(288.847104) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Sco' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#000000' font-weight='500' transform='rotate(288.847104 50.0 21.89) translate(0 0.1968)'>33'</text>
@@ -481,7 +481,7 @@
     <use xlink:href='#Medium_Coeli' kr:slug='Medium_Coeli' kr:node='Glyph' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#000000' font-weight='500' transform='rotate(347.347283 50.0 14.21) translate(0 0.2408)'>7º</text>
-  <g transform='translate(50.0 17.89) rotate(347.347283) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(347.347283) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#000000' font-weight='500' transform='rotate(347.347283 50.0 21.89) translate(0 0.1968)'>3'</text>
@@ -494,7 +494,7 @@
     <use xlink:href='#Moon' kr:slug='Moon' kr:node='Glyph' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#000000' font-weight='500' transform='rotate(373.835496 50.0 14.21) translate(0 0.2240)'>3º</text>
-  <g transform='translate(50.0 17.89) rotate(373.835496) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(373.835496) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Aqu' fill='#000000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#000000' font-weight='500' transform='rotate(373.835496 50.0 21.89) translate(0 0.1968)'>32'</text>
@@ -505,29 +505,29 @@
 </g>
 <g kr:node='HouseRing'>
 <path d='M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 M 30.5,50.0 A 19.5,19.5 0 1,1 69.5,50.0 A 19.5,19.5 0 1,1 30.5,50.0 Z' fill='#d0d0d0' fill-rule='evenodd'/>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='1' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-19.904366 50.0 50.0) rotate(109.904366 50.0 29.25)'>1</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='2' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-50.161212 50.0 50.0) rotate(140.161212 50.0 29.25)'>2</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='3' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-68.930487 50.0 50.0) rotate(158.930487 50.0 29.25)'>3</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='4' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-86.468184 50.0 50.0) rotate(176.468184 50.0 29.25)'>4</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='5' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-108.981980 50.0 50.0) rotate(198.981980 50.0 29.25)'>5</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='6' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-151.187437 50.0 50.0) rotate(241.187437 50.0 29.25)'>6</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='7' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-199.904366 50.0 50.0) rotate(289.904366 50.0 29.25)'>7</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='8' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-230.161212 50.0 50.0) rotate(320.161212 50.0 29.25)'>8</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='9' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-248.930487 50.0 50.0) rotate(338.930487 50.0 29.25)'>9</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='10' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-266.468184 50.0 50.0) rotate(356.468184 50.0 29.25)'>10</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='11' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-288.981980 50.0 50.0) rotate(378.981980 50.0 29.25)'>11</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#727272' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='12' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#111111' font-weight='500' transform='rotate(-331.187437 50.0 50.0) rotate(421.187437 50.0 29.25)'>12</text></g>
 </g>
 <g kr:node='HouseSector' kr:house='1'><path d='M 50.000000,0.000000 A 50.0,50.0 0 0,0 17.988660,11.590702 L 37.515578,35.020374 A 19.5,19.5 0 0,1 50.000000,30.500000 Z' fill='transparent' stroke='none' pointer-events='all'/></g>

--- a/docs/charts/modern_classic_natal.svg
+++ b/docs/charts/modern_classic_natal.svg
@@ -94,8 +94,8 @@
 <g kr:node='ModernHoroscope' font-family='Arial, Helvetica, Liberation Sans, sans-serif' transform='rotate(-90 50.0 50.0)'>
 <g kr:node='ZodiacBackgrounds'>
   <g kr:node='ZodiacSign' kr:sign='Ari' kr:signnumber='0'>
-  <path d='M 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 L 41.783889,4.739692 A 46.0,46.0 0 0,1 65.514793,6.695368 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 L 41.783889,4.739692 A 46.0,46.0 0 0,1 65.514793,6.695368 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-355.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(445.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Ari' />
@@ -103,8 +103,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Tau' kr:signnumber='1'>
-  <path d='M 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 L 20.254485,14.911479 A 46.0,46.0 0 0,1 41.783889,4.739692 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 L 20.254485,14.911479 A 46.0,46.0 0 0,1 41.783889,4.739692 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-25.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(115.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Tau' />
@@ -112,8 +112,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Gem' kr:signnumber='2'>
-  <path d='M 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 L 6.695368,34.485207 A 46.0,46.0 0 0,1 20.254485,14.911479 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 L 6.695368,34.485207 A 46.0,46.0 0 0,1 20.254485,14.911479 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-55.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(145.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Gem' />
@@ -121,8 +121,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Can' kr:signnumber='3'>
-  <path d='M 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 L 4.739692,58.216111 A 46.0,46.0 0 0,1 6.695368,34.485207 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 L 4.739692,58.216111 A 46.0,46.0 0 0,1 6.695368,34.485207 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-85.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(175.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Can' />
@@ -130,8 +130,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Leo' kr:signnumber='4'>
-  <path d='M 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 L 14.911479,79.745515 A 46.0,46.0 0 0,1 4.739692,58.216111 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 L 14.911479,79.745515 A 46.0,46.0 0 0,1 4.739692,58.216111 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-115.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(205.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Leo' />
@@ -139,8 +139,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Vir' kr:signnumber='5'>
-  <path d='M 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 L 34.485207,93.304632 A 46.0,46.0 0 0,1 14.911479,79.745515 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 L 34.485207,93.304632 A 46.0,46.0 0 0,1 14.911479,79.745515 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-145.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(235.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Vir' />
@@ -148,8 +148,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Lib' kr:signnumber='6'>
-  <path d='M 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 L 58.216111,95.260308 A 46.0,46.0 0 0,1 34.485207,93.304632 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 L 58.216111,95.260308 A 46.0,46.0 0 0,1 34.485207,93.304632 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-175.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(265.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Lib' />
@@ -157,8 +157,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sco' kr:signnumber='7'>
-  <path d='M 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 L 79.745515,85.088521 A 46.0,46.0 0 0,1 58.216111,95.260308 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 L 79.745515,85.088521 A 46.0,46.0 0 0,1 58.216111,95.260308 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-205.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(295.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sco' />
@@ -166,8 +166,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sag' kr:signnumber='8'>
-  <path d='M 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 L 93.304632,65.514793 A 46.0,46.0 0 0,1 79.745515,85.088521 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 L 93.304632,65.514793 A 46.0,46.0 0 0,1 79.745515,85.088521 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-235.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(325.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sag' />
@@ -175,8 +175,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Cap' kr:signnumber='9'>
-  <path d='M 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 L 95.260308,41.783889 A 46.0,46.0 0 0,1 93.304632,65.514793 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 L 95.260308,41.783889 A 46.0,46.0 0 0,1 93.304632,65.514793 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-265.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(355.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Cap' />
@@ -184,8 +184,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Aqu' kr:signnumber='10'>
-  <path d='M 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 L 85.088521,20.254485 A 46.0,46.0 0 0,1 95.260308,41.783889 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 L 85.088521,20.254485 A 46.0,46.0 0 0,1 95.260308,41.783889 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-295.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(385.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Aqu' />
@@ -193,8 +193,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Pis' kr:signnumber='11'>
-  <path d='M 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 L 65.514793,6.695368 A 46.0,46.0 0 0,1 85.088521,20.254485 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 L 65.514793,6.695368 A 46.0,46.0 0 0,1 85.088521,20.254485 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-325.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(415.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Pis' />
@@ -301,28 +301,28 @@
 </g>
 <g kr:node='PlanetRing'>
 <path d='M 5.347999999999999,50.0 A 44.652,44.652 0 1,1 94.652,50.0 A 44.652,44.652 0 1,1 5.347999999999999,50.0 M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 Z' fill='#f4f4f5' fill-rule='evenodd' stroke='#d4d4d8' stroke-width='0.25'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='ChartPoint' kr:house='First_House' kr:sign='Ari' kr:absoluteposition='19.711128718293267' kr:signposition='19.711128718293267' kr:slug='Ascendant' kr:speed='886.944184' kr:cx='164.33152' kr:cy='290.0' transform='rotate(-0.000000 50.0 50.0)'>
   <g transform='translate(50.0 10.22) rotate(90.000000) scale(0.172368) translate(-12 -12)'>
     <use xlink:href='#Ascendant' kr:slug='Ascendant' kr:node='Glyph' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#7f3f00' font-weight='500' transform='rotate(90.000000 50.0 14.21) translate(0 0.2240)'>19º</text>
-  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Ari' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#7f3f00' font-weight='500' transform='rotate(90.000000 50.0 21.89) translate(0 0.2124)'>42'</text>
@@ -335,7 +335,7 @@
     <use xlink:href='#Saturn' kr:slug='Saturn' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(110.648968 50.0 14.21) translate(0 0.2240)'>13º</text>
-  <g transform='translate(50.0 17.89) rotate(110.648968) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(110.648968) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(110.648968 50.0 21.89) translate(0 0.2124)'>12'</text>
@@ -349,7 +349,7 @@
     <use xlink:href='#Jupiter' kr:slug='Jupiter' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(116.835659 50.0 14.21) translate(0 0.2240)'>13º</text>
-  <g transform='translate(50.0 17.89) rotate(116.835659) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(116.835659) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(116.835659 50.0 21.89) translate(0 0.2124)'>41'</text>
@@ -363,7 +363,7 @@
     <use xlink:href='#Uranus' kr:slug='Uranus' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(125.840888 50.0 14.21) translate(0 0.2240)'>25º</text>
-  <g transform='translate(50.0 17.89) rotate(125.840888) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(125.840888) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(125.840888 50.0 21.89) translate(0 0.1968)'>33'</text>
@@ -377,7 +377,7 @@
     <use xlink:href='#Chiron' kr:slug='Chiron' kr:node='Glyph' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#505705' font-weight='500' transform='rotate(189.491565 50.0 14.21) translate(0 0.2240)'>0º</text>
-  <g transform='translate(50.0 17.89) rotate(189.491565) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(189.491565) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#505705' font-weight='500' transform='rotate(189.491565 50.0 21.89) translate(0 0.1968)'>34'</text>
@@ -390,7 +390,7 @@
     <use xlink:href='#Pluto' kr:slug='Pluto' kr:node='Glyph' fill='#713f04' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#713f04' font-weight='500' transform='rotate(195.842483 50.0 14.21) translate(0 0.2408)'>4º</text>
-  <g transform='translate(50.0 17.89) rotate(195.842483) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(195.842483) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#713f04' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#713f04' font-weight='500' transform='rotate(195.842483 50.0 21.89) translate(0 0.2124)'>11'</text>
@@ -403,7 +403,7 @@
     <use xlink:href='#Venus' kr:slug='Venus' kr:node='Glyph' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#400052' font-weight='500' transform='rotate(223.504289 50.0 14.21) translate(0 0.2240)'>3º</text>
-  <g transform='translate(50.0 17.89) rotate(223.504289) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(223.504289) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#400052' font-weight='500' transform='rotate(223.504289 50.0 21.89) translate(0 0.2124)'>12'</text>
@@ -416,7 +416,7 @@
     <use xlink:href='#Neptune' kr:slug='Neptune' kr:node='Glyph' fill='#06537f' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#06537f' font-weight='500' transform='rotate(246.318991 50.0 14.21) translate(0 0.2240)'>26º</text>
-  <g transform='translate(50.0 17.89) rotate(246.318991) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(246.318991) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#06537f' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#06537f' font-weight='500' transform='rotate(246.318991 50.0 21.89) translate(0 0.2124)'>1'</text>
@@ -429,7 +429,7 @@
     <use xlink:href='#Mars' kr:slug='Mars' kr:node='Glyph' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#540000' font-weight='500' transform='rotate(252.951402 50.0 14.21) translate(0 0.2408)'>2º</text>
-  <g transform='translate(50.0 17.89) rotate(252.951402) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(252.951402) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#540000' font-weight='500' transform='rotate(252.951402 50.0 21.89) translate(0 0.1968)'>39'</text>
@@ -442,7 +442,7 @@
     <use xlink:href='#True_North_Lunar_Node' kr:slug='True_North_Lunar_Node' kr:node='Glyph' fill='#4c1541' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#4c1541' font-weight='500' transform='rotate(261.257298 50.0 14.21) translate(0 0.2408)'>11º</text>
-  <g transform='translate(50.0 17.89) rotate(261.257298) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(261.257298) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#4c1541' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#4c1541' font-weight='500' transform='rotate(261.257298 50.0 21.89) translate(0 0.2124)'>1'</text>
@@ -455,7 +455,7 @@
     <use xlink:href='#Sun' kr:slug='Sun' kr:node='Glyph' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#7e3e00' font-weight='500' transform='rotate(266.612587 50.0 14.21) translate(0 0.2240)'>16º</text>
-  <g transform='translate(50.0 17.89) rotate(266.612587) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(266.612587) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#7e3e00' font-weight='500' transform='rotate(266.612587 50.0 21.89) translate(0 0.1968)'>16'</text>
@@ -468,7 +468,7 @@
     <use xlink:href='#Mercury' kr:slug='Mercury' kr:node='Glyph' fill='#520800' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#520800' font-weight='500' transform='rotate(288.847104 50.0 14.21) translate(0 0.2240)'>8º</text>
-  <g transform='translate(50.0 17.89) rotate(288.847104) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(288.847104) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Sco' fill='#520800' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#520800' font-weight='500' transform='rotate(288.847104 50.0 21.89) translate(0 0.1968)'>33'</text>
@@ -481,7 +481,7 @@
     <use xlink:href='#Medium_Coeli' kr:slug='Medium_Coeli' kr:node='Glyph' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#a80000' font-weight='500' transform='rotate(347.347283 50.0 14.21) translate(0 0.2408)'>7º</text>
-  <g transform='translate(50.0 17.89) rotate(347.347283) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(347.347283) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#a80000' font-weight='500' transform='rotate(347.347283 50.0 21.89) translate(0 0.1968)'>3'</text>
@@ -494,7 +494,7 @@
     <use xlink:href='#Moon' kr:slug='Moon' kr:node='Glyph' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#150052' font-weight='500' transform='rotate(373.835496 50.0 14.21) translate(0 0.2240)'>3º</text>
-  <g transform='translate(50.0 17.89) rotate(373.835496) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(373.835496) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Aqu' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#150052' font-weight='500' transform='rotate(373.835496 50.0 21.89) translate(0 0.1968)'>32'</text>
@@ -505,29 +505,29 @@
 </g>
 <g kr:node='HouseRing'>
 <path d='M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 M 30.5,50.0 A 19.5,19.5 0 1,1 69.5,50.0 A 19.5,19.5 0 1,1 30.5,50.0 Z' fill='#e4e4e7' fill-rule='evenodd'/>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='1' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-19.904366 50.0 50.0) rotate(109.904366 50.0 29.25)'>1</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='2' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-50.161212 50.0 50.0) rotate(140.161212 50.0 29.25)'>2</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='3' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-68.930487 50.0 50.0) rotate(158.930487 50.0 29.25)'>3</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='4' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-86.468184 50.0 50.0) rotate(176.468184 50.0 29.25)'>4</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='5' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-108.981980 50.0 50.0) rotate(198.981980 50.0 29.25)'>5</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='6' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-151.187437 50.0 50.0) rotate(241.187437 50.0 29.25)'>6</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='7' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-199.904366 50.0 50.0) rotate(289.904366 50.0 29.25)'>7</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='8' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-230.161212 50.0 50.0) rotate(320.161212 50.0 29.25)'>8</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='9' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-248.930487 50.0 50.0) rotate(338.930487 50.0 29.25)'>9</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='10' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-266.468184 50.0 50.0) rotate(356.468184 50.0 29.25)'>10</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='11' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-288.981980 50.0 50.0) rotate(378.981980 50.0 29.25)'>11</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='12' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-331.187437 50.0 50.0) rotate(421.187437 50.0 29.25)'>12</text></g>
 </g>
 <g kr:node='HouseSector' kr:house='1'><path d='M 50.000000,0.000000 A 50.0,50.0 0 0,0 17.988660,11.590702 L 37.515578,35.020374 A 19.5,19.5 0 0,1 50.000000,30.500000 Z' fill='transparent' stroke='none' pointer-events='all'/></g>

--- a/docs/charts/modern_dark_natal.svg
+++ b/docs/charts/modern_dark_natal.svg
@@ -301,28 +301,28 @@
 </g>
 <g kr:node='PlanetRing'>
 <path d='M 5.347999999999999,50.0 A 44.652,44.652 0 1,1 94.652,50.0 A 44.652,44.652 0 1,1 5.347999999999999,50.0 M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 Z' fill='#1a2540' fill-rule='evenodd' stroke='#384a6b' stroke-width='0.25'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#627cad)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#627cad)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#627cad)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#627cad)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#627cad)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#627cad)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#627cad' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#334366' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#627cad' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#627cad' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#334366' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#627cad' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#627cad' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='ChartPoint' kr:house='First_House' kr:sign='Ari' kr:absoluteposition='19.711128718293267' kr:signposition='19.711128718293267' kr:slug='Ascendant' kr:speed='886.944184' kr:cx='164.33152' kr:cy='290.0' transform='rotate(-0.000000 50.0 50.0)'>
   <g transform='translate(50.0 10.22) rotate(90.000000) scale(0.172368) translate(-12 -12)'>
     <use xlink:href='#Ascendant' kr:slug='Ascendant' kr:node='Glyph' fill='#f4bf50' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#f4bf50' font-weight='500' transform='rotate(90.000000 50.0 14.21) translate(0 0.2240)'>19º</text>
-  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Ari' fill='#f4bf50' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#f4bf50' font-weight='500' transform='rotate(90.000000 50.0 21.89) translate(0 0.2124)'>42'</text>
@@ -335,7 +335,7 @@
     <use xlink:href='#Saturn' kr:slug='Saturn' kr:node='Glyph' fill='#fb7085' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#fb7085' font-weight='500' transform='rotate(110.648968 50.0 14.21) translate(0 0.2240)'>13º</text>
-  <g transform='translate(50.0 17.89) rotate(110.648968) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(110.648968) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#fb7085' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#fb7085' font-weight='500' transform='rotate(110.648968 50.0 21.89) translate(0 0.2124)'>12'</text>
@@ -349,7 +349,7 @@
     <use xlink:href='#Jupiter' kr:slug='Jupiter' kr:node='Glyph' fill='#fb7085' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#fb7085' font-weight='500' transform='rotate(116.835659 50.0 14.21) translate(0 0.2240)'>13º</text>
-  <g transform='translate(50.0 17.89) rotate(116.835659) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(116.835659) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#fb7085' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#fb7085' font-weight='500' transform='rotate(116.835659 50.0 21.89) translate(0 0.2124)'>41'</text>
@@ -363,7 +363,7 @@
     <use xlink:href='#Uranus' kr:slug='Uranus' kr:node='Glyph' fill='#fb7085' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#fb7085' font-weight='500' transform='rotate(125.840888 50.0 14.21) translate(0 0.2240)'>25º</text>
-  <g transform='translate(50.0 17.89) rotate(125.840888) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(125.840888) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#fb7085' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#fb7085' font-weight='500' transform='rotate(125.840888 50.0 21.89) translate(0 0.1968)'>33'</text>
@@ -377,7 +377,7 @@
     <use xlink:href='#Chiron' kr:slug='Chiron' kr:node='Glyph' fill='#a3abfa' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#a3abfa' font-weight='500' transform='rotate(189.491565 50.0 14.21) translate(0 0.2240)'>0º</text>
-  <g transform='translate(50.0 17.89) rotate(189.491565) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(189.491565) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#a3abfa' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#a3abfa' font-weight='500' transform='rotate(189.491565 50.0 21.89) translate(0 0.1968)'>34'</text>
@@ -390,7 +390,7 @@
     <use xlink:href='#Pluto' kr:slug='Pluto' kr:node='Glyph' fill='#a3abfa' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#a3abfa' font-weight='500' transform='rotate(195.842483 50.0 14.21) translate(0 0.2408)'>4º</text>
-  <g transform='translate(50.0 17.89) rotate(195.842483) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(195.842483) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#a3abfa' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#a3abfa' font-weight='500' transform='rotate(195.842483 50.0 21.89) translate(0 0.2124)'>11'</text>
@@ -403,7 +403,7 @@
     <use xlink:href='#Venus' kr:slug='Venus' kr:node='Glyph' fill='#f792c6' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#f792c6' font-weight='500' transform='rotate(223.504289 50.0 14.21) translate(0 0.2240)'>3º</text>
-  <g transform='translate(50.0 17.89) rotate(223.504289) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(223.504289) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#f792c6' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#f792c6' font-weight='500' transform='rotate(223.504289 50.0 21.89) translate(0 0.2124)'>12'</text>
@@ -416,7 +416,7 @@
     <use xlink:href='#Neptune' kr:slug='Neptune' kr:node='Glyph' fill='#38bdf8' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#38bdf8' font-weight='500' transform='rotate(246.318991 50.0 14.21) translate(0 0.2240)'>26º</text>
-  <g transform='translate(50.0 17.89) rotate(246.318991) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(246.318991) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#38bdf8' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#38bdf8' font-weight='500' transform='rotate(246.318991 50.0 21.89) translate(0 0.2124)'>1'</text>
@@ -429,7 +429,7 @@
     <use xlink:href='#Mars' kr:slug='Mars' kr:node='Glyph' fill='#f4bf50' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#f4bf50' font-weight='500' transform='rotate(252.951402 50.0 14.21) translate(0 0.2408)'>2º</text>
-  <g transform='translate(50.0 17.89) rotate(252.951402) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(252.951402) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#f4bf50' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#f4bf50' font-weight='500' transform='rotate(252.951402 50.0 21.89) translate(0 0.1968)'>39'</text>
@@ -442,7 +442,7 @@
     <use xlink:href='#True_North_Lunar_Node' kr:slug='True_North_Lunar_Node' kr:node='Glyph' fill='#f4bf50' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#f4bf50' font-weight='500' transform='rotate(261.257298 50.0 14.21) translate(0 0.2408)'>11º</text>
-  <g transform='translate(50.0 17.89) rotate(261.257298) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(261.257298) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#f4bf50' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#f4bf50' font-weight='500' transform='rotate(261.257298 50.0 21.89) translate(0 0.2124)'>1'</text>
@@ -455,7 +455,7 @@
     <use xlink:href='#Sun' kr:slug='Sun' kr:node='Glyph' fill='#f4bf50' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#f4bf50' font-weight='500' transform='rotate(266.612587 50.0 14.21) translate(0 0.2240)'>16º</text>
-  <g transform='translate(50.0 17.89) rotate(266.612587) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(266.612587) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#f4bf50' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#f4bf50' font-weight='500' transform='rotate(266.612587 50.0 21.89) translate(0 0.1968)'>16'</text>
@@ -468,7 +468,7 @@
     <use xlink:href='#Mercury' kr:slug='Mercury' kr:node='Glyph' fill='#38bdf8' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#38bdf8' font-weight='500' transform='rotate(288.847104 50.0 14.21) translate(0 0.2240)'>8º</text>
-  <g transform='translate(50.0 17.89) rotate(288.847104) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(288.847104) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Sco' fill='#38bdf8' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#38bdf8' font-weight='500' transform='rotate(288.847104 50.0 21.89) translate(0 0.1968)'>33'</text>
@@ -481,7 +481,7 @@
     <use xlink:href='#Medium_Coeli' kr:slug='Medium_Coeli' kr:node='Glyph' fill='#f4bf50' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#f4bf50' font-weight='500' transform='rotate(347.347283 50.0 14.21) translate(0 0.2408)'>7º</text>
-  <g transform='translate(50.0 17.89) rotate(347.347283) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(347.347283) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#f4bf50' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#f4bf50' font-weight='500' transform='rotate(347.347283 50.0 21.89) translate(0 0.1968)'>3'</text>
@@ -494,7 +494,7 @@
     <use xlink:href='#Moon' kr:slug='Moon' kr:node='Glyph' fill='#a3abfa' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#a3abfa' font-weight='500' transform='rotate(373.835496 50.0 14.21) translate(0 0.2240)'>3º</text>
-  <g transform='translate(50.0 17.89) rotate(373.835496) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(373.835496) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Aqu' fill='#a3abfa' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#a3abfa' font-weight='500' transform='rotate(373.835496 50.0 21.89) translate(0 0.1968)'>32'</text>
@@ -505,29 +505,29 @@
 </g>
 <g kr:node='HouseRing'>
 <path d='M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 M 30.5,50.0 A 19.5,19.5 0 1,1 69.5,50.0 A 19.5,19.5 0 1,1 30.5,50.0 Z' fill='#243050' fill-rule='evenodd'/>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='1' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-19.904366 50.0 50.0) rotate(109.904366 50.0 29.25)'>1</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='2' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-50.161212 50.0 50.0) rotate(140.161212 50.0 29.25)'>2</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='3' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-68.930487 50.0 50.0) rotate(158.930487 50.0 29.25)'>3</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='4' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-86.468184 50.0 50.0) rotate(176.468184 50.0 29.25)'>4</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='5' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-108.981980 50.0 50.0) rotate(198.981980 50.0 29.25)'>5</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='6' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-151.187437 50.0 50.0) rotate(241.187437 50.0 29.25)'>6</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='7' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-199.904366 50.0 50.0) rotate(289.904366 50.0 29.25)'>7</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='8' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-230.161212 50.0 50.0) rotate(320.161212 50.0 29.25)'>8</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='9' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-248.930487 50.0 50.0) rotate(338.930487 50.0 29.25)'>9</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='10' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-266.468184 50.0 50.0) rotate(356.468184 50.0 29.25)'>10</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='11' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-288.981980 50.0 50.0) rotate(378.981980 50.0 29.25)'>11</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#627cad' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='12' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#c8cbd0' font-weight='500' transform='rotate(-331.187437 50.0 50.0) rotate(421.187437 50.0 29.25)'>12</text></g>
 </g>
 <g kr:node='HouseSector' kr:house='1'><path d='M 50.000000,0.000000 A 50.0,50.0 0 0,0 17.988660,11.590702 L 37.515578,35.020374 A 19.5,19.5 0 0,1 50.000000,30.500000 Z' fill='transparent' stroke='none' pointer-events='all'/></g>

--- a/docs/charts/modern_default_natal.svg
+++ b/docs/charts/modern_default_natal.svg
@@ -94,8 +94,8 @@
 <g kr:node='ModernHoroscope' font-family='Arial, Helvetica, Liberation Sans, sans-serif' transform='rotate(-90 50.0 50.0)'>
 <g kr:node='ZodiacBackgrounds'>
   <g kr:node='ZodiacSign' kr:sign='Ari' kr:signnumber='0'>
-  <path d='M 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 L 41.783889,4.739692 A 46.0,46.0 0 0,1 65.514793,6.695368 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 L 41.783889,4.739692 A 46.0,46.0 0 0,1 65.514793,6.695368 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 66.863906,2.929747 A 50.0,50.0 0 0,0 41.069445,0.804013 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-355.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(445.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Ari' />
@@ -103,8 +103,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Tau' kr:signnumber='1'>
-  <path d='M 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 L 20.254485,14.911479 A 46.0,46.0 0 0,1 41.783889,4.739692 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 L 20.254485,14.911479 A 46.0,46.0 0 0,1 41.783889,4.739692 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 41.069445,0.804013 A 50.0,50.0 0 0,0 17.667918,11.860303 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-25.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(115.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Tau' />
@@ -112,8 +112,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Gem' kr:signnumber='2'>
-  <path d='M 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 L 6.695368,34.485207 A 46.0,46.0 0 0,1 20.254485,14.911479 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 L 6.695368,34.485207 A 46.0,46.0 0 0,1 20.254485,14.911479 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 17.667918,11.860303 A 50.0,50.0 0 0,0 2.929747,33.136094 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-55.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(145.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Gem' />
@@ -121,8 +121,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Can' kr:signnumber='3'>
-  <path d='M 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 L 4.739692,58.216111 A 46.0,46.0 0 0,1 6.695368,34.485207 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 L 4.739692,58.216111 A 46.0,46.0 0 0,1 6.695368,34.485207 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 2.929747,33.136094 A 50.0,50.0 0 0,0 0.804013,58.930555 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-85.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(175.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Can' />
@@ -130,8 +130,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Leo' kr:signnumber='4'>
-  <path d='M 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 L 14.911479,79.745515 A 46.0,46.0 0 0,1 4.739692,58.216111 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 L 14.911479,79.745515 A 46.0,46.0 0 0,1 4.739692,58.216111 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 0.804013,58.930555 A 50.0,50.0 0 0,0 11.860303,82.332082 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-115.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(205.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Leo' />
@@ -139,8 +139,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Vir' kr:signnumber='5'>
-  <path d='M 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 L 34.485207,93.304632 A 46.0,46.0 0 0,1 14.911479,79.745515 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 L 34.485207,93.304632 A 46.0,46.0 0 0,1 14.911479,79.745515 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 11.860303,82.332082 A 50.0,50.0 0 0,0 33.136094,97.070253 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-145.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(235.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Vir' />
@@ -148,8 +148,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Lib' kr:signnumber='6'>
-  <path d='M 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 L 58.216111,95.260308 A 46.0,46.0 0 0,1 34.485207,93.304632 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 L 58.216111,95.260308 A 46.0,46.0 0 0,1 34.485207,93.304632 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 33.136094,97.070253 A 50.0,50.0 0 0,0 58.930555,99.195987 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-175.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(265.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Lib' />
@@ -157,8 +157,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sco' kr:signnumber='7'>
-  <path d='M 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 L 79.745515,85.088521 A 46.0,46.0 0 0,1 58.216111,95.260308 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 L 79.745515,85.088521 A 46.0,46.0 0 0,1 58.216111,95.260308 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 58.930555,99.195987 A 50.0,50.0 0 0,0 82.332082,88.139697 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-205.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(295.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sco' />
@@ -166,8 +166,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Sag' kr:signnumber='8'>
-  <path d='M 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 L 93.304632,65.514793 A 46.0,46.0 0 0,1 79.745515,85.088521 Z' fill='#ff7200' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 Z' fill='#ff7200' fill-opacity='0' pointer-events='none' />
+  <path d='M 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 L 93.304632,65.514793 A 46.0,46.0 0 0,1 79.745515,85.088521 Z' fill='#ffb880' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 82.332082,88.139697 A 50.0,50.0 0 0,0 97.070253,66.863906 Z' fill='#ffb880' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-235.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(325.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Sag' />
@@ -175,8 +175,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Cap' kr:signnumber='9'>
-  <path d='M 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 L 95.260308,41.783889 A 46.0,46.0 0 0,1 93.304632,65.514793 Z' fill='#6b3d00' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 Z' fill='#6b3d00' fill-opacity='0' pointer-events='none' />
+  <path d='M 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 L 95.260308,41.783889 A 46.0,46.0 0 0,1 93.304632,65.514793 Z' fill='#b59e80' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 97.070253,66.863906 A 50.0,50.0 0 0,0 99.195987,41.069445 Z' fill='#b59e80' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-265.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(355.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Cap' />
@@ -184,8 +184,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Aqu' kr:signnumber='10'>
-  <path d='M 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 L 85.088521,20.254485 A 46.0,46.0 0 0,1 95.260308,41.783889 Z' fill='#69acf1' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 Z' fill='#69acf1' fill-opacity='0' pointer-events='none' />
+  <path d='M 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 L 85.088521,20.254485 A 46.0,46.0 0 0,1 95.260308,41.783889 Z' fill='#b4d6f8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 99.195987,41.069445 A 50.0,50.0 0 0,0 88.139697,17.667918 Z' fill='#b4d6f8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-295.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(385.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Aqu' />
@@ -193,8 +193,8 @@
   </g>
   </g>
   <g kr:node='ZodiacSign' kr:sign='Pis' kr:signnumber='11'>
-  <path d='M 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 L 65.514793,6.695368 A 46.0,46.0 0 0,1 85.088521,20.254485 Z' fill='#2b4972' style='fill-opacity: 0.5' />
-  <path kr:highlight='sign-full' d='M 50.0,50.0 L 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 Z' fill='#2b4972' fill-opacity='0' pointer-events='none' />
+  <path d='M 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 L 65.514793,6.695368 A 46.0,46.0 0 0,1 85.088521,20.254485 Z' fill='#95a4b8' style='fill-opacity: 1' />
+  <path kr:highlight='sign-full' d='M 50.0,50.0 L 88.139697,17.667918 A 50.0,50.0 0 0,0 66.863906,2.929747 Z' fill='#95a4b8' fill-opacity='0' pointer-events='none' />
   <g transform='rotate(-325.288871 50.0 50.0)'>
     <g transform='translate(50.0 2.0) rotate(415.288871) scale(0.09) translate(-16 -16)'>
       <use xlink:href='#Pis' />
@@ -301,28 +301,28 @@
 </g>
 <g kr:node='PlanetRing'>
 <path d='M 5.347999999999999,50.0 A 44.652,44.652 0 1,1 94.652,50.0 A 44.652,44.652 0 1,1 5.347999999999999,50.0 M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 Z' fill='#f4f4f5' fill-rule='evenodd' stroke='#d4d4d8' stroke-width='0.25'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#81818d)' stroke-width='0.6' stroke-opacity='0.35' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
-<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.417' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='8.417' x2='50.0' y2='23.376' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='8.572' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='8.572' x2='50.0' y2='23.376' stroke='#ccccd1' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='23.376' x2='50.0' y2='28.000' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='5.348' x2='50.0' y2='28.0' stroke='#81818d' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='ChartPoint' kr:house='First_House' kr:sign='Ari' kr:absoluteposition='19.711128718293267' kr:signposition='19.711128718293267' kr:slug='Ascendant' kr:speed='886.944184' kr:cx='164.33152' kr:cy='290.0' transform='rotate(-0.000000 50.0 50.0)'>
   <g transform='translate(50.0 10.22) rotate(90.000000) scale(0.172368) translate(-12 -12)'>
     <use xlink:href='#Ascendant' kr:slug='Ascendant' kr:node='Glyph' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#7f3f00' font-weight='500' transform='rotate(90.000000 50.0 14.21) translate(0 0.2240)'>19º</text>
-  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(90.000000) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Ari' fill='#7f3f00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#7f3f00' font-weight='500' transform='rotate(90.000000 50.0 21.89) translate(0 0.2124)'>42'</text>
@@ -335,7 +335,7 @@
     <use xlink:href='#Saturn' kr:slug='Saturn' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(110.648968 50.0 14.21) translate(0 0.2240)'>13º</text>
-  <g transform='translate(50.0 17.89) rotate(110.648968) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(110.648968) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(110.648968 50.0 21.89) translate(0 0.2124)'>12'</text>
@@ -349,7 +349,7 @@
     <use xlink:href='#Jupiter' kr:slug='Jupiter' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(116.835659 50.0 14.21) translate(0 0.2240)'>13º</text>
-  <g transform='translate(50.0 17.89) rotate(116.835659) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(116.835659) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(116.835659 50.0 21.89) translate(0 0.2124)'>41'</text>
@@ -363,7 +363,7 @@
     <use xlink:href='#Uranus' kr:slug='Uranus' kr:node='Glyph' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#b03030' font-weight='500' transform='rotate(125.840888 50.0 14.21) translate(0 0.2240)'>25º</text>
-  <g transform='translate(50.0 17.89) rotate(125.840888) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(125.840888) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Tau' fill='#b03030' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#b03030' font-weight='500' transform='rotate(125.840888 50.0 21.89) translate(0 0.1968)'>33'</text>
@@ -377,7 +377,7 @@
     <use xlink:href='#Chiron' kr:slug='Chiron' kr:node='Glyph' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#505705' font-weight='500' transform='rotate(189.491565 50.0 14.21) translate(0 0.2240)'>0º</text>
-  <g transform='translate(50.0 17.89) rotate(189.491565) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(189.491565) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#505705' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#505705' font-weight='500' transform='rotate(189.491565 50.0 21.89) translate(0 0.1968)'>34'</text>
@@ -390,7 +390,7 @@
     <use xlink:href='#Pluto' kr:slug='Pluto' kr:node='Glyph' fill='#713f04' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#713f04' font-weight='500' transform='rotate(195.842483 50.0 14.21) translate(0 0.2408)'>4º</text>
-  <g transform='translate(50.0 17.89) rotate(195.842483) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(195.842483) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Leo' fill='#713f04' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#713f04' font-weight='500' transform='rotate(195.842483 50.0 21.89) translate(0 0.2124)'>11'</text>
@@ -403,7 +403,7 @@
     <use xlink:href='#Venus' kr:slug='Venus' kr:node='Glyph' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#400052' font-weight='500' transform='rotate(223.504289 50.0 14.21) translate(0 0.2240)'>3º</text>
-  <g transform='translate(50.0 17.89) rotate(223.504289) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(223.504289) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#400052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#400052' font-weight='500' transform='rotate(223.504289 50.0 21.89) translate(0 0.2124)'>12'</text>
@@ -416,7 +416,7 @@
     <use xlink:href='#Neptune' kr:slug='Neptune' kr:node='Glyph' fill='#06537f' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#06537f' font-weight='500' transform='rotate(246.318991 50.0 14.21) translate(0 0.2240)'>26º</text>
-  <g transform='translate(50.0 17.89) rotate(246.318991) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(246.318991) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Vir' fill='#06537f' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#06537f' font-weight='500' transform='rotate(246.318991 50.0 21.89) translate(0 0.2124)'>1'</text>
@@ -429,7 +429,7 @@
     <use xlink:href='#Mars' kr:slug='Mars' kr:node='Glyph' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#540000' font-weight='500' transform='rotate(252.951402 50.0 14.21) translate(0 0.2408)'>2º</text>
-  <g transform='translate(50.0 17.89) rotate(252.951402) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(252.951402) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#540000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#540000' font-weight='500' transform='rotate(252.951402 50.0 21.89) translate(0 0.1968)'>39'</text>
@@ -442,7 +442,7 @@
     <use xlink:href='#True_North_Lunar_Node' kr:slug='True_North_Lunar_Node' kr:node='Glyph' fill='#4c1541' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#4c1541' font-weight='500' transform='rotate(261.257298 50.0 14.21) translate(0 0.2408)'>11º</text>
-  <g transform='translate(50.0 17.89) rotate(261.257298) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(261.257298) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#4c1541' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#4c1541' font-weight='500' transform='rotate(261.257298 50.0 21.89) translate(0 0.2124)'>1'</text>
@@ -455,7 +455,7 @@
     <use xlink:href='#Sun' kr:slug='Sun' kr:node='Glyph' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#7e3e00' font-weight='500' transform='rotate(266.612587 50.0 14.21) translate(0 0.2240)'>16º</text>
-  <g transform='translate(50.0 17.89) rotate(266.612587) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(266.612587) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Lib' fill='#7e3e00' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#7e3e00' font-weight='500' transform='rotate(266.612587 50.0 21.89) translate(0 0.1968)'>16'</text>
@@ -468,7 +468,7 @@
     <use xlink:href='#Mercury' kr:slug='Mercury' kr:node='Glyph' fill='#520800' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#520800' font-weight='500' transform='rotate(288.847104 50.0 14.21) translate(0 0.2240)'>8º</text>
-  <g transform='translate(50.0 17.89) rotate(288.847104) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(288.847104) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Sco' fill='#520800' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#520800' font-weight='500' transform='rotate(288.847104 50.0 21.89) translate(0 0.1968)'>33'</text>
@@ -481,7 +481,7 @@
     <use xlink:href='#Medium_Coeli' kr:slug='Medium_Coeli' kr:node='Glyph' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#a80000' font-weight='500' transform='rotate(347.347283 50.0 14.21) translate(0 0.2408)'>7º</text>
-  <g transform='translate(50.0 17.89) rotate(347.347283) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(347.347283) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Cap' fill='#a80000' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#a80000' font-weight='500' transform='rotate(347.347283 50.0 21.89) translate(0 0.1968)'>3'</text>
@@ -494,7 +494,7 @@
     <use xlink:href='#Moon' kr:slug='Moon' kr:node='Glyph' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='14.21' font-size='2.24' fill='#150052' font-weight='500' transform='rotate(373.835496 50.0 14.21) translate(0 0.2240)'>3º</text>
-  <g transform='translate(50.0 17.89) rotate(373.835496) scale(0.092781) translate(-16 -16)'>
+  <g transform='translate(50.0 17.89) rotate(373.835496) scale(0.085356) translate(-16 -16)'>
     <use xlink:href='#Aqu' fill='#150052' />
   </g>
   <text text-anchor='middle' dominant-baseline='middle' x='50.0' y='21.89' font-size='2.072' fill='#150052' font-weight='500' transform='rotate(373.835496 50.0 21.89) translate(0 0.1968)'>32'</text>
@@ -505,29 +505,29 @@
 </g>
 <g kr:node='HouseRing'>
 <path d='M 28.0,50.0 A 22.0,22.0 0 1,1 72.0,50.0 A 22.0,22.0 0 1,1 28.0,50.0 M 30.5,50.0 A 19.5,19.5 0 1,1 69.5,50.0 A 19.5,19.5 0 1,1 30.5,50.0 Z' fill='#e4e4e7' fill-rule='evenodd'/>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-0.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='1' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-19.904366 50.0 50.0) rotate(109.904366 50.0 29.25)'>1</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-39.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='2' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-50.161212 50.0 50.0) rotate(140.161212 50.0 29.25)'>2</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-60.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='3' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-68.930487 50.0 50.0) rotate(158.930487 50.0 29.25)'>3</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-77.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='4' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-86.468184 50.0 50.0) rotate(176.468184 50.0 29.25)'>4</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-95.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='5' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-108.981980 50.0 50.0) rotate(198.981980 50.0 29.25)'>5</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-122.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='6' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-151.187437 50.0 50.0) rotate(241.187437 50.0 29.25)'>6</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-180.000000 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='7' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-199.904366 50.0 50.0) rotate(289.904366 50.0 29.25)'>7</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-219.808733 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='8' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-230.161212 50.0 50.0) rotate(320.161212 50.0 29.25)'>8</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-240.513692 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='9' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-248.930487 50.0 50.0) rotate(338.930487 50.0 29.25)'>9</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.6' transform='rotate(-257.347283 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='10' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-266.468184 50.0 50.0) rotate(356.468184 50.0 29.25)'>10</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-275.589086 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='11' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-288.981980 50.0 50.0) rotate(378.981980 50.0 29.25)'>11</text></g>
-<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d)' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
+<line x1='50.0' y1='28.0' x2='50.0' y2='30.5' stroke='#81818d' stroke-width='0.07' transform='rotate(-302.374874 50.0 50.0)'/>
 <g kr:node='HouseNumber' kr:house='12' kr:horoscope='0'><text text-anchor='middle' dominant-baseline='middle' x='50.0' y='29.25' font-size='1.5' fill='#000000' font-weight='500' transform='rotate(-331.187437 50.0 50.0) rotate(421.187437 50.0 29.25)'>12</text></g>
 </g>
 <g kr:node='HouseSector' kr:house='1'><path d='M 50.000000,0.000000 A 50.0,50.0 0 0,0 17.988660,11.590702 L 37.515578,35.020374 A 19.5,19.5 0 0,1 50.000000,30.500000 Z' fill='transparent' stroke='none' pointer-events='all'/></g>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,67 @@
+# examples/
+
+Runnable scripts, one topic each. All of them are **offline**: every subject
+carries explicit `lng`, `lat` and `tz_str` with `online=False`, so nothing here
+contacts GeoNames or needs an account.
+
+Run any of them with:
+
+```bash
+uv run python examples/<script>.py
+```
+
+Scripts that render charts write into `examples/output/`, which is gitignored;
+the rest print to stdout.
+
+## Charts
+
+| Script | What it shows |
+| :-- | :-- |
+| `quickstart_natal_chart.py` | The shortest path: subject → chart data → SVG. |
+| `modern_chart_john_lennon.py` | The modern style (the v6 default) in all three themes. |
+| `glyph_size_example.py` | The same natal wheel at `glyph_size` `small` / `medium` / `large`. |
+| `svg_extended_example.py` | The six opt-in chart marks, each on a subject that has its referent. |
+| `planetary_return.py` | A solar return, cast and drawn. |
+
+## Data and serialization
+
+| Script | What it shows |
+| :-- | :-- |
+| `aspects_synastry.py` | Synastry aspects through the unified `AspectsFactory`. |
+| `synastry_data_example.py` | A synastry `ChartDataModel` dumped as JSON. |
+| `moon_phase_json_example.py` | The Moon Phase Overview model as JSON. |
+| `context_serializer_example.py` | `to_context()` over every chart type — the AI/LLM XML export. |
+| `house_comparison_context_example.py` | The house-overlay section of the context export, for synastry and transits. |
+
+## Reports
+
+| Script | What it shows |
+| :-- | :-- |
+| `subject_report_example.py` | A bare subject report (no chart data). |
+| `natal_report_example.py` | A natal report from `SingleChartDataModel`. |
+| `synastry_report_example.py` | A synastry report from `DualChartDataModel`. |
+| `transit_report_example.py` | A transit report from `DualChartDataModel`. |
+| `composite_report_example.py` | A composite (midpoint) chart report. |
+| `solar_return_report_example.py` | A solar return report, single wheel. |
+| `dual_return_report_example.py` | A return report as a dual wheel against the natal. |
+| `moon_phase_report_example.py` | The Moon Phase Overview as text. |
+| `current_time_report.py` | A full report for the current moment. |
+| `technique_reports_example.py` | Profections, firdaria, horary, receptions, releasing and dominants, as text. |
+
+## Techniques
+
+| Script | What it shows |
+| :-- | :-- |
+| `profections_example.py` | Annual profections: the year-lord and its house. |
+| `firdaria_example.py` | Firdaria: the Persian major and minor periods. |
+| `horary_example.py` | Horary significators and the considerations before judgment. |
+| `mutual_receptions_example.py` | Domicile and exaltation receptions between classical planets. |
+
+## Time series and sky events
+
+| Script | What it shows |
+| :-- | :-- |
+| `transits_time_range.py` | Weekly transits over a range, via `EphemerisDataFactory` + `TransitsTimeRangeFactory`. |
+| `retrograde_periods_example.py` | Retrograde spans for 2026, with the clipped-bound flags; Chiron opt-in. |
+| `sign_periods_example.py` | Where every planet sits, sign by sign, across one month. |
+| `timing_factories_example.py` | Sun times, planetary hours, void-of-course Moon, lunations and mundane aspects — one call each. |

--- a/examples/context_serializer_example.py
+++ b/examples/context_serializer_example.py
@@ -27,7 +27,18 @@ print("EXAMPLE 1: NATAL CHART")
 print("=" * 80)
 
 subject = AstrologicalSubjectFactory.from_birth_data(
-    "John Lennon", 1940, 10, 9, 18, 30, "Liverpool", "GB", suppress_geonames_warning=True
+    "John Lennon",
+    1940,
+    10,
+    9,
+    18,
+    30,
+    "Liverpool",
+    "GB",
+    lng=-2.9916,
+    lat=53.4084,
+    tz_str="Europe/London",
+    online=False,
 )
 
 natal_context = to_context(subject)
@@ -48,7 +59,18 @@ print("EXAMPLE 3: SYNASTRY CHART")
 print("=" * 80)
 
 subject2 = AstrologicalSubjectFactory.from_birth_data(
-    "Yoko Ono", 1933, 2, 18, 20, 30, "Tokyo", "JP", suppress_geonames_warning=True
+    "Yoko Ono",
+    1933,
+    2,
+    18,
+    20,
+    30,
+    "Tokyo",
+    "JP",
+    lng=139.6503,
+    lat=35.6762,
+    tz_str="Asia/Tokyo",
+    online=False,
 )
 
 synastry_data = ChartDataFactory.create_synastry_chart_data(first_subject=subject, second_subject=subject2)
@@ -101,7 +123,18 @@ print("(Using the historic date when John Lennon met Paul McCartney: July 6, 195
 
 # Create a transit moment for when John Lennon met Paul McCartney
 transit_moment = AstrologicalSubjectFactory.from_birth_data(
-    "Transit - Lennon meets McCartney", 1957, 7, 6, 18, 0, "Liverpool", "GB", suppress_geonames_warning=True
+    "Transit - Lennon meets McCartney",
+    1957,
+    7,
+    6,
+    18,
+    0,
+    "Liverpool",
+    "GB",
+    lng=-2.9916,
+    lat=53.4084,
+    tz_str="Europe/London",
+    online=False,
 )
 
 transit_data = ChartDataFactory.create_transit_chart_data(natal_subject=subject, transit_subject=transit_moment)

--- a/examples/glyph_size_example.py
+++ b/examples/glyph_size_example.py
@@ -1,0 +1,45 @@
+"""The same modern natal chart at all three glyph sizes.
+
+``glyph_size`` (``"small"``, ``"medium"``, ``"large"``) scales the planet
+cluster of the modern wheel — the glyph and the degree/sign/minute rows that
+travel with it. The wheel itself does not change size; what changes is how much
+of it the readings occupy, and therefore how crowded a busy chart looks.
+
+Writes three SVGs into ``examples/output/``.
+"""
+
+from pathlib import Path
+
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
+
+GLYPH_SIZES = ["small", "medium", "large"]
+
+
+def main() -> None:
+    output_dir = Path(__file__).parent / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    lennon = AstrologicalSubjectFactory.from_birth_data(
+        name="John Lennon",
+        year=1940,
+        month=10,
+        day=9,
+        hour=18,
+        minute=30,
+        lng=-2.9916,
+        lat=53.4084,
+        tz_str="Europe/London",
+        city="Liverpool",
+        nation="GB",
+        online=False,
+    )
+    chart_data = ChartDataFactory.create_natal_chart_data(lennon)
+
+    for glyph_size in GLYPH_SIZES:
+        drawer = ChartDrawer(chart_data=chart_data, glyph_size=glyph_size)
+        drawer.save_svg(output_path=output_dir, filename=f"lennon_natal_{glyph_size}")
+        print(f"glyph_size={glyph_size:<6} -> {output_dir / f'lennon_natal_{glyph_size}.svg'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/house_comparison_context_example.py
+++ b/examples/house_comparison_context_example.py
@@ -11,11 +11,33 @@ from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, to_context
 
 # Create two subjects for synastry
 john = AstrologicalSubjectFactory.from_birth_data(
-    name="John", year=1990, month=5, day=15, hour=10, minute=30, city="London", nation="GB"
+    name="John",
+    year=1990,
+    month=5,
+    day=15,
+    hour=10,
+    minute=30,
+    city="London",
+    nation="GB",
+    lng=-0.1276,
+    lat=51.5072,
+    tz_str="Europe/London",
+    online=False,
 )
 
 jane = AstrologicalSubjectFactory.from_birth_data(
-    name="Jane", year=1992, month=8, day=23, hour=14, minute=45, city="Paris", nation="FR"
+    name="Jane",
+    year=1992,
+    month=8,
+    day=23,
+    hour=14,
+    minute=45,
+    city="Paris",
+    nation="FR",
+    lng=2.3522,
+    lat=48.8566,
+    tz_str="Europe/Paris",
+    online=False,
 )
 
 # Create synastry chart data with house comparison
@@ -37,7 +59,15 @@ print(context)
 # - Jane's planets in John's houses
 
 # For transit charts, the same works but with special handling:
-transit = AstrologicalSubjectFactory.from_current_time(name="Current Transit", city="London", nation="GB")
+transit = AstrologicalSubjectFactory.from_current_time(
+    name="Current Transit",
+    city="London",
+    nation="GB",
+    lng=-0.1276,
+    lat=51.5072,
+    tz_str="Europe/London",
+    online=False,
+)
 
 transit_data = ChartDataFactory.create_transit_chart_data(
     natal_subject=john, transit_subject=transit, include_house_comparison=True

--- a/examples/planetary_return.py
+++ b/examples/planetary_return.py
@@ -40,7 +40,7 @@ def main() -> None:
     solar_return = factory.next_return_from_date(2025, 12, 1, return_type="Solar")
 
     chart_data = ChartDataFactory.create_return_chart_data(natal, solar_return)
-    drawer = ChartDrawer(chart_data=chart_data, theme="light")
+    drawer = ChartDrawer(chart_data=chart_data, theme="classic")
     drawer.save_svg(output_path=output_dir, filename="grace_hopper_solar_return", minify=True)
 
     print("Solar return cast for:", solar_return.iso_formatted_local_datetime)

--- a/examples/retrograde_periods_example.py
+++ b/examples/retrograde_periods_example.py
@@ -1,0 +1,32 @@
+"""Retrograde spans of 2026: where each planet turns back, and where it turns forward.
+
+``RetrogradeStationFactory.retrograde_periods_from_iso_range`` pairs the
+retrograde and direct stations into spans. A span that was already running when
+the window opened, or still running when it closed, is flagged as clipped — the
+station itself lies outside the range, so its bound is the window edge.
+
+Chiron is opt-in: pass it in ``planets`` to have it searched as well.
+"""
+
+from kerykeion import RetrogradeStationFactory
+
+DEFAULT_PLANETS = ["Mercury", "Venus", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune", "Pluto"]
+
+
+def main() -> None:
+    result = RetrogradeStationFactory.retrograde_periods_from_iso_range(
+        "2026-01-01",
+        "2026-12-31",
+        planets=[*DEFAULT_PLANETS, "Chiron"],
+    )
+
+    print(f"Retrograde periods in 2026 ({len(result.periods)} spans)")
+    print("-" * 78)
+    for period in result.periods:
+        start_mark = " (clipped)" if period.start_clipped else ""
+        end_mark = " (clipped)" if period.end_clipped else ""
+        print(f"{period.planet:<10} {period.start[:10]}{start_mark}  ->  {period.end[:10]}{end_mark}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sign_periods_example.py
+++ b/examples/sign_periods_example.py
@@ -1,0 +1,29 @@
+"""Where every planet sits, sign by sign, across one month.
+
+``SignIngressFactory.sign_periods_from_iso_range`` turns the ingress moments
+into stays: one row per planet per sign, with the entry and exit instants. A
+stay already under way when the window opens (or still under way when it closes)
+is flagged as clipped, because the ingress itself falls outside the range.
+
+The Moon is opt-in — it changes sign every two and a half days, so it is only
+searched when named in ``planets``.
+"""
+
+from kerykeion import SignIngressFactory
+
+PLANETS = ["Sun", "Mercury", "Venus", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune", "Pluto"]
+
+
+def main() -> None:
+    result = SignIngressFactory.sign_periods_from_iso_range("2026-03-01", "2026-04-01", planets=PLANETS)
+
+    print(f"Sign stays, 2026-03-01 to 2026-04-01 ({len(result.periods)} stays)")
+    print("-" * 78)
+    for period in result.periods:
+        start_mark = "<" if period.start_clipped else " "
+        end_mark = ">" if period.end_clipped else " "
+        print(f"{period.planet:<10} {period.sign:<4} {start_mark}{period.start[:10]}  ..  {period.end[:10]}{end_mark}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/synastry_data_example.py
+++ b/examples/synastry_data_example.py
@@ -1,9 +1,18 @@
+"""Synastry chart data as JSON, for two subjects cast at the current moment."""
+
 from kerykeion.astrological_subject.factory import AstrologicalSubjectFactory
 from kerykeion.chart_data.factory import ChartDataFactory
 
+ROME = {
+    "lng": 12.4964,
+    "lat": 41.9028,
+    "tz_str": "Europe/Rome",
+    "online": False,
+}
+
 # Create a natal chart data
-subject = AstrologicalSubjectFactory.from_current_time(name="Test Subject")
-second_subject = AstrologicalSubjectFactory.from_current_time(name="Second Subject")
+subject = AstrologicalSubjectFactory.from_current_time(name="Test Subject", city="Rome", nation="IT", **ROME)
+second_subject = AstrologicalSubjectFactory.from_current_time(name="Second Subject", city="Rome", nation="IT", **ROME)
 synastry_data = ChartDataFactory.create_synastry_chart_data(subject, second_subject)
 
 print(synastry_data.model_dump_json(indent=2))

--- a/examples/timing_factories_example.py
+++ b/examples/timing_factories_example.py
@@ -1,0 +1,56 @@
+"""The five timing factories, one call each, all offline.
+
+Each answers a different "when" about the same day and place (Rome, 4 June 2026):
+
+* ``SunTimesFactory`` — sunrise, sunset, solar noon and the twilights.
+* ``PlanetaryHoursFactory`` — the Chaldean hour ruling a given moment.
+* ``VoidOfCourseMoonFactory`` — whether the Moon has finished aspecting before
+  its next ingress.
+* ``LunationFinderFactory`` — the New/Full Moon moments over a range.
+* ``MundaneAspectFactory`` — exact transiting-to-transiting aspects over a range.
+"""
+
+from kerykeion import (
+    LunationFinderFactory,
+    MundaneAspectFactory,
+    PlanetaryHoursFactory,
+    SunTimesFactory,
+    VoidOfCourseMoonFactory,
+)
+
+ROME_LAT = 41.9028
+ROME_LNG = 12.4964
+ROME_TZ = "Europe/Rome"
+
+
+def main() -> None:
+    sun_times = SunTimesFactory.from_date(2026, 6, 4, latitude=ROME_LAT, longitude=ROME_LNG, tz_str=ROME_TZ)
+    print("Sun times      :", f"sunrise {sun_times.sunrise}  solar noon {sun_times.solar_noon}")
+    print("                 sunset  {}  day length {}".format(sun_times.sunset, sun_times.day_length))
+
+    hours = PlanetaryHoursFactory.from_datetime(
+        2026, 6, 4, 15, 30, latitude=ROME_LAT, longitude=ROME_LNG, tz_str=ROME_TZ
+    )
+    print("Planetary hour :", f"day ruler {hours.day_ruler}, hour {hours.current_index} ruled by {hours.current_ruler}")
+
+    voc = VoidOfCourseMoonFactory.from_datetime(2026, 6, 4, 15, 30, tz_str=ROME_TZ)
+    state = "void of course" if voc.is_void_of_course else "still aspecting"
+    print("Moon           :", f"in {voc.moon_sign}, {state}; ingress into {voc.next_sign} at {voc.ingress}")
+
+    lunations = LunationFinderFactory.from_iso_range("2026-06-01", "2026-07-01", phases=["new", "full"])
+    for lunation in lunations.lunations:
+        print("Lunation       :", f"{lunation.phase} at {lunation.iso_utc}")
+
+    mundane = MundaneAspectFactory.from_iso_range(
+        "2026-06-01",
+        "2026-07-01",
+        points=["Sun", "Mercury", "Venus", "Mars", "Jupiter"],
+        aspects=["conjunction", "square", "opposition", "trine"],
+    )
+    print(f"Mundane aspects: {len(mundane.aspects)} exact in June 2026")
+    for aspect in mundane.aspects[:3]:
+        print("                ", f"{aspect.point_a} {aspect.aspect} {aspect.point_b} at {aspect.iso_utc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/kerykeion/llms.txt
+++ b/kerykeion/llms.txt
@@ -135,7 +135,16 @@ subject = AstrologicalSubjectFactory.from_birth_data(
 asc = subject.first_house  # Ascendant
 mc = subject.tenth_house   # Midheaven
 print(f"Ascendant: {asc.sign} {asc.abs_pos:.2f}°")
+print(subject.coincident_house_cusps)   # [] on every ordinary chart
 ```
+
+`coincident_house_cusps` holds the groups of house numbers (1-based) whose cusps
+stand on ONE longitude — houses with no width, which can never contain anything.
+It is `[]` for every ordinary chart and only fills at extreme latitudes under
+systems that crowd their cusps. An angle that IS such a cusp is filed in the
+house that cusp opens (`subject.imum_coeli.house == "Fourth_House"` when the IC
+is the fourth cusp), even where several cusps coincide: the identity is recorded
+at the house call, since twelve longitudes alone cannot answer it.
 
 ### Lunar Phase
 
@@ -226,7 +235,17 @@ person2 = AstrologicalSubjectFactory.from_birth_data(
 composite_factory = CompositeSubjectFactory(person1, person2)
 composite_subject = composite_factory.get_midpoint_composite_subject_model()
 composite_data = ChartDataFactory.create_composite_chart_data(composite_subject)
+print(composite_subject.house_anchor, composite_subject.house_frame)
 ```
+
+Where the two charts' angles are nearly opposed the twelve near midpoints stop
+running in order, and the cusp ring is repaired by holding one angle at its near
+midpoint and moving the others onto their far one. `house_anchor` picks which
+angle is held — `"auto"` (default), `"ascendant"` or `"midheaven"` — and
+`house_frame` on the model reports what actually happened: `"anchored"` (a frame
+was hung and the twelve cover the circle once), `"midpoints"` (no frame, but
+still a house division) or `"gapped"` (neither). It is a request, not a
+guarantee. Both fields are `None` on a Davison chart, which needs no frame.
 
 ### Custom Aspects
 
@@ -272,7 +291,7 @@ svg_string = drawer.generate_svg_string()
 # Or save to file. Default filenames carry the style suffix:
 # "... - Modern.svg" / "... - Classic.svg".
 from pathlib import Path
-output_dir = Path("charts")
+output_dir = Path("charts_output")
 output_dir.mkdir(exist_ok=True)
 drawer.save_svg(output_path=output_dir)
 ```
@@ -511,6 +530,101 @@ Each is `None` when the subject's civil day has no such event: the Moon rises
 ~50 minutes later each day, so about one day in thirty has no moonrise and
 another has no moonset.
 
+## 5D. Sign Periods and Retrograde Periods
+
+The ingress and station finders report what CHANGES inside a range. A planet
+that neither ingresses nor stations in a month leaves no trace in them, so a
+calendar cannot answer "which sign is Jupiter in on the 1st?" or "is Saturn
+retrograde right now?" from the events alone. Two more entry points report the
+SPANS themselves, with the same argument list.
+
+```python
+from kerykeion import SignIngressFactory, RetrogradeStationFactory
+
+# Per planet, the contiguous stays covering the whole range.
+stays = SignIngressFactory.sign_periods_from_iso_range(
+    "2026-03-01", "2026-03-31", planets=["Sun"]
+)
+for stay in stays.periods:
+    print(stay.planet, stay.sign, stay.start, "->", stay.end,
+          stay.start_clipped, stay.end_clipped)
+# Sun Pis 2026-03-01T00:00:00 -> 2026-03-20T14:45:58 True False
+# Sun Ari 2026-03-20T14:45:58 -> 2026-04-01T00:00:00 False True
+
+# Retrograde spans, clipped to the range.
+spans = RetrogradeStationFactory.retrograde_periods_from_iso_range(
+    "2025-03-01", "2025-03-31", planets=["Mercury"]
+)
+for span in spans.periods:
+    print(span.planet, span.start, "->", span.end, span.start_clipped, span.end_clipped)
+```
+
+`sign_periods_from_iso_range` / `sign_periods_from_julian_day` return a
+`SignPeriodsCollectionModel` of `SignPeriodModel` (`planet`, `sign`, `sign_num`,
+`start_jd`, `end_jd`, `start`, `end`, `start_clipped`, `end_clipped`). The stays
+are contiguous: one stay's `end` IS the next one's `start`, at the ingress
+instant. The sign at the range start is read inside the SAME ephemeris session
+as the scan, so a sidereal request yields sidereal stays bounded by sidereal
+ingress instants and the first stay can never disagree with the ingresses after
+it. The Moon is opt-in, as for ingresses.
+
+`retrograde_periods_from_iso_range` / `retrograde_periods_from_julian_day`
+return a `RetrogradePeriodsCollectionModel` of `RetrogradePeriodModel` (`planet`,
+`start_jd`, `end_jd`, `start`, `end`, `start_clipped`, `end_clipped`). A
+retrograde station opens a span, a direct station closes it, and the range edges
+clip: a planet already retrograde on the 1st is reported from the 1st with
+`start_clipped=True`. Periods carry no sign — station instants are
+zodiac-independent. Stations that do not alternate raise `KerykeionException`.
+`"Chiron"` is accepted opt-in by the station finder and the periods alike; the
+default set stays Mercury..Pluto.
+
+A clipped bound says where the RANGE cut the span, not where the real boundary
+is — nothing is searched outside the range beyond a 50 ms probe past either
+bound, which exists so that a bound which is itself an instant this library
+reported is recognised as the boundary it is (and left unclipped) rather than
+missed by a hair of bisection error.
+
+## 5E. Returns: reported instants are re-usable as seeds
+
+Return instants are reported truncated to the whole second, and ordering between
+a seed and a return is decided at that same resolution. Feed a reported instant
+back into any `*_from_iso_formatted_time` entry point and you step exactly one
+return — `next(reported(N)) == N + 1`, `previous(reported(N)) == N - 1`, and
+`previous(next(r)) == r` instant for instant. This holds for Solar, Lunar,
+heliocentric and lunar-node searches.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, PlanetaryReturnFactory
+
+natal = AstrologicalSubjectFactory.from_birth_data(
+    "Example", 1990, 6, 15, 14, 30,
+    lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False
+)
+factory = PlanetaryReturnFactory(
+    natal, lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False
+)
+this_year = factory.next_return_from_date(2025, 1, 1, return_type="Solar")
+next_year = factory.next_return_from_iso_formatted_time(
+    this_year.iso_formatted_utc_datetime, "Solar"      # steps forward, never stalls
+)
+back = factory.next_return_from_iso_formatted_time(
+    next_year.iso_formatted_utc_datetime, "Solar", backwards=True
+)
+assert back.iso_formatted_utc_datetime == this_year.iso_formatted_utc_datetime
+```
+
+Two consequences: a seed inside the same second as a crossing selects the
+FOLLOWING return, so seeding a solar-return search with the natal instant itself
+returns the first birthday rather than the birth moment; and only the ISO entry
+points snap their seed — `next_return_from_date` and the `*_from_year` wrappers
+keep their inclusive midnight seed. A seed at the edge of the civil range
+refuses with `KerykeionException` naming the range (years 1 to 9999) instead of
+overflowing `datetime`; seeds are normalized to UTC before that check.
+
+Identify a return by its INSTANT, never by a period: born on 1 January, the 2024
+solar return falls on 1 January and the next on 31 December of the same year, so
+"the return of 2024" names two charts.
+
 ## 6. AI Context Serialization
 
 Convert any Kerykeion model to AI-readable XML:
@@ -546,7 +660,10 @@ structured data. Strictly non-qualitative/non-interpretive. Optional/None fields
 CompositeSubjectModel, PlanetReturnModel, AspectModel, SingleChartDataModel,
 DualChartDataModel, ElementDistributionModel, QualityDistributionModel,
 TransitMomentModel, TransitsTimeRangeModel, PointInHouseModel, HouseComparisonModel,
-MoonPhaseOverviewModel.
+MoonPhaseOverviewModel, SolarArcSubjectModel, and a non-empty `list[MidpointModel]`.
+Anything else raises `TypeError`. An EMPTY list also raises — it cannot be told
+from an empty aspects list — so call `midpoints_to_context([])` from
+`kerykeion.context` directly when you mean an empty midpoint set.
 
 ## 7. Complete Workflow Examples
 
@@ -623,8 +740,12 @@ Arabic Parts: Pars_Fortunae, Pars_Spiritus, Pars_Amoris, Pars_Fidei
 Fixed Stars: 1,447 catalog names on the default libephemeris backend; `DEFAULT_FIXED_STARS` selects 23 common stars (Regulus, Spica, Sirius, Aldebaran, Antares, Fomalhaut, Algol, + 16 more). Configure them separately with `active_fixed_stars`.
 TNOs: Eris, Sedna, Makemake, Haumea, Quaoar, Orcus, Ixion
 Uranian: Cupido, Hades, Zeus, Kronos, Apollon, Admetos, Vulkanus, Poseidon
-Lilith variants: Mean_Lilith, True_Lilith, Interpolated_Lilith, Mean_Priapus, True_Priapus
-Others: Earth, Vertex, Anti_Vertex
+Lilith variants: Mean_Lilith, True_Lilith, Interpolated_Lilith, Mean_Priapus, True_Priapus, Interpolated_Perigee
+Others: Earth, Pholus, White_Moon, Vertex, Anti_Vertex
+
+The full vocabulary is the `AstrologicalPoint` literal (76 values, of which 23
+are fixed-star names kept only for v5 type compatibility — put stars in
+`active_fixed_stars`, never in `active_points`).
 
 ### Motion States
 
@@ -791,9 +912,19 @@ ai_xml = to_context(chart_data)
 
 ## Environment Variables
 
+Kerykeion reads exactly five:
+
 ```bash
+export KERYKEION_BACKEND="libephemeris"             # or "swisseph"; default: auto-detect
+export KERYKEION_LEB_MODE="leb"                     # leb (sealed, default) | auto | skyfield | horizons
+export KERYKEION_EPHE_PATH="/path/to/se1files"      # swisseph only; a no-op on libephemeris
 export KERYKEION_GEONAMES_USERNAME="your_username"  # For online mode
+export KERYKEION_GEONAMES_CACHE_NAME="/path/to/db"  # Overrides the GeoNames HTTP-cache path
 ```
+
+An invalid `KERYKEION_BACKEND` or `KERYKEION_LEB_MODE` raises `ValueError` at
+import time. `LIBEPHEMERIS_PRECISION` is NOT a kerykeion variable and is never
+read by it.
 
 ## Quick Reference Table
 
@@ -821,6 +952,11 @@ export KERYKEION_GEONAMES_USERNAME="your_username"  # For online mode
 | Star Discovery   | `FixedStarDiscoveryFactory`    | Subject + orb    |
 | ACG Lines        | `AstroCartographyFactory`      | Subject          |
 | Mundane Aspects  | `MundaneAspectFactory`         | UTC date range   |
+| Sign ingresses   | `SignIngressFactory`           | UTC date range   |
+| Sign periods     | `SignIngressFactory.sign_periods_from_iso_range` | UTC date range |
+| Retrograde stations | `RetrogradeStationFactory`  | UTC date range   |
+| Retrograde periods | `RetrogradeStationFactory.retrograde_periods_from_iso_range` | UTC date range |
+| Lunations        | `LunationFinderFactory`        | UTC date range   |
 | Void-of-Course   | `VoidOfCourseMoonFactory`      | Moment/range     |
 | Sun Times        | `SunTimesFactory`              | Date + location  |
 | Planetary Hours  | `PlanetaryHoursFactory`        | Moment + location|

--- a/kerykeion/utilities/core.py
+++ b/kerykeion/utilities/core.py
@@ -2160,7 +2160,13 @@ def inline_css_variables_in_svg(svg_content: str) -> str:
         else:
             return ""
 
-    variable_usage_pattern = re.compile(r"var\(\s*(--[\w-]+)\s*(,\s*([^)]+))?\s*\)")
+    # The fallback may itself contain one level of parentheses — a nested
+    # ``var(--other, #hex)`` or an ``rgba(...)`` — so it is matched with
+    # balanced parens rather than ``[^)]+``. The narrower pattern stopped at
+    # the first ``)``, substituted the value, and left the outer ``)`` behind
+    # as ``stroke='#81818d)'``: an invalid colour the browser drops, which is
+    # what every modern-wheel cusp line did in the README's inlined charts.
+    variable_usage_pattern = re.compile(r"var\(\s*(--[\w-]+)\s*(,\s*([^()]*(?:\([^()]*\)[^()]*)*))?\s*\)")
 
     processed_svg = svg_without_style_blocks
     # Nested var() references need repeated passes, but self-/mutually-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ all = ["pyswisseph>=2.10.3.1"]
 [project.urls]
 Homepage = "https://www.kerykeion.net/"
 Repository = "https://github.com/g-battaglia/kerykeion"
+Documentation = "https://www.kerykeion.net/content/docs/"
+Changelog = "https://github.com/g-battaglia/kerykeion/blob/alpha/v6/CHANGELOG.md"
+Issues = "https://github.com/g-battaglia/kerykeion/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,7 +17,8 @@ them, regenerate — and read the diff, because that diff is the change.
 
 | Script | `poe` task | What it rewrites |
 | :-- | :-- | :-- |
-| `regenerate_all.py` | `regenerate:all` | Everything below, in dependency order. |
+| `regenerate_all.py` | `regenerate:positions`, `regenerate:configurations` | The positions and subjects (`--positions --subjects`), and the configuration fixtures (`--configurations`): house systems, sidereal modes, perspectives, returns, composite, ephemeris and Arabic parts, under `tests/data/configurations/`. |
+| — | `regenerate:all` | Everything in this table, in dependency order, at the extended tier. |
 | `regenerate_test_charts.py` | `regenerate:svg:base` | The core SVG baselines in `tests/data/svg/`. The subject's name becomes the filename, so a variant is named by naming its subject. |
 | `regenerate_test_charts_extended.py` | `regenerate:svg:extended` | The rest of `tests/data/svg/`: themes, 2 700 years of dates, and geographic sweeps. |
 | `generate_modern_baselines.py` | `regenerate:svg:modern` | The modern-style baselines. Filenames are explicit here, not derived. |
@@ -27,20 +28,21 @@ them, regenerate — and read the diff, because that diff is the change.
 | `regenerate_synastry_aspects.py` | `regenerate:aspects:synastry` | `tests/data/expected_synastry_aspects.py`. |
 | `regenerate_report_snapshots.py` | `regenerate:reports:snapshots` | The text-report golden files in `tests/fixtures/`. |
 | `regenerate_test_output.py` | `regenerate:reports:output` | The report-snapshot output fixtures. |
-| `regenerate_docs_charts.py` | — | `docs/charts/`, which the README embeds by raw URL. Run it after anything that changes how a chart looks, or the README shows a chart the library no longer draws. |
-| `generate_v6_test_gallery.py` | — | `tests/data/v6_gallery/` and its index page. |
+| `regenerate_docs_charts.py` | `regenerate:docs-charts` | `docs/charts/`, which the README embeds by raw URL. Run it after anything that changes how a chart looks, or the README shows a chart the library no longer draws. |
+| `generate_v6_test_gallery.py` | `regenerate:gallery-v6` | `tests/data/v6_gallery/` and its index page. |
 
-`regenerate:svg`, `regenerate:reports`, `regenerate:positions` and
-`regenerate:aspects` run the groups above and set
-`LIBEPHEMERIS_PRECISION=extended` — without it, dates before roughly 1600 fall
-outside the loaded ephemeris and their fixtures are silently left stale.
+`regenerate:svg`, `regenerate:reports`, `regenerate:positions`,
+`regenerate:aspects`, `regenerate:configurations`, `regenerate:docs-charts` and
+`regenerate:gallery-v6` all set `LIBEPHEMERIS_PRECISION=extended` — without it,
+dates before roughly 1600 fall outside the loaded ephemeris and their fixtures
+are silently left stale. `regenerate:all` runs all of them in dependency order.
 
 ## Looking at the output
 
 | Script | `poe` task | What it produces |
 | :-- | :-- | :-- |
 | `generate_svg_validation_gallery.py` | `gallery`, `gallery:index` | The visual validation sweep (see below). |
-| `generate_glyph_gallery.py` | — | A self-contained poster of every chart glyph, plus its Markdown page. |
+| `generate_glyph_gallery.py` | `regenerate:glyph-gallery` | A self-contained poster of every chart glyph, plus its Markdown page. |
 | `generate_glyph_playground.py` | `playground` | `glyph_playground.html` — the modern cluster's three sizes and nine air steps per ring, pre-drawn, with sliders for the sizes and the row spacing. See below. |
 | `report_modern_displacement.py` | — | How far the modern decluttering moves each planet from its true position. Reads the SVG back through `charts.svg_metadata`, so it measures what was drawn rather than what was intended. |
 | `benchmark.py` | `benchmark` | Timings for subject creation, aspects and SVG rendering. |
@@ -65,7 +67,9 @@ in the targets say so; edit the script, never the output.
 
 | Script | `poe` task | Target |
 | :-- | :-- | :-- |
+| `glyph_catalog.py` | — | Not a generator: the single list of what the glyph set contains, in the order it ships. `build_chart_glyphs.py` and `generate_glyph_gallery.py` both read it, because the list used to live in both and had drifted — the published gallery was missing five symbols. |
 | `build_chart_glyphs.py` | — | The `<symbol>` definitions between the `GLYPHS:BEGIN`/`GLYPHS:END` markers in all four SVG templates. |
+| `derive_modern_cluster_profiles.py` | — | The `GLYPH_SIZE_PROFILES` literals in `charts/draw_modern.py` — the small and large cluster layouts, derived from the shipped, eye-tuned medium by scaling the element sizes by `k` and every quantity of air the cluster owns by the same rule. The medium is the source and is never derived; `test_derivation_reproduces_the_shipped_profiles` keeps the two from drifting. |
 | `regenerate_glyph_widths.py` | `regenerate:glyph-widths` | `charts/glyph_metrics.py` — the per-character width tables the info panel measures rows against. Reads the reference fonts, so macOS only. |
 | `measure_modern_separation.py` | `regenerate:glyph-ink` | `charts/glyph_ink_metrics.py` — the ink extents of every modern glyph, measured in a real browser. Interactive: it opens a page. The modern wheel's spacing is derived from these numbers, so changing a glyph without re-measuring invalidates the separation model. |
 | `extract_swisseph_full_docs.py` | — | One-off extraction of upstream ephemeris documentation. |

--- a/site/docs/active_points.md
+++ b/site/docs/active_points.md
@@ -129,7 +129,7 @@ inactive by default and are selected with `active_fixed_stars`, not
 | `Antares` | ~1.1 | Royal star, intensity and obsession |
 | `Fomalhaut` | ~1.2 | Royal star, idealism and vision |
 
-#### Behenian Stars (12, not listed above)
+#### Behenian Stars (11, not listed above)
 
 | Point | Magnitude | Description |
 | :---- | :-------- | :---------- |
@@ -144,12 +144,12 @@ inactive by default and are selected with `active_fixed_stars`, not
 | `Alphecca` | ~2.2 | Gemma, the jewel in the crown |
 | `Algorab` | ~2.9 | Delta Corvi, cunning |
 | `Deneb_Algedi` | ~2.8 | Tail of the goat, law and justice |
-| `Alkaid` | ~1.9 | Tip of Great Bear's tail, mourning and leadership |
 
-#### Other Bright Stars (7)
+#### Other Bright Stars (8)
 
 | Point | Magnitude | Description |
 | :---- | :-------- | :---------- |
+| `Alkaid` | ~1.9 | Tip of Great Bear's tail, mourning and leadership |
 | `Canopus` | -0.7 | Second brightest, pathfinding and navigation |
 | `Rigel` | 0.1 | Knowledge and ambition |
 | `Betelgeuse` | 0.4 | Fame and endings |
@@ -255,7 +255,7 @@ print(f"Pars Fortunae: {subject.pars_fortunae.sign} at {subject.pars_fortunae.po
 
 ## Diurnal / Nocturnal Detection
 
-Since v5.8.0, the `AstrologicalSubjectModel` includes an `is_diurnal` boolean field. This determines whether the chart is a day chart (Sun above the horizon) or a night chart (Sun below). It is used internally for Arabic Parts calculation (for `Pars_Fortunae` and `Pars_Spiritus` the formula reverses in night charts; `Pars_Amoris` and `Pars_Fidei` use the same formula regardless of sect, as shown in the table above).
+The `AstrologicalSubjectModel` carries an `is_diurnal` boolean field. This determines whether the chart is a day chart (Sun above the horizon) or a night chart (Sun below). It is used internally for Arabic Parts calculation (for `Pars_Fortunae` and `Pars_Spiritus` the formula reverses in night charts; `Pars_Amoris` and `Pars_Fidei` use the same formula regardless of sect, as shown in the table above).
 
 ```python
 subject = AstrologicalSubjectFactory.from_birth_data(

--- a/site/docs/aspects.md
+++ b/site/docs/aspects.md
@@ -30,7 +30,10 @@ Calculates aspects within a single astrological subject.
 from kerykeion import AstrologicalSubjectFactory, AspectsFactory
 
 # Create subject
-subject = AstrologicalSubjectFactory.from_birth_data("Alice", 1990, 6, 15, 12, 0, "London", "GB")
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Alice", 1990, 6, 15, 12, 0,
+    lng=-0.1276, lat=51.5074, tz_str="Europe/London", online=False,
+)
 
 # Calculate aspects
 aspects_data = AspectsFactory.single_chart_aspects(subject)
@@ -59,7 +62,10 @@ Calculates aspects between two different subjects (Synastry/Transits).
 
 ```python
 # Create second subject
-subject_b = AstrologicalSubjectFactory.from_birth_data("Bob", 1992, 8, 20, 14, 30, "New York", "US")
+subject_b = AstrologicalSubjectFactory.from_birth_data(
+    "Bob", 1992, 8, 20, 14, 30,
+    lng=-74.006, lat=40.7128, tz_str="America/New_York", online=False,
+)
 
 # Calculate synastry
 synastry = AspectsFactory.dual_chart_aspects(subject, subject_b)
@@ -156,9 +162,19 @@ aspects = AspectsFactory.single_chart_aspects(subject, axis_orb_limit=2.0)
 
 Widen or tighten the orb for specific points (for example, give the luminaries a
 larger orb). `point_orb_adjustments` maps a point name to a **finite additive
-adjustment** in degrees, and `point_orb_adjustment_strategy` (default
-`"max_explicit"`) controls how the two endpoints' adjustments combine. NaN and
-infinite adjustments are rejected before calculation.
+adjustment** in degrees, and `point_orb_adjustment_strategy` controls how the
+two endpoints' adjustments combine. NaN and infinite adjustments are rejected
+before calculation.
+
+| Strategy | Combination |
+| :------- | :---------- |
+| `"max_explicit"` (default) | The larger of the adjustments that are actually configured. |
+| `"min_explicit"` | The smaller of the configured adjustments — a negative one still tightens the pair. |
+| `"sum"` | Both adjustments added together. |
+| `"none"` | No adjustment; the base orb stands. |
+
+Only *explicitly configured* points take part: an unconfigured endpoint is
+absent from the comparison rather than counted as `0.0`.
 
 ```python
 # Add 1.5° to aspects involving the Sun or Moon.
@@ -282,6 +298,13 @@ Applying
 
 Low-level function to check if two points form an aspect.
 
+`get_aspect_from_two_points(aspects_settings, point_one, point_two, extra_orb=0.0)`
+
+`extra_orb` accepts either a number, applied to every aspect's base orb, or a
+mapping of aspect name → adjustment (missing names get `0.0`; the caller
+resolves any `"*"` wildcard before building the mapping). The effective orb is
+clamped to `>= 0.0`.
+
 ```python
 from kerykeion.aspects.utils import get_aspect_from_two_points
 
@@ -290,8 +313,17 @@ aspect = get_aspect_from_two_points(
     0.0,
     120.5,
 )
-# Returns dict with aspect details if found, else verdict=False
+print(aspect["verdict"], aspect["name"], round(aspect["orbit"], 2))
 ```
+
+**Expected Output:**
+
+```text
+True trine 0.5
+```
+
+`verdict` is `False` when no configured aspect matches; `orbit` always reports
+the distance from exactness.
 
 ### `get_active_points_list`
 

--- a/site/docs/astro_cartography_factory.md
+++ b/site/docs/astro_cartography_factory.md
@@ -44,7 +44,13 @@ Compute ACG lines for a natal chart.
 | `lat_range` | tuple[float, float]      | (-66, 66)  | Finite ordered bounds within -90..+90 degrees            |
 | `planets`   | list[str] or tuple[str, ...] or None | None | Supported planet names (defaults to Sun through Pluto); malformed or unknown entries raise `KerykeionException` |
 
-**Returns:** `List[ACGLineModel]` -- one per planet per line type.
+**Returns:** `List[ACGLineModel]` -- up to one per planet per line type. A
+requested planet the subject does not carry (it is absent from its
+`active_points`) is dropped, and an empty selection returns an empty list.
+Every selected planet always gets its MC and IC lines, but the ASC and DSC
+lines are emitted only when the horizon equation has a solution at at least
+one sampled latitude: a body circumpolar (or never rising) across the whole
+`lat_range` carries no ASC/DSC entry at all.
 
 ## Data Models
 

--- a/site/docs/astrological_subject_factory.md
+++ b/site/docs/astrological_subject_factory.md
@@ -51,7 +51,7 @@ print(f"Ascendant: {subject.ascendant.sign} {subject.ascendant.abs_pos:.2f}°")
 | `name`                     | `str`                    | `"Now"`         | Name or identifier for the subject.                                    |
 | `year`, `month`, `day`     | `Optional[int]`          | `None`          | Date components. Defaults to current date if omitted.                  |
 | `hour`, `minute`           | `Optional[int]`          | `None`          | Time components. Defaults to current time if omitted.                  |
-| `seconds`                  | `int`                    | `0`             | Seconds component of the time.                                         |
+| `seconds`                  | `int`                    | `0`             | Seconds component of the time. Keyword-only.                           |
 | `city`                     | `Optional[str]`          | `None`          | City name (used with `online=True`).                                   |
 | `nation`                   | `Optional[str]`          | `None`          | ISO Country code (e.g., "GB").                                         |
 | `lng`, `lat`               | `Optional[float]`        | `None`          | Coordinates (used with `online=False` or as override).                 |
@@ -59,7 +59,7 @@ print(f"Ascendant: {subject.ascendant.sign} {subject.ascendant.abs_pos:.2f}°")
 | `geonames_username`        | `Optional[str]`          | `None`          | GeoNames username (required for `online=True`). Can also be set via `KERYKEION_GEONAMES_USERNAME` env var. |
 | `online`                   | `bool`                   | `True`          | Whether to fetch location/timezone data from GeoNames API.             |
 | `zodiac_type`              | `ZodiacType`             | `"Tropical"`    | "Tropical" or "Sidereal".                                              |
-| `sidereal_mode`            | `Optional[SiderealMode]` | `None`          | Ayanamsha mode (e.g., "LAHIRI"). Required if `zodiac_type="Sidereal"`. |
+| `sidereal_mode`            | `Optional[SiderealMode]` | `None`          | Ayanamsha mode (e.g. `"LAHIRI"`). Defaults to `FAGAN_BRADLEY` when `zodiac_type="Sidereal"`; setting it with a Tropical zodiac raises `KerykeionException`. |
 | `houses_system_identifier` | `HousesSystemIdentifier` | `"P"`           | House system code (e.g., "P" for Placidus, "W" for Whole Sign).        |
 | `perspective_type`         | `PerspectiveType`        | `"Apparent Geocentric"` | 11 options including Geocentric, Heliocentric, Topocentric, Barycentric, and Planetocentric variants. |
 | `active_points`            | `Optional[List[str]]`    | `None`          | List of points to calculate. If `None`, uses `DEFAULT_ACTIVE_POINTS` (14 points).  |
@@ -103,7 +103,7 @@ subject = AstrologicalSubjectFactory.from_iso_utc_time(
 | `lng`, `lat`               | `Optional[float]`        | `None`                  | Explicit coordinates override lookup values. Missing values are looked up online or fall back to `0.0`, `51.5074` offline. |
 | `online`                   | `bool`                   | `True`                  | Whether to resolve location via GeoNames API.                          |
 | `zodiac_type`              | `ZodiacType`             | `"Tropical"`            | `"Tropical"` or `"Sidereal"`.                                          |
-| `sidereal_mode`            | `Optional[SiderealMode]` | `None`                  | Ayanamsha mode. Required if `zodiac_type="Sidereal"`.                  |
+| `sidereal_mode`            | `Optional[SiderealMode]` | `None`                  | Ayanamsha mode (e.g. `"LAHIRI"`). Defaults to `FAGAN_BRADLEY` when `zodiac_type="Sidereal"`; setting it with a Tropical zodiac raises `KerykeionException`. |
 | `houses_system_identifier` | `HousesSystemIdentifier` | `"P"`                   | House system code.                                                     |
 | `perspective_type`         | `PerspectiveType`        | `"Apparent Geocentric"` | Calculation perspective.                                               |
 | `active_points`            | `Optional[List[str]]`    | `None`                  | Points to calculate.                                                   |
@@ -144,7 +144,7 @@ now_chart = AstrologicalSubjectFactory.from_current_time(
 | `tz_str`                   | `Optional[str]`          | `None`                  | Timezone string. Required if `online=False`.                           |
 | `online`                   | `bool`                   | `True`                  | Whether to resolve location via GeoNames API.                          |
 | `zodiac_type`              | `ZodiacType`             | `"Tropical"`            | `"Tropical"` or `"Sidereal"`.                                          |
-| `sidereal_mode`            | `Optional[SiderealMode]` | `None`                  | Ayanamsha mode. Required if `zodiac_type="Sidereal"`.                  |
+| `sidereal_mode`            | `Optional[SiderealMode]` | `None`                  | Ayanamsha mode (e.g. `"LAHIRI"`). Defaults to `FAGAN_BRADLEY` when `zodiac_type="Sidereal"`; setting it with a Tropical zodiac raises `KerykeionException`. |
 | `houses_system_identifier` | `HousesSystemIdentifier` | `"P"`                   | House system code.                                                     |
 | `perspective_type`         | `PerspectiveType`        | `"Apparent Geocentric"` | Calculation perspective.                                               |
 | `active_points`            | `Optional[List[str]]`    | `None`                  | Points to calculate.                                                   |
@@ -186,6 +186,13 @@ Use `position` for display purposes and `abs_pos` for calculations (aspect detec
 | **"A"**    | Equal         | Equal 30° houses starting from Ascendant.                                 |
 | **"M"**    | Morinus       | Space-based system.                                                       |
 
+`subject.coincident_house_cusps` (`list[list[int]]`) groups the house numbers
+whose cusps fall on the same longitude, leaving the houses between them with no
+width. It is empty for every chart whose twelve cusps are twelve distinct
+points, which is every ordinary chart; some systems crowd cusps together at
+extreme latitudes, and the cusps are reported as computed rather than repaired,
+so this field is where that shows.
+
 ### Zodiac Types
 
 - **Tropical** (Default): Fixed to seasons (0° Aries = Vernal Equinox). Standard in Western astrology.
@@ -211,7 +218,11 @@ These opt-in features add extra data to the subject model. All are disabled by d
 
 ### Essential Dignities (`calculate_dignities=True`)
 
-Adds `essential_dignity` field to each point (Domicile, Exaltation, Detriment, Fall, Term, Peregrine).
+Adds five fields to each point: `essential_dignity` (the strongest dignity
+held: `"Domicile"`, `"Exaltation"`, `"Triplicity"`, `"Term"`, `"Face"`, or,
+when only a debility applies, `"Detriment"` or `"Fall"`, and `"Peregrine"` when
+none applies), `dignity_score` (the summed Ptolemaic weights), `term_ruler`,
+`decan_ruler`, and `decan_number`.
 
 ```python
 subject = AstrologicalSubjectFactory.from_birth_data(
@@ -253,11 +264,11 @@ Derived charts inherit the setting: `PlanetaryReturnFactory` (which also accepts
 
 ### Gauquelin Sectors (`calculate_gauquelin=True`)
 
-Adds `gauquelin_sector` field (1-36) to each point, plus `gauquelin_sector_cusps` on the subject.
+Adds `gauquelin_sector` (`Optional[float]`, 1-36, fractional within the sector) to each point, plus `gauquelin_sector_cusps` on the subject.
 
 ### Nutation (`calculate_nutation=True`)
 
-Adds `subject.nutation` with `true_obliquity`, `mean_obliquity`, `nutation_in_longitude`, and `nutation_in_obliquity`.
+Adds `subject.nutation` with `true_obliquity`, `mean_obliquity`, `nutation_longitude`, and `nutation_obliquity`.
 
 ### Local Space (`calculate_local_space=True`)
 

--- a/site/docs/backend_precision_comparison.md
+++ b/site/docs/backend_precision_comparison.md
@@ -24,7 +24,7 @@ user or contributor may encounter.
 | Ephemeris source | Swiss Ephemeris (Moshier / `.se1` files) | NASA JPL DE440 / DE441 via LEB/Skyfield |
 | License          | AGPL-3.0                                 | AGPL-3.0                            |
 | Install          | `pip install kerykeion[swiss]`           | Included by default                 |
-| Bundled range    | Depends on installed Swiss `.se1` files | 1849–2150 (DE440s)                  |
+| Bundled range    | Depends on installed Swiss `.se1` files | 1850–2150 (DE440s)                  |
 | Wider range      | Install the required Swiss data files    | Download medium/extended LEB tiers  |
 | Compilation      | Requires C compiler                      | None                                |
 
@@ -113,12 +113,16 @@ JPL's numerical integration.
 ## Uranian / hypothetical planets
 
 The 8 Hamburg School hypothetical planets (Cupido, Hades, Zeus, Kronos,
-Apollon, Admetos, Vulkanus, Poseidon) are supported on both backends
-via Swiss Ephemeris IDs 40-47.
+Apollon, Admetos, Vulkanus, Poseidon) are supported on both backends.
+
+They are fictitious bodies, so neither backend reads them from an ephemeris
+file. On libephemeris they are always evaluated from the runtime analytical
+model and carry `source="Analytical"` (never `"LEB"`) at every tier and for
+every date; the White Moon (Selena) is computed the same way. swisseph
+evaluates its own hypothetical-planet series.
 
 Positions agree within ~1 deg. The larger tolerance is due to
-differences in how each backend evaluates the hypothetical-planet
-polynomial series.
+differences in how each backend evaluates the polynomial series.
 
 ---
 
@@ -128,7 +132,7 @@ Both backends are tested across three ephemeris tiers:
 
 | Tier             | Range           | Subjects |
 | ---------------- | --------------- | -------- |
-| Base (DE440s)    | 1849 - 2150     | 11       |
+| Base (DE440s)    | 1850 - 2150     | 11       |
 | Medium (DE440)   | 1550 - 2650     | 16       |
 | Extended (DE441) | -13200 - +17191 | 25       |
 
@@ -164,7 +168,7 @@ in automated test comparisons:
 | **Aspect list at orb boundaries** | A few aspects near the orb limit may appear in one backend and not the other, producing slightly different aspect tables. |
 | **SVG chart layout** | Small position differences cause different overlap-resolution paths in the chart renderer, producing structurally different (but visually equivalent) SVG output. |
 | **Minor bodies on ancient dates** | For dates before ~1550 CE, libephemeris may return `None` for TNOs (Eris, Sedna, etc.), Juno, and Vesta because the underlying SPK segments do not cover that range. swisseph falls back to its built-in Moshier analytical ephemeris and still returns a value. |
-| **Uranian hypothetical planets** | Positions agree within ~1 deg. The larger tolerance reflects differences in how each backend evaluates the Hamburg School polynomial series for bodies 40-47. |
+| **Uranian hypothetical planets** | Positions agree within ~1 deg. The larger tolerance reflects differences in how each backend evaluates the Hamburg School polynomial series. On libephemeris these points are always analytical (`source="Analytical"`), never file-backed. |
 
 ---
 
@@ -179,8 +183,19 @@ measured deltas:
 | Planet speed              | 0.0001 deg/day     | 0.05 deg/day                   |
 | Declination               | 0.01 deg           | 0.15 deg                       |
 | House cusps               | 0.01 deg           | 0.15 deg                       |
-| SVG chart comparison      | exact (1e-10)      | 0.5 deg + structural tolerance |
-| Report golden files       | exact string match | 10.0 numeric tolerance         |
+
+Golden files are not cross-backend comparisons and do not use those numbers:
+
+| Golden corpus | Structure | Numbers |
+| ------------- | --------- | ------- |
+| SVG baselines | Fatal on **both** backends: line count, count of numbers per line, and the numbers-blanked skeleton must match exactly. | `abs_tol = 1e-4`, no relative component, and **only** on libephemeris — the backend the baselines were generated with. On swisseph the numeric half is skipped with a reason. |
+| Report snapshots | Fatal: line count and the non-numeric skeleton must match exactly. | `abs_tol = 0.01`, enough for a last-decimal display flip and nothing more. |
+
+Numeric strictness is backend-scoped on purpose: measured over the 369 golden
+tests, structural strictness costs 6 baselines on swisseph and 5 on
+libephemeris, while numeric strictness would cost 155 on swisseph against 5 on
+libephemeris. The two backends compute different charts, and a single tolerance
+wide enough to cover that difference is wide enough to hide a redrawn chart.
 
 ---
 

--- a/site/docs/chart-glyphs.md
+++ b/site/docs/chart-glyphs.md
@@ -4,7 +4,7 @@ Visual reference for the astrological glyphs used in Kerykeion charts: planets, 
 
 Every glyph is geometry — no font is needed to render a chart. The colours shown are the light theme's; each is a CSS variable a theme can override.
 
-![Kerykeion chart glyphs](assets/chart-glyphs.svg)
+![Kerykeion chart glyphs](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/site/docs/assets/chart-glyphs.svg)
 
 ## Glyphs by family
 

--- a/site/docs/chart_data_factory.md
+++ b/site/docs/chart_data_factory.md
@@ -41,7 +41,7 @@ print(f"Qualities: {natal_data.quality_distribution.cardinal_percentage}% Cardin
 | Parameter                    | Type                       | Default      | Description                                                                   |
 | :--------------------------- | :------------------------- | :----------- | :---------------------------------------------------------------------------- |
 | `subject`                    | `AstrologicalSubjectModel` | **Required** | The subject to create chart data for. Also accepts `CompositeSubjectModel` or `PlanetReturnModel`. |
-| `active_points`              | `List[str]`                | `None`       | Custom points list. If `None`, uses the first subject's own `active_points`.  |
+| `active_points`              | `List[str]`                | `None`       | Custom points list, intersected with the subject's own `active_points` (points the subject never computed are dropped). If `None`, uses the subject's own list. |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to natal defaults. Each item: `{"name": "conjunction", "orb": 10}`. |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only. |
 | `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; `None` resolves to the natal Sun/Moon preset. Keyword-only. |
@@ -79,7 +79,7 @@ if synastry_data.relationship_score:
 | :--------------------------- | :------------------------- | :----------- | :---------------------------------------------------------------------------- |
 | `first_subject`              | `AstrologicalSubjectModel` | **Required** | Primary subject.                                                              |
 | `second_subject`             | `AstrologicalSubjectModel` | **Required** | Partner subject.                                                              |
-| `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
+| `active_points`              | `List[str]`                | `None`       | Custom points list, intersected with both subjects' own `active_points`. If `None`, uses the points common to both. |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to natal defaults.             |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
 | `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; `None` resolves to the natal Sun/Moon preset. Keyword-only. |
@@ -104,7 +104,7 @@ transit_data = ChartDataFactory.create_transit_chart_data(subject, now)
 | :--------------------------- | :------------------------- | :----------- | :---------------------------------------------------------------------------- |
 | `natal_subject`              | `AstrologicalSubjectModel` | **Required** | Birth chart.                                                                  |
 | `transit_subject`            | `AstrologicalSubjectModel` | **Required** | Current time chart.                                                           |
-| `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
+| `active_points`              | `List[str]`                | `None`       | Custom points list, intersected with both subjects' own `active_points`. If `None`, uses the points common to both. |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list; `None` resolves to predictive defaults.                  |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
 | `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
@@ -129,7 +129,7 @@ composite_data = ChartDataFactory.create_composite_chart_data(composite_subject)
 | Parameter                    | Type                       | Default      | Description                                                                   |
 | :--------------------------- | :------------------------- | :----------- | :---------------------------------------------------------------------------- |
 | `composite_subject`          | `CompositeSubjectModel`    | **Required** | Composite subject from `CompositeSubjectFactory`.                             |
-| `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
+| `active_points`              | `List[str]`                | `None`       | Custom points list, intersected with the composite subject's own `active_points`. |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to natal defaults.             |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
 | `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; `None` resolves to the natal Sun/Moon preset. Keyword-only. |
@@ -156,7 +156,7 @@ return_data = ChartDataFactory.create_return_chart_data(subject, solar_return)
 | :--------------------------- | :------------------------- | :----------- | :---------------------------------------------------------------------------- |
 | `natal_subject`              | `AstrologicalSubjectModel` | **Required** | The natal subject (inner wheel).                                              |
 | `return_subject`             | `PlanetReturnModel`        | **Required** | The return subject from `PlanetaryReturnFactory`.                             |
-| `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
+| `active_points`              | `List[str]`                | `None`       | Custom points list, intersected with both subjects' own `active_points`. If `None`, uses the points common to both. |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to predictive defaults.        |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
 | `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
@@ -178,7 +178,7 @@ single_return_data = ChartDataFactory.create_single_wheel_return_chart_data(sola
 | Parameter                    | Type                       | Default      | Description                                                                   |
 | :--------------------------- | :------------------------- | :----------- | :---------------------------------------------------------------------------- |
 | `return_subject`             | `PlanetReturnModel`        | **Required** | The return subject.                                                           |
-| `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
+| `active_points`              | `List[str]`                | `None`       | Custom points list, intersected with the return subject's own `active_points`. |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to predictive defaults.        |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
 | `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
@@ -203,7 +203,7 @@ progression_data = ChartDataFactory.create_progression_chart_data(subject, progr
 | :--------------------------- | :------------------------- | :----------- | :---------------------------------------------------------------------------- |
 | `natal_subject`              | `AstrologicalSubjectModel` | **Required** | The natal subject (inner ring).                                               |
 | `progressed_subject`         | `AstrologicalSubjectModel` | **Required** | Progressed subject from `SecondaryProgressionFactory.compute()`.              |
-| `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
+| `active_points`              | `List[str]`                | `None`       | Custom points list, intersected with both subjects' own `active_points`. If `None`, uses the points common to both. |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; `None` resolves to predictive defaults.        |
 | `axis_orb_limit`             | `float`                    | `None`       | Finite positive stricter orb for angles; `None` disables it. Keyword-only.    |
 | `point_orb_adjustments`      | `Mapping[str, float \| Mapping[str, float]]` | `None`       | Finite additive per-point orb adjustments; predictive methods apply none by default. Keyword-only. |
@@ -229,7 +229,7 @@ chart_data = ChartDataFactory.create_chart_data(
 | `chart_type`                 | `ChartType`                | **Required** | `"Natal"`, `"Synastry"`, `"Transit"`, `"Composite"`, `"Progression"`, `"DualReturnChart"`, `"SingleReturnChart"`. |
 | `first_subject`              | Subject Model              | **Required** | Primary subject.                                                              |
 | `second_subject`             | Subject Model              | `None`       | Second subject (for dual-chart types).                                        |
-| `active_points`              | `List[str]`                | `None`       | Custom points list.                                                           |
+| `active_points`              | `List[str]`                | `None`       | Custom points list, intersected with the first subject's own `active_points` and, for dual charts, with the second subject's. If `None`, uses the subject's own list. |
 | `active_aspects`             | `List[ActiveAspect]`       | `None`       | Custom aspects list with orbs; chart-type defaults are resolved internally.   |
 | `include_house_comparison`   | `bool`                     | `True`       | Calculate house overlays (dual charts only).                                  |
 | `include_relationship_score` | `bool`                     | `False`      | Calculate compatibility score (synastry only).                                |
@@ -239,29 +239,41 @@ chart_data = ChartDataFactory.create_chart_data(
 | `distribution_method`        | `str`                      | `"weighted"` | `"weighted"` or `"pure_count"`. Keyword-only.                                 |
 | `custom_distribution_weights`| `Mapping[str, float]`      | `None`       | Override point weights. Keyword-only.                                         |
 
+An unknown `chart_type`, or a missing `second_subject` for a dual chart type,
+raises `KerykeionException`; so does a `first_subject`/`second_subject` whose
+model class does not match the requested chart type (for example a `Composite`
+chart whose first subject is not a `CompositeSubjectModel`).
+
 ## Data Models
 
 ### `SingleChartDataModel`
 
 Used for Natal, Composite, and Single Return charts.
 
-- `subject`: The `AstrologicalSubjectModel`.
+- `chart_type`: `"Natal"`, `"Composite"` or `"SingleReturnChart"`.
+- `subject`: The subject — an `AstrologicalSubjectModel`, `CompositeSubjectModel` or `PlanetReturnModel`.
 - `aspects`: List of internal aspects.
 - `element_distribution`: Fire/Earth/Air/Water breakdown.
 - `quality_distribution`: Cardinal/Fixed/Mutable breakdown.
 - `angularities`: List of `AngularityModel` — classical planets conjunct the four angles (Ascendant, Medium Coeli, Descendant, Imum Coeli) within the orb (default 8°). Each entry carries `point`, `angle`, and `distance`.
 - `stelliums`: List of `StelliumModel` — houses with three or more classical planets. Each entry carries `house` (1-12) and `points` (list of planet names).
+- `active_points`: The points actually used, after the intersection described above.
+- `active_aspects`: The aspects and orbs actually used.
 
 ### `DualChartDataModel`
 
-Used for Synastry, Transit, and Dual Return charts.
+Used for Synastry, Transit, Progression, and Dual Return charts.
 
+- `chart_type`: `"Transit"`, `"Synastry"`, `"DualReturnChart"` or `"Progression"`.
 - `first_subject`, `second_subject`: The two subjects.
 - `aspects`: Inter-chart aspects.
 - `relationship_score`: Compatibility score (if requested).
 - `house_comparison`: Planet overlays in houses (if requested).
+- `element_distribution`, `quality_distribution`: Combined over both subjects for Synastry; over the first subject alone for Transit, Progression and Dual Return charts.
 - `first_subject_angularities`, `first_subject_stelliums`: Angularities and stelliums for the first (natal) subject.
-- `second_subject_angularities`, `second_subject_stelliums`: Angularities and stelliums for the second (transit/partner/return) subject.
+- `second_subject_angularities`, `second_subject_stelliums`: Angularities and stelliums for the second (transit/partner/progressed/return) subject.
+- `active_points`: The points actually used, after the intersection described above.
+- `active_aspects`: The aspects and orbs actually used.
 
 ## Analysis Example
 

--- a/site/docs/chart_internals.md
+++ b/site/docs/chart_internals.md
@@ -41,6 +41,12 @@ These functions return SVG string elements.
 | `draw_transit_ring(...)`                 | Draws the outer ring used in transit charts.                           |
 | `draw_transit_ring_degree_steps(...)`    | Draws degree markings for the transit ring.                            |
 | `draw_zodiac_slice(...)`                 | Draws the colored wedge/arc for a zodiac sign.                         |
+| `draw_house_sectors(...)`                | Transparent house wedges, so a viewer can highlight a house.           |
+| `draw_gauquelin_sectors(...)`            | The 36 Gauquelin sector divisions, replacing the 12-house ring.        |
+| `draw_gauquelin_sector_hit_areas(...)`   | The matching 36 transparent wedges for interactive highlighting.       |
+| `draw_gauquelin_unified_grid(...)`       | One Gauquelin table in place of both the planet grid and the cusp grid. |
+| `make_lunar_phase(degrees_between, latitude)` | The SVG fragment rendering the Moon's illuminated phase.           |
+| `out_of_bounds_badge_svg(point, text_color)` | The `OOB` badge for a point, or nothing when it is inside the bounds. |
 
 ### Calculation & Formatting Utilities
 
@@ -51,7 +57,7 @@ These functions return SVG string elements.
 | `calculate_synastry_element_points(...)`           | Internal calculation for synastry element comparison.               |
 | `calculate_synastry_quality_points(...)`           | Internal calculation for synastry quality comparison.               |
 | `calculate_moon_phase_chart_params(...)`           | Calculates lunar phase icon parameters.                             |
-| `convert_decimal_to_degree_string(dec)`            | Converts a float degree (e.g., 12.5) to a string (e.g., "12° 30'"). |
+| `convert_decimal_to_degree_string(dec, format_type="3")` | Converts a float degree (e.g. 12.5) to a string (e.g. "12° 30'"). `format_type` selects the `"1"` / `"2"` / `"3"` layout. |
 | `convert_longitude_coordinate_to_string(coord, east_label, west_label)` | Converts a longitude coordinate to a readable string. |
 | `convert_latitude_coordinate_to_string(coord, north_label, south_label)` | Converts a latitude coordinate to a readable string. |
 | `hms_to_decimal_hours(hours, minutes, seconds)`    | Combines hours, minutes, seconds into a decimal hour.               |
@@ -59,6 +65,12 @@ These functions return SVG string elements.
 | `format_location_string(location, max_length=35)` | Truncates a location string to fit within a max length. |
 | `get_decoded_kerykeion_celestial_point_name(name)` | Decodes internal point names to human names.                        |
 | `timedelta_to_decimal_hours(datetime_offset)`      | Converts a `timedelta` offset to a float in hours.                  |
+| `escape_svg_text(value)`                           | Escapes a plain-text value for safe embedding in SVG markup.        |
+| `label_separation_degrees(label_width_px, radius_px, gutter_px=3.0)` | The degrees two labels of that width need at that radius for their ink to clear. |
+| `separate_collapsed_wedges(boundaries, spans, reversed_wedges, minimum)` | Gives every wedge at least `minimum` degrees, taken from what the widest can spare. |
+| `planet_grid_column_width(names=(), show_out_of_bounds=False, font_size=10.0)` | Column stride wide enough that a name never lands on the row before it. |
+| `gauquelin_column_width(with_out_of_bounds=False)` | Width of one Gauquelin column, wider when it carries OOB badges.     |
+| `abbreviate_point_name(name, max_width=56.0, font_size=10.0)` | Shortens a name with a full stop until its ink fits `max_width`. |
 
 ---
 
@@ -71,6 +83,82 @@ Import from: `kerykeion.charts.draw_planets`
 The main function for rendering planetary glyphs on the chart wheel. It handles collision detection and placement adjustment to prevent overlapping symbols.
 
 > **Note:** This function has a complex internal signature with many positional parameters (radius, celestial points settings, circle radii, house degree references, chart type, etc.). It is intended for internal use by `ChartDrawer`. Refer to the source code at `kerykeion/charts/draw_planets.py` for the full parameter list if building custom renderers.
+
+---
+
+## Modern Renderer (`kerykeion.charts.draw_modern`)
+
+The modern style draws the wheel as five concentric rings inside a `0 0 100 100`
+viewBox centred on `(50, 50)`, positioning everything by rotation
+(`rotate(-angle 50 50)`):
+
+1. House cusps with sign glyphs and degree/minute data
+2. A graduated ruler scale (1° / 5° / 10° ticks)
+3. Planet data clusters with their indicator/tether lines
+4. House numbers 1-12
+5. Aspect lines at the core, with small glyphs at their midpoints
+
+| Entry point | Description |
+| :---------- | :---------- |
+| `draw_modern_horoscope(...)` | The single-subject wheel; emits the `<g kr:node="ModernHoroscope">` root. |
+| `draw_modern_dual_horoscope(...)` | The two-ring wheel for Transit, Synastry, DualReturnChart and Progression; emits `<g kr:node="ModernDualHoroscope" kr:charttype="...">`. |
+| `motion_marker(...)` | The `RX` / `SR` / `SD` marker for a point's marker row. |
+| `ClusterProfile` | The measured geometry of one planet cluster (row heights, offsets) that the layout works from. |
+
+## SVG Metadata (`kerykeion.charts.svg_metadata`)
+
+Both ends of the `kr:` vocabulary described in
+[Charts](/content/docs/charts#machine-readable-svg-point-metadata): the emitter
+and the parser that reads the markup back. Three serializers draw celestial
+points (classic primary, classic secondary, modern), and one sentence spoken by
+all three is what makes an absent attribute mean "no such state" rather than "a
+style that forgot to say so".
+
+| Name | Description |
+| :--- | :---------- |
+| `point_state_attributes(point) -> str` | The `kr:` attributes describing a point's physical state. The single emitter all three serializers call. |
+| `parse_chart_points(svg) -> list[ChartPointTag]` | Every ChartPoint group in the markup, in document order. |
+| `parse_indicators(svg) -> list[IndicatorTag]` | Every Indicator (tether line) group, in document order. |
+| `ChartPointTag` | One rendered point: `slug`, `horoscope`, `display_angle`, `sign`, `sign_position`, `retrograde`, `motion_state`, `speed`, `declination`, `out_of_bounds`, `angularities`, `stellium`, `magnitude`, `near_point`, `orb`. |
+| `IndicatorTag` | One tether line: `slug`, `horoscope`, `true_angle` — the point's **true** wheel angle, before decluttering moved the glyph. |
+
+The parsing grammar tolerates attribute order and either quote style.
+
+## Label Spreading (`kerykeion.charts.spreading`)
+
+Two things close together in the sky are close together on the page, and at some
+point their ink meets. This module holds the mathematics both the planet
+clusters and the house numbers use to avoid that.
+
+| Function | Description |
+| :------- | :---------- |
+| `isotonic_non_decreasing(values)` | The pool-adjacent-violators algorithm. |
+| `spread_around_wheel(angles, min_separation, half_extents=None)` | The complete answer for labels of one uniform size, such as a house number. |
+
+Isotonic regression rather than pushing each collision aside: it is the
+placement that minimises total movement subject to the separation, so a tight
+cluster is *centred* on where it really is instead of sliding off in whichever
+direction the sweep happened to run — and the order is preserved by
+construction, which for numbers running 1 to 12 is not a nicety.
+
+## Glyph Measurements (`glyph_metrics`, `glyph_ink_metrics`)
+
+Two generated data modules. They are data files that happen to be Python, kept
+apart from the renderer so a re-measurement's diff lands here.
+
+- **`kerykeion.charts.glyph_metrics`** — per-character advance widths as a
+  fraction of the em, taken as the widest each character reaches across Times,
+  Helvetica and Arial Unicode. `estimate_text_width` is its only consumer, and
+  the info panel's row guard is what it serves. Regenerated by
+  `scripts/regenerate_glyph_widths.py`.
+- **`kerykeion.charts.glyph_ink_metrics`** — the measured **ink** extents of
+  everything a modern planet cluster draws, produced by rasterizing the symbols
+  in a browser rather than reading layout boxes (half the glyphs are
+  stroke-only, and `getBBox` excludes stroke width). `*_HALF_WIDTH` /
+  `*_HALF_HEIGHT` give the widest reach of real ink from an element's anchor;
+  `*_INK_CENTRE` gives how far the ink's midpoint sits from that anchor, which
+  is what keeps a cluster's rows from reading as a crooked skewer. Regenerated
+  by `poe regenerate:glyph-ink`.
 
 ---
 

--- a/site/docs/charts.md
+++ b/site/docs/charts.md
@@ -32,11 +32,14 @@ Creating any chart follows the same 3-step process:
 3.  **Draw**: Use `ChartDrawer` to render the SVG.
 
 ```python
-from kerykeion import AstrologicalSubjectFactory, ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
-# 1. Subject
-subject = AstrologicalSubjectFactory.from_birth_data("Alice", 1990, 6, 15, 12, 0, "London", "GB")
+# 1. Subject (offline: explicit coordinates, no GeoNames lookup)
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Alice", 1990, 6, 15, 12, 0,
+    lng=-0.1276, lat=51.5074, tz_str="Europe/London",
+    online=False,
+)
 
 # 2. Data
 chart_data = ChartDataFactory.create_natal_chart_data(subject)
@@ -185,7 +188,7 @@ drawer.save_wheel_only_svg_file(output_path, filename="wheel", style="classic")
 
 The classic-only options `external_view`, `show_degree_indicators` and `show_aspect_icons` only take effect with `style="classic"`; the modern renderer ignores them and logs a warning.
 
-Since v5.12, `style` and `show_zodiac_background_ring` can also be set on the `ChartDrawer` constructor as per-instance defaults. Per-render overrides via the render methods still work.
+`style` and `show_zodiac_background_ring` can also be set on the `ChartDrawer` constructor as per-instance defaults. Per-render overrides via the render methods still work.
 
 ## Configuration & Customization
 
@@ -205,6 +208,9 @@ drawer = ChartDrawer(
 - `"classic"` (Default): White background, traditional look.
 - `"dark"`: Modern dark mode.
 - `"black-and-white"`: High contrast monochrome for print.
+- `None`: No CSS theme is emitted at all. The drawing inherits its colours from
+  the document that hosts it, which is what an embedded chart on a themed page
+  wants. Any other value raises `KerykeionException`.
 
 ### Languages
 
@@ -335,10 +341,12 @@ drawer.save_aspect_grid_only_svg_file(output_dir, filename="grid_only")
 
 **Constructor Parameters:**
 
+Everything after `chart_data` is keyword-only.
+
 | Parameter                       | Type                     | Default      | Description                                 |
 | :------------------------------ | :----------------------- | :----------- | :------------------------------------------ |
 | `chart_data`                    | `ChartDataModel`         | **Required** | Pre-computed data from a Factory.           |
-| `theme`                         | `KerykeionChartTheme`    | `"classic"`  | Visual theme (e.g. `"dark"`).               |
+| `theme`                         | `KerykeionChartTheme \| None` | `"classic"`  | Visual theme (`"classic"`, `"dark"`, `"black-and-white"`); `None` emits no CSS. |
 | `chart_language`                | `KerykeionChartLanguage` | `"EN"`       | Label language (`"IT"`, `"ES"`, etc).       |
 | `transparent_background`        | `bool`                   | `False`      | Remove background color.                    |
 | `external_view`                 | `bool`                   | `False`      | Place planets on outer ring (Single chart). |
@@ -385,6 +393,22 @@ All render/save methods accept `minify` and `remove_css_variables`. The full-cha
 - `save_wheel_only_svg_file(output_path, filename, minify, remove_css_variables, *, style, show_zodiac_background_ring, glyph_size)`
 - `save_aspect_grid_only_svg_file(output_path, filename, minify, remove_css_variables)`
 
+**Where the files land.** On every `save_*` method `output_path` and `filename`
+both default to `None`. A `None` `output_path` writes to the user's home
+directory, and a `None` `filename` builds one from the subject and the chart
+type:
+
+| Method | Default filename |
+| :-- | :-- |
+| `save_svg` | `{name} - {chart_type} Chart - Modern.svg`, or `... - Classic.svg` when the effective style is `"classic"` |
+| `save_wheel_only_svg_file` | `{name} - {chart_type} Chart - Modern Wheel Only.svg`, or `... - Classic Wheel Only.svg` |
+| `save_aspect_grid_only_svg_file` | `{name} - {chart_type} Chart - Aspect Grid Only.svg` |
+
+Pass an explicit `output_path` in any script that should not scatter charts
+across the home directory. The basename is sanitised (path separators, `..` and
+leading dots become underscores) and a target resolving outside `output_path`
+raises `KerykeionException`.
+
 ## Machine-Readable SVG Point Metadata
 
 Every rendered celestial point is a `<g kr:node="ChartPoint">` with stable
@@ -425,6 +449,7 @@ such state from a chart style that forgot to say so.
 | `kr:magnitude`    | fixed stars                                           | Apparent visual magnitude, 2 decimals.               |
 | `kr:nearpoint`    | a fixed star surfaced by discovery                    | The point that brought the star in.                  |
 | `kr:orb`          | a fixed star surfaced by discovery                    | Arc to that point in degrees, 4 decimals.            |
+| `kr:retrograde`   | the point **is** retrograde                           | `"true"`.                                            |
 
 Chart-level analyses are annotated onto the finished markup rather than emitted
 by the point serializers, and in a dual wheel each ring is annotated from its
@@ -458,6 +483,28 @@ browser client maps `kr:name` to `data-kr-name` through `/\bkr:([a-zA-Z]+)=/`
 before sanitizing), so a name carrying an underscore or a digit would be dropped
 in silence instead of rejected loudly. That is why the attributes read
 `motionstate` and `nearpoint` rather than `motion_state` and `near_point`.
+
+### Chart-Level Nodes
+
+Every group the renderer emits carries a `kr:node` tag naming what it is —
+`ChartPoint`, `Glyph`, `Cusp`, `CuspRing`, `HouseSector`, `HouseNumber`,
+`HouseRing`, `PlanetRing`, `RulerRing`, `Aspect`, `AspectCore`,
+`AspectsGridRect`, `ZodiacSign`, `ZodiacBackgrounds`, `GauquelinSector`,
+`Indicator`, `ConnectingLine`, and the wheel roots themselves. Selecting on
+`kr:node` is how a consumer finds a layer without depending on element order.
+
+The modern wheel root is `<g kr:node="ModernHoroscope">` (single charts) or
+`<g kr:node="ModernDualHoroscope">` (Transit, Synastry, DualReturnChart,
+Progression, which also carry `kr:charttype`). Both roots are stamped with the
+planet-cluster size:
+
+| Attribute       | Emitted when                                   | Value                    |
+| :-------------- | :--------------------------------------------- | :----------------------- |
+| `kr:glyphsize`  | `glyph_size` is `"small"` or `"large"`          | `"small"` or `"large"`.  |
+
+The default `"medium"` is written as absence, the same way `kr:oob` and
+`kr:retrograde` mark only the exception. The classic style has no such root and
+never stamps the attribute.
 
 `kerykeion.charts.svg_metadata` holds both ends of this contract: the emitter
 (`point_state_attributes`) and a parser that reads the markup back.

--- a/site/docs/composite_subject_factory.md
+++ b/site/docs/composite_subject_factory.md
@@ -82,8 +82,18 @@ svg = drawer.generate_svg_string()
 | `first_subject`  | `AstrologicalSubjectModel` | **Required** | First person's natal subject.                                                     |
 | `second_subject` | `AstrologicalSubjectModel` | **Required** | Second person's natal subject.                                                    |
 | `chart_name`     | `Optional[str]`            | `None`       | Custom name for the composite chart. If `None`, auto-generates as `"{name1} and {name2} Composite Chart"`. |
+| `house_anchor`   | `Literal["auto", "ascendant", "midheaven"]` | `"auto"` | Which angle keeps its near midpoint when the twelve cusp midpoints do not form a house division. See [Methodology](#methodology). |
 
-**Method:** Call `get_midpoint_composite_subject_model()` on the factory instance to get the `CompositeSubjectModel`.
+The constructor raises `KerykeionException` when the two subjects share no
+active point at all: a composite needs at least one, and the two construction
+paths would otherwise diverge silently.
+
+## Methods
+
+| Method                                                                              | Returns                 | Description                                                                |
+| :---------------------------------------------------------------------------------- | :---------------------- | :-------------------------------------------------------------------------- |
+| `get_midpoint_composite_subject_model()`                                            | `CompositeSubjectModel` | The midpoint composite: every position is the mean of the two charts'.     |
+| `get_davison_composite_subject_model(*, custom_ayanamsa_t0=None, custom_ayanamsa_ayan_t0=None)` | `CompositeSubjectModel` | The Davison composite: a real chart cast for the midpoint moment and place. Both keyword arguments are needed only for `sidereal_mode="USER"` parents. |
 
 ## Requirements
 
@@ -144,8 +154,8 @@ print(composite.effective_houses_system_name)        # "Porphyry"
 for record in composite.polar_house_fallbacks:
     print(record.latitude, record.requested_house_system_identifier,
           record.used_house_system_identifier)
-# 78.2232 P O
-# 79.0    P O
+# 69.6492 P O
+# 67.8558 P O
 ```
 
 The requested pair is deliberately left untouched. A substitution forced by one parent's latitude is a fact about that parent, not a preference the relationship adopted, and the requested value is what a relocation or a re-cast has to start from. The substitution stays visible because the parents' own records travel with the composite, and the `effective_houses_system_*` view is derived from them.
@@ -168,19 +178,25 @@ print(davison.sun.sign, f"{davison.sun.abs_pos:.2f}°")
 
 When the input subjects use `sidereal_mode="USER"`, pass `custom_ayanamsa_t0` and `custom_ayanamsa_ayan_t0` to `get_davison_composite_subject_model()` so the Davison chart is built with the same ayanamsa. The return value is a `CompositeSubjectModel` with `composite_chart_type="Davison"`.
 
+A Davison chart averages no cusps, so it has no frame to speak of: both
+`house_anchor` and `house_frame` are `None` on it. The model enforces the pair
+— on a midpoint composite both are set, on a Davison neither is.
+
 ## Methodology
 
-- **Midpoint method**: Positions are calculated as the shortest-arc mean between the two input points (e.g., Aries 0° and Aries 20° = Aries 10°); house cusps are also taken by midpoint, which is why both parents' cusps have to come from the same division. Only points present in _both_ input subjects are included.
+- **Midpoint method**: Positions are calculated as the shortest-arc mean between the two input points (e.g., Aries 0° and Aries 20° = Aries 10°); house cusps are also taken by midpoint, which is why both parents' cusps have to come from the same division. `active_points` is the intersection of the two subjects' point sets.
 
   Between two points on a circle there are two midpoints, half a turn apart, and taking the nearer one for each of the twelve cusps independently breaks down when the two charts' angles are nearly opposed: the choice flips partway round the ring, the twelve arcs come to 1080° instead of 360°, and the result is not a house division at all. About one pair in sixteen is affected. The cusps are repaired the way the field documents — Solar Fire moves the offending cusps to their long-arc midpoint, Kepler calls it flipping the houses 180°, Townley prescribes it for the stray cusp and its opposite — by holding one angle at its near midpoint and moving the others.
 
-  `house_anchor` chooses which angle is held: `"auto"` (the default; whichever of the Ascendant and the Midheaven has its two base cusps closer together, which is Solar Fire's rule and its default too), `"ascendant"`, or `"midheaven"` (Kepler's two named methods). Anything else raises. A chart whose near midpoints already run in order is returned untouched, value for value, and the anchor is recorded on the model as `house_anchor` so the result can be reproduced.
+  `house_anchor` chooses which angle is held: `"auto"` (the default; whichever of the Ascendant and the Midheaven has its two base cusps closer together, which is Solar Fire's rule and its default too), `"ascendant"`, or `"midheaven"` (Kepler's two named methods). Anything else raises. A chart whose near midpoints already run in order keeps them as its cusps, but the whole ring may still be turned half a circle so that the held angle stays on the cusp it shares a number with -- a rotation leaves the twelve tiling exactly as they were, and half a turn takes each cusp from one midpoint of its pair to the other. The anchor is recorded on the model as `house_anchor` so the result can be reproduced.
 
-  The four angles follow their cusp only where the parents made them one point. Under a quadrant system the first cusp is the Ascendant and the tenth the Midheaven, and the composite keeps that true; under whole sign, equal, Morinus or meridian houses they are different points, and the angle stays the midpoint of its own pair — an angle is where the ecliptic meets the horizon and the meridian, and no house system moves it.
+  What the ring actually turned out to be is recorded separately, in `house_frame`: `"anchored"` (a frame was hung from the requested angle and the twelve cover the circle exactly once -- the anchor was held), `"midpoints"` (no frame spans the two charts, so every position is its own near midpoint, and the twelve are still a house division), or `"gapped"` (as `"midpoints"`, but the twelve are *not* a house division: they leave gaps, and a longitude falling in one is named for the house whose cusp it last passed, which is a reading rather than a containment). `house_anchor` says what was asked for; `house_frame` says what was built. `composite.coincident_house_cusps` groups the house numbers whose midpoint cusps landed on one longitude, exactly as on an ordinary subject.
+
+  The four angles follow their cusp only where **both** parents put the angle on that cusp: it is their cusps that are being averaged, so the identity may be used only where they both have it. Quadrant systems put all four angles on their cusps, equal houses the Ascendant and the Descendant only, meridian houses the Midheaven and the Imum Coeli only, whole sign and Morinus none. Everywhere else the angle stays the midpoint of its own pair — an angle is where the ecliptic meets the horizon and the meridian, and no house system moves it.
 
   Where the two subjects' houses run opposite ways round the wheel — one of them born inside the polar circle under a system that reverses there — no arrangement of midpoints makes a ring, and the library says so on its logger rather than shipping the chart quietly.
 - **Davison method**: The two birth moments (Julian Day) and the two locations (lat/lng) are averaged, then a standard natal chart is cast for that derived moment and place.
-- **Active Points**: For the midpoint composite, only points present in _both_ input subjects are included.
+- **Active Points**: For the midpoint composite, `active_points` is the intersection of the two subjects' point sets — it says what was asked for, and the display and aspect filters read it. Beyond that list the composite always materialises the four angles (Ascendant, Medium Coeli, Descendant, Imum Coeli) and derives the opposite of any point it carries at exactly 180°, so a horizon, a meridian and a node section are always present. Deriving rather than averaging is deliberate: two points half a circle apart are the same unordered pair as their own opposites, so a symmetric mean would put a south node on top of its north node.
 
 ---
 

--- a/site/docs/constants.md
+++ b/site/docs/constants.md
@@ -86,8 +86,6 @@ When customizing `active_points`, you can use any of the following string identi
 ### Special Points
 
 -   `Earth` (meaningful in heliocentric perspective)
--   `Vertex`
--   `Anti_Vertex`
 -   `Interpolated_Perigee`
 -   `White_Moon` (Selena)
 
@@ -158,6 +156,17 @@ Identifiers for configuring `active_aspects`.
 -   `sesquiquadrate` (135°)
 -   `biquintile` (144°)
 -   `quincunx` (150°)
+
+### Declination Aspects
+
+-   `parallel` (equal declination, same side of the equator)
+-   `contra-parallel` (equal declination, opposite sides)
+
+These two are members of `AspectName`, but they are **not** requested through
+`active_aspects`: they compare declination rather than ecliptic longitude, so
+they come from `AspectsFactory.single_chart_declination_aspects()` and
+`AspectsFactory.dual_chart_declination_aspects()`. Passing either name in
+`active_aspects` logs a warning and is ignored by the longitude scan.
 
 ## Default Preset Constants
 

--- a/site/docs/context_serializer.md
+++ b/site/docs/context_serializer.md
@@ -18,7 +18,12 @@ The primary function is `to_context()`. It takes a Kerykeion model and returns a
 from kerykeion import AstrologicalSubjectFactory, to_context
 
 # 1. Create Model
-subject = AstrologicalSubjectFactory.from_birth_data("Alice", 1990, 1, 1, 12, 0, "London", "GB")
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Alice", 1990, 1, 1, 12, 0,
+    city="London", nation="GB",
+    lng=-0.1257, lat=51.5085, tz_str="Europe/London",
+    online=False,
+)
 
 # 2. Serialize for AI
 ai_context = to_context(subject)
@@ -29,16 +34,23 @@ print(ai_context)
 
 ```xml
 <chart name="Alice">
-  <birth_data date="1990-01-01 12:00" city="London" nation="GB" ... />
+  <birth_data date="1990-01-01 12:00" city="London" nation="GB" lat="51.51" lng="-0.13" lng_dir="W" tz="Europe/London" />
   <config zodiac="Tropical" house_system="Placidus" perspective="Apparent Geocentric" />
   <planets>
-    <point name="Sun" position="10.81" sign="Capricorn" element="Earth" quality="Cardinal" house="Tenth House" motion="direct" speed="1.02" />
+    <point name="Sun" position="10.81" sign="Capricorn" abs_pos="280.81" quality="Cardinal" element="Earth" house="Tenth House" motion="direct" speed="1.0195" declination="-23.00" source="LEB" precision_class="ephemeris" />
     ...
   </planets>
-  <houses>...</houses>
+  <houses>
+    <house name="First_House" cusp="24.95" sign="Aries" />
+    ...
+  </houses>
   <lunar_phase name="Waxing Crescent" phase="5" degrees_between="52.45" emoji="🌒" />
 </chart>
 ```
+
+`source` and `precision_class` carry the point's provenance (`LEB`, `SPK`,
+`Analytical`, ...) and `declination` its equatorial position, so a model reading
+the context can tell a computed body from a derived one.
 
 ## Supported Models
 
@@ -54,6 +66,8 @@ You can pass almost any Kerykeion object to `to_context`:
 - `ElementDistributionModel`, `QualityDistributionModel`
 - `PointInHouseModel`, `HouseComparisonModel`
 - `TransitMomentModel`, `TransitsTimeRangeModel`
+- `SolarArcSubjectModel`
+- `list[MidpointModel]` — a list, not a single midpoint
 
 ## AI Integration Example
 
@@ -77,17 +91,19 @@ For finer control, use these individual converters:
 | :-------------------------------- | :------------------------- | :-------------------------------------- |
 | `kerykeion_point_to_context`      | `KerykeionPointModel`      | Single planet/point as `<point />`.     |
 | `lunar_phase_to_context`          | `LunarPhaseModel`          | Lunar phase as `<lunar_phase />`.       |
-| `aspect_to_context`               | `AspectModel`              | Aspect as `<aspect />`.                 |
+| `aspect_to_context(aspect, is_synastry=False, is_transit=False)` | `AspectModel` | Aspect as `<aspect />`. The two flags label which chart the contact belongs to. |
 | `point_in_house_to_context`       | `PointInHouseModel`        | Point in house as `<point_in_house />`. |
 | `astrological_subject_to_context` | `AstrologicalSubjectModel` | Full subject as `<chart>...</chart>`.   |
 | `single_chart_data_to_context`    | `SingleChartDataModel`     | Natal chart as `<chart_analysis>`.      |
 | `dual_chart_data_to_context`      | `DualChartDataModel`       | Synastry/Transit as `<chart_analysis>`. |
 | `element_distribution_to_context` | `ElementDistributionModel` | Element breakdown as `<element_distribution />`. |
 | `quality_distribution_to_context` | `QualityDistributionModel` | Quality breakdown as `<quality_distribution />`. |
-| `house_comparison_to_context`     | `HouseComparisonModel`     | House overlay as `<house_overlay>`.     |
+| `house_comparison_to_context(house_comparison, is_transit=False)` | `HouseComparisonModel` | House overlay as `<house_overlay>`. |
 | `transit_moment_to_context`       | `TransitMomentModel`       | Transit snapshot as `<transit_moment>`. |
 | `transits_time_range_to_context`  | `TransitsTimeRangeModel`   | Time-range transits as `<transit_analysis>`. |
 | `moon_phase_overview_to_context`  | `MoonPhaseOverviewModel`   | Moon phase overview as `<moon_phase_overview>`. |
+| `solar_arc_to_context`            | `SolarArcSubjectModel`     | Solar arc directions as `<solar_arc_analysis>`. |
+| `midpoints_to_context`            | `list[MidpointModel]`      | A midpoint set as `<midpoints_analysis>`. |
 
 ```python
 from kerykeion.context.serializer import kerykeion_point_to_context
@@ -95,7 +111,8 @@ from kerykeion.context.serializer import kerykeion_point_to_context
 sun_context = kerykeion_point_to_context(subject.sun)
 print(sun_context)
 # <point name="Sun" position="10.81" sign="Capricorn" abs_pos="280.81"
-#   quality="Cardinal" element="Earth" house="Tenth House" motion="direct" speed="1.02" />
+#   quality="Cardinal" element="Earth" house="Tenth House" motion="direct"
+#   speed="1.0195" declination="-23.00" source="LEB" precision_class="ephemeris" />
 ```
 
 ## XML Format Details

--- a/site/docs/cookbook.md
+++ b/site/docs/cookbook.md
@@ -206,6 +206,8 @@ for person1, person2 in combinations(subjects, 2):
 
 ```python
 import json
+from pathlib import Path
+
 from kerykeion import AstrologicalSubjectFactory, ChartDataFactory
 
 subject = AstrologicalSubjectFactory.from_birth_data(
@@ -219,16 +221,21 @@ chart_data = ChartDataFactory.create_natal_chart_data(subject)
 # Export to JSON
 json_output = chart_data.model_dump_json(indent=2)
 
-with open("chart_data.json", "w") as f:
+output_dir = Path("charts_output")
+output_dir.mkdir(exist_ok=True)
+
+with open(output_dir / "chart_data.json", "w") as f:
     f.write(json_output)
 
-print("Chart data exported to chart_data.json")
+print("Chart data exported to charts_output/chart_data.json")
 ```
 
 ### Export Planetary Positions to CSV
 
 ```python
 import csv
+from pathlib import Path
+
 from kerykeion import AstrologicalSubjectFactory
 
 subject = AstrologicalSubjectFactory.from_birth_data(
@@ -240,7 +247,10 @@ subject = AstrologicalSubjectFactory.from_birth_data(
 planets = ["sun", "moon", "mercury", "venus", "mars", 
            "jupiter", "saturn", "uranus", "neptune", "pluto"]
 
-with open("planetary_positions.csv", "w", newline="") as f:
+output_dir = Path("charts_output")
+output_dir.mkdir(exist_ok=True)
+
+with open(output_dir / "planetary_positions.csv", "w", newline="") as f:
     writer = csv.writer(f)
     writer.writerow(["Planet", "Sign", "Position", "House", "Retrograde", "Speed", "Declination", "Magnitude"])
     
@@ -257,7 +267,7 @@ with open("planetary_positions.csv", "w", newline="") as f:
             f"{planet.magnitude:.2f}" if planet.magnitude is not None else "",
         ])
 
-print("Positions exported to planetary_positions.csv")
+print("Positions exported to charts_output/planetary_positions.csv")
 ```
 
 **Output CSV:**
@@ -374,6 +384,12 @@ drawer.save_svg(output_path=output_dir, filename="traditional-planets-only")
 
 ### Including All Available Points
 
+`active_points` must be passed to `AstrologicalSubjectFactory.from_birth_data`:
+that is where the points are computed. The same argument on
+`ChartDataFactory.create_natal_chart_data` only *narrows* what the subject
+already carries, so handing the full preset to the chart data factory alone
+leaves the 14 default points untouched.
+
 ```python
 from kerykeion import AstrologicalSubjectFactory, ChartDataFactory
 from kerykeion.settings.config_constants import ALL_ACTIVE_POINTS
@@ -381,17 +397,24 @@ from kerykeion.settings.config_constants import ALL_ACTIVE_POINTS
 subject = AstrologicalSubjectFactory.from_birth_data(
     "Example", 1990, 7, 15, 10, 30,
     lng=-0.1276, lat=51.5074, tz_str="Europe/London",
-    online=False
-)
-
-# Use the ALL_ACTIVE_POINTS preset (53 points including TNOs, Uranian, etc.)
-chart_data = ChartDataFactory.create_natal_chart_data(
-    subject,
+    online=False,
     active_points=ALL_ACTIVE_POINTS,
 )
 
+chart_data = ChartDataFactory.create_natal_chart_data(subject)
+
 print(f"Chart includes {len(chart_data.subject.active_points)} points")
 ```
+
+**Output:**
+```
+Chart includes 52 points
+```
+
+`ALL_ACTIVE_POINTS` holds 53 names; `Earth` is dropped with an informational log
+line in the default Apparent Geocentric perspective, since it has no position as
+seen from itself. Switch to `perspective_type="Heliocentric"` and the Sun goes
+instead.
 
 ---
 
@@ -399,121 +422,117 @@ print(f"Chart includes {len(chart_data.subject.active_points)} points")
 
 ### Find the Next Exact Aspect
 
-```python
-from datetime import date, timedelta
-from kerykeion import AstrologicalSubjectFactory, AspectsFactory
-
-def find_next_exact_aspect(natal_subject, planet1, planet2, aspect_type, 
-                           start_date, max_days=365):
-    """Find when two planets form an exact aspect."""
-    
-    for day_offset in range(max_days):
-        check_date = start_date + timedelta(days=day_offset)
-        
-        transit = AstrologicalSubjectFactory.from_birth_data(
-            "Transit", check_date.year, check_date.month, check_date.day, 12, 0,
-            lng=natal_subject.lng, lat=natal_subject.lat, 
-            tz_str=natal_subject.tz_str, online=False
-        )
-        
-        aspects = AspectsFactory.dual_chart_aspects(natal_subject, transit)
-        
-        for asp in aspects.aspects:
-            if (asp.p1_name == planet1 and asp.p2_name == planet2 and 
-                asp.aspect == aspect_type and asp.orbit < 1.0):
-                return check_date, asp.orbit
-    
-    return None, None
-
-# Example usage
-subject = AstrologicalSubjectFactory.from_birth_data(
-    "Example", 1990, 7, 15, 10, 30,
-    lng=-0.1276, lat=51.5074, tz_str="Europe/London",
-    online=False
-)
-
-found_date, orb = find_next_exact_aspect(
-    subject, "Sun", "Jupiter", "conjunction",
-    date(2024, 1, 1)
-)
-
-if found_date:
-    print(f"Next Sun-Jupiter conjunction: {found_date} (orb: {orb:.2f}°)")
-```
-
-### Calculate Planetary Hours
+`TransitsTimeRangeFactory.get_transit_events()` groups a scanned range into
+discrete events; `refine_exact_moments=True` then ternary-searches between the
+two bracketing samples for the sub-step instant of exactness.
 
 ```python
 from datetime import datetime, timedelta
+
 from kerykeion import AstrologicalSubjectFactory
+from kerykeion.ephemeris_data.factory import EphemerisDataFactory
+from kerykeion.transits.factory import TransitsTimeRangeFactory
 
-def get_planetary_hours(date_obj, lng, lat, tz_str):
-    """Calculate planetary hours for a given day."""
-    
-    # Simplified calculation (actual would need sunrise/sunset times)
-    # This uses a fixed 6 AM sunrise and 6 PM sunset
-    
-    day_planets = ["Sun", "Moon", "Mars", "Mercury", "Jupiter", "Venus", "Saturn"]
-    night_planets = day_planets.copy()
-    
-    # Day of week determines starting planet
-    # Sunday=0 starts with Sun, Monday=1 with Moon, etc.
-    weekday = date_obj.weekday()
-    day_order = (weekday + 1) % 7  # Adjust for Python's Monday=0
-    
-    hours = []
-    for i in range(24):
-        planet_index = (day_order + i) % 7
-        hour_start = datetime(date_obj.year, date_obj.month, date_obj.day, i, 0)
-        hours.append({
-            "hour": i,
-            "start": hour_start.strftime("%H:%M"),
-            "planet": day_planets[planet_index]
-        })
-    
-    return hours
-
-# Example
-from datetime import date
-hours = get_planetary_hours(date(2024, 7, 15), -0.1276, 51.5074, "Europe/London")
-
-print("Planetary Hours for July 15, 2024:")
-for h in hours[:12]:  # First 12 hours
-    print(f"  {h['start']}: {h['planet']}")
-```
-
-### Check if Moon is Void-of-Course
-
-```python
-from kerykeion import AstrologicalSubjectFactory, AspectsFactory
-
-def is_moon_void_of_course(subject):
-    """
-    Check if the Moon is void-of-course (no more major aspects before sign change).
-    Simplified version - checks if Moon has any applying aspects.
-    """
-    
-    aspects = AspectsFactory.single_chart_aspects(subject)
-    
-    moon_aspects = [a for a in aspects.aspects 
-                    if (a.p1_name == "Moon" or a.p2_name == "Moon")
-                    and a.aspect_movement == "Applying"
-                    and a.aspect in ["conjunction", "opposition", "trine", "square", "sextile"]]
-    
-    return len(moon_aspects) == 0
-
-# Example
-subject = AstrologicalSubjectFactory.from_birth_data(
-    "Now", 2024, 7, 15, 14, 30,
+natal = AstrologicalSubjectFactory.from_birth_data(
+    "Example", 1990, 7, 15, 10, 30,
     lng=-0.1276, lat=51.5074, tz_str="Europe/London",
-    online=False
+    online=False,
 )
 
-if is_moon_void_of_course(subject):
-    print(f"Moon is void-of-course in {subject.moon.sign}")
-else:
-    print(f"Moon in {subject.moon.sign} is NOT void-of-course")
+start = datetime(2024, 1, 1)
+ephemeris = EphemerisDataFactory(
+    start_datetime=start,
+    end_datetime=start + timedelta(days=120),
+    step_type="days",
+    step=1,
+    lat=natal.lat,
+    lng=natal.lng,
+    tz_str=natal.tz_str,
+).get_ephemeris_data_as_astrological_subjects()
+
+events = TransitsTimeRangeFactory(
+    natal_chart=natal,
+    ephemeris_data_points=ephemeris,
+    active_points=["Sun", "Jupiter"],
+).get_transit_events(refine_exact_moments=True)
+
+# Transiting Sun to natal Jupiter only
+for event in events.events:
+    if event.p1_name == "Sun" and event.p2_name == "Jupiter":
+        print(f"{event.aspect}: {event.exact_moment} (min orb {event.min_orb:.4f}°)")
 ```
+
+**Output:**
+```
+opposition: 2024-01-13T05:59:51.601033+00:00 (min orb 0.0000°)
+trine: 2024-03-12T14:58:37.784670+00:00 (min orb 0.0000°)
+square: 2024-04-11T22:43:25.292653+00:00 (min orb 0.0000°)
+```
+
+The step size sets the resolution of the search: a `"days"` step can miss a fast
+pair that comes and goes inside one day, so use `step_type="hours"` for the Moon.
+A pair with no exact hit in the range simply yields no event.
+
+See [Transits Time Range Factory](/content/docs/transits_time_range_factory) for
+the full API.
+
+### Planetary Hours
+
+`PlanetaryHoursFactory` divides real sunrise-to-sunset into twelve unequal day
+hours and sunset-to-next-sunrise into twelve night hours, then rules them in
+Chaldean order starting from the weekday ruler. Equal clock hours are not the
+same thing and give the wrong ruler for most of the day.
+
+```python
+from kerykeion import PlanetaryHoursFactory
+
+hours = PlanetaryHoursFactory.from_datetime(
+    2024, 7, 15, 14, 30,
+    latitude=51.5074,
+    longitude=-0.1276,
+    tz_str="Europe/London",
+)
+
+print(f"Day ruler: {hours.day_ruler}")
+print(f"Current hour {hours.current_index}: {hours.current_ruler}")
+
+for planetary_hour in hours.hours[:6]:
+    phase = "day" if planetary_hour.is_diurnal else "night"
+    print(f"  {planetary_hour.index:2d} ({phase}) {planetary_hour.ruler}")
+```
+
+A moment before sunrise belongs to the previous planetary day, which the factory
+resolves for you. Polar day or night leaves the bounding sunrise or sunset
+undefined and raises `KerykeionException`. See
+[Planetary Hours Factory](/content/docs/planetary_hours_factory).
+
+### Check if the Moon is Void-of-Course
+
+The Moon is void after its last exact Ptolemaic aspect in its current sign,
+until the next ingress. That is a claim about the *future* of the sign, so it
+cannot be read off a single chart's aspect list.
+`VoidOfCourseMoonFactory` scans forward for it.
+
+```python
+from kerykeion import VoidOfCourseMoonFactory
+
+state = VoidOfCourseMoonFactory.from_datetime(
+    2024, 7, 15, 14, 30,
+    tz_str="Europe/London",
+)
+
+if state.is_void_of_course:
+    print(f"Moon is void-of-course in {state.moon_sign} until {state.void_end}")
+else:
+    print(f"Moon in {state.moon_sign} is not void; the void opens at {state.void_start}")
+
+if state.last_aspect is not None:
+    print(f"Last aspect: {state.last_aspect.aspect} to {state.last_aspect.planet}")
+```
+
+`from_iso_range(start_date, end_date)` returns every complete window over a
+range instead of the state at one moment. See
+[Void-of-Course Moon Factory](/content/docs/void_of_course_moon_factory).
 
 ### Secondary Progressions
 
@@ -578,28 +597,28 @@ print(f"Same object: {subject1 is subject2}")  # True
 
 ### Minimize Active Points for Speed
 
+The cost is in computing the points, which happens in
+`AstrologicalSubjectFactory`. Narrowing `active_points` on the chart data
+factory filters an already-computed subject and saves nothing:
+
 ```python
-from kerykeion import AstrologicalSubjectFactory, ChartDataFactory
 import time
 
-subject = AstrologicalSubjectFactory.from_birth_data(
-    "Example", 1990, 7, 15, 10, 30,
-    lng=-0.1276, lat=51.5074, tz_str="Europe/London",
-    online=False
-)
+from kerykeion import AstrologicalSubjectFactory
 
-# Minimal points for faster calculation
 minimal_points = ["Sun", "Moon", "Ascendant"]
 
 start = time.time()
-for _ in range(100):
-    chart_data = ChartDataFactory.create_natal_chart_data(
-        subject,
-        active_points=minimal_points
+for _ in range(20):
+    subject = AstrologicalSubjectFactory.from_birth_data(
+        "Example", 1990, 7, 15, 10, 30,
+        lng=-0.1276, lat=51.5074, tz_str="Europe/London",
+        online=False,
+        active_points=minimal_points,
     )
 elapsed = time.time() - start
 
-print(f"100 charts with 3 points: {elapsed:.2f}s")
+print(f"20 subjects with 3 points: {elapsed:.2f}s")
 ```
 
 ### Skip Unnecessary Calculations

--- a/site/docs/dominants_factory.md
+++ b/site/docs/dominants_factory.md
@@ -74,21 +74,24 @@ Returns the sorted list of built-in strategy identifiers: `["almuten_figuris", "
 | `strategy_name`     | str             | Human-readable name of the strategy used.               |
 | `method`            | `DominantMethod` or None | Built-in method identifier (or `None` for custom). |
 | `planets`           | list[`DominantScoreModel`] | Ranked planetary/point dominants.              |
-| `signs`             | list            | Ranked sign dominants.                                  |
-| `elements`          | list            | Ranked element dominants (Fire/Earth/Air/Water).        |
-| `qualities`         | list            | Ranked mode/quality dominants (Cardinal/Fixed/Mutable). |
-| `houses`            | list            | Ranked house dominants.                                 |
-| `polarities`        | list            | Ranked polarity dominants (Yang/Yin, i.e. masculine/feminine). |
-| `hemispheres`       | list            | Ranked hemisphere dominants (N/S, E/W).                 |
-| `quadrants`         | list            | Ranked quadrant dominants.                              |
+| `signs`             | list[`DominantScoreModel`] | Ranked sign dominants.                         |
+| `elements`          | list[`DominantScoreModel`] | Ranked element dominants (Fire/Earth/Air/Water). |
+| `qualities`         | list[`DominantScoreModel`] | Ranked mode/quality dominants (Cardinal/Fixed/Mutable). |
+| `houses`            | list[`DominantScoreModel`] | Ranked house dominants.                        |
+| `polarities`        | list[`DominantScoreModel`] | Ranked polarity dominants (Yang/Yin, i.e. masculine/feminine). |
+| `hemispheres`       | list[`DominantScoreModel`] | Ranked hemisphere dominants (N/S, E/W).        |
+| `quadrants`         | list[`DominantScoreModel`] | Ranked quadrant dominants.                     |
 | `dominant_planet`   | str or None     | Convenience winner of `planets`.                        |
-| `dominant_sign`     | str or None     | Convenience winner of `signs`.                          |
-| `dominant_element`  | str or None     | Convenience winner of `elements`.                       |
-| `dominant_quality`  | str or None     | Convenience winner of `qualities`.                      |
-| `dominant_house`    | str or None     | Convenience winner of `houses`.                         |
+| `dominant_sign`     | `Sign` or None  | Convenience winner of `signs`.                          |
+| `dominant_element`  | `Element` or None | Convenience winner of `elements`.                     |
+| `dominant_quality`  | `Quality` or None | Convenience winner of `qualities`.                    |
+| `dominant_house`    | `Houses` or None | Convenience winner of `houses`.                        |
 | `score_breakdown`   | list[`DominantBreakdownItemModel`] | Per-rule audit trail; empty unless `include_score_breakdown=True`. |
 
-A school only populates the categories it computes (e.g. the `elemental` school leaves `planets`/`houses` empty); uncomputed categories are simply absent/empty.
+Every category is always present as a list, so the shape of the model is the
+same for every school: one that does not compute a category leaves the list
+empty and the matching `dominant_*` winner `None` (the `elemental` school, for
+instance, returns empty `planets` and `houses` and a `None` `dominant_planet`).
 
 `DominantScoreModel` gives every ranked item a `name`, raw `score`, normalized
 `percentage`, 1-based `rank`, and `is_dominant` flag. Each
@@ -100,9 +103,19 @@ Custom strategies implement the runtime-checkable `DominantStrategy` protocol.
 Subclass `BaseDominantStrategy` when its shared validation and result-building
 helpers are useful, or provide any independent object satisfying the protocol.
 
-The related essential-dignity helpers return `TriplicityLordsModel`, whose
-`primary`, `secondary`, and `participating` rulers are ordered for the requested
-day/night sect.
+The related essential-dignity helper,
+`get_triplicity_lords(element, is_diurnal)` from `kerykeion.dignities`, returns
+a `TriplicityLordsModel` whose `primary`, `secondary`, and `participating`
+rulers are ordered for the requested day/night sect. `element` is one of
+`"Fire"`, `"Earth"`, `"Air"`, `"Water"` — anything else raises
+`KerykeionException` — and `is_diurnal` selects which lord is `primary`:
+
+```python
+from kerykeion.dignities import get_triplicity_lords
+
+lords = get_triplicity_lords("Fire", True)
+print(lords.primary, lords.secondary, lords.participating)
+```
 
 ---
 

--- a/site/docs/eclipse_factory.md
+++ b/site/docs/eclipse_factory.md
@@ -95,17 +95,17 @@ sidereal_results = EclipseFactory.search_global(
 | `type`         | str            | Eclipse type: total, annular, partial, annular-total |
 | `maximum_jd`   | float          | Julian Day of maximum eclipse              |
 | `datestamp`     | str            | ISO 8601 formatted datetime of maximum     |
-| `magnitude`    | float or None          | Fraction of solar diameter covered          |
-| `obscuration`  | float or None          | Fraction of solar disk area covered         |
-| `sun_altitude` | float or None  | Sun altitude at maximum (degrees)          |
+| `magnitude`    | float or None          | Fraction of solar diameter covered. Observer-dependent: populated by `search_from_location`, always `None` in `search_global`. |
+| `obscuration`  | float or None          | Fraction of solar disk area covered. Observer-dependent: populated by `search_from_location`, always `None` in `search_global`. |
+| `sun_altitude` | float or None  | Sun altitude at maximum (degrees). Set only by `search_from_location`; `None` in `search_global`. |
 | `ecliptic_longitude` | float or None | Eclipse longitude at maximum in the requested zodiac (0–360). |
 | `sign`         | str or None    | Zodiac sign at maximum in the requested zodiac. |
 | `sign_num`     | int or None    | Zodiac sign index (0=Aries). |
 | `degree`       | float or None  | Degree within the sign (0–30). |
 | `saros`        | int or None    | Saros series number when the active backend/catalog provides one. |
 | `inex`         | int or None    | Reserved Inex series number; currently `None` because available nearest-series results are not trustworthy. |
-| `gamma`        | float or None  | Shadow-axis distance from Earth's centre, in Earth radii, when supported by the backend. |
-| `duration_minutes` | float or None | Central total/annular phase duration at the point of greatest eclipse; `None` for partial eclipses or unsupported backends. |
+| `gamma`        | float or None  | Shadow-axis distance from Earth's centre, in Earth radii. A global central-line property: set only by `search_global` (and only when supported by the backend); `None` in `search_from_location`. |
+| `duration_minutes` | float or None | Central total/annular phase duration at the point of greatest eclipse. Set only by `search_global`; `None` in `search_from_location`, for partial eclipses, or on unsupported backends. |
 
 ### `LunarEclipseModel`
 

--- a/site/docs/element_quality_distribution.md
+++ b/site/docs/element_quality_distribution.md
@@ -12,7 +12,7 @@ Kerykeion calculates a balance report for Elements (Fire/Earth/Air/Water) and Qu
 
 ## Usage
 
-Configure the distribution method when creating chart data via `ChartDataFactory`. Both `distribution_method` and `custom_distribution_weights` are **keyword-only** parameters available on all `ChartDataFactory` methods.
+Configure the distribution method when creating chart data via `ChartDataFactory`. Both `distribution_method` and `custom_distribution_weights` are **keyword-only** parameters available on all `ChartDataFactory` methods. `distribution_method` is `Literal["pure_count", "weighted"]` and defaults to `"weighted"`.
 
 ```python
 from kerykeion import AstrologicalSubjectFactory, ChartDataFactory
@@ -69,15 +69,27 @@ Mutable: 54%
 
 In **Weighted** mode, points contribute different amounts to the score.
 
-| Points                                         | Weight  |
-| :--------------------------------------------- | :------ |
-| `Sun`, `Moon`, `Ascendant`                     | **2.0** |
-| `Mercury`, `Venus`, `Mars`, `MC`, `Desc`, `IC` | **1.5** |
-| `Jupiter`, `Saturn`                            | **1.0** |
-| `Vertex`, `Pars_Fortunae`                      | **0.8** |
-| `Chiron`                                       | **0.6** |
-| `Ceres`, `Uranus`, `Neptune`, `Pluto`, `Lunar Nodes` | **0.5** |
-| `Pallas`, `Juno`, `Vesta` (other asteroids)    | **0.4** |
+The table is `DEFAULT_WEIGHTED_POINT_WEIGHTS` in `kerykeion.charts.utils`, and it
+covers every member of `AstrologicalPoint` — all 76 names, fixed stars included.
+
+| Points                                                                     | Weight  |
+| :------------------------------------------------------------------------- | :------ |
+| `Sun`, `Moon`, `Ascendant`                                                 | **2.0** |
+| `Mercury`, `Venus`, `Mars`, `Medium_Coeli`, `Descendant`, `Imum_Coeli`     | **1.5** |
+| `Jupiter`, `Saturn`                                                        | **1.0** |
+| `Vertex`, `Anti_Vertex`, `Pars_Fortunae`                                   | **0.8** |
+| `Pars_Spiritus`                                                            | **0.7** |
+| `Chiron`, `Pars_Amoris`, `Pars_Fidei`                                      | **0.6** |
+| `Uranus`, `Neptune`, `Pluto`, the four lunar nodes, `Ceres`, the Lilith and Priapus variants, `Interpolated_Perigee`, `White_Moon` | **0.5** |
+| `Pallas`, `Juno`, `Vesta`                                                  | **0.4** |
+| `Pholus`, the seven TNOs (`Eris`, `Sedna`, `Haumea`, `Makemake`, `Ixion`, `Orcus`, `Quaoar`), the eight Uranian points, `Earth` | **0.3** |
+| The 23 fixed stars of `DEFAULT_FIXED_STARS`                                | **0.2** |
+
+A point outside the table takes the fallback weight, `1.0`. An **active fixed
+star** outside the table is the one exception: it takes a dedicated star
+fallback of `0.2`, so a catalog star can never inherit a planet-grade weight.
+In `pure_count` mode both fallbacks are `1.0`, since every counted item must
+contribute exactly one.
 
 ## Custom Weights
 

--- a/site/docs/ephemeris_backend.md
+++ b/site/docs/ephemeris_backend.md
@@ -84,30 +84,70 @@ Controls the calculation pipeline. Default: `"leb"` (mandatory `.leb` files).
 KERYKEION_LEB_MODE=auto python my_script.py
 ```
 
+The mode is applied with `set_calc_mode()` at import time, and in the default
+`leb` mode Kerykeion additionally pins `set_network_policy("sealed")`. Both
+calls override whatever libephemeris read from its own `LIBEPHEMERIS_MODE` /
+`LIBEPHEMERIS_NETWORK_POLICY` variables, so setting those has no effect on a
+Kerykeion process — use `KERYKEION_LEB_MODE`. `reset_ephemeris_session()`
+re-applies the pinned mode after every reset, since a reset would otherwise
+leave the session in `auto` and silently re-enable the Skyfield fallback.
+
+### `LIBEPHEMERIS_PRECISION`
+
+*Only applies when libephemeris is the active backend.*
+
+Selects the ephemeris tier — `base`, `medium` or `extended` — and therefore the
+date range that can be computed. Unset, libephemeris auto-detects the widest
+tier the installed kernel can serve. A date outside the active range raises
+`KerykeionException`; sealed `leb` mode does not substitute a lower-precision
+source.
+
+```bash
+LIBEPHEMERIS_PRECISION=extended python my_script.py
+```
+
 #### Installing `.leb` files
 
 `.leb` files contain precomputed Chebyshev polynomial approximations and
 live in `~/.libephemeris/leb/`. Download them with:
 
 ```python
+# doc-snippet: no-run — downloads ephemeris kernels
 from libephemeris import download_leb_for_tier
 
 # Every tier installs the SAME 14-body core (Sun-Pluto, Earth,
 # Mean/True Node, Mean Apogee). Tiers differ by DATE RANGE, not by
 # which bodies the core contains.
-download_leb_for_tier("base")      # 1850-2150, ~10 MB (bundled in the wheel)
-download_leb_for_tier("medium")    # 1550-2650, ~37 MB
-download_leb_for_tier("extended")  # full range (incl. BCE dates), ~1154 MB
+download_leb_for_tier("base")      # 1850-2150 (DE440s), ~31 MB, bundled
+download_leb_for_tier("medium")    # 1550-2650 (DE440), ~114 MB
+download_leb_for_tier("extended")  # -13200 to +17191 (DE441), ~3.1 GB
 ```
+
+The authoritative table is `libephemeris.list_tiers()`, which reports each
+tier's name, kernel file, range and size.
 
 Asteroids (Chiron, Ceres, Pallas, Juno, Vesta), other curated minor
 bodies and exotics (centaurs, trans-Neptunians), and lunar apsides are
 **separate companion groups**, available at every tier — they are not
 folded into the core by tier. Install them alongside the core with
-`download_leb2_for_tier(tier, groups=[...])`. The Hamburg/Uranian points
-and the White Moon need **no files at all**: they are fictitious bodies,
-always computed from their runtime analytical models (provenance
-`source="Analytical"`), at every tier and for every date.
+`download_leb2_for_tier`, which lives in `libephemeris.download` rather than at
+the package root:
+
+```python
+# doc-snippet: no-run — downloads ephemeris kernels
+from libephemeris.download import download_leb2_for_tier
+
+download_leb2_for_tier("medium", groups=["core", "asteroids"])
+```
+
+`download_leb2_for_tier(tier_name, groups=None, force=False, show_progress=True,
+quiet=False, activate=True)`; the group names are `core`, `asteroids`, `exotics`
+and `apogee` (`libephemeris.leb_groups.LEB2_GROUPS`), and `groups=None` installs
+all of them.
+
+The Hamburg/Uranian points and the White Moon need **no files at all**: they are
+fictitious bodies, always computed from their runtime analytical models
+(provenance `source="Analytical"`), at every tier and for every date.
 
 ## Architecture
 
@@ -122,8 +162,31 @@ kerykeion.ephemeris_backend   <-- single import point
        +-- EPHE_DATA_PATH     (resolved data directory)
        |
        v
-~28 consumer modules          <-- all import: from kerykeion.ephemeris_backend import ephe
+29 consumer modules           <-- from kerykeion.ephemeris_backend.backend
+                                  import ephe, ephemeris_session
 ```
+
+### Package Exports
+
+`kerykeion.ephemeris_backend.__all__`:
+
+| Name | What it is |
+| :-- | :-- |
+| `ephe` | The selected backend module itself (`libephemeris` or `swisseph`). |
+| `BACKEND_NAME` | `"libephemeris"` or `"swisseph"`. |
+| `EPHE_DATA_PATH` | Resolved ephemeris data directory. |
+| `EPHEMERIS_LOCK` | The lock every backend call is serialized behind. |
+| `ephemeris_session` | Context manager: takes the lock, applies zodiac/sidereal/perspective/topocentric configuration, yields the `iflag`, resets and releases on exit. |
+| `reset_ephemeris_session` | Resets per-calculation backend state and re-pins the calc mode. Callers must hold `EPHEMERIS_LOCK`; never call `ephe.close()` directly. |
+| `houses_ex2_with_polar_fallback` | House cusps with the polar substitution applied. |
+| `houses_ex2_with_polar_fallback_ex` | Same, also returning the fallback record. |
+| `houses_ring_with_polar_fallback` | Cusp ring variant for the 36-sector Gauquelin grid. |
+| `HouseRing` | Return type of the ring helper. |
+| `POLAR_HOUSES_ERROR_TYPES` | Backend exception types that mean "undefined at this latitude". |
+| `DEFAULT_SWEPH_DOWNLOAD_DIR` | Where the Swiss Ephemeris data files are looked for. |
+
+The polar helpers are the only supported way to compute houses above the polar
+circle.
 
 **Key design decisions:**
 
@@ -182,9 +245,25 @@ poe test:compare
 
 The `test:lib` and `test:swe` suites are **identical** -- same test files,
 same assertions. The only difference is the `KERYKEION_BACKEND` environment
-variable. Golden-file tests (SVG baselines, report snapshots) use numeric
-tolerance (0.5 degrees) to accommodate the minor positional deltas between
-backends.
+variable.
+
+Golden-file tests do **not** use a loose numeric tolerance. For SVG baselines
+(`tests/data/compare_svg_lines.py`) the contract has two halves:
+
+- **Structure is fatal on both backends.** Line count, the count of numbers per
+  line, and each line with its numbers blanked out must match the baseline
+  exactly, or the test fails and names the line.
+- **Numbers are compared only on `libephemeris`**, the backend the baselines
+  were generated with, at `abs_tol = 1e-4` with no relative component. A DMS
+  label printed to the second cannot move by less than 2.78e-4, so any flipped
+  label is rejected. On the other backend the structural assertions still run in
+  full and the test then reports SKIPPED with a reason — not compared is not the
+  same as compared and equal.
+
+Report snapshots (`tests/core/test_report.py`) apply the same shape: line count
+and the non-numeric skeleton must match exactly, and numbers are compared at
+`abs_tol = 0.01`, which absorbs display-rounding flips of the last printed
+decimals and nothing more.
 
 ### Numerical Differences
 

--- a/site/docs/ephemeris_data_factory.md
+++ b/site/docs/ephemeris_data_factory.md
@@ -52,6 +52,9 @@ A `fixed_stars` key is added to each sample **only when** the factory was built 
 
 The `planets` and `houses` lists hold `KerykeionPointModel` instances -- not plain dicts -- which support both attribute access (`point.abs_pos`) and dictionary-style subscripting (`point["abs_pos"]`).
 
+`date` is the UTC instant of the sample, serialised with `datetime.isoformat()`
+from a timezone-aware datetime, so it always ends in the `+00:00` offset.
+
 | Parameter  | Type   | Default | Description                                              |
 | :--------- | :----- | :------ | :------------------------------------------------------- |
 | `as_model` | `bool` | `False` | If `True`, returns `EphemerisDictModel` instances instead of dicts. |
@@ -61,7 +64,7 @@ The `planets` and `houses` lists hold `KerykeionPointModel` instances -- not pla
 ```text
 [
   {
-    "date": "2024-01-01T00:00:00",
+    "date": "2024-01-01T00:00:00+00:00",
     "planets": [
       KerykeionPointModel(name="Sun", abs_pos=280.04, sign="Cap", ...),
       ...
@@ -123,8 +126,18 @@ print(subjects[0].sun.sign)
 | `custom_ayanamsa_t0`      | Reference epoch (Julian Day) for USER sidereal mode | `None` |
 | `custom_ayanamsa_ayan_t0` | Ayanamsa offset in degrees at epoch (USER mode)     | `None` |
 | `active_points`            | Points computed on every generated subject | `None` (= `DEFAULT_ACTIVE_POINTS`) |
+| `active_fixed_stars`       | Fixed stars computed on every generated subject; adds a `fixed_stars` key to each sample | `None` (= none) |
+| `altitude`                 | Observer altitude in metres, used only with the `"Topocentric"` perspective | `None` |
 
 _Note: You can override safety limits by passing `None` if you need large datasets. Both `custom_ayanamsa_t0` and `custom_ayanamsa_ayan_t0` are required when `sidereal_mode="USER"`._
+
+### Raises
+
+The constructor raises `ValueError` for a non-positive `step`, for an unknown
+`step_type`, when the sample count exceeds the `max_days` / `max_hours` /
+`max_minutes` limit in force, and -- as `"No dates found. Check the date range
+and step values."` -- when the range yields no sample at all, which is what an
+inverted range (`end_datetime` before `start_datetime`) produces.
 
 _Note: When feeding `TransitsTimeRangeFactory` with non-default points (asteroids, TNOs, extra angles), pass the **same** `active_points` list here — aspects can only be detected for points present on both the natal and the ephemeris subjects; the transit factory warns if a requested point is present on only one side (missing from the ephemeris series or from the natal chart)._
 

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -14,7 +14,15 @@ This page covers common issues, error messages, and their solutions when using K
 
 ### "You need to set the city if you want to use the online mode!"
 
-**Cause:** Using `online=True` without providing a `city` parameter.
+**Cause:** `PlanetaryReturnFactory` was constructed with `online=True` and no
+`city` (the companion message *"You need to set the city and nation if you want
+to use the online mode!"* covers a missing `nation`). Both are raised by that
+factory only.
+
+`AstrologicalSubjectFactory.from_birth_data` never raises them: with `online=True`
+and no `city` it falls back to `"Greenwich"` / `"GB"` and looks *that* up, so a
+missing city produces a chart for the wrong place rather than an error. Always
+name the city, or pass coordinates and `online=False`.
 
 **Solution:** Either provide city/nation or switch to offline mode:
 
@@ -35,9 +43,16 @@ subject = AstrologicalSubjectFactory.from_birth_data(
 )
 ```
 
-### "No data found for this city, try again!"
+### "No data found for this city, try again! Maybe check your connection?"
 
-**Cause:** GeoNames API couldn't find the city, or network issues.
+**Cause:** `PlanetaryReturnFactory` asked GeoNames for a city and got nothing back.
+
+The equivalent failure on `AstrologicalSubjectFactory.from_birth_data` reads
+*"Missing data from geonames: `<fields>`. Check your connection or try a
+different location."*, naming the fields the response was missing
+(`countryCode`, `timezonestr`, `lat`, `lng`). A response whose `lat`/`lng` are
+present but not numeric raises *"Invalid coordinates from geonames for
+`<city>`, `<nation>` ..."* instead.
 
 **Solutions:**
 1. Check the city name spelling
@@ -223,9 +238,22 @@ subject = AstrologicalSubjectFactory.from_birth_data(
 )
 ```
 
-### "Both subjects must have the same zodiac type/house system/perspective"
+### "Both subjects must have the same ..."
 
-**Cause:** Creating a composite chart with subjects that have different configurations.
+**Cause:** Creating a composite chart with subjects that have different
+configurations. `CompositeSubjectFactory` checks six properties and names the
+first mismatch it finds:
+
+- `Both subjects must have the same zodiac type`
+- `Both subjects must have the same sidereal mode`
+- `Both subjects must have the same custom ayanamsa values` (only when `sidereal_mode="USER"`)
+- `Both subjects must have the same houses system`
+- `Both subjects must have the same houses system name`
+- `Both subjects must have the same perspective type`
+
+Disjoint `active_points` are refused separately, with *"The two subjects share
+no common active points; a composite chart needs at least one. Align their
+active_points."*
 
 **Solution:** Ensure both subjects have identical settings:
 
@@ -326,24 +354,44 @@ subject = AstrologicalSubjectFactory.from_birth_data(
 )
 ```
 
-### Thread Safety Warning
+### Threads, Locks, and Throughput
 
-**Issue:** `AstrologicalSubjectFactory` is NOT thread-safe.
+**Issue:** the ephemeris backend keeps process-global state (ephemeris path,
+sidereal mode, topocentric observer), so two concurrent calculations would
+overwrite each other's configuration.
 
-**Reason:** The underlying Swiss Ephemeris library maintains global state.
+**What Kerykeion does about it:** every backend call is serialised behind an
+internal lock. `kerykeion.ephemeris_backend` exposes `EPHEMERIS_LOCK` and the
+`ephemeris_session` context manager, which acquires the lock, applies the
+requested configuration, yields the calculation flag, then resets the session
+and releases the lock. Calling the factories from several threads is therefore
+**safe** — but not **parallel**: the threads queue on that lock.
 
-**Solution:** Use separate processes or implement locking:
+**Solution:** for throughput, use processes rather than threads. Each process
+gets its own backend state and runs at full speed.
 
 ```python
-import threading
+from concurrent.futures import ProcessPoolExecutor
 
-lock = threading.Lock()
+def build(birth_data):
+    from kerykeion import AstrologicalSubjectFactory
+    return AstrologicalSubjectFactory.from_birth_data(**birth_data)
 
-def calculate_chart(data):
-    with lock:  # Ensure only one calculation at a time
-        subject = AstrologicalSubjectFactory.from_birth_data(**data)
-        return subject
+births = [
+    {"name": "Alice", "year": 1990, "month": 1, "day": 1, "hour": 12, "minute": 0,
+     "lng": -0.1276, "lat": 51.5074, "tz_str": "Europe/London", "online": False},
+    {"name": "Bob", "year": 1992, "month": 6, "day": 15, "hour": 8, "minute": 30,
+     "lng": -74.006, "lat": 40.7128, "tz_str": "America/New_York", "online": False},
+]
+
+if __name__ == "__main__":
+    with ProcessPoolExecutor(max_workers=2) as pool:
+        for subject in pool.map(build, births):
+            print(subject.name, subject.sun.sign)
 ```
+
+Only reach for `EPHEMERIS_LOCK` directly if you call `ephe.*` yourself; the
+public factories already hold it.
 
 ### Large Number of Active Points
 
@@ -368,15 +416,20 @@ chart_data = ChartDataFactory.create_natal_chart_data(
 
 ### Forgetting `online=False` with Manual Coordinates
 
+GeoNames is contacted only when `tz_str`, `lat` or `lng` is missing, so a call
+that already carries all three computes offline whatever `online` says. What
+`online=True` still costs there is the default-username warning and the
+ambiguity of a call whose intent is not stated:
+
 ```python
-# Wrong: Has coordinates but online=True (will try to use GeoNames anyway)
+# Works, but says the opposite of what it does
 subject = AstrologicalSubjectFactory.from_birth_data(
     "John", 1990, 1, 1, 12, 0,
     lng=-0.1276, lat=51.5074, tz_str="Europe/London"
     # Missing online=False
 )
 
-# Correct
+# Correct: the mode matches the data
 subject = AstrologicalSubjectFactory.from_birth_data(
     "John", 1990, 1, 1, 12, 0,
     lng=-0.1276, lat=51.5074, tz_str="Europe/London",
@@ -384,9 +437,39 @@ subject = AstrologicalSubjectFactory.from_birth_data(
 )
 ```
 
+Drop any one of the three and `online=True` does reach the network — with
+coordinates but no `tz_str` and no `city`, the timezone is resolved from the
+coordinates themselves rather than from the `"Greenwich"` default. With
+`online=False` the same call raises `KerykeionException("For offline mode, you
+must provide timezone (tz_str) and coordinates (lat, lng)")`.
+
 ### Using Removed v4 API
 
-If you see `ImportError: cannot import name 'AstrologicalSubject'`, you're using the old v4 API that was removed in v6:
+`kerykeion.__getattr__` raises `ImportError` (not `AttributeError`) for every
+name removed in v6, so the message reaches you verbatim through
+`from kerykeion import ...`:
+
+```text
+'AstrologicalSubject' was removed in v6. Use the factory instead:
+    from kerykeion import AstrologicalSubjectFactory
+    subject = AstrologicalSubjectFactory.from_birth_data(...)
+
+Note: v6 also changed defaults that affect RESULTS, not just imports:
+  - active points: 18 -> 14 (Descendant, Imum_Coeli, True_South_Lunar_Node,
+    Mean_Lilith are no longer active unless requested)
+  - aspect orbs are narrower (conjunction/opposition 10 -> 6 degrees,
+    quintile dropped), and transits/returns/progressions now use a flat
+    3-degree orb, so expect FEWER aspects
+  - chart style: 'classic' -> 'modern'
+Porting the call above does not restore v5 output. See 'What changes in the
+results' in the guide; kerykeion.settings.V5_DEFAULT_ACTIVE_POINTS restores
+the old point set, and the guide gives the v5 aspect list.
+Migration guide: https://www.kerykeion.net/content/docs/migration
+```
+
+The trade-off is that `hasattr(kerykeion, "AstrologicalSubject")` and
+`getattr(kerykeion, "AstrologicalSubject", None)` raise as well; feature-detect
+with `try` / `except ImportError`.
 
 ```python
 # REMOVED in v6 (raises ImportError):
@@ -409,6 +492,18 @@ See the [Migration Guide](/content/docs/migration) and [Legacy API](/content/doc
 ## FAQ
 
 ### How do I suppress the GeoNames warning?
+
+The warning fires because the shared default username is in use. Registering
+your own account and exporting it removes both the warning and the shared rate
+limit:
+
+```bash
+export KERYKEION_GEONAMES_USERNAME="your_username"
+```
+
+The username is resolved from `geonames_username`, then the
+`KERYKEION_GEONAMES_USERNAME` environment variable, then the shared default. To
+silence the warning without changing the username:
 
 ```python
 # doc-snippet: no-run — illustrative fragment (placeholder arguments)
@@ -438,9 +533,10 @@ Two messages people ask about:
   passed the perspective's center body in `active_points`, and it has no
   position as seen from itself. Remove it from your list or ignore the line.
 - `LEB body=NN ... unavailable in sealed mode` for bodies 40–47/56 (Uranian
-  points, White Moon) — a logging bug fixed in libephemeris 3.1.0: those
+  points, White Moon) — a logging bug of older libephemeris releases. Those
   bodies are always computed from their analytical models by design, and the
-  routing is no longer reported as a warning. Upgrade rather than filter.
+  routing is no longer reported as a warning. Kerykeion's dependency floor is
+  already `libephemeris>=3.1.0`, so a fresh install does not show the line.
 
 ### How do I cache GeoNames results?
 
@@ -467,11 +563,44 @@ Some TNOs (Eris, Sedna, etc.) may not have ephemeris data for all dates. If calc
 
 ### Can I use historical dates?
 
-Yes, Kerykeion supports historical dates including BCE dates. The Swiss Ephemeris handles Julian/Gregorian calendar conversion automatically.
+How far back depends on the ephemeris tier installed for the default
+libephemeris backend. Outside the active range a date does not degrade quietly:
+it raises `KerykeionException("Cannot calculate Sun for JD ...: ... is outside
+active LEB coverage range ...")`, because sealed `leb` mode refuses to
+substitute a lower-precision source.
 
-### Why do Placidus houses fail for my location?
+| Tier | Range | Kernel | Size |
+| :-- | :-- | :-- | :-- |
+| `base` | 1850 - 2150 | DE440s | ~31 MB (bundled) |
+| `medium` | 1550 - 2650 | DE440 | ~114 MB |
+| `extended` | -13200 to +17191 (BCE included) | DE441 | ~3.1 GB |
 
-Placidus and Koch house systems fail at extreme latitudes (>60°). Use Whole Sign (`W`) or Equal (`A`) houses instead:
+Install a wider tier to reach earlier dates:
+
+```python
+# doc-snippet: no-run — downloads a multi-gigabyte ephemeris kernel
+import libephemeris
+
+libephemeris.download_leb_for_tier("extended")
+```
+
+The optional Swiss Ephemeris backend (`pip install kerykeion[swiss]`, then
+`KERYKEION_BACKEND=swisseph`) is the other route: it falls back to its built-in
+Moshier analytical ephemeris for dates its data files do not cover. Both
+backends handle the Julian/Gregorian calendar switch themselves.
+
+### Why did my Placidus chart come back with Porphyry cusps?
+
+Quadrant systems (Placidus `"P"`, Koch `"K"`, ...) are undefined inside the
+polar circle, so Kerykeion substitutes Porphyry (`"O"`) **at the real latitude**
+rather than failing or moving the observer. The substitution is logged, recorded
+in `subject.polar_house_fallbacks`, and reported by
+`effective_houses_system_identifier` while `houses_system_identifier` still
+returns what you asked for. See [Polar Latitudes](#polar-latitudes) for the full
+behaviour, including why the boundary is not a fixed 66°.
+
+To pick the division yourself instead of accepting a substitute, use one that is
+defined everywhere:
 
 ```python
 # doc-snippet: no-run — illustrative fragment (placeholder arguments)

--- a/site/docs/fetch_geonames.md
+++ b/site/docs/fetch_geonames.md
@@ -10,8 +10,9 @@ order: 21
 
 The `FetchGeonames` class provides an interface to the GeoNames API to retrieve geographical coordinates and timezone information necessary for chart calculations.
 
-> [!NOTE]
-> This module requires internet access and valid credentials for the GeoNames API.
+**Note:** this module requires internet access and a GeoNames username. The
+built-in default account is shared and rate-limited; register a free one at
+[geonames.org](https://www.geonames.org/login) for anything beyond trying it out.
 
 ## Usage
 
@@ -100,13 +101,46 @@ Returns a dictionary containing the necessary data for Kerykeion calculations.
 -   `countryCode`: Country code
 -   `timezonestr`: Timezone ID (e.g., "Europe/Rome")
 
+#### `get_timezone_for_coordinates(lat, lng)`
+
+Resolves the timezone for explicit coordinates through the GeoNames
+`timezoneJSON` endpoint. It performs no city search, and reuses the same cached
+session, so repeated lookups are served locally.
+
+**Returns:** `dict[str, str]` with `timezonestr` (and the cache status) on
+success; an **empty dict** when the response carries no `timezoneId` or the
+request fails.
+
+This is the path `AstrologicalSubjectFactory.from_birth_data` takes when it is
+given coordinates and no `tz_str` and no `city` — resolving the zone from the
+`"Greenwich"` default would silently build the chart in the wrong zone.
+
+#### `close()`
+
+Closes the underlying cached HTTP session and releases its file handles. Each
+`FetchGeonames` opens a sqlite-backed `CachedSession` (two file descriptors), so
+a long-lived caller that keeps instances referenced can otherwise exhaust them.
+The class is also a context manager, which is the preferred form:
+
+```python
+# doc-snippet: no-run — contacts the GeoNames API
+from kerykeion.geonames.fetcher import FetchGeonames
+
+with FetchGeonames("Rome", "IT") as geonames:
+    data = geonames.get_serialized_data()
+```
+
 #### `set_default_cache_name(cache_name)` (classmethod)
 
-Override the default cache path used when none is provided.
+Override the default cache path used when none is provided. The current value is
+readable as the class attribute `FetchGeonames.default_cache_name`, a `Path`
+that starts at `~/.kerykeion/cache/kerykeion_geonames_cache` and is also
+settable through `KERYKEION_GEONAMES_CACHE_NAME`.
 
 ```python
 from pathlib import Path
 FetchGeonames.set_default_cache_name(Path("/custom/cache/path"))
+print(FetchGeonames.default_cache_name)
 ```
 
 ---

--- a/site/docs/firdaria_factory.md
+++ b/site/docs/firdaria_factory.md
@@ -42,7 +42,7 @@ Build the firdaria timeline for a subject.
 | :--------------- | :------------------------- | :------ | :---------------------------------------------------------------------------------------------- |
 | `subject`        | `AstrologicalSubjectModel` | --      | The natal chart. Requires a real sect (`is_diurnal` must be a boolean). Midpoint composites are rejected. |
 | `target_date`    | str (ISO date/datetime) or None | None | Date the current period is resolved against. Astronomical year numbering accepted. When omitted, now in the subject's timezone. |
-| `life_cap_years` | int                        | 120     | How far the timeline extends, in years of life.                                                 |
+| `life_cap_years` | int                        | 120     | How far the timeline extends, in years of life. Values below 1 are raised to 1. Periods are emitted whole, so the last one can end past the cap. |
 
 **Returns:** `FirdariaModel`
 
@@ -55,7 +55,7 @@ Build the firdaria timeline for a subject.
 | Field         | Type                             | Description                                                      |
 | :------------ | :------------------------------- | :--------------------------------------------------------------- |
 | `is_diurnal`  | `bool`                           | Sect the sequence was chosen from.                               |
-| `periods`     | `list[FirdariaPeriodModel]`      | Major periods from birth up to the life cap, in order.           |
+| `periods`     | `list[FirdariaPeriodModel]`      | Major periods from birth, in order. The sequence is unrolled until the life cap is reached, and the period that reaches it is kept whole: with the default cap of 120 a diurnal timeline ends at age 126. |
 | `current`     | `FirdariaPeriodModel \| None`    | The major period containing the target date, if any.             |
 | `current_sub` | `FirdariaSubPeriodModel \| None` | The sub-period containing the target date, if any.               |
 

--- a/site/docs/fixed_star_discovery_factory.md
+++ b/site/docs/fixed_star_discovery_factory.md
@@ -45,28 +45,36 @@ Find fixed stars conjunct natal planets within the given orb.
 
 Each returned `KerykeionPointModel` is enriched with discovery metadata:
 
-| Field         | Description                                    |
-| :------------ | :--------------------------------------------- |
-| `name`        | Star name from the catalog                     |
-| `sign`        | Zodiac sign                                    |
-| `position`    | Position within the sign (0-30)                |
-| `abs_pos`     | Absolute ecliptic longitude (0-360)            |
-| `magnitude`   | Apparent visual magnitude                      |
-| `declination` | Equatorial declination                         |
-| `house`       | House placement (if house cusps are available)  |
-| `near_point`  | Name of the nearest conjunct natal planet      |
-| `orb`         | Orb of the conjunction in degrees              |
+| Field             | Type        | Description                                              |
+| :---------------- | :---------- | :-------------------------------------------------------- |
+| `name`            | str         | Star name from the catalog                                |
+| `sign`            | str         | Zodiac sign                                               |
+| `position`        | float       | Position within the sign (0-30)                           |
+| `degree`          | float       | Same value as `position`, under the generic point name    |
+| `abs_pos`         | float       | Absolute ecliptic longitude (0-360)                       |
+| `longitude`       | float       | Same value as `abs_pos`                                   |
+| `latitude`        | float       | Ecliptic latitude of the star                             |
+| `magnitude`       | float       | Apparent visual magnitude                                 |
+| `declination`     | float       | Equatorial declination                                    |
+| `speed`           | float       | Apparent longitudinal drift, dominated by precession      |
+| `retrograde`      | bool        | Always `False`: a fixed star never retrogrades            |
+| `house`           | str or None | House placement (if house cusps are available)            |
+| `near_point`      | str         | Name of the nearest conjunct natal point                  |
+| `orb`             | float       | Orb of the conjunction in degrees                         |
+| `aspect`          | str         | Always `"conjunction"` -- the only aspect this factory looks for |
+| `source`          | str         | Which ephemeris source supplied the position              |
+| `precision_class` | str         | Precision tier of that source                             |
 
 ## Catalog Source
 
-The catalog is sourced from **libephemeris** (the default backend). On the swisseph backend, the factory requires `sefstars.txt` to be present in the ephemeris data path (see [Swiss Ephemeris Configuration](/content/docs/swisseph_configuration) for details).
+The catalog is sourced from **libephemeris** (the default backend). On the swisseph backend, the factory requires `sefstars.txt` to be present in the ephemeris data path (see [Swiss Ephemeris Configuration](/content/docs/swisseph_configuration) for details); without it the scan logs a warning and returns whatever it could resolve, which is an incomplete list rather than an error.
 
 Catalog enumeration uses immutable `FixedStarMetadataModel` entries containing
 `name`, canonical `slug`, optional Hipparcos number, nomenclature, visual
-magnitude, and `constellation` (the IAU three-letter abbreviation of the star's
-constellation, e.g. `"Ori"` for Orion, derived from the nomenclature; `None` when
-the star has no standard constellation assignment). Discovery results remain
-enriched `KerykeionPointModel` objects as described above.
+magnitude, and `constellation` (the full IAU constellation name, e.g.
+`"Orion"`, derived from the nomenclature suffix; `None` when the star has no
+standard constellation assignment). Discovery results remain enriched
+`KerykeionPointModel` objects as described above.
 
 ## Wider Orb Example
 

--- a/site/docs/glossary.md
+++ b/site/docs/glossary.md
@@ -82,7 +82,7 @@ In astrology, "planets" includes the Sun and Moon (called "luminaries"), plus Me
 | Planet | Represents | Orbit |
 |:-------|:-----------|:------|
 | **Sun** | Core identity, ego, vitality | 1 year |
-| **Moon** | Emotions, instincts, habits | 28 days |
+| **Moon** | Emotions, instincts, habits | 27.3 days sidereal / 29.5 days synodic |
 | **Mercury** | Communication, thinking | 88 days |
 | **Venus** | Love, beauty, values | 225 days |
 | **Mars** | Action, energy, desire | 2 years |
@@ -176,6 +176,12 @@ aspect.orbit  # The actual deviation from exact
 ### Applying vs Separating
 - **Applying**: Planets moving toward exact aspect (considered stronger)
 - **Separating**: Planets moving away from exact aspect
+- **Static**: Neither — the pair's relative speed is too small to say which way
+  the aspect is going, which happens between two slow outer planets or when one
+  of them is at a station
+
+`AspectModel.aspect_movement` is `Literal["Applying", "Separating", "Static"]`,
+so a consumer must handle all three.
 
 ---
 
@@ -215,6 +221,13 @@ When a planet appears to move backward through the zodiac due to relative orbita
 if subject.mercury.retrograde:
     print("Mercury is retrograde")
 ```
+
+`retrograde` is the bare sign of the speed. `motion_state` grades it against the
+body's own mean daily motion: `retrograde`, `stationary`,
+`stationary_retrograde`, `stationary_direct`, `slow`, `average`, `fast`. The two
+station values name which turn the planet is making — the sign of the speed
+cannot tell them apart, since both stations are approached from one side of zero
+and left on the other.
 
 ### Declination
 A planet's angular distance north or south of the celestial equator. Planets with the same declination are "in parallel."

--- a/site/docs/heliacal_factory.md
+++ b/site/docs/heliacal_factory.md
@@ -19,6 +19,18 @@ The `HeliacalFactory` calculates **heliacal events** -- the first/last visibilit
 | `EVENING_FIRST`    | Evening first (Mercury/Venus only)                 |
 | `MORNING_LAST`     | Morning last (Mercury/Venus only)                  |
 
+These constants are exported from the `kerykeion.heliacal` subpackage, not from
+the top-level `kerykeion` namespace:
+
+```python
+from kerykeion.heliacal import (
+    HELIACAL_RISING,
+    HELIACAL_SETTING,
+    EVENING_FIRST,
+    MORNING_LAST,
+)
+```
+
 ## Basic Usage
 
 ```python
@@ -42,6 +54,17 @@ print(f"Venus heliacal rising: {event.datestamp}")
 
 ## Methods
 
+### `HeliacalFactory(ephe_path=None)`
+
+Build a factory. The instance is stateless apart from the ephemeris path.
+
+| Parameter   | Type          | Default | Description                                                 |
+| :---------- | :------------ | :------ | :---------------------------------------------------------- |
+| `ephe_path` | str or None   | None    | Path to the ephemeris data directory. `None` falls back to the path configured via `KERYKEION_EPHE_PATH` (or the empty string). |
+
+The path is applied per calculation, inside the ephemeris session each method
+opens, rather than mutating global backend state at construction time.
+
 ### `next_heliacal_rising(julian_day, planet_name_or_star, geopos=None, atmo=None, observer=None, *, lat=None, lng=None, altitude=None)`
 
 Find the next heliacal rising after the given Julian Day.
@@ -58,6 +81,12 @@ Find the next heliacal rising after the given Julian Day.
 | `altitude`             | float or None                          | None         | Finite observer altitude in metres; defaults to `0` with `lat`/`lng`. |
 
 **Returns:** `HeliacalEventModel`
+
+**Raises:** `KerykeionException` when no rising is found after `julian_day`,
+when the body is not a supported planet or a recognized fixed-star name, or
+when the search date falls outside the available ephemeris range. The first two
+cases share one message: the backend reports them identically, so the exception
+names both possibilities and suggests widening the window.
 
 ### `search_events(julian_day, geopos=None, count=5, planets=None, event_types=None, atmo=None, observer=None, *, lat=None, lng=None, altitude=None)`
 

--- a/site/docs/house_comparison.md
+++ b/site/docs/house_comparison.md
@@ -15,12 +15,17 @@ The `HouseComparisonFactory` performs a bidirectional analysis of where one subj
 Initialize the factory with two subjects to generate a bidirectional comparison report showing planet-in-house placements.
 
 ```python
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.house_comparison import HouseComparisonFactory
+from kerykeion import AstrologicalSubjectFactory, HouseComparisonFactory
 
-# 1. Create Subjects
-person_a = AstrologicalSubjectFactory.from_birth_data("Alice", 1990, 5, 15, 10, 30, "Rome", "IT")
-person_b = AstrologicalSubjectFactory.from_birth_data("Bob", 1992, 8, 23, 14, 45, "Milan", "IT")
+# 1. Create Subjects (offline mode: explicit coordinates, no GeoNames lookup)
+person_a = AstrologicalSubjectFactory.from_birth_data(
+    "Alice", 1990, 5, 15, 10, 30,
+    lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False,
+)
+person_b = AstrologicalSubjectFactory.from_birth_data(
+    "Bob", 1992, 8, 23, 14, 45,
+    lng=9.19, lat=45.4642, tz_str="Europe/Rome", online=False,
+)
 
 # 2. Generate Comparison
 factory = HouseComparisonFactory(person_a, person_b)
@@ -39,6 +44,11 @@ for point in comparison.second_points_in_first_houses:
 ## Data Structure
 
 The `HouseComparisonModel` contains:
+
+**Subject Names:**
+
+- `first_subject_name`: Name of the first subject.
+- `second_subject_name`: Name of the second subject.
 
 **Point Comparisons:**
 
@@ -69,6 +79,17 @@ Each point model includes:
 | `first_subject`  | `AstrologicalSubjectModel` or `PlanetReturnModel` | Required    | First subject for comparison.  |
 | `second_subject` | `AstrologicalSubjectModel` or `PlanetReturnModel` | Required    | Second subject for comparison. |
 | `active_points`  | `List[AstrologicalPoint]`  | `DEFAULT_ACTIVE_POINTS` | Points to include in analysis. |
+
+## Raises
+
+The constructor raises `KerykeionException` when the two subjects do not share
+the same reference frame — zodiac type, perspective type, and (for sidereal
+charts) sidereal mode — or when either input is not a subject-like model at all.
+Overlaying a Tropical chart's points on a Sidereal chart's houses compares
+longitudes measured from different zero points, so it is rejected up front.
+
+The house system identifier is deliberately **not** compared: a house overlay
+between two subjects cast with different house systems is legitimate.
 
 ## Utility Functions
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -12,8 +12,8 @@ order: 1
 
 ### What you can do with Kerykeion
 
-- **Calculate** positions for 63+ celestial points (planets, asteroids, TNOs, fixed stars, Arabic parts)
-- **Generate** professional SVG charts in 6 themes, 2 styles, and 10 languages
+- **Calculate** positions for 53 chart points (planets, asteroids, TNOs, Uranian points, Arabic parts) plus fixed stars from a 1,447-name catalog
+- **Generate** professional SVG charts in 3 themes (plus `theme=None`), 2 styles, and 10 languages
 - **Analyze** aspects, element/quality distributions, and relationship compatibility
 - **Forecast** with solar/lunar returns, transits over time ranges, and ephemeris data
 - **Integrate** with AI/LLMs via structured XML context serialization
@@ -32,8 +32,7 @@ Requires **Python 3.12** or higher.
 ## Quick Start
 
 ```python
-from kerykeion import AstrologicalSubjectFactory, ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
 
 # Create an astrological subject (offline mode with explicit coordinates)
 subject = AstrologicalSubjectFactory.from_birth_data(
@@ -80,7 +79,7 @@ For more examples, see the [Examples Gallery](/content/examples/).
 
 -   **[Astrological Subject Factory](/content/docs/astrological_subject_factory)**: Creating astrological subjects from birth data, ISO timestamps, or current time.
 -   **[Chart Data Factory](/content/docs/chart_data_factory)**: Calculating structured chart data for natal, synastry, transit, composite, and return charts.
--   **[Charts Module](/content/docs/charts)**: Rendering professional SVG charts with `ChartDrawer`.
+-   **[Charts Module](/content/docs/charts)**: Rendering professional SVG charts with `ChartDrawer`, in the modern or classic style and at three planet-cluster sizes (`glyph_size`).
 -   **[Chart Glyphs](/content/docs/chart-glyphs)**: Visual reference for every glyph rendered in charts (planets, points, signs, aspects).
 -   **[Report Module](/content/docs/report)**: Generating human-readable text reports.
 
@@ -98,7 +97,7 @@ For more examples, see the [Examples Gallery](/content/examples/).
 ## Forecasting
 
 -   **[Planetary Return Factory](/content/docs/planetary_return_factory)**: Calculating solar and lunar returns with relocation support.
--   **[Moon Phase Details Factory](/content/docs/moon_phase_details_factory)**: Rich lunar phase context with illumination, upcoming phases, eclipses, and sun info.
+-   **[Moon Phase Details Factory](/content/docs/moon_phase_details_factory)**: Rich lunar phase context with illumination, upcoming phases, eclipses, sun info, and moonrise/moonset.
 -   **[Transits Time Range Factory](/content/docs/transits_time_range_factory)**: Tracking transit aspects over a date range.
 -   **[Ephemeris Data Factory](/content/docs/ephemeris_data_factory)**: Generating time-series planetary position data.
 -   **[Secondary Progressions](/content/docs/secondary_progressions_factory)**: Day-for-a-year progressions via `SecondaryProgressionFactory`.
@@ -108,8 +107,8 @@ For more examples, see the [Examples Gallery](/content/examples/).
 -   **[Profections](/content/docs/profections_factory)**: Annual profection timeline via `ProfectionsFactory`.
 -   **[Firdaria](/content/docs/firdaria_factory)**: Persian planetary time-lord periods via `FirdariaFactory`.
 -   **[Lunation Finder](/content/docs/lunation_factory)**: New/First-Quarter/Full/Last-Quarter Moons over a date range.
--   **[Retrograde Stations](/content/docs/retrograde_station_factory)**: Planetary retrograde/direct stations over a date range.
--   **[Sign Ingresses](/content/docs/sign_ingress_factory)**: Planet sign-change moments over a date range.
+-   **[Retrograde Stations](/content/docs/retrograde_station_factory)**: Planetary retrograde/direct stations over a date range, or complete retrograde periods via `retrograde_periods_from_iso_range` (Chiron is opt-in).
+-   **[Sign Ingresses](/content/docs/sign_ingress_factory)**: Planet sign-change moments over a date range, or the sign occupancy periods between them via `sign_periods_from_iso_range`.
 -   **[Mundane Aspects](/content/docs/mundane_aspects_factory)**: Exact transiting-to-transiting aspects for calendar aspectarians.
 -   **[Void-of-Course Moon](/content/docs/void_of_course_moon_factory)**: Current void state and complete void windows over a range.
 -   **[Sun Times](/content/docs/sun_times_factory)**: Sunrise, sunset, twilight, solar noon, and day length.
@@ -130,7 +129,7 @@ For more examples, see the [Examples Gallery](/content/examples/).
 ## Reference
 
 -   **[Types & Schemas](/content/docs/schemas)**: Complete Pydantic model and type reference.
--   **[Active Points](/content/docs/active_points)**: Reference for 53 non-star chart points, separately configured fixed stars, and their presets.
+-   **[Active Points](/content/docs/active_points)**: Reference for the 53 non-star chart points, separately configured fixed stars, and their presets.
 -   **[Cookbook](/content/docs/cookbook)**: Practical recipes and code snippets for common tasks.
 -   **[Constants](/content/docs/constants)**: Exhaustive lists of points, aspects, and preset constants.
 -   **[Utilities](/content/docs/utilities)**: Helper functions for zodiac math, Julian Day, and SVG processing.

--- a/site/docs/lunation_factory.md
+++ b/site/docs/lunation_factory.md
@@ -77,8 +77,8 @@ Each `LunationModel` item has:
 | `phase`      | str   | `new` / `first_quarter` / `full` / `last_quarter`.    |
 | `iso_utc`    | str   | ISO 8601 UTC datetime of the exact phase.             |
 | `julian_day` | float | Julian Day (UT) of the exact phase.                   |
-| `sun`        | object | Sun position (sign + longitude) at the lunation.     |
-| `moon`       | object | Moon position (sign + longitude) at the lunation.    |
+| `sun`        | `KerykeionPointModel` | Sun position at the phase: `sign`, `sign_num`, `position`, `abs_pos`, `element`, `quality`, `emoji`. Chart-only fields such as `house` and `retrograde` are `None`. |
+| `moon`       | `KerykeionPointModel` | Moon position at the phase, same fields.             |
 
 ---
 

--- a/site/docs/midpoint_factory.md
+++ b/site/docs/midpoint_factory.md
@@ -44,7 +44,7 @@ Compute every pairwise midpoint and (optionally) aspect activations.
 | Parameter        | Type              | Default | Description                                           |
 | :--------------- | :---------------- | :------ | :---------------------------------------------------- |
 | `subject`        | AstrologicalSubjectModel | --  | The natal/event chart to analyse                      |
-| `active_points`  | Sequence[str] or None | None | Points to use as midpoint constituents (defaults to standard set) |
+| `active_points`  | Sequence[str] or None | None | Points to use as midpoint constituents. Defaults to `DEFAULT_PREDICTIVE_POINTS`: Sun through Pluto, True North Lunar Node, Chiron, Ascendant and Medium Coeli. Names the subject does not carry are skipped, and fewer than two resolved points give an empty list |
 | `compute_aspects`| bool              | True    | Also compute third-point aspect activations           |
 | `aspect_orb`     | float             | 1.0     | Orb in degrees for aspect-to-midpoint detection       |
 | `aspects`        | Sequence[str] or None | None | Whitelist of aspect names (defaults to all configured) |
@@ -60,7 +60,12 @@ Materialize midpoints as `KerykeionPointModel` entries so the chart drawer can r
 | `subject`    | AstrologicalSubjectModel | The natal subject                          |
 | `pair_names` | Sequence[str]  | Pair identifiers in `"A_B"` form (e.g. `"Sun_Moon"`)    |
 
-**Returns:** `List[KerykeionPointModel]`
+**Returns:** `List[KerykeionPointModel]`, one per resolved pair, named
+`"A_B_Midpoint"` with `point_type="Midpoint"` and sign, element, quality and
+house derived from the midpoint longitude on the shorter arc. Both sides of a
+pair must resolve in the subject's own `active_points`: a pair that does not
+is skipped and logged as a warning. A repeated pair, or the reversed `"B_A"`
+twin of one already emitted, is skipped too — the first occurrence wins.
 
 ## Data Models
 

--- a/site/docs/migration.md
+++ b/site/docs/migration.md
@@ -35,7 +35,7 @@ from kerykeion import AstrologicalSubject
 
 subject = AstrologicalSubject(
     "John", 1990, 1, 1, 12, 0,
-    city="London", nat="GB"
+    city="London", nation="GB"
 )
 ```
 
@@ -136,9 +136,9 @@ Key changes:
 
 ### 4. Lunar Node Naming
 
-All lunar node properties have been renamed for clarity:
+All lunar node properties were renamed for clarity:
 
-| v4 Property | v5 Property |
+| v4 Property | v6 Property |
 |:------------|:------------|
 | `subject.mean_node` | `subject.mean_north_lunar_node` |
 | `subject.true_node` | `subject.true_north_lunar_node` |
@@ -147,14 +147,14 @@ All lunar node properties have been renamed for clarity:
 
 In active_points lists:
 
-| v4 String | v5 String |
+| v4 String | v6 String |
 |:----------|:----------|
 | `"Mean_Node"` | `"Mean_North_Lunar_Node"` |
 | `"True_Node"` | `"True_North_Lunar_Node"` |
 
 ### 5. Import Path Changes
 
-| v4 Import | v5 Import |
+| v4 Import | v6 Import |
 |:----------|:----------|
 | `from kerykeion.kr_types import *` | `from kerykeion.schemas import *` |
 | `from kerykeion.kr_types.kr_literals import Planet` | `from kerykeion.schemas.literals import AstrologicalPoint` |
@@ -274,11 +274,11 @@ This is the largest silent change, and it has three separate parts. Expect **few
 | square | 5° | 6° |
 | quintile | 1° | *removed from the defaults* |
 
-**Non-natal charts moved to a flat 3°.** In v5 every chart type used the same defaults. In v6 only the natal family (`Natal`, `Synastry`, `Composite`) uses `DEFAULT_ACTIVE_ASPECTS`; transits, returns and progressions use `PREDICTIVE_ACTIVE_ASPECTS`, which is 3° for all five aspects.
+**Non-natal charts moved to a flat 3°.** In v5 every chart type used the same defaults. In v6 only the natal family (`Natal`, `Synastry`, `Composite`) uses `DEFAULT_ACTIVE_ASPECTS`; transits, returns and progressions use `PREDICTIVE_ACTIVE_ASPECTS`, which is 3° for all five aspects. Both presets live in `kerykeion.settings.config_constants`.
 
 The difference is small on a natal chart and large everywhere else. On one sample chart: 38 natal aspects under v6 against 40 with the v5 orbs — but **19 transit aspects against 51**. If your code reads transits, returns or progressions, this is the change to look at first.
 
-**Luminaries gained a 1.5° bonus — natal family only.** `DEFAULT_NATAL_POINT_ORB_ADJUSTMENTS` widens aspects involving the Sun or the Moon. It applies *only* where `chart_type` is in the natal family; every other `create_*_chart_data` already uses no adjustment, so `point_orb_adjustments={}` is a no-op there.
+**Luminaries gained a 1.5° bonus — natal family only.** `DEFAULT_NATAL_POINT_ORB_ADJUSTMENTS` (also in `kerykeion.settings.config_constants`) widens aspects involving the Sun or the Moon. It applies *only* where `chart_type` is in the natal family; every other `create_*_chart_data` already uses no adjustment, so `point_orb_adjustments={}` is a no-op there.
 
 To restore v5 orbs, pass the aspect list explicitly — this is the part `V5_DEFAULT_ACTIVE_POINTS` does *not* cover:
 
@@ -379,8 +379,14 @@ v5 included a compatibility layer in `kerykeion.backword` that allowed gradual m
 # from kerykeion import AstrologicalSubject, KerykeionChartSVG
 
 # New
-from kerykeion import AstrologicalSubjectFactory, ChartDataFactory
-from kerykeion.charts.drawer import ChartDrawer
+from pathlib import Path
+
+from kerykeion import (
+    AspectsFactory,
+    AstrologicalSubjectFactory,
+    ChartDataFactory,
+    ChartDrawer,
+)
 ```
 
 ### Step 2: Update Subject Creation

--- a/site/docs/moon_phase_details_factory.md
+++ b/site/docs/moon_phase_details_factory.md
@@ -8,7 +8,7 @@ order: 12
 
 # Moon Phase Details Factory
 
-The `MoonPhaseDetailsFactory` builds a complete `MoonPhaseOverviewModel` from an existing `AstrologicalSubjectModel`. While the basic `LunarPhaseModel` attached to every subject provides the Sun-Moon angle, phase name, and emoji, this factory enriches that data into a full lunar context suitable for UI display, API responses, or detailed reports.
+The `MoonPhaseDetailsFactory` builds a complete `MoonPhaseOverviewModel` from an existing `AstrologicalSubjectModel`. While the basic `LunarPhaseModel` attached to every subject already provides the Sun-Moon angle, phase name, emoji, `major_phase` and waxing/waning `stage`, this factory enriches that data into a full lunar context suitable for UI display, API responses, or detailed reports.
 
 ## What It Provides
 
@@ -172,7 +172,7 @@ This produces a formatted ASCII table report with sections for Moon Summary, Ill
 - **Polar regions**: When the Sun does not rise or set (polar day/night), sunrise and sunset fields will be `None`.
 - **Days without a moonrise or a moonset**: The Moon rises about 50 minutes later each day, so roughly one civil day in thirty has no moonrise at all, and another has no moonset. The backend always answers with the *next* event, which on those days belongs to tomorrow; anything falling outside the subject's own civil day is reported as `None` rather than passed off as today's.
 - **Missing lunar phase**: If the subject was created with `calculate_lunar_phase=False`, the moon summary will contain only `None` fields — except `moonrise` / `moonset`, which are computed regardless, since a horizon crossing is a fact about the place and the day rather than about the phase.
-- **No coordinates**: If the subject has no `lat`/`lng`, sun times and position will be `None`, and location fields will be empty.
+- **No coordinates**: If the subject has no `lat`/`lng`, sun times and position will be `None`, and the location block's `latitude`/`longitude` will be `None` — `precision` and `using_default_location` are still set from the call's arguments.
 
 ---
 

--- a/site/docs/mundane_aspects_factory.md
+++ b/site/docs/mundane_aspects_factory.md
@@ -33,7 +33,9 @@ for event in result.aspects:
 
 `from_iso_range(start_date, end_date, points=None, aspects=None, zodiac_type="Tropical", sidereal_mode=None) -> MundaneAspectsCollectionModel`
 
-ISO inputs are treated as UTC; a date-only end includes the entire final day.
+Naive ISO inputs are treated as UTC; an offset-aware input is converted to UTC
+before the scan. A date-only end includes the entire final day. A malformed ISO
+string raises `KerykeionException`.
 
 ### `from_julian_day`
 
@@ -47,9 +49,45 @@ By default the factory scans Sun through Pluto (Moon excluded) and the five
 Ptolemaic aspects. Pass the Moon explicitly for lunar aspectarian events. An
 explicit empty `points` or `aspects` list returns an empty collection.
 
+## Accepted Names
+
+`points` accepts these bodies, listed here in the canonical fast-to-slow order
+that also fixes which member of a pair becomes `point_a`:
+
+`Moon`, `Mercury`, `Venus`, `Sun`, `Mars`, `Jupiter`, `Saturn`, `Chiron`,
+`Uranus`, `Neptune`, `Pluto`, `Mean_North_Lunar_Node`, `True_North_Lunar_Node`.
+
+`aspects` accepts the longitude aspects of `DEFAULT_CHART_ASPECTS_SETTINGS`:
+`conjunction`, `semi-sextile`, `semi-square`, `sextile`, `quintile`, `square`,
+`trine`, `sesquiquadrate`, `biquintile`, `quincunx`, `opposition`. Declination
+aspects (`parallel`, `contra-parallel`) are not longitude events and are
+rejected with `ValueError`, as is any other unknown name.
+
 ## Models
 
-`MundaneAspectsCollectionModel` contains `start_jd`, `end_jd`, and chronological
-`aspects`. Each `MundaneAspectModel` contains `point_a`, `point_b`, `aspect`,
-`aspect_degrees`, `julian_day`, `iso_utc`, both bodies' longitude/sign, and both
-retrograde flags. Body ordering is canonical and independent of caller order.
+### `MundaneAspectsCollectionModel`
+
+| Field      | Type                      | Description                            |
+| :--------- | :------------------------ | :------------------------------------- |
+| `start_jd` | float                     | Requested Julian Day (UT) range start. |
+| `end_jd`   | float                     | Requested Julian Day (UT) range end.   |
+| `aspects`  | list[MundaneAspectModel]  | Chronologically ordered exact aspects. |
+
+### `MundaneAspectModel`
+
+Body ordering is canonical and independent of caller order.
+
+| Field                | Type  | Description                                                   |
+| :------------------- | :---- | :------------------------------------------------------------ |
+| `point_a`            | str   | First body (canonical fast-to-slow order).                     |
+| `point_b`            | str   | Second body.                                                   |
+| `aspect`             | str   | Aspect name, e.g. `"square"`.                                  |
+| `aspect_degrees`     | float | The aspect's exact angle in degrees.                           |
+| `julian_day`         | float | Julian Day (UT) of the exact perfection.                       |
+| `iso_utc`            | str   | ISO 8601 UTC datetime of the exact perfection.                 |
+| `point_a_longitude`  | float | Ecliptic longitude of `point_a` at the event (requested zodiac). |
+| `point_b_longitude`  | float | Ecliptic longitude of `point_b` at the event (requested zodiac). |
+| `point_a_sign`       | Sign  | Sign of `point_a` at the event.                                |
+| `point_b_sign`       | Sign  | Sign of `point_b` at the event.                                |
+| `point_a_retrograde` | bool  | `True` if `point_a` is retrograde at the event.                |
+| `point_b_retrograde` | bool  | `True` if `point_b` is retrograde at the event.                |

--- a/site/docs/occultation_factory.md
+++ b/site/docs/occultation_factory.md
@@ -35,7 +35,7 @@ Find occultations visible from anywhere on Earth.
 | Parameter    | Type  | Default | Description                                      |
 | :----------- | :---- | :------ | :----------------------------------------------- |
 | `julian_day` | float | --      | Finite starting Julian Day (UT) for the search   |
-| `planet_id`  | int   | --      | Planet identifier (ephe-style constant, e.g. `ephe.VENUS`) |
+| `planet_id`  | int or str | -- | Body identifier: an ephe-style constant (e.g. `ephe.VENUS`) or a planet name (e.g. `"Venus"`) |
 | `count`      | int   | 5       | Number of events to return                       |
 
 **Returns:** `List[OccultationModel]`
@@ -47,7 +47,7 @@ Find occultations visible from a specific location.
 | Parameter    | Type  | Default | Description                                      |
 | :----------- | :---- | :------ | :----------------------------------------------- |
 | `julian_day` | float | --      | Finite starting Julian Day (UT) for the search   |
-| `planet_id`  | int   | --      | Planet identifier (ephe-style constant)           |
+| `planet_id`  | int or str | -- | Body identifier: an ephe-style constant or a planet name |
 | `lat`        | float | --      | Geographic latitude in [-90, 90] (north positive) |
 | `lng`        | float | --      | Geographic longitude in [-180, 180] (east positive) |
 | `count`      | int   | 5       | Number of events to return                       |
@@ -55,7 +55,10 @@ Find occultations visible from a specific location.
 **Returns:** `List[OccultationModel]`
 
 For both search methods, `count` must be between 0 and 1,000 inclusive;
-invalid counts raise `ValueError` before any backend call.
+invalid counts raise `ValueError` before any backend call. A `planet_id` that
+is neither an `int` nor a `str` raises `TypeError`, and a body outside the
+occultable set (see [Planet Identifiers](#planet-identifiers)) raises
+`KerykeionException`.
 
 ```python
 # Find occultations visible from Rome
@@ -70,15 +73,34 @@ events = factory.search_local(
 
 ## Planet Identifiers
 
-Use `ephe` constants for the `planet_id` parameter:
+`planet_id` accepts either an `ephe` constant or the body's name as a string:
 
-| Planet  | Constant       |
-| :------ | :------------- |
-| Mercury | `ephe.MERCURY`  |
-| Venus   | `ephe.VENUS`    |
-| Mars    | `ephe.MARS`     |
-| Jupiter | `ephe.JUPITER`  |
-| Saturn  | `ephe.SATURN`   |
+| Planet  | Constant       | Name        |
+| :------ | :------------- | :---------- |
+| Mercury | `ephe.MERCURY`  | `"Mercury"` |
+| Venus   | `ephe.VENUS`    | `"Venus"`   |
+| Mars    | `ephe.MARS`     | `"Mars"`    |
+| Jupiter | `ephe.JUPITER`  | `"Jupiter"` |
+| Saturn  | `ephe.SATURN`   | `"Saturn"`  |
+
+A name is resolved through the project-wide name-to-ID map, so
+`factory.search_global(jd, "Venus")` and `factory.search_global(jd, ephe.VENUS)`
+are equivalent.
+
+### Accepted Bodies
+
+Only physically real bodies can be occulted by the Moon, so both forms are
+restricted to: **Sun, Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune,
+Pluto, Chiron, Pholus, Ceres, Pallas, Juno, Vesta**.
+
+Anything else raises:
+
+- `KerykeionException` — an unknown planet name, or a known name/ID outside the
+  set above: the calculated points (lunar nodes, Lilith and apogee variants, the
+  Uranian hypotheticals) have no disk to be covered, and the Moon and the Earth
+  are not occultable either.
+- `TypeError` — a `planet_id` that is neither an `int` nor a `str` (booleans
+  included).
 
 ## Data Models
 

--- a/site/docs/planetary_hours_factory.md
+++ b/site/docs/planetary_hours_factory.md
@@ -38,11 +38,37 @@ The date and clock time are interpreted in `tz_str`. Latitude is north-positive
 `KerykeionException`. Planetary hours are undefined when a bounding sunrise or
 sunset is absent (polar day/night), which also raises `KerykeionException`.
 
+A planetary day runs from one sunrise to the next, so both ends of the
+representable calendar are refused with `KerykeionException`: an evening of
+9999-12-31 would need the sunrise of 10000-01-01, and a morning of 0001-01-01
+before sunrise would need the sunset of the day before year 1.
+
 ## Models
 
-`PlanetaryHoursModel` contains the planetary-day `date`, timezone and
-coordinates, `day_ruler`, `current_index`, `current_ruler`, the bounding
-`sunrise`, `sunset`, `next_sunrise`, and all 24 `hours`.
+### `PlanetaryHoursModel`
 
-Each `PlanetaryHourModel` has a 1-based `index`, `ruler`, `is_diurnal`, `start`,
-and `end`. All event instants are timezone-aware UTC datetimes.
+| Field           | Type                     | Description                                                     |
+| :-------------- | :----------------------- | :-------------------------------------------------------------- |
+| `date`          | str                      | Civil date (ISO) of the planetary day's sunrise, in `timezone`. |
+| `timezone`      | str                      | IANA timezone identifier.                                        |
+| `latitude`      | float                    | Observer latitude in degrees.                                    |
+| `longitude`     | float                    | Observer longitude in degrees.                                   |
+| `day_ruler`     | ClassicalPlanet          | Planet ruling the whole planetary day (from the weekday).        |
+| `current_index` | int                      | 1-based index of the hour containing the requested moment.       |
+| `current_ruler` | ClassicalPlanet          | Ruler of the hour containing the requested moment.               |
+| `sunrise`       | datetime                 | Sunrise opening the day hours.                                   |
+| `sunset`        | datetime                 | Sunset dividing day and night hours.                             |
+| `next_sunrise`  | datetime                 | Sunrise closing the night hours.                                 |
+| `hours`         | list[PlanetaryHourModel] | All 24 planetary hours, in chronological order.                  |
+
+### `PlanetaryHourModel`
+
+| Field        | Type            | Description                                                          |
+| :----------- | :-------------- | :------------------------------------------------------------------- |
+| `index`      | int             | 1-based position in the sequence (1-24).                             |
+| `ruler`      | ClassicalPlanet | Classical planet ruling the hour.                                    |
+| `is_diurnal` | bool            | `True` for the 12 day hours, `False` for the 12 night hours.         |
+| `start`      | datetime        | Hour start.                                                          |
+| `end`        | datetime        | Hour end.                                                            |
+
+All event instants are timezone-aware UTC datetimes.

--- a/site/docs/planetary_nodes_factory.md
+++ b/site/docs/planetary_nodes_factory.md
@@ -66,23 +66,29 @@ print(moon.apoapsis.abs_pos == subject.mean_lilith.abs_pos)   # True
 
 Calculate nodes from an existing astrological subject.
 
+The node and apsis longitudes -- and the sign metadata derived from them --
+are computed in the subject's own zodiac frame: a sidereal subject gets
+sidereal longitudes, consistent with the rest of its chart.
+
 | Parameter | Type                     | Default | Description                                |
 | :-------- | :----------------------- | :------ | :----------------------------------------- |
-| `subject` | AstrologicalSubjectModel | --      | An astrological subject                    |
-| `method`  | str                      | "mean"  | "mean" or "osculating"                     |
-| `planets` | List[str] or None        | None    | Planet names (defaults to Moon through Pluto; the Sun is deliberately excluded — it has no geocentric nodes) |
+| `subject` | AstrologicalSubjectModel | --      | An astrological subject with a Julian Day (composites are rejected) |
+| `method`  | str                      | "mean"  | "mean" or "osculating"; any other value raises `KerykeionException` |
+| `planets` | List[str] or None        | None    | Planet names (defaults to Moon through Pluto; an unknown name raises `ValueError`). The Sun is deliberately excluded — it has no geocentric nodes — and requesting it raises `KerykeionException` |
 
 **Returns:** `PlanetaryNodesCollectionModel`
 
 ### `from_julian_day(julian_day, method, planets)`
 
-Calculate nodes from a Julian Day number.
+Calculate nodes from a Julian Day number. A bare instant carries no zodiac
+frame, so the longitudes are always tropical -- pass a subject to
+`from_subject` when sidereal ones are wanted.
 
 | Parameter    | Type              | Default | Description            |
 | :----------- | :---------------- | :------ | :--------------------- |
 | `julian_day` | float             | --      | Finite Julian Day number |
-| `method`     | str               | "mean"  | "mean" or "osculating" |
-| `planets`    | List[str] or None | None    | Planet names           |
+| `method`     | str               | "mean"  | "mean" or "osculating"; any other value raises `KerykeionException` |
+| `planets`    | List[str] or None | None    | Planet names; an unknown name raises `ValueError`, and "Sun" raises `KerykeionException` |
 
 **Returns:** `PlanetaryNodesCollectionModel`
 

--- a/site/docs/planetary_phenomena_factory.md
+++ b/site/docs/planetary_phenomena_factory.md
@@ -72,7 +72,7 @@ A central solar eclipse is **not** a promise of `"cazimi"`, and the reason is th
 
 ## Methods
 
-### `from_subject(subject, planets)`
+### `from_subject(subject, planets, solar_phase_thresholds)`
 
 Calculate phenomena from an existing astrological subject.
 
@@ -84,7 +84,11 @@ Calculate phenomena from an existing astrological subject.
 
 **Returns:** `PlanetaryPhenomenaCollectionModel`
 
-### `from_julian_day(julian_day, planets)`
+**Raises:** `KerykeionException` if the subject has no Julian Day — a composite
+subject has no single moment in time and is not supported here. An unknown or
+mistyped planet name raises `ValueError` (names are case-sensitive).
+
+### `from_julian_day(julian_day, planets, solar_phase_thresholds)`
 
 Calculate phenomena from a Julian Day number.
 
@@ -95,6 +99,11 @@ Calculate phenomena from a Julian Day number.
 | `solar_phase_thresholds` | SolarPhaseThresholdsModel or None | None | Cut-offs for `solar_phase`; defaults to the classical 0.2833° / 8.5° / 17° |
 
 **Returns:** `PlanetaryPhenomenaCollectionModel`
+
+**Raises:** `ValueError` for an unknown or mistyped planet name (names are
+case-sensitive) or a non-finite `julian_day`, and `KerykeionException` if every
+requested planet fails, which usually means the ephemeris backend is unavailable
+or the moment is out of its range.
 
 ## Supported Planets
 

--- a/site/docs/planetary_return_factory.md
+++ b/site/docs/planetary_return_factory.md
@@ -104,7 +104,10 @@ solar_return = return_factory.next_return_from_date(2024, 1, 1, return_type="Sol
 print(f"Return ayanamsa: {solar_return.ayanamsa_value:.4f}°")
 ```
 
-> Both `custom_ayanamsa_t0` and `custom_ayanamsa_ayan_t0` are required when the natal subject uses `sidereal_mode="USER"`. Omitting them raises a `KerykeionException`.
+> When the natal subject uses `sidereal_mode="USER"`, passing
+> `custom_ayanamsa_t0` and `custom_ayanamsa_ayan_t0` explicitly overrides the
+> natal's; leaving them out reads them from the natal subject. The constructor
+> raises `KerykeionException` only when neither source provides both.
 
 ## Supported Return Types
 
@@ -125,7 +128,7 @@ helio = return_factory.next_heliocentric_return_from_year("Jupiter", 2026)
 print(helio.iso_formatted_utc_datetime)
 ```
 
-Convenience wrappers mirror the Solar/Lunar ones: `next_heliocentric_return_from_year(planet_name, year)`, `next_heliocentric_return_from_date(...)`, `next_heliocentric_return_from_iso_formatted_time(...)`.
+Convenience wrappers mirror the Solar/Lunar ones: `next_heliocentric_return_from_year(planet_name, year)`, `next_heliocentric_return_from_date(planet_name, year, month, day=1, backwards=False)`, `next_heliocentric_return_from_iso_formatted_time(planet_name, iso_formatted_time, backwards=False)`.
 
 ## Lunar Node Crossings
 
@@ -136,7 +139,7 @@ crossing = return_factory.next_lunar_node_crossing_from_year(2026)
 print(crossing.iso_formatted_utc_datetime)
 ```
 
-Convenience wrappers: `next_lunar_node_crossing_from_year(year)`, `next_lunar_node_crossing_from_date(...)`, `next_lunar_node_crossing_from_iso_formatted_time(...)`.
+Convenience wrappers: `next_lunar_node_crossing_from_year(year)`, `next_lunar_node_crossing_from_date(year, month, day=1, backwards=False)`, `next_lunar_node_crossing_from_iso_formatted_time(iso_formatted_time, backwards=False)`.
 
 ## Constructor Parameters
 
@@ -177,7 +180,7 @@ result = return_factory.next_return_from_date(2025, 1, 1, return_type="Solar")
 | `year`        | `int`        | **Required** | Year to start searching from.            |
 | `month`       | `int`        | **Required** | Month to start searching from.           |
 | `day`         | `int`        | `1`          | Day to start searching from.             |
-| `return_type` | `ReturnType` | **Required** | `"Solar"` or `"Lunar"` (keyword-only).   |
+| `return_type` | `SolarLunarReturnType` | **Required** | `"Solar"` or `"Lunar"` (keyword-only).   |
 | `backwards`   | `bool`       | `False`      | If `True`, return the most recent return before the starting date instead of the next one. |
 
 ### `next_return_from_iso_formatted_time(iso_formatted_time, return_type, backwards=False)`
@@ -191,7 +194,7 @@ result = return_factory.next_return_from_iso_formatted_time("2024-06-15T12:00:00
 | Parameter            | Type         | Default      | Description                              |
 | :------------------- | :----------- | :----------- | :--------------------------------------- |
 | `iso_formatted_time` | `str`        | **Required** | ISO 8601 timestamp at which to start the search (naive values are read as UTC). |
-| `return_type`        | `ReturnType` | **Required** | `"Solar"` or `"Lunar"`.                  |
+| `return_type`        | `SolarLunarReturnType` | **Required** | `"Solar"` or `"Lunar"`.                  |
 | `backwards`          | `bool`       | `False`      | If `True`, search for the most recent return before the timestamp. |
 
 Return instants are reported truncated to the whole second, and the search is

--- a/site/docs/primary_directions_factory.md
+++ b/site/docs/primary_directions_factory.md
@@ -47,9 +47,11 @@ Compute primary directions for a natal chart.
 | `subject`   | AstrologicalSubjectModel  | --         | The natal chart subject                                 |
 | `max_years` | float                     | 100        | Finite, non-negative maximum number of years to compute directions for |
 | `rate_key`  | "ptolemy" or "naibod"     | "ptolemy"  | Conversion rate (ptolemy: 1 deg = 1 yr, naibod: 0.98564 deg = 1 yr); other values raise `KerykeionException` |
-| `aspects`   | List[str] or None         | None       | Unique supported aspect names; non-strings, unknown names, and malformed entries raise `KerykeionException` |
+| `aspects`   | List[str] or None         | None       | Supported aspect names; repeated names are collapsed to one; non-strings, unknown names, and malformed entries raise `KerykeionException` |
 
-**Returns:** `List[PrimaryDirectionModel]` sorted by `direction_years`.
+**Returns:** `List[PrimaryDirectionModel]` sorted by `direction_years`. Only
+directions whose `direction_years` is above 0.1 and not greater than
+`max_years` are kept: an arc that resolves to 0.1 years or less is dropped.
 
 ### `compute_speculum(subject)`
 
@@ -87,10 +89,14 @@ the observer coordinates including `subject.altitude` (sea level when `None`).
 | `is_converse`     | bool  | `True` for converse directions (see note below)   |
 
 > **Note:** `compute()` returns both **direct** (`is_converse=False`) and
-> **converse** (`is_converse=True`) entries interleaved, so the same
-> promissor/significator pair appears twice at different arcs. The converse
-> arc is an explicit sign-flip approximation of the classical technique —
-> filter on `is_converse` if you only want the traditional direct directions.
+> **converse** (`is_converse=True`) entries interleaved, so each aspect point
+> yields two arcs. Sextile, square and trine are directed to both the dexter
+> and the sinister aspect point (`longitude - aspect` and `longitude +
+> aspect`), while conjunction and opposition have a single one: the same
+> promissor/significator/aspect combination therefore appears up to four times
+> for the former and twice for the latter. The converse arc is an explicit
+> sign-flip approximation of the classical technique — filter on `is_converse`
+> if you only want the traditional direct directions.
 
 ### `SpeculumEntryModel`
 

--- a/site/docs/relationship_score_factory.md
+++ b/site/docs/relationship_score_factory.md
@@ -33,8 +33,7 @@ This numerical approach is useful for:
 To calculate a score, create two astrological subjects via `AstrologicalSubjectFactory` (one for each partner) and pass them to the factory.
 
 ```python
-from kerykeion import AstrologicalSubjectFactory
-from kerykeion.relationship_score.factory import RelationshipScoreFactory
+from kerykeion import AstrologicalSubjectFactory, RelationshipScoreFactory
 
 # 1. Create Subjects (offline mode: explicit coordinates, no GeoNames lookup)
 person_a = AstrologicalSubjectFactory.from_birth_data(
@@ -71,7 +70,7 @@ for aspect in score_model.aspects[:3]:
 **Expected Output:**
 
 ```text
-Sun sextile Sun (orb: 3.6354400115408794°)
+Sun sextile Sun (orb: 3.6354400137083758°)
 Ascendant trine Moon (orb: 2.242423320728676°)
 ```
 
@@ -84,16 +83,34 @@ Ascendant trine Moon (orb: 2.242423320728676°)
 | `use_only_major_aspects` | `bool`  | `True`   | Only consider major aspects (conj, opp, sq, etc). |
 | `axis_orb_limit`         | `float` | `None`   | Finite, positive stricter orb for angles (Asc, MC). Keyword-only.  |
 
+## Raises
+
+`KerykeionException` is raised when:
+
+- The two subjects do not share the same reference frame — zodiac type,
+  perspective type, and (for sidereal charts) sidereal mode. The check runs in
+  the constructor, before any aspect is computed. House systems are not
+  compared, and are allowed to differ.
+- Either input is not a subject-like model at all (it does not expose the frame
+  attributes).
+- `axis_orb_limit` is given but is not a finite, positive number.
+- Either subject was built without the Sun in its active points. The Discepolo
+  method is defined on the Sun (destiny sign) and the luminary aspects, so
+  `get_relationship_score()` fails rather than returning a partial score.
+
 ## Score Categories
 
-| Score       | Category         | Description                                     |
-| :---------- | :--------------- | :---------------------------------------------- |
-| **0 - 5**   | Minimal          | Low compatibility, few significant connections. |
-| **5 - 10**  | Medium           | Moderate compatibility.                         |
-| **10 - 15** | Important        | Strong compatibility, notable connections.      |
-| **15 - 20** | Very Important   | High compatibility, significant harmony.        |
-| **20 - 30** | Exceptional      | Outstanding compatibility.                      |
-| **30+**     | Rare Exceptional | Extraordinary cosmic connection.                |
+Each bound is strict: a category applies while `score_value` is **below** its
+threshold, so a score of exactly 5 is Medium, and exactly 20 is Exceptional.
+
+| Score         | Category         | Description                                     |
+| :------------ | :--------------- | :---------------------------------------------- |
+| **< 5**       | Minimal          | Low compatibility, few significant connections. |
+| **5 - < 10**  | Medium           | Moderate compatibility.                         |
+| **10 - < 15** | Important        | Strong compatibility, notable connections.      |
+| **15 - < 20** | Very Important   | High compatibility, significant harmony.        |
+| **20 - < 30** | Exceptional      | Outstanding compatibility.                      |
+| **>= 30**     | Rare Exceptional | Extraordinary cosmic connection.                |
 
 ## Scoring System Details
 
@@ -107,9 +124,11 @@ The algorithm awards points for specific "Destiny" indicators and aspects.
 | **Sun-Ascendant**          | +4        | Any major aspect.                                             |
 | **Moon-Ascendant**         | +4        | Any major aspect.                                             |
 | **Venus-Mars**             | +4        | Any major aspect.                                             |
-| **Other Sun/Moon**         | +4        | Other major aspects involving Luminaries.                     |
+| **Sun-Sun** (other)        | +4        | Any Sun-Sun aspect other than conjunction, opposition or square. |
+| **Sun-Moon** (other)       | +4        | Any Sun-Moon aspect other than conjunction.                   |
 
-_Note: The system prioritizes "Luminaries" (Sun/Moon) and Angles._
+_Note: The system prioritizes "Luminaries" (Sun/Moon) and Angles. Moon-Moon
+aspects carry no rule and score nothing._
 
 ## Return Model (`RelationshipScoreModel`)
 

--- a/site/docs/relocated_chart_factory.md
+++ b/site/docs/relocated_chart_factory.md
@@ -57,15 +57,35 @@ Relocate a natal chart to a new geographic location.
 
 **Returns:** `AstrologicalSubjectModel` with relocated houses and angles.
 
+**Raises:** `KerykeionException` if the subject uses the `"Topocentric"`
+perspective -- its planetary positions embed the parallax of the natal
+observer, so they cannot be kept while the observer moves coherently. Re-create
+the subject with the new coordinates instead. Also `KerykeionException` for a
+geometrically impossible `|new_lat| > 90`;
+`new_lng` is not rejected but wrapped into `[-180, 180)`, so `370` is read as
+`10` east.
+
 ## What Changes
 
-| Unchanged              | Recalculated                    |
-| :--------------------- | :------------------------------ |
-| All planetary positions | Ascendant (1st house cusp)     |
-| Planetary speeds        | Medium Coeli (10th house cusp) |
-| Aspects between planets | All 12 house cusps             |
-| Fixed star positions    | Descendant, Imum Coeli         |
-|                        | Planet-in-house assignments     |
+| Unchanged               | Recalculated                                                |
+| :---------------------- | :---------------------------------------------------------- |
+| All planetary positions | Ascendant, Medium Coeli, Descendant, Imum Coeli             |
+| Planetary speeds        | All 12 house cusps                                          |
+| Aspects between planets | Vertex and Anti-Vertex                                      |
+| Fixed star longitudes   | Planet-in-house assignments, fixed stars and midpoints included |
+| Midpoint longitudes     | `is_diurnal`, and the essential dignities that depend on sect |
+|                         | The Ascendant-derived Arabic parts, with the re-selected sect |
+|                         | `polar_house_fallbacks` and `coincident_house_cusps`         |
+|                         | The local ISO datetime, when `new_tz_str` is given           |
+
+Three per-point enrichments describe the natal horizon and cannot survive the
+move, so they are reset to `None` rather than carried over stale: `azimuth`,
+`altitude_above_horizon` and `gauquelin_sector` on every point (fixed stars
+included), along with `gauquelin_sector_cusps` on the subject.
+
+For a sidereal subject the house ring is computed tropically and then shifted
+by the natal `ayanamsa_value`, the same value the natal cusps used, so the
+relocated cusps land in the subject's own sidereal zodiac.
 
 ## Use Cases
 

--- a/site/docs/report.md
+++ b/site/docs/report.md
@@ -2,7 +2,7 @@
 title: 'Report Module'
 description: 'Generate human-readable text reports and tables from your astrological data. Ideal for CLI applications, debugging, and consolidated chart summaries.'
 category: 'Core'
-tags: ['docs', 'reports', 'cli', 'kerykeion']
+tags: ['docs', 'reports', 'kerykeion']
 order: 5
 ---
 
@@ -64,7 +64,12 @@ The simplest way to use the generator is to print the report directly to `stdout
 ```python
 from kerykeion import ReportGenerator, AstrologicalSubjectFactory
 
-subject = AstrologicalSubjectFactory.from_birth_data("Alice", 1990, 6, 15, 12, 0, "London", "GB")
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Alice", 1990, 6, 15, 12, 0,
+    city="London", nation="GB",
+    lng=-0.1257, lat=51.5085, tz_str="Europe/London",
+    online=False,
+)
 ReportGenerator(subject).print_report()
 ```
 
@@ -101,16 +106,17 @@ Alice — Subject Report
 | Active Points Count | 14                  |
 +---------------------+---------------------+
 
-+Celestial Points-------+--------+----------+--------------+---------+------+---------------+
-| Point                 | Sign   | Position | Speed        | Decl.   | Ret. | House         |
-+-----------------------+--------+----------+--------------+---------+------+---------------+
-| Ascendant             | Vir ♍ | 14.74°   | +253.7350°/d | N/A     | -    | First House   |
-| Medium Coeli          | Gem ♊ | 9.98°    | +338.4840°/d | N/A     | -    | Tenth House   |
-| Sun                   | Gem ♊ | 24.09°   | +0.9551°/d   | +23.31° | -    | Tenth House   |
-| Moon                  | Pis ♓ | 14.80°   | +13.3469°/d  | -3.13°  | -    | Seventh House |
-| Mercury               | Gem ♊ | 5.62°    | +1.7140°/d   | +19.60° | -    | Ninth House   |
-| ...                                                                                       |
-+-----------------------+--------+----------+--------------+---------+------+---------------+
++Celestial Points-------+--------+----------+--------------+------------+---------+-----+------+---------------+
+| Point                 | Sign   | Position | Speed        | Motion     | Decl.   | OOB | Ret. | House         |
++-----------------------+--------+----------+--------------+------------+---------+-----+------+---------------+
+| Ascendant             | Vir ♍ | 14.74°   | +253.7365°/d | -          | N/A     | -   | -    | First House   |
+| Medium Coeli          | Gem ♊ | 9.98°    | +338.4858°/d | -          | N/A     | -   | -    | Tenth House   |
+| Sun                   | Gem ♊ | 24.09°   | +0.9551°/d   | Average    | +23.31° | -   | -    | Tenth House   |
+| Moon                  | Pis ♓ | 14.80°   | +13.3469°/d  | Average    | -3.13°  | -   | -    | Seventh House |
+| Mercury               | Gem ♊ | 5.62°    | +1.7140°/d   | Fast       | +19.60° | -   | -    | Ninth House   |
+| Uranus                | Cap ♑ | 8.17°    | -0.0389°/d   | Retrograde | -23.51° | Y   | R    | Fourth House  |
+| ...                                                                                                             |
++-----------------------+--------+----------+--------------+------------+---------+-----+------+---------------+
 
 ...
 
@@ -130,11 +136,14 @@ Use `generate_report()` to return the string instead of printing it.
 ```python
 from kerykeion import ChartDataFactory
 
+from pathlib import Path
+
 natal_data = ChartDataFactory.create_natal_chart_data(subject)
 report_text = ReportGenerator(natal_data).generate_report(include_aspects=True)
 
-with open("report.txt", "w") as f:
-    f.write(report_text)
+output_dir = Path("charts_output")
+output_dir.mkdir(exist_ok=True)
+(output_dir / "report.txt").write_text(report_text, encoding="utf-8")
 ```
 
 ### Synastry / Transit Report
@@ -181,18 +190,21 @@ See the [Moon Phase Details Factory](/content/docs/moon_phase_details_factory) d
 
 ## Configuration
 
-| Parameter         | Type                                                                    | Default      | Description                                                                                          |
-| :---------------- | :---------------------------------------------------------------------- | :----------- | :--------------------------------------------------------------------------------------------------- |
-| `model`           | `ChartDataModel`, `AstrologicalSubjectModel`, or `MoonPhaseOverviewModel` | **Required** | The data model to generate the report for.                                                           |
-| `include_aspects` | `bool`                                                                  | `True`       | Include the Aspect table (default: `True`). Ignored for moon phase overview reports.                 |
-| `max_aspects`     | `int`                                                                   | `None`       | Limit the number of aspects shown (default: `None` = all). Ignored for moon phase overview reports.  |
+`ReportGenerator(model, *, include_aspects=True, max_aspects=None)` — everything
+after `model` is keyword-only.
+
+| Parameter         | Type   | Default      | Description                                                                                          |
+| :---------------- | :----- | :----------- | :--------------------------------------------------------------------------------------------------- |
+| `model`           | One of the nine models listed under [Supported Inputs](#supported-inputs): `ChartDataModel` (`SingleChartDataModel` / `DualChartDataModel`), `AstrologicalSubjectModel`, `MoonPhaseOverviewModel`, `ProfectionsModel`, `FirdariaModel`, `HoraryIndicatorsModel`, `MutualReceptionsModel`, `DominantsModel`, `ZodiacalReleasingModel` | **Required** | The data model to generate the report for. |
+| `include_aspects` | `bool` | `True`       | Include the Aspect table. Ignored by the report layouts that have none.                              |
+| `max_aspects`     | `int \| None` | `None` | Limit the number of aspects shown (`None` = all). Ignored by the report layouts that have none.      |
 
 ## Public API
 
 | Method                                                           | Description                             |
 | :--------------------------------------------------------------- | :-------------------------------------- |
-| `generate_report(include_aspects=None, max_aspects=None) -> str` | Build the report content as a string.   |
-| `print_report(include_aspects=None, max_aspects=None) -> None`   | Print the generated report to `stdout`. |
+| `generate_report(*, include_aspects=None, max_aspects=None) -> str` | Build the report content as a string. Both arguments are keyword-only; `None` keeps the constructor's value. |
+| `print_report(*, include_aspects=None, max_aspects=None) -> None`   | Print the generated report to `stdout`, same arguments. |
 
 ---
 

--- a/site/docs/retrograde_station_factory.md
+++ b/site/docs/retrograde_station_factory.md
@@ -47,7 +47,7 @@ sidereal = RetrogradeStationFactory.from_iso_range(
 | :-------------- | :--------------------- | :----------- | :------------------------------------------------------------------------- |
 | `start_date`    | str (ISO)              | --           | Range start (a date-only value starts at 00:00 UTC).                      |
 | `end_date`      | str (ISO)              | --           | Range end (a date-only value is widened through the end of that UTC day). |
-| `planets`       | list[str] or None      | None         | Subset of planet names. Defaults to Mercury–Pluto.                       |
+| `planets`       | list[str] or None      | None         | Subset of planet names. Defaults to Mercury–Pluto; `"Chiron"` is accepted on request. Any other name (the Sun and the Moon included, since they never station) raises `ValueError`. |
 | `zodiac_type`   | `ZodiacType`           | `"Tropical"` | `"Tropical"` or `"Sidereal"`; affects reported longitude/sign, not station time. |
 | `sidereal_mode` | `SiderealMode` or None | None         | Required ayanamsha when `zodiac_type="Sidereal"`.                       |
 
@@ -82,6 +82,87 @@ Each `StationModel` item has:
 | `sign_num`           | int   | Sign index (0–11).                                  |
 | `degree`             | float | Degree within the sign (0–30).                      |
 | `ecliptic_longitude` | float | Absolute ecliptic longitude (0–360).                |
+
+## Retrograde Periods
+
+Stations answer *when did the motion turn?*. Retrograde periods answer *was
+this planet retrograde on that date?* -- the spans of retrograde motion
+themselves, so a planet that neither turned retrograde nor turned direct
+inside the range is still reported, with both bounds flagged as the range
+edges. A retrograde station opens a span, a direct station closes it, and the
+range clips whatever it cuts.
+
+```python
+from kerykeion import RetrogradeStationFactory
+
+periods = RetrogradeStationFactory.retrograde_periods_from_iso_range(
+    "2026-01-01", "2026-12-31", planets=["Mercury"]
+)
+for period in periods.periods:
+    print(period.planet, period.start, "->", period.end, period.start_clipped, period.end_clipped)
+# Mercury 2026-02-26T06:48:10Z -> 2026-03-20T19:32:50Z False False
+# Mercury 2026-06-29T17:35:55Z -> 2026-07-23T22:57:51Z False False
+# Mercury 2026-10-24T07:12:42Z -> 2026-11-13T15:53:52Z False False
+```
+
+`"Chiron"` is opt-in here too, and its slow retrograde arcs show the clipping:
+
+```python
+chiron = RetrogradeStationFactory.retrograde_periods_from_iso_range(
+    "2026-01-01", "2026-12-31", planets=["Chiron"]
+)
+first = chiron.periods[0]
+print(first.start, first.start_clipped)  # 2026-01-01T00:00:00Z True
+```
+
+### `retrograde_periods_from_iso_range(start_date, end_date, planets=None, zodiac_type="Tropical", sidereal_mode=None)`
+
+Same parameters as `from_iso_range`. **Returns:** `RetrogradePeriodsCollectionModel`.
+
+### `retrograde_periods_from_julian_day(start_jd, end_jd, planets=None, zodiac_type="Tropical", sidereal_mode=None)`
+
+Same as above with Julian Day (UT) bounds. **Raises** the same
+`KerykeionException` / `ValueError` as `from_julian_day`, plus a
+`KerykeionException` when the stations of one planet do not alternate (a
+retrograde station while already retrograde, or a direct station while
+direct).
+
+### `RetrogradePeriodsCollectionModel`
+
+| Field      | Type  | Description                                          |
+| :--------- | :---- | :--------------------------------------------------- |
+| `start_jd` | float | Requested Julian Day (UT) range start.               |
+| `end_jd`   | float | Requested Julian Day (UT) range end.                 |
+| `periods`  | list  | The `RetrogradePeriodModel` spans, planet by planet. |
+
+Each `RetrogradePeriodModel` item has:
+
+| Field           | Type  | Description                                                          |
+| :-------------- | :---- | :------------------------------------------------------------------- |
+| `planet`        | str   | Planet the span belongs to.                                          |
+| `start_jd`      | float | Julian Day (UT) the retrograde motion begins, clipped to the range start. |
+| `end_jd`        | float | Julian Day (UT) the retrograde motion ends, clipped to the range end. |
+| `start`         | str   | ISO 8601 UTC of `start_jd`.                                          |
+| `end`           | str   | ISO 8601 UTC of `end_jd`.                                            |
+| `start_clipped` | bool  | True when the planet was already retrograde at the range start.      |
+| `end_clipped`   | bool  | True when the planet is still retrograde at the range end.           |
+
+A period carries no sign: a station instant is the same in every zodiac, so
+`zodiac_type` and `sidereal_mode` change nothing in the output beyond being
+validated.
+
+**Clipping and the range edges.** A clipped bound says where the range cut the
+span, not where the real station is: nothing is searched outside the range
+except a single edge probe. That probe reaches a solver's resolution -- 50 ms,
+ten times the bisection's own error and twenty times finer than the second the
+ISO strings resolve -- past either bound, so a range whose bound is a station
+instant this library reported behaves as intended: a station on the range
+start sets the initial motion (rather than the sign of a speed that is
+numerically zero there) and a station on the range end closes its span
+unclipped. A station any farther from a bound, however close, is a real
+station. Spans within the range are exactly the instants `from_julian_day`
+reports for the same range. An empty or inverted range yields no periods, and
+only a zero-length span is dropped.
 
 ---
 

--- a/site/docs/schemas.md
+++ b/site/docs/schemas.md
@@ -89,6 +89,36 @@ Detailed information about a celestial body or house cusp.
 | `motion_state` | `MotionState \| None`           | Speed classification (`retrograde`/`stationary`/`stationary_retrograde`/`stationary_direct`/`slow`/`average`/`fast`). Populated for the ten planets in Earth-centred perspectives. |
 | `azimuth`    | `float \| None`                   | Azimuth angle in degrees. Requires `calculate_local_space=True` |
 | `altitude_above_horizon` | `float \| None`       | Altitude above horizon. Requires `calculate_local_space=True` |
+| `ecliptic_latitude` | `float \| None`            | Ecliptic latitude in degrees north (+) or south (-) of the ecliptic plane |
+| `decan_number` | `int \| None`                  | Decan (1-3) within the sign, each spanning 10° |
+| `decan_ruler`  | `str \| None`                  | Ruling planet of the Chaldean decan |
+| `term_ruler`   | `str \| None`                  | Ruling planet of the Egyptian term (bound) |
+| `dignity_score` | `int \| None`                 | Net Ptolemaic dignity score: the sum of every applicable dignity (domicile +5, exaltation +4, triplicity +3, term +2, face +1) and debility (detriment -5, fall -4) |
+| `nakshatra_number` | `int \| None`              | Nakshatra number (1-27). Requires `calculate_nakshatra=True` |
+
+**Provenance fields.** Every point records where its numbers came from:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| `source` | `str \| None` | Ephemeris or derivation source selected for this point (`LEB`, `SPK`, `Skyfield`, `Analytical`, `Derived`, ...) |
+| `precision_class` | `str \| None` | Machine-readable source class: `ephemeris`, `analytical`, `numerical-model`, `approximate`, `mixed`, `unverified-local` |
+| `source_reviewed` | `bool \| None` | Whether the active source artifact passed the backend's pinned review gate |
+| `ephemeris_coverage_start_jd` | `float \| None` | First Julian Day covered by the selected source, when the backend reports it |
+| `ephemeris_coverage_end_jd` | `float \| None` | Last Julian Day covered by the selected source, when the backend reports it |
+
+**Fixed-star discovery fields.** Populated on the points returned by
+[`FixedStarDiscoveryFactory`](/content/docs/fixed_star_discovery_factory) and
+left `None` everywhere else:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| `near_point` | `str \| None` | Nearest chart point that surfaced this star |
+| `aspect` | `str \| None` | Aspect name for the contact, usually `"conjunction"` |
+| `orb` | `float \| None` | Orb from `near_point` in degrees |
+| `longitude` | `float \| None` | Ecliptic longitude for discovery consumers; mirrors `abs_pos` |
+| `latitude` | `float \| None` | Ecliptic latitude for discovery results |
+| `degree` | `float \| None` | Degree within the sign for discovery consumers; mirrors `position` |
+
 
 ### SingleChartDataModel
 
@@ -209,9 +239,9 @@ substitute.
 - `polar_house_fallbacks` (`list[PolarHouseFallbackModel]`, empty when nothing was substituted) records each substitution: the requested and used systems, the real latitude, the latitude the successful call ran at, the epoch's polar threshold and obliquity, and which chart products changed.
 - `effective_houses_system_identifier` / `effective_houses_system_name` are derived from that list and report the division the cusps really came from. With no fallback they equal the requested pair.
 
-New in v5.12: `ayanamsa_value` (`float | None`) -- the computed ayanamsa offset in degrees for sidereal charts (`None` for tropical).
+`ayanamsa_value` (`float | None`) -- the computed ayanamsa offset in degrees for sidereal charts (`None` for tropical).
 
-New in v6: `nakshatra_ayanamsa` (`SiderealMode | None`) and `nakshatra_ayanamsa_value` (`float | None`) -- the ayanamsa a **non-sidereal** chart rotated its longitudes by to derive the nakshatras, and the offset in degrees it actually subtracted. Both are `None` on a sidereal chart (its own `sidereal_mode`/`ayanamsa_value` apply), on a chart that computed no nakshatras, and when `nakshatra_ayanamsa=None` selected the legacy uncorrected behaviour.
+`nakshatra_ayanamsa` (`SiderealMode | None`) and `nakshatra_ayanamsa_value` (`float | None`) -- the ayanamsa a **non-sidereal** chart rotated its longitudes by to derive the nakshatras, and the offset in degrees it actually subtracted. Both are `None` on a sidereal chart (its own `sidereal_mode`/`ayanamsa_value` apply), on a chart that computed no nakshatras, and when `nakshatra_ayanamsa=None` selected the legacy uncorrected behaviour.
 
 ### EphemerisDictModel
 
@@ -474,6 +504,7 @@ These models are returned by the v6 advanced calculation factories. Each factory
 | `OccultationModel` | [`OccultationFactory`](/content/docs/occultation_factory) | A single lunar occultation event |
 | `ACGLineModel` | [`AstroCartographyFactory`](/content/docs/astro_cartography_factory) | A planetary line on the ACG map |
 | `ACGLinePointModel` | `AstroCartographyFactory` | A geographic coordinate on an ACG line |
+| `FixedStarMetadataModel` | [`FixedStarCatalog`](/content/docs/fixed_star_discovery_factory) | One catalog entry: `name`, `slug`, `hip_number`, `nomenclature`, `magnitude`, `constellation` |
 
 ### Traditional / Hellenistic Models
 
@@ -489,6 +520,43 @@ These models are returned by the v6 advanced calculation factories. Each factory
 | `HoraryIndicatorsModel` | [`HoraryIndicatorsFactory`](/content/docs/horary_factory) | Horary chart analysis with significators and considerations |
 | `HorarySignificatorModel` | `HoraryIndicatorsFactory` | A horary significator planet |
 | `HoraryConsiderationModel` | `HoraryIndicatorsFactory` | A horary consideration before judgment |
+| `DominantsModel` | [`DominantsFactory`](/content/docs/dominants_factory) | Full dominants result: per-category score tables plus the winning planet/sign/element/quality/house and the score breakdown |
+| `DominantScoreModel` | `DominantsFactory` | One scored entry (`name`, `score`, `percentage`, `rank`, `is_dominant`) |
+| `DominantBreakdownItemModel` | `DominantsFactory` | One audit row explaining where a score came from (`category`, `target`, `rule`, `points`, `detail`) |
+| `ZodiacalReleasingModel` | [`ZodiacalReleasingFactory`](/content/docs/zodiacal_releasing_factory) | Aphesis timeline from the Lot of Fortune or Spirit, plus the current path |
+| `ZRPeriodModel` | `ZodiacalReleasingFactory` | One releasing period, with `is_angular`, `is_loosing_the_bond` and nested `subperiods` |
+| `TriplicityLordsModel` | `kerykeion.dignities.get_triplicity_lords` | Primary, secondary and participating triplicity lords for an element and sect |
+
+### Calendar / Event Models
+
+Returned by the factories that scan a date range for discrete moments. Every
+collection carries the requested `start_jd` / `end_jd` alongside its results,
+and every instant is a timezone-aware UTC datetime unless the field name says
+Julian Day.
+
+| Model | Factory | Description |
+| :---- | :------ | :---------- |
+| `LunationModel` | [`LunationFinderFactory`](/content/docs/lunation_factory) | One New/First-Quarter/Full/Last-Quarter Moon, with the Sun and Moon positions at that instant |
+| `LunationsCollectionModel` | `LunationFinderFactory` | `lunations` over the requested range |
+| `StationModel` | [`RetrogradeStationFactory`](/content/docs/retrograde_station_factory) | One retrograde or direct station: `planet`, `station_type`, instant, sign and longitude |
+| `RetrogradeStationsCollectionModel` | `RetrogradeStationFactory` | `stations` over the requested range |
+| `RetrogradePeriodModel` | `RetrogradeStationFactory` | A complete retrograde arc (`start`/`end`), with `start_clipped` / `end_clipped` when the range cut it |
+| `RetrogradePeriodsCollectionModel` | `RetrogradeStationFactory` | `periods` over the requested range |
+| `IngressModel` | [`SignIngressFactory`](/content/docs/sign_ingress_factory) | One sign change: `from_sign` to `sign`, `retrograde`, and `season_marker` for the solstice/equinox ingresses |
+| `SignIngressesCollectionModel` | `SignIngressFactory` | `ingresses` over the requested range |
+| `SignPeriodModel` | `SignIngressFactory` | The stay of one planet in one sign, with the same clip flags |
+| `SignPeriodsCollectionModel` | `SignIngressFactory` | `periods` over the requested range |
+| `MundaneAspectModel` | [`MundaneAspectFactory`](/content/docs/mundane_aspects_factory) | One exact transiting-to-transiting aspect, with both points' longitude, sign and retrograde state |
+| `MundaneAspectsCollectionModel` | `MundaneAspectFactory` | `aspects` over the requested range |
+| `TransitEventModel` | [`TransitsTimeRangeFactory`](/content/docs/transits_time_range_factory) | One transit contact grouped into an event: `applying_start`, `exact_moment`, `separating_end`, `min_orb`, `orb_rate` |
+| `TransitEventsTimeRangeModel` | `TransitsTimeRangeFactory` | Chronological `events` plus the natal `subject` they were measured against |
+| `VoidOfCourseMoonModel` | [`VoidOfCourseMoonFactory`](/content/docs/void_of_course_moon_factory) | Void state at one moment: `is_void_of_course`, the window, and the aspects that bound it |
+| `VoidOfCourseWindowModel` | `VoidOfCourseMoonFactory` | One complete void window with its `duration_minutes` |
+| `VoidOfCourseWindowsCollectionModel` | `VoidOfCourseMoonFactory` | Non-overlapping `windows` over the requested range |
+| `VoidOfCourseAspectModel` | `VoidOfCourseMoonFactory` | The `planet`, `aspect`, `aspect_degrees` and `exact_time` of a bounding aspect |
+| `SunTimesModel` | [`SunTimesFactory`](/content/docs/sun_times_factory) | Sunrise, sunset, solar noon, day length, the three twilights, and the polar day/night flags |
+| `PlanetaryHoursModel` | [`PlanetaryHoursFactory`](/content/docs/planetary_hours_factory) | The planetary day: `day_ruler`, `current_index`, `current_ruler`, its three bounding solar events, and all 24 `hours` |
+| `PlanetaryHourModel` | `PlanetaryHoursFactory` | One unequal hour: `index`, `ruler`, `is_diurnal`, `start`, `end` |
 
 ### Chart Analysis Models
 
@@ -717,7 +785,7 @@ The Ayanamsa (precession mode) used for Sidereal calculations.
 
 48 modes total: 47 named + USER for custom ayanamsa definitions.
 
-**Classic modes (pre-v5.12):**
+**Classic modes:**
 
 | Value               | Description                                                  |
 | :------------------ | :----------------------------------------------------------- |
@@ -742,7 +810,7 @@ The Ayanamsa (precession mode) used for Sidereal calculations.
 | `"J1900"`           | Julian epoch J1900.0 reference frame.                        |
 | `"B1950"`           | Besselian epoch B1950.0 reference frame.                     |
 
-**New in v5.12:**
+**Extended modes:**
 
 | Value                       | Category           | Description                                          |
 | :-------------------------- | :----------------- | :--------------------------------------------------- |
@@ -1041,7 +1109,7 @@ These models are used internally for SVG generation but exposed for advanced cus
 
 ### `ChartTemplateModel`
 
-Variables passed to the Jinja2 template for rendering the SVG.
+Variables passed to the XML `string.Template` for rendering the SVG.
 
 | Field                                  | Type    | Description                                            |
 | :------------------------------------- | :------ | :----------------------------------------------------- |

--- a/site/docs/settings.md
+++ b/site/docs/settings.md
@@ -20,7 +20,9 @@ Import from: `kerykeion.settings.config_constants`
 | :------------------------------------- | :----------------------------------------------------------------- |
 | `DEFAULT_ACTIVE_POINTS`                | Standard points: Sun, Moon, the planets, the True North Node, Chiron, plus Asc & MC (14 points) |
 | `TRADITIONAL_ASTROLOGY_ACTIVE_POINTS`  | Classical planets (Sun-Saturn) + True Lunar Nodes (9 points)       |
-| `ALL_ACTIVE_POINTS`                    | Complete list including asteroids, TNOs, Uranian points, and Arabic parts (no fixed stars -- those are requested via `active_fixed_stars`) |
+| `ALL_ACTIVE_POINTS`                    | Complete list including asteroids, TNOs, Uranian points, and Arabic parts (53 names; no fixed stars -- those are requested via `active_fixed_stars`) |
+| `V5_DEFAULT_ACTIVE_POINTS`             | The v5 default set (18 points), for reproducing pre-v6 output. Also importable from `kerykeion.settings` |
+| `DEFAULT_PREDICTIVE_POINTS`            | The 14 points the predictive factories scan by default. Import from `kerykeion.settings.chart_defaults` |
 
 ```python
 from kerykeion.settings.config_constants import (
@@ -51,6 +53,12 @@ subject = AstrologicalSubjectFactory.from_birth_data(
 | `DEFAULT_ACTIVE_ASPECTS`         | Core aspects (conj, opp, trine, sextile, square)     |
 | `ALL_ACTIVE_ASPECTS`             | Includes minor aspects (semi-sextile, quincunx, etc.)            |
 | `DISCEPOLO_SCORE_ACTIVE_ASPECTS` | Orbs per Ciro Discepolo scoring methodology                      |
+| `PREDICTIVE_ACTIVE_ASPECTS`      | The five Ptolemaic aspects at a flat 3° orb -- the default for transits, returns and progressions |
+
+`DEFAULT_NATAL_POINT_ORB_ADJUSTMENTS` (`{"Sun": 1.5, "Moon": 1.5}`) widens the
+orb for the luminaries in natal work; see
+[Aspects](/content/docs/aspects) for how the adjustments
+are combined.
 
 ```python
 from kerykeion import AspectsFactory
@@ -71,6 +79,29 @@ Import from: `kerykeion.settings.chart_defaults` (also re-exported from `kerykei
 | `DEFAULT_CHART_COLORS`              | Default color scheme for charts.             |
 | `DEFAULT_CELESTIAL_POINTS_SETTINGS` | Default settings for planets (colors, etc.). |
 | `DEFAULT_CHART_ASPECTS_SETTINGS`    | Default aspect configuration.                |
+| `KNOWN_GLYPH_NAMES`                 | `frozenset` of the 55 point names that ship a dedicated SVG `<symbol>`. |
+
+Two builders extend the celestial-point settings at render time with entries the
+static table cannot hold, because the names are only known once the chart is
+computed:
+
+| Helper | Signature | Purpose |
+| :----- | :-------- | :------ |
+| `build_dynamic_fixed_star_settings` | `(star_names: list[str], existing_settings: list \| tuple)` | Appends a settings entry per catalog fixed star in the chart. |
+| `build_dynamic_midpoint_settings` | `(midpoint_names: list[str], existing_settings: list \| tuple)` | Appends a settings entry per computed midpoint. |
+| `resolve_glyph_id` | `(name: str) -> str` | Maps a point name to its SVG `<symbol>` id. Pair-specific midpoint names resolve to the generic `"Midpoint"` glyph; a name outside `KNOWN_GLYPH_NAMES` falls back to `"FixedStar"`. |
+
+### Fixed-Star and Zodiac Defaults
+
+Import from: `kerykeion.settings.config_constants`
+
+| Constant | Value | Description |
+| :------- | :---- | :---------- |
+| `DEFAULT_FIXED_STARS` | 23 names | The opt-in fixed-star preset: the 15 Behenian stars plus 8 further bright stars. |
+| `ROYAL_FIXED_STARS` | 4 names | Aldebaran, Regulus, Antares, Fomalhaut. |
+| `BEHENIAN_FIXED_STARS` | 15 names | The medieval Behenian set (the 4 Royal Stars among them). |
+| `DEFAULT_SIDEREAL_MODE` | `"FAGAN_BRADLEY"` | Ayanamsa used when `zodiac_type="Sidereal"` and no `sidereal_mode` is given. |
+| `DEFAULT_NAKSHATRA_AYANAMSA` | `"LAHIRI"` | Ayanamsa used to place nakshatras on a non-sidereal chart. |
 
 ## Settings Model
 
@@ -120,6 +151,21 @@ overrides = {
     }
 }
 settings = load_language_settings(overrides)
+```
+
+### `load_language_pair`
+
+`load_language_pair(language, overrides=None) -> tuple[dict, dict]`
+
+Returns `(selected_language, english_fallback)` and materializes only those two,
+avoiding the full-table deepcopy `load_language_settings` performs. This is what
+`ChartDrawer` uses to resolve its labels.
+
+```python
+from kerykeion.settings import load_language_pair
+
+italian, english = load_language_pair("IT")
+print(italian["celestial_points"]["Sun"])
 ```
 
 ### `load_settings_mapping` (deprecated)

--- a/site/docs/sign_ingress_factory.md
+++ b/site/docs/sign_ingress_factory.md
@@ -88,6 +88,78 @@ Each `IngressModel` item has:
 `season_marker` is deliberately `None` for every sidereal ingress: a sidereal
 cardinal-sign boundary is not the astronomical equinox or solstice.
 
+## Sign Periods
+
+Ingresses answer *when does the sign change?*. Sign periods answer *which sign
+is this planet in on that date?* -- the stays themselves, so a planet that does
+not change sign at all inside the range is still reported, as a single stay
+covering the whole range. Per planet the stays are contiguous and ordered: the
+`end` of one is the `start` of the next, which is the ingress instant, and
+together they cover the range from bound to bound.
+
+```python
+from kerykeion import SignIngressFactory
+
+periods = SignIngressFactory.sign_periods_from_iso_range(
+    "2026-01-01", "2026-12-31", planets=["Jupiter"]
+)
+for period in periods.periods:
+    print(period.planet, period.sign, period.start, "->", period.end, period.start_clipped, period.end_clipped)
+# Jupiter Can 2026-01-01T00:00:00Z -> 2026-06-30T05:52:22Z True False
+# Jupiter Leo 2026-06-30T05:52:22Z -> 2027-01-01T00:00:00Z False True
+```
+
+The Moon is opt-in here as well (`planets=[..., "Moon"]`), and gives roughly
+thirteen stays a month.
+
+### `sign_periods_from_iso_range(start_date, end_date, planets=None, zodiac_type="Tropical", sidereal_mode=None)`
+
+Same parameters as `from_iso_range`. **Returns:** `SignPeriodsCollectionModel`.
+
+### `sign_periods_from_julian_day(start_jd, end_jd, planets=None, zodiac_type="Tropical", sidereal_mode=None)`
+
+Same as above with Julian Day (UT) bounds, and the same
+`KerykeionException` / `ValueError` as `from_julian_day`.
+
+### `SignPeriodsCollectionModel`
+
+| Field      | Type  | Description                                    |
+| :--------- | :---- | :--------------------------------------------- |
+| `start_jd` | float | Requested Julian Day (UT) range start.         |
+| `end_jd`   | float | Requested Julian Day (UT) range end.           |
+| `periods`  | list  | The `SignPeriodModel` stays, planet by planet. |
+
+Each `SignPeriodModel` item has:
+
+| Field           | Type  | Description                                                    |
+| :-------------- | :---- | :-------------------------------------------------------------- |
+| `planet`        | str   | Planet the stay belongs to.                                    |
+| `sign`          | str   | Sign the planet is in for the whole stay.                      |
+| `sign_num`      | int   | Index of that sign (0–11, 0 = Aries).                          |
+| `start_jd`      | float | Julian Day (UT) the stay begins, clipped to the range start.   |
+| `end_jd`        | float | Julian Day (UT) the stay ends, clipped to the range end.       |
+| `start`         | str   | ISO 8601 UTC of `start_jd`.                                    |
+| `end`           | str   | ISO 8601 UTC of `end_jd`.                                      |
+| `start_clipped` | bool  | True when the sign was entered before the range.               |
+| `end_clipped`   | bool  | True when the sign is left after the range.                    |
+
+The sign at the range start is read inside the same ephemeris session, and so
+in the same zodiac frame, as the ingress scan: a sidereal request yields
+sidereal stays with sidereal ingress instants, and the first stay can never
+disagree with the ingresses that follow it.
+
+**Clipping and the range edges.** A clipped bound is the range edge, not an
+ingress; nothing is searched outside the range except a single edge probe.
+That probe reaches a solver's resolution -- 50 ms, ten times the bisection's
+own error and twenty times finer than the second the ISO strings resolve --
+past either bound, so a range that starts or ends on an ingress instant this
+library reported opens or closes the stay there unclipped, instead of emitting
+a hair-thin stay on the wrong side of the crossing. An ingress any farther
+from a bound, inside or outside the range, is what it is: a boundary between
+two stays, or out of range. Ingresses within the range are exactly the
+instants `from_julian_day` reports for the same range. An empty or inverted
+range yields no periods.
+
 ---
 
 > **Need this in production?** Use the [Astrologer API](https://www.kerykeion.net/astrologer-api/subscribe) for hosted calculations, charts, and AI interpretations - no server setup required. [Learn more →](/content/docs/astrologer-api)

--- a/site/docs/sun_times_factory.md
+++ b/site/docs/sun_times_factory.md
@@ -44,11 +44,29 @@ Invalid coordinates, timezone names, and civil dates raise
 
 ## `SunTimesModel`
 
-The result contains `date`, `timezone`, `latitude`, `longitude`, `sunrise`,
-`sunset`, `solar_noon`, `day_length`, `is_polar_day`, `is_polar_night`,
-`civil_dawn`, `civil_dusk`, `nautical_dawn`, `nautical_dusk`,
-`astronomical_dawn`, and `astronomical_dusk`.
+All instants are timezone-aware UTC `datetime` objects; `day_length` is a
+`timedelta`.
 
-At high latitudes a date may have no complete sunrise-to-sunset pair. Missing
-events, `solar_noon`, or `day_length` are then `None`, and the applicable polar
-flag is set. On transition dates sunrise and sunset may be present independently.
+| Field | Type | Description |
+| :-- | :-- | :-- |
+| `date` | str | Civil date (`YYYY-MM-DD`) in the requested timezone. |
+| `timezone` | str | IANA timezone identifier the date is anchored to. |
+| `latitude` | float | Observer latitude in degrees, north positive. |
+| `longitude` | float | Observer longitude in degrees, east positive. |
+| `sunrise` | datetime or None | Sunrise (upper limb, atmospheric refraction applied). |
+| `sunset` | datetime or None | Sunset (upper limb, atmospheric refraction applied). |
+| `solar_noon` | datetime or None | Meridian transit -- true local noon, not the midpoint of the rise/set pair. |
+| `day_length` | timedelta or None | Sunset minus sunrise. |
+| `is_polar_day` | bool | The Sun stays above the horizon for the whole civil date. |
+| `is_polar_night` | bool | The Sun stays below the horizon for the whole civil date. |
+| `civil_dawn`, `civil_dusk` | datetime or None | Sun 6° below the horizon. |
+| `nautical_dawn`, `nautical_dusk` | datetime or None | Sun 12° below the horizon. |
+| `astronomical_dawn`, `astronomical_dusk` | datetime or None | Sun 18° below the horizon. |
+
+At high latitudes a date may have no complete sunrise-to-sunset pair. The
+missing events and `day_length` are then `None` and the applicable polar flag is
+set, but `solar_noon` is still reported -- the Sun culminates on a day it never
+rises -- and is `None` only when the backend cannot find the transit at all. On
+transition dates sunrise and sunset may be present independently, and a paired
+sunset may fall on the following civil date, so `day_length` can exceed 24
+hours when daylight spans local midnight.

--- a/site/docs/swisseph_configuration.md
+++ b/site/docs/swisseph_configuration.md
@@ -246,4 +246,4 @@ only Kerykeion's own AGPL-3.0 license applies.
 | Fixed stars | Native catalog | `sefstars.txt` file |
 
 For a detailed numerical comparison, see
-[Backend Precision Comparison](backend_precision_comparison.md).
+[Backend Precision Comparison](/content/docs/backend_precision_comparison).

--- a/site/docs/transits_time_range_factory.md
+++ b/site/docs/transits_time_range_factory.md
@@ -36,9 +36,10 @@ from kerykeion import AstrologicalSubjectFactory
 from kerykeion.ephemeris_data.factory import EphemerisDataFactory
 from kerykeion.transits.factory import TransitsTimeRangeFactory
 
-# 1. Create Natal Subject
+# 1. Create Natal Subject (offline mode: explicit coordinates, no GeoNames lookup)
 natal_subject = AstrologicalSubjectFactory.from_birth_data(
-    "Alice", 1990, 6, 15, 12, 0, "London", "GB"
+    "Alice", 1990, 6, 15, 12, 0,
+    lng=-0.1278, lat=51.5074, tz_str="Europe/London", online=False,
 )
 
 # 2. Generate Ephemeris Data (e.g., for 30 days starting now)
@@ -69,9 +70,20 @@ transit_factory = TransitsTimeRangeFactory(
 results = transit_factory.get_transit_moments()
 ```
 
+### Ephemeris Generation Errors
+
+`EphemerisDataFactory` raises `ValueError` for an invalid time series:
+
+- `step` is not a positive integer.
+- `step_type` is not `"days"`, `"hours"` or `"minutes"`.
+- The projected number of samples exceeds `max_days`, `max_hours` or `max_minutes`.
+- The range produces no dates at all — in particular an inverted range, where `end_datetime` precedes `start_datetime`, raises `ValueError("No dates found. Check the date range and step values.")`.
+
+All of these are raised while sizing the series, before any chart is computed.
+
 ## Analyzing Results
 
-The results contain a list of `transit_moments`, each representing a point in time where valid aspects were found.
+The results contain a list of `transits`, each entry representing a point in time where valid aspects were found.
 
 ```python
 print(f"Total time points analyzed: {len(results.transits)}")
@@ -88,10 +100,11 @@ for moment in results.transits:
 
 The `get_transit_moments()` method returns `TransitsTimeRangeModel`, a specialized object simplifying access to the data.
 
-- `results.dates`: List of all ISO timestamps checked.
-- `results.transits`: List of objects containing:
+- `results.transits`: List of `TransitMomentModel` objects containing:
   - `date`: The specific timestamp.
   - `aspects`: List of `AspectModel` objects (Transiting Planet -> Natal Planet).
+- `results.subject`: The natal `AstrologicalSubjectModel` the transits were measured against (`None` when it was not carried through).
+- `results.dates`: List of all ISO timestamps checked (`None` when not populated).
 
 ## Constructor Parameters
 
@@ -102,7 +115,7 @@ The `get_transit_moments()` method returns `TransitsTimeRangeModel`, a specializ
 | `active_points` | `List[AstrologicalPoint]` | `DEFAULT_ACTIVE_POINTS` | Points to include in calculation. |
 | `active_aspects` | `List[ActiveAspect]` | `PREDICTIVE_ACTIVE_ASPECTS` | Aspect types and orbs to use (tight 3° predictive orbs by default). |
 | `settings_file` | `Path`, `KerykeionSettingsModel`, `dict`, or `None` | `None` | Custom orb/calculation settings. |
-| `axis_orb_limit` | `float` | `None` | Finite, positive stricter orb for angles (Asc, MC). |
+| `axis_orb_limit` | `float` | `None` | Finite, positive stricter orb for angles (Asc, MC). Keyword-only. |
 
 ## Transit Events with Exact Moment Refinement (v6)
 
@@ -123,7 +136,9 @@ for ev in events.events[:5]:
 When `refine_exact_moments=True`, the factory performs a ternary search between the two ephemeris steps that bracket the minimum orb, yielding a much more precise `exact_moment` timestamp.
 
 The return type is `TransitEventsTimeRangeModel`: its chronological `events`
-list contains `TransitEventModel` objects. Each event records `p1_name`,
+list contains `TransitEventModel` objects, and `subject` carries the natal
+`AstrologicalSubjectModel` the events were measured against (`None` when it was
+not carried through). Each event records `p1_name`,
 `p2_name`, `aspect`, optional `applying_start`/`separating_end`, `exact_moment`,
 `min_orb`, and optional `orb_rate`. A missing phase boundary means it was
 outside the sampled range or missed by a step too coarse for that fast pass.

--- a/site/docs/tutorial.md
+++ b/site/docs/tutorial.md
@@ -384,8 +384,9 @@ report = ReportGenerator(natal_data)
 report_text = report.generate_report(max_aspects=10)
 
 # Save to file
-with open("alice_report.txt", "w") as f:
-    f.write(report_text)
+report_dir = Path("charts_output")
+report_dir.mkdir(exist_ok=True)
+(report_dir / "alice_report.txt").write_text(report_text, encoding="utf-8")
 ```
 
 ### Element and Quality Distribution

--- a/site/docs/utilities.md
+++ b/site/docs/utilities.md
@@ -17,9 +17,11 @@ Functions for handling circular degrees and zodiac positions.
 | Function                                           | Description                                               |
 | :------------------------------------------------- | :-------------------------------------------------------- |
 | `get_number_from_name(name)`                       | Converts point name (e.g., "Sun") to Swiss Ephemeris ID.  |
-| `get_kerykeion_point_from_degree(deg, name, point_type, speed=None, declination=None, magnitude=None)` | Creates a full `KerykeionPointModel` from a degree. |
+| `get_kerykeion_point_from_degree(deg, name, point_type, speed=None, declination=None, magnitude=None, ecliptic_latitude=None)` | Creates a full `KerykeionPointModel` from a degree. |
 | `circular_mean(pos1, pos2)`                        | Calculates mean of two angles, handling 0°/360° crossing. |
-| `is_point_between(start, end, point)`              | Checks if a degree lies between two others on a circle.   |
+| `is_point_between(start, end, point, *, allow_reflex=False)` | Checks if a degree lies on the arc from `start` to `end`. The arc is the short way round unless `allow_reflex=True`. |
+| `normalize_longitude(lng)`                         | A longitude into the `[-180, 180)` range the ephemeris backend expects. |
+| `wrap_180(angle)`                                  | An angle into the signed range `[-180, 180)`. |
 | `circular_sort(degrees)`                           | Sorts degrees clockwise starting from the first element.  |
 
 ```python
@@ -48,8 +50,11 @@ Functions for working with astrological houses.
 | `validate_latitude(lat)`                     | Returns a finite latitude in [-90, 90] unchanged; otherwise raises `KerykeionException`. |
 | `validate_longitude(lng)`                    | Returns a finite longitude in [-180, 180] unchanged; otherwise raises `KerykeionException`. |
 | `check_and_adjust_polar_latitude(lat)`       | Clamps a latitude to the ±66° limit. Narrow use only — see below. |
+| `angle_house_identities(cusps, asc, mc)`     | Which house each angle opens, for the angles this chart puts on a cusp. |
+| `coincident_cusp_groups(cusps)`              | The sets of house numbers whose cusps stand on the same longitude. |
+| `HOUSE_FIELD_NAMES`                          | The twelve subject attribute names, in order: `("first_house", ..., "twelfth_house")`. |
 
-`check_and_adjust_polar_latitude` is **not** the general answer to a house system undefined inside the polar circle. A chart cast there keeps its real latitude and substitutes a house system that is defined everywhere; moving the observer instead would report cusps for a place the subject was not born in. The only remaining caller is `kerykeion/ephemeris_backend.py`, inside the `clamp_latitude` branch, which serves Gauquelin sectors alone: their 36-sector division has no 12-cusp substitute, so retrying just inside the limit is the only way to produce that shape at all. Use `validate_latitude` for plain range checks.
+`check_and_adjust_polar_latitude` is **not** the general answer to a house system undefined inside the polar circle. A chart cast there keeps its real latitude and substitutes a house system that is defined everywhere; moving the observer instead would report cusps for a place the subject was not born in. The only remaining caller is `kerykeion/ephemeris_backend/backend.py`, inside the `clamp_latitude` branch, which serves Gauquelin sectors alone: their 36-sector division has no 12-cusp substitute, so retrying just inside the limit is the only way to produce that shape at all. Use `validate_latitude` for plain range checks.
 
 ```python
 from kerykeion.utilities import get_planet_house, get_house_number
@@ -68,6 +73,45 @@ Functions for temporal conversions.
 | :----------------------- | :----------------------------------------------- |
 | `datetime_to_julian(dt)` | Converts Python `datetime` to Julian Day number. |
 | `julian_to_datetime(jd)` | Converts Julian Day number to Python `datetime`. |
+| `civil_jd(year, month, day, hour=0.0)` | Julian Day of a civil moment in the engine's calendar convention. BCE-safe. |
+| `civil_leap_year(year)`  | The leap rule in that same convention. |
+| `jd_to_iso_date(jd)`     | ISO date of a Julian Day, BCE-safe. |
+| `jd_to_iso_datetime(jd)` | ISO datetime (second resolution) of a Julian Day, BCE-safe. |
+| `parse_astronomical_iso_moment(value)` | Parses a naive ISO date/datetime into `(year, month, day, decimal_hour)`, astronomical years included. |
+
+### Timezones
+
+| Function | Description |
+| :------- | :---------- |
+| `safe_timezone(tz_str)` | Resolves an IANA name to a `ZoneInfo`, raising `KerykeionException` if it is not one. |
+| `is_nonexistent(naive, tz)` | Whether a naive wall time never occurred (spring-forward gap). |
+| `is_ambiguous(naive, tz)` | Whether a naive wall time occurred twice (fall-back fold). |
+| `localize_naive(naive, tz, *, is_dst=None)` | Attaches `tz` to a naive wall time, resolving a gap or fold explicitly rather than guessing. |
+
+### Formatting
+
+| Function | Description |
+| :------- | :---------- |
+| `format_ancient_iso(year, month, day, decimal_hour, utc_offset_hours)` | An ISO 8601 extended-year string for a possibly negative year. |
+| `format_astronomical_iso_date(year, month, day)` | `YYYY-MM-DD` with astronomical year numbering (0 = 1 BCE, -1 = 2 BCE). |
+| `format_iso_display(iso, fmt="%Y-%m-%d %H:%M")` | Formats an ISO datetime string for display, BCE included. |
+| `extract_year_from_iso(iso)` | The year as an `int`, BCE dates included. |
+| `format_degrees_below_bound(value, upper_bound, decimals=2)` | Formats a degree so the *rounded* string stays below `upper_bound` — a position of 29.999° never prints as `30.00`. |
+| `format_timedelta_hhmm(td)` | Renders a duration as `H:MM`, rounded to whole minutes. |
+
+### Subject Frames and Anchors
+
+Helpers that read a subject-like model without caring which model it is.
+
+| Function | Description |
+| :------- | :---------- |
+| `has_terrestrial_frame(subject)` | Whether the subject's planet longitudes share the angles' Earth frame. |
+| `require_same_frame(first, second)` | Raises when two subjects' reference frames differ — the guard a dual chart needs before comparing them. |
+| `TERRESTRIAL_PERSPECTIVES` | The `frozenset` those two test against: `Apparent Geocentric`, `True Geocentric`, `Topocentric`. |
+| `resolve_sect_is_diurnal(subject)` | Sect (day/night), defaulting to day. |
+| `resolve_subject_birth_datetime(subject)` | Local (naive) birth or anchor datetime. |
+| `resolve_subject_local_moment(subject)` | The same moment as `(year, month, day, decimal_hour)`. |
+| `resolve_subject_local_now(subject)` | Current wall-clock time in the subject's own timezone, naive. |
 
 ```python
 from kerykeion.utilities import datetime_to_julian
@@ -106,6 +150,7 @@ General purpose tools for list management, logging, and SVG optimization.
 | `inline_css_variables_in_svg(svg_content)`        | Replaces CSS variables with static values for export. |
 | `normalize_zodiac_type(str)`                      | Normalizes string to "Tropical" or "Sidereal".        |
 | `distribute_percentages_to_100(values)`           | Rounds percentages ensuring they sum exactly to 100%. |
+| `strip_illegal_control_chars(value)`              | Drops XML-1.0-illegal and terminal-control characters from a stringified value, so user text cannot break the SVG or the terminal. |
 
 ## Lunar Helpers
 

--- a/site/docs/void_of_course_moon_factory.md
+++ b/site/docs/void_of_course_moon_factory.md
@@ -10,8 +10,11 @@ order: 59
 
 `VoidOfCourseMoonFactory` uses the classical definition: the Moon is void after
 its last exact Ptolemaic aspect to the Sun, Mercury, Venus, Mars, Jupiter, or
-Saturn in its current sign, until the next sign ingress. The shared
-`PTOLEMAIC_ASPECTS` constant names the five aspect families. This calculation
+Saturn in its current sign, until the next sign ingress. The five aspects
+considered are conjunction, sextile, square, trine and opposition; the scan
+reads them from its own `PTOLEMAIC_ASPECTS` name/degree tuple in
+`kerykeion.void_of_course_moon.utils`, not from the top-level
+`kerykeion.PTOLEMAIC_ASPECTS` used by the predictive modules. This calculation
 is geocentric and needs no observer coordinates.
 
 ## Current State
@@ -32,21 +35,62 @@ print(state.void_start, state.void_end, state.last_aspect, state.next_aspect)
 For `zodiac_type="Sidereal"`, `sidereal_mode` is required; sign boundaries and
 therefore void windows shift with the ayanamsha.
 
+**Raises** `KerykeionException` for an invalid timezone, an invalid zodiac
+configuration, or a date outside the available ephemeris range.
+
 ## Range Search
 
 `from_iso_range(start_date, end_date, *, zodiac_type="Tropical", sidereal_mode=None) -> VoidOfCourseWindowsCollectionModel`
 
-ISO inputs are treated as UTC. A date-only end includes that entire UTC day.
-Returned windows are not clipped: the first can begin before `start_date` and
-the last can end after `end_date` when they intersect the requested range.
+Naive ISO inputs are treated as UTC; an offset-aware input is converted to UTC.
+A date-only end includes that entire UTC day. Returned windows are not clipped:
+the first can begin before `start_date` and the last can end after `end_date`
+when they intersect the requested range.
+
+**Raises** `KerykeionException` for a malformed ISO input, an invalid zodiac
+configuration, or an ephemeris-range failure mid-scan.
 
 ## Models
 
-- `VoidOfCourseMoonModel`: current boolean state, `moon_sign`, `next_sign`,
-  `ingress`, `void_start`, `void_end`, `last_aspect`, and `next_aspect`.
-- `VoidOfCourseWindowModel`: one full window, its signs, start/end,
-  `duration_minutes`, and opening `last_aspect`.
-- `VoidOfCourseWindowsCollectionModel`: requested `start_jd`/`end_jd` and the
-  chronological `windows` list.
-- `VoidOfCourseAspectModel`: target `planet`, `aspect`, exact angle, and
-  timezone-aware UTC `exact_time`.
+All instants are timezone-aware UTC datetimes.
+
+### `VoidOfCourseMoonModel`
+
+| Field               | Type                     | Description                                                              |
+| :------------------ | :----------------------- | :----------------------------------------------------------------------- |
+| `is_void_of_course` | bool                     | `True` if the queried moment lies inside the void window.                 |
+| `moon_sign`         | Sign                     | Sign the Moon currently occupies.                                         |
+| `next_sign`         | Sign                     | Sign the Moon ingresses into next.                                        |
+| `ingress`           | datetime                 | Moment the Moon enters `next_sign`; equals `void_end`.                    |
+| `void_start`        | datetime                 | Last in-sign aspect, or the sign-entry moment for a whole-sign void.      |
+| `void_end`          | datetime                 | End of the void window, equal to `ingress`.                               |
+| `last_aspect`       | VoidOfCourseAspectModel or None | Last exact aspect before ingress; `None` for a whole-sign void.    |
+| `next_aspect`       | VoidOfCourseAspectModel or None | First exact aspect after the ingress, which ends the lull.          |
+
+### `VoidOfCourseWindowModel`
+
+| Field              | Type                     | Description                                                        |
+| :----------------- | :----------------------- | :------------------------------------------------------------------ |
+| `moon_sign`        | Sign                     | Sign the Moon is leaving (where the void happens).                   |
+| `next_sign`        | Sign                     | Sign the Moon ingresses into, ending the void.                       |
+| `void_start`       | datetime                 | Start of the window — last in-sign aspect, or the sign-entry moment. |
+| `void_end`         | datetime                 | End of the window, i.e. the ingress instant.                         |
+| `duration_minutes` | float                    | Window length in minutes.                                            |
+| `last_aspect`      | VoidOfCourseAspectModel or None | Aspect that opened the void; `None` for a whole-sign void.     |
+
+### `VoidOfCourseWindowsCollectionModel`
+
+| Field      | Type                           | Description                            |
+| :--------- | :----------------------------- | :------------------------------------- |
+| `start_jd` | float                          | Requested Julian Day (UT) range start. |
+| `end_jd`   | float                          | Requested Julian Day (UT) range end.   |
+| `windows`  | list[VoidOfCourseWindowModel]  | Chronological, non-overlapping windows. |
+
+### `VoidOfCourseAspectModel`
+
+| Field            | Type     | Description                                                        |
+| :--------------- | :------- | :------------------------------------------------------------------ |
+| `planet`         | str      | Body the Moon aspects (Sun, Mercury, Venus, Mars, Jupiter, Saturn). |
+| `aspect`         | str      | Aspect name (conjunction, sextile, square, trine, opposition).      |
+| `aspect_degrees` | float    | The aspect's exact angle in degrees (0, 60, 90, 120, 180).          |
+| `exact_time`     | datetime | Moment the aspect perfects.                                          |

--- a/site/docs/zodiacal_releasing_factory.md
+++ b/site/docs/zodiacal_releasing_factory.md
@@ -17,7 +17,11 @@ A known birth time is required (the technique is built from the Ascendant and th
 ```python
 from kerykeion import AstrologicalSubjectFactory, ZodiacalReleasingFactory
 
-subject = AstrologicalSubjectFactory.from_birth_data("Jane", 1990, 6, 15, 12, 0, "Rome", "IT")
+# Offline mode: explicit coordinates, no GeoNames lookup
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Jane", 1990, 6, 15, 12, 0,
+    lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False,
+)
 
 zr = ZodiacalReleasingFactory.from_subject(subject, lot="fortune", levels=2, target_date="2026-06-04")
 print(zr.lot_sign, len(zr.periods), "top-level periods")
@@ -38,11 +42,20 @@ Build the zodiacal-releasing periods for a subject.
 | `lot`            | `"fortune"` / `"spirit"`   | `"fortune"`  | Which Lot to release from.                                                                |
 | `levels`         | int                        | 2            | Subdivision levels to compute (1–4). L1/L2 are built in full; deeper levels only along the target-date path. |
 | `target_date`    | str (ISO `YYYY-MM-DD`) or None | None     | Date used to mark the current period chain. When omitted, only full levels (≤ 2) are built. |
-| `life_cap_years` | int                        | (default)    | How far the L1 timeline extends, in years of life.                                       |
+| `life_cap_years` | int                        | 100          | How far the L1 timeline extends, in years of life (`DEFAULT_LIFE_CAP_YEARS`).             |
+
+When `target_date` falls beyond `life_cap_years`, the L1 timeline is extended to
+cover the target date plus a ten-year margin, so the current path is always
+resolvable. A shorter cap is never applied in that case.
 
 **Returns:** `ZodiacalReleasingModel`
 
-**Raises:** `KerykeionException` for an unknown `lot`, an unresolvable Lot (missing birth time), or an unparseable `target_date`.
+**Raises:** `KerykeionException` for an unknown `lot`; an unresolvable Lot
+(missing birth time, so no Ascendant/Sun/Moon); an unparseable `target_date`; a
+timezone-aware `target_date` (pass a bare ISO date such as `"2026-06-04"`); or a
+subject with no single moment in time to anchor the timeline — a midpoint
+composite. Returns and Davison charts are accepted: they resolve through their
+ISO timestamp.
 
 ## Data Models
 
@@ -58,7 +71,20 @@ Build the zodiacal-releasing periods for a subject.
 
 ### `ZRPeriodModel`
 
-Each period carries its ruling `sign`, `level` (L1–L4), start/end dates, sub-periods, and flags such as the "loosing of the bond" jump and peak/angular markers.
+One period at a given level of subdivision. Periods nest: an L1 (years) period
+contains L2 (months) sub-periods, and so on.
+
+| Field                 | Type                  | Description                                            |
+| :-------------------- | :-------------------- | :---------------------------------------------------- |
+| `sign`                | str                   | Three-letter code of the sign ruling the period (`"Ari"` … `"Pis"`). |
+| `ruler`               | str or None           | Traditional (domicile) ruler of that sign.          |
+| `level`               | int                   | Subdivision level (1 = years, 2 = months, 3 = days, …). |
+| `start`               | str                   | Start date (ISO `YYYY-MM-DD`).                      |
+| `end`                 | str                   | End date (ISO `YYYY-MM-DD`).                        |
+| `years`               | float                 | Nominal length in years at this level (the sign's general years divided by `12 ** (level - 1)`). |
+| `is_angular`          | bool                  | `True` for a peak period: the sign is angular (1st/4th/7th/10th) from the natal Lot of Fortune, the reference used for every released lot. |
+| `is_loosing_the_bond` | bool                  | `True` when the period begins after a "loosing of the bond" jump to the opposite sign. |
+| `subperiods`          | list[`ZRPeriodModel`] | Nested sub-periods one level deeper (possibly empty). |
 
 ---
 

--- a/site/examples/active-points.md
+++ b/site/examples/active-points.md
@@ -20,15 +20,16 @@ The `TRADITIONAL_ASTROLOGY_ACTIVE_POINTS` preset includes only the 7 classical p
 from kerykeion import AstrologicalSubjectFactory, ChartDataFactory
 from kerykeion.settings.config_constants import TRADITIONAL_ASTROLOGY_ACTIVE_POINTS
 
+# The preset belongs on from_birth_data: that is where the points are computed.
+# Passing it only to create_natal_chart_data would narrow the chart while the
+# subject kept its 14 defaults.
 subject = AstrologicalSubjectFactory.from_birth_data(
     "Traditional Chart", 1990, 6, 15, 12, 0,
     lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False,
-)
-
-chart_data = ChartDataFactory.create_natal_chart_data(
-    subject,
     active_points=TRADITIONAL_ASTROLOGY_ACTIVE_POINTS,
 )
+
+chart_data = ChartDataFactory.create_natal_chart_data(subject)
 
 # Only classical planets and nodes will appear
 for point_name in ["sun", "moon", "mars", "jupiter", "saturn"]:
@@ -118,12 +119,13 @@ subject = AstrologicalSubjectFactory.from_birth_data(
     active_fixed_stars=DEFAULT_FIXED_STARS,
 )
 
-chart_data = ChartDataFactory.create_natal_chart_data(
-    subject,
-    active_points=ALL_ACTIVE_POINTS,
-)
+chart_data = ChartDataFactory.create_natal_chart_data(subject)
 
-# Generate a chart with all 53 non-star points plus the configured fixed stars
+print(f"Points on the chart: {len(chart_data.subject.active_points)}")
+
+# 52, not 53: Earth is dropped in the default Apparent Geocentric perspective,
+# where it has no position as seen from itself. The configured fixed stars are
+# separate and are not counted here.
 chart = ChartDrawer(chart_data=chart_data)
 output_dir = Path("charts_output")
 output_dir.mkdir(exist_ok=True)

--- a/site/examples/chart-marks.md
+++ b/site/examples/chart-marks.md
@@ -1,0 +1,172 @@
+---
+title: 'Chart Marks'
+tags: ['examples', 'charts', 'marks', 'retrograde', 'out of bounds', 'kerykeion']
+order: 18
+---
+
+# Chart Marks
+
+Six constructor options draw facts the chart data already carries but the wheel
+never showed. All six default to `False`, so nothing new arrives on an upgrade,
+and each is **silent where it has no referent** — a chart with no station, a
+tropical zodiac, a house system that was honoured. Turning one on therefore
+cannot produce an empty claim: a chart that shows nothing is telling you there
+was nothing to show.
+
+| Option | Where it draws |
+| :--- | :--- |
+| `show_motion_state` | On the wheel: `SR` at a retrograde station, `SD` at a direct one, in the row that already holds `RX`. The modern style also recolours the planet's cluster. |
+| `show_out_of_bounds` | In the point tables, as an `OOB` badge past the retrograde glyph; in the Gauquelin grid, off the declination column. |
+| `show_aspect_movement` | On the aspect lines: a separating aspect is dashed, an applying one stays solid. |
+| `show_relationship_score` | In the info panel: `Relationship Score: 16 (Very Important)`. Needs a score on the chart data. |
+| `show_ayanamsa_value` | On a sidereal chart's zodiac line, after the mode name: `Ayanamsa: Lahiri (23°43')`. |
+| `show_polar_fallback_note` | On the domification line, as `Porphyry* (polar fallback)`, when the requested system was substituted. |
+
+Full reference: [Optional Marks](/content/docs/charts#optional-marks).
+
+## Turning them all on
+
+Switching on every mark is safe, and is how one flag set serves very different
+charts without any of them claiming something it does not have.
+
+```python
+from pathlib import Path
+
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
+
+MARKS_ALL_ON = {
+    "show_motion_state": True,
+    "show_out_of_bounds": True,
+    "show_aspect_movement": True,
+    "show_relationship_score": True,
+    "show_ayanamsa_value": True,
+    "show_polar_fallback_note": True,
+}
+
+output_dir = Path("charts_output")
+output_dir.mkdir(exist_ok=True)
+```
+
+## Stations, out-of-bounds, and aspect movement
+
+25 August 1990 carries three referents at once: Mercury crawls at 0.012°/day —
+a stationary retrograde — and Uranus sits past the Sun's maximum declination.
+
+```python
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Mercury Station", 1990, 8, 25, 12, 0,
+    city="London", nation="GB",
+    lng=-0.1276, lat=51.5074, tz_str="Europe/London",
+    online=False,
+)
+
+chart_data = ChartDataFactory.create_natal_chart_data(subject)
+
+print(subject.mercury.motion_state)      # stationary_retrograde
+print(subject.uranus.is_out_of_bounds)   # True
+
+ChartDrawer(chart_data, **MARKS_ALL_ON).save_svg(
+    output_path=output_dir,
+    filename="marks-wheel",
+)
+```
+
+**Output:**
+```
+stationary_retrograde
+True
+```
+
+![Marks on a wheel with a station and an out-of-bounds planet](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/docs/charts/marks_wheel_modern.svg)
+
+The same chart in the classic style, which writes the station letters at the
+foot of the glyph where its `℞` sits:
+
+![The same marks in the classic style](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/docs/charts/marks_wheel_classic.svg)
+
+## The ayanamsa value
+
+`show_ayanamsa_value` appends the offset to the zodiac line, and only a sidereal
+chart has one to append.
+
+```python
+sidereal = AstrologicalSubjectFactory.from_birth_data(
+    "John Lennon", 1940, 10, 9, 18, 30,
+    city="Liverpool", nation="GB",
+    lng=-2.9916, lat=53.4084, tz_str="Europe/London",
+    zodiac_type="Sidereal", sidereal_mode="LAHIRI",
+    online=False,
+)
+
+ChartDrawer(
+    ChartDataFactory.create_natal_chart_data(sidereal), **MARKS_ALL_ON
+).save_svg(output_path=output_dir, filename="marks-sidereal")
+```
+
+![A sidereal chart with the ayanamsa value on the zodiac line](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/docs/charts/marks_sidereal_modern.svg)
+
+## The polar fallback note
+
+Placidus is undefined inside the polar circle, so the cusps came from another
+system, and `show_polar_fallback_note` is what makes the info panel admit it.
+
+```python
+polar = AstrologicalSubjectFactory.from_birth_data(
+    "Longyearbyen", 1990, 6, 15, 12, 0,
+    city="Longyearbyen", nation="SJ",
+    lng=15.6, lat=78.2, tz_str="Arctic/Longyearbyen",
+    houses_system_identifier="P",
+    online=False,
+)
+
+print(polar.effective_houses_system_identifier)  # "O" — Porphyry stood in
+
+ChartDrawer(
+    ChartDataFactory.create_natal_chart_data(polar), **MARKS_ALL_ON
+).save_svg(output_path=output_dir, filename="marks-polar")
+```
+
+**Output:**
+```
+O
+```
+
+![A polar chart whose domification line admits the substitution](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/docs/charts/marks_polar_modern.svg)
+
+## The relationship score
+
+`create_synastry_chart_data` computes a score unless
+`include_relationship_score=False`, and `show_relationship_score` prints it.
+
+```python
+john = AstrologicalSubjectFactory.from_birth_data(
+    "John Lennon", 1940, 10, 9, 18, 30,
+    city="Liverpool", nation="GB",
+    lng=-2.9916, lat=53.4084, tz_str="Europe/London",
+    online=False,
+)
+paul = AstrologicalSubjectFactory.from_birth_data(
+    "Paul McCartney", 1942, 6, 18, 15, 30,
+    city="Liverpool", nation="GB",
+    lng=-2.9916, lat=53.4084, tz_str="Europe/London",
+    online=False,
+)
+
+ChartDrawer(
+    ChartDataFactory.create_synastry_chart_data(john, paul), **MARKS_ALL_ON
+).save_svg(output_path=output_dir, filename="marks-synastry")
+```
+
+![A synastry chart with the relationship score in the info panel](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/docs/charts/marks_synastry_modern.svg)
+
+## The state is in the SVG either way
+
+The marks decide what a reader sees drawn, not what the markup carries. Every
+ChartPoint group already holds `kr:motionstate`, `kr:speed`, `kr:declination`,
+`kr:oob` and `kr:retrograde` whether or not the corresponding option is on — so
+a consumer parsing the SVG never needs them switched on. See
+[Point State](/content/docs/charts#point-state).
+
+---
+
+> **Need this in production?** Use the [Astrologer API](https://www.kerykeion.net/astrologer-api/subscribe) for hosted calculations, charts, and AI interpretations - no server setup required. [Learn more →](/content/docs/astrologer-api)

--- a/site/examples/composite-chart.md
+++ b/site/examples/composite-chart.md
@@ -1,0 +1,156 @@
+---
+title: 'Composite Chart'
+tags: ['examples', 'composite', 'davison', 'relationships', 'charts', 'kerykeion']
+order: 20
+---
+
+# Composite Chart
+
+A composite chart is a single chart standing for the relationship itself, rather
+than a comparison of two charts the way synastry is. `CompositeSubjectFactory`
+builds one two ways from the same pair of subjects.
+
+| Method | What it does |
+| :--- | :--- |
+| `get_midpoint_composite_subject_model()` | Averages the two charts: every position is the midpoint of the two. |
+| `get_davison_composite_subject_model()` | Averages the two birth **moments** and **places**, then casts a real chart for that derived date and location. |
+
+## Midpoint composite
+
+```python
+from pathlib import Path
+
+from kerykeion import (
+    AstrologicalSubjectFactory,
+    ChartDataFactory,
+    ChartDrawer,
+    CompositeSubjectFactory,
+)
+
+angelina = AstrologicalSubjectFactory.from_birth_data(
+    "Angelina Jolie", 1975, 6, 4, 9, 9,
+    city="Los Angeles", nation="US",
+    lng=-118.15, lat=34.03, tz_str="America/Los_Angeles",
+    online=False,
+)
+brad = AstrologicalSubjectFactory.from_birth_data(
+    "Brad Pitt", 1963, 12, 18, 6, 31,
+    city="Shawnee", nation="US",
+    lng=-96.56, lat=35.20, tz_str="America/Chicago",
+    online=False,
+)
+
+factory = CompositeSubjectFactory(angelina, brad)
+composite = factory.get_midpoint_composite_subject_model()
+
+print(composite.name)
+print(composite.composite_chart_type)
+print(f"Sun: {composite.sun.sign} {composite.sun.abs_pos:.2f}°")
+print(f"Moon: {composite.moon.sign} {composite.moon.abs_pos:.2f}°")
+print(f"Ascendant: {composite.first_house.sign} {composite.first_house.abs_pos:.2f}°")
+```
+
+**Output:**
+```
+Angelina Jolie and Brad Pitt Composite Chart
+Midpoint
+Sun: Pis 349.64°
+Moon: Pis 332.96°
+Ascendant: Lib 185.62°
+```
+
+The result is a `CompositeSubjectModel`, which `ChartDataFactory` draws like any
+other subject:
+
+```python
+chart_data = ChartDataFactory.create_composite_chart_data(composite)
+
+output_dir = Path("charts_output")
+output_dir.mkdir(exist_ok=True)
+ChartDrawer(chart_data).save_svg(
+    output_path=output_dir,
+    filename="jolie-pitt-composite",
+)
+```
+
+![Midpoint composite chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/Angelina%20Jolie%20and%20Brad%20Pitt%20Composite%20Chart%20-%20Composite%20Chart%20-%20Modern.svg)
+
+## Davison composite
+
+The Davison chart is a real chart: its positions actually occurred, at a moment
+and a place halfway between the two births.
+
+```python
+davison = factory.get_davison_composite_subject_model()
+
+print(davison.composite_chart_type)
+print(davison.iso_formatted_utc_datetime)
+print(f"{davison.lat:.3f}, {davison.lng:.3f}")
+print(f"Sun: {davison.sun.sign} {davison.sun.abs_pos:.2f}°")
+```
+
+**Output:**
+```
+Davison
+1969-09-10T14:20:00+00:00
+34.615, -107.355
+Sun: Vir 167.69°
+```
+
+The two methods give different charts on purpose: the midpoint composite is an
+average of two skies, the Davison is one sky that existed.
+
+## `house_anchor`
+
+Between two points on a circle there are two midpoints, half a turn apart.
+Taking the nearer one for each of the twelve cusps independently breaks down
+when the two charts' angles are nearly opposed — the choice flips partway round
+the ring, and the twelve arcs come to 1080° instead of 360°. About one pair in
+sixteen is affected.
+
+`house_anchor` decides which angle is held at its near midpoint while the others
+move, which is how the field repairs it:
+
+| Value | Behaviour |
+| :--- | :--- |
+| `"auto"` (default) | Whichever of the Ascendant and the Midheaven has its two base cusps closer together. |
+| `"ascendant"` | Hold the Ascendant. |
+| `"midheaven"` | Hold the Midheaven. |
+
+Anything else raises `KerykeionException`.
+
+```python
+anchored = CompositeSubjectFactory(
+    angelina, brad, house_anchor="midheaven"
+).get_midpoint_composite_subject_model()
+
+print(anchored.house_anchor)  # what was asked for
+print(anchored.house_frame)   # what was actually built
+```
+
+`house_frame` reports the outcome rather than the request: `"anchored"` (a frame
+was hung from the angle and the twelve cover the circle exactly once),
+`"midpoints"` (no frame spans the two charts, so every cusp is its own near
+midpoint and the twelve are still a house division), or `"gapped"` (as
+`"midpoints"`, but the twelve leave gaps). A Davison chart averages no cusps, so
+both fields are `None` on it.
+
+## What the two subjects must agree on
+
+The midpoint method averages cusps, so both parents' cusps have to come from the
+same house division — and a subject's *requested* and *effective* systems can
+differ, since a quadrant system is substituted inside the polar circle. The
+factory compares `effective_houses_system_identifier` and refuses with a message
+naming both. Zodiac type, sidereal mode, custom ayanamsa values, house system
+name and perspective must match too.
+
+A Davison composite is free of all of it: it recasts a whole new chart rather
+than averaging cusps.
+
+See [Composite Subject Factory](/content/docs/composite_subject_factory) for the
+full methodology, and [Relationship Score](/content/examples/relationship-score)
+for the other way of measuring a pair.
+
+---
+
+> **Need this in production?** Use the [Astrologer API](https://www.kerykeion.net/astrologer-api/subscribe) for hosted calculations, charts, and AI interpretations - no server setup required. [Learn more →](/content/docs/astrologer-api)

--- a/site/examples/cusp-comparison.md
+++ b/site/examples/cusp-comparison.md
@@ -62,11 +62,11 @@ This produces:
 
 ### Synastry Chart with House Comparison
 
-![Synastry Chart with House Comparison](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/main/tests/data/svg/John%20Lennon%20-%20Synastry%20Chart%20-%20House%20Comparison%20Only.svg)
+![Synastry Chart with House Comparison](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Synastry%20Chart%20-%20House%20Comparison%20Only.svg)
 
 ### Transit Chart with Cusp Comparison
 
-![Transit Chart with Cusp Comparison](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/main/tests/data/svg/John%20Lennon%20-%20Transit%20Chart%20-%20Cusp%20Comparison%20Only.svg)
+![Transit Chart with Cusp Comparison](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Transit%20Chart%20-%20Cusp%20Comparison%20Only.svg)
 
 ## Accessing Cusp Comparison in Reports
 

--- a/site/examples/dual-return-chart.md
+++ b/site/examples/dual-return-chart.md
@@ -69,7 +69,7 @@ This will generate a dual-wheel chart where:
 
 ### Solar Return Example
 
-![Solar Return Chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/main/tests/data/svg/John%20Lennon%20-%20DualReturnChart%20Chart%20-%20Solar%20Return%20-%20House%20Comparison%20Only.svg)
+![Solar Return Chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20DualReturnChart%20Chart%20-%20Solar%20Return%20-%20House%20Comparison%20Only.svg)
 
 ### Lunar Return Example
 
@@ -85,23 +85,28 @@ chart_data = ChartDataFactory.create_return_chart_data(
 )
 ```
 
-![Lunar Return Chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/main/tests/data/svg/John%20Lennon%20-%20DualReturnChart%20Chart%20-%20Lunar%20Return%20-%20No%20House%20Comparison.svg)
+![Lunar Return Chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20DualReturnChart%20Chart%20-%20Lunar%20Return%20-%20No%20House%20Comparison.svg)
 
 ## Toggling Degree Indicators
 
-All charts can display radial **degree indicators** for planets. You can disable them for a cleaner layout:
+The classic wheel can display radial **degree indicators** for planets;
+`show_degree_indicators=False` hides them for a cleaner layout. The option is
+**classic-only**: the modern renderer draws its own graduated ruler ring and
+logs a warning when the flag is set, so pass `style="classic"` alongside it.
 
 ```python
 drawer = ChartDrawer(
     chart_data=chart_data,
     show_cusp_position_comparison=True,
     show_degree_indicators=False,  # hide radial degree indicators
+    style="classic",               # the option only takes effect here
 )
 
 svg_content = drawer.generate_svg_string()
 ```
 
-Set `show_degree_indicators=True` (the default) to keep the indicators for both single and dual wheels.
+`show_degree_indicators=True` (the default) keeps the indicators. The same
+classic-only rule applies to `external_view` and `show_aspect_icons`.
 
 ---
 

--- a/site/examples/ephemeris-data.md
+++ b/site/examples/ephemeris-data.md
@@ -84,7 +84,9 @@ factory = EphemerisDataFactory(
 subjects = factory.get_ephemeris_data_as_astrological_subjects()
 
 for subject in subjects:
-    print(f"{subject.name}: Sun in {subject.sun.sign}, Moon in {subject.moon.sign}")
+    # subject.name is "Now" for every sample — the date is on the model itself
+    print(f"{subject.iso_formatted_local_datetime[:10]}: "
+          f"Sun in {subject.sun.sign}, Moon in {subject.moon.sign}")
 ```
 
 ## Constructor Parameters
@@ -98,10 +100,16 @@ for subject in subjects:
 | `lat` | `float` | `51.4769` | Latitude for house calculations |
 | `lng` | `float` | `0.0005` | Longitude for house calculations |
 | `tz_str` | `str` | `"Etc/UTC"` | Timezone string |
+| `is_dst` | `bool` | `False` | How to resolve a wall time that falls in a DST fold |
 | `zodiac_type` | `ZodiacType` | `"Tropical"` | Tropical or Sidereal zodiac |
 | `sidereal_mode` | `SiderealMode` | `None` | Ayanamsa for sidereal mode |
+| `custom_ayanamsa_t0` | `float \| None` | `None` | Reference Julian Day for `sidereal_mode="USER"` |
+| `custom_ayanamsa_ayan_t0` | `float \| None` | `None` | Ayanamsa value at `custom_ayanamsa_t0` |
 | `houses_system_identifier` | `str` | `"P"` | House system (Placidus default) |
 | `perspective_type` | `PerspectiveType` | `"Apparent Geocentric"` | Observation perspective |
+| `active_points` | `list[AstrologicalPoint] \| None` | `None` | Points each sample computes; `None` uses the default 14 |
+| `active_fixed_stars` | `list[str] \| None` | `None` | Fixed stars each sample computes |
+| `altitude` | `float \| None` | `None` | Observer altitude in metres, for topocentric work |
 | `max_days` | `int` | `730` | Safety limit for day ranges |
 | `max_hours` | `int` | `8760` | Safety limit for hour ranges |
 | `max_minutes` | `int` | `525600` | Safety limit for minute ranges |

--- a/site/examples/glyph-sizes.md
+++ b/site/examples/glyph-sizes.md
@@ -1,0 +1,115 @@
+---
+title: 'Glyph Sizes'
+tags: ['examples', 'charts', 'modern', 'glyphs', 'kerykeion']
+order: 17
+---
+
+# Glyph Sizes
+
+The modern wheel draws each point as a **cluster**: the glyph, the degree, the
+sign, and a marker row for retrograde or station letters. `glyph_size` picks how
+large that cluster is drawn, and the wheel's decluttering works to the size it
+was given, so nothing collides at any of the three settings.
+
+| `glyph_size` | What it draws |
+| :--- | :--- |
+| `"small"` | The medium cluster at 90%. More room between neighbours, useful for a chart with many active points. |
+| `"medium"` | The default. |
+| `"large"` | The planet glyph at the classic style's own size, in the default configuration — zodiac background ring on, per-glyph optical map applied. |
+
+The option is **modern-only**: the classic wheel ignores it. Anything other than
+those three raises `KerykeionException` — from the constructor and from every
+render method alike.
+
+## Setting the size
+
+`glyph_size` is a constructor argument (a per-instance default) and a per-call
+override on `save_svg`, `generate_svg_string`, `save_wheel_only_svg_file` and
+`generate_wheel_only_svg_string`. A per-call value applies to that call only and
+does not stick.
+
+```python
+from pathlib import Path
+
+from kerykeion import AstrologicalSubjectFactory, ChartDataFactory, ChartDrawer
+
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "John Lennon", 1940, 10, 9, 18, 30,
+    city="Liverpool", nation="GB",
+    lng=-2.97794, lat=53.41058, tz_str="Europe/London",
+    online=False,
+)
+
+chart_data = ChartDataFactory.create_natal_chart_data(subject)
+drawer = ChartDrawer(chart_data)
+
+output_dir = Path("charts_output")
+output_dir.mkdir(exist_ok=True)
+
+for size in ("small", "medium", "large"):
+    drawer.save_svg(
+        output_path=output_dir,
+        filename=f"lennon-{size}",
+        glyph_size=size,
+    )
+```
+
+Give each render its own `filename`: without one they would all fall back to the
+same default name and overwrite each other.
+
+### Small
+
+![Modern natal chart, small glyphs](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Natal%20Chart%20-%20Modern%20Small.svg)
+
+### Medium (default)
+
+![Modern natal chart, medium glyphs](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Natal%20Chart%20-%20Modern.svg)
+
+### Large
+
+![Modern natal chart, large glyphs](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Natal%20Chart%20-%20Modern%20Large.svg)
+
+## Setting it once for a drawer
+
+```python
+big = ChartDrawer(chart_data, glyph_size="large")
+
+# Both of these render large
+wheel = big.generate_wheel_only_svg_string()
+full = big.generate_svg_string()
+
+# ...and this one does not: the per-call value wins for this call alone
+small_once = big.generate_svg_string(glyph_size="small")
+```
+
+## Reading the size back out of the SVG
+
+The wheel root carries `kr:glyphsize` when the size is not the default:
+
+```python
+import re
+
+svg = ChartDrawer(chart_data).generate_svg_string(glyph_size="large")
+root = re.search(r"<g kr:node=.ModernHoroscope.[^>]*>", svg)
+print("kr:glyphsize" in root.group(0))
+```
+
+**Output:**
+```
+True
+```
+
+`"medium"` is written as absence, the same way `kr:oob` and `kr:retrograde` mark
+only the exception. See
+[Machine-Readable SVG Point Metadata](/content/docs/charts#machine-readable-svg-point-metadata).
+
+## Choosing one
+
+- Many active points, or a dual wheel — `"small"`, which buys separation.
+- A chart printed beside a classic one — `"large"`, whose planet glyphs match the
+  classic engine's own size.
+- Anything else — the default.
+
+---
+
+> **Need this in production?** Use the [Astrologer API](https://www.kerykeion.net/astrologer-api/subscribe) for hosted calculations, charts, and AI interpretations - no server setup required. [Learn more →](/content/docs/astrologer-api)

--- a/site/examples/houses-systems.md
+++ b/site/examples/houses-systems.md
@@ -6,7 +6,7 @@ order: 7
 
 # House Systems
 
-Kerykeion supports **23 different house systems** from the Swiss Ephemeris. Each system divides the celestial sphere differently, affecting house cusp positions (though planetary positions remain the same).
+Kerykeion supports **23 different house systems** (Swiss Ephemeris letter codes, honoured by both backends). Each system divides the celestial sphere differently, affecting house cusp positions (though planetary positions remain the same).
 
 ## Choosing a House System
 
@@ -17,14 +17,15 @@ The choice of house system depends on your astrological tradition and preference
 - **Medieval**: Regiomontanus or Alcabitius
 - **Vedic/Jyotish**: Whole Sign or Sripati
 - **Horary**: Regiomontanus
-- **Extreme Latitudes** (>60°): Whole Sign or Equal (Placidus/Koch fail near poles)
+- **Inside the polar circle**: Whole Sign, Equal or Porphyry — the quadrant
+  systems are undefined there and Kerykeion substitutes one for them (see below)
 
 ## Complete House Systems Reference
 
 | ID  | Name                        | Description |
 |:---:|:---------------------------|:------------|
-| `P` | **Placidus** | **Default.** Most popular in modern Western astrology. Time-based system that divides the diurnal arc into equal time segments. May fail at extreme latitudes. |
-| `K` | **Koch** | Popular in Germany and for natal work. Similar to Placidus but uses birthplace latitude differently. Also fails at extreme latitudes. |
+| `P` | **Placidus** | **Default.** Most popular in modern Western astrology. Time-based system that divides the diurnal arc into equal time segments. Undefined inside the polar circle. |
+| `K` | **Koch** | Popular in Germany and for natal work. Similar to Placidus but uses birthplace latitude differently. Also undefined inside the polar circle. |
 | `W` | **Whole Sign** | Ancient system where each house equals one entire zodiac sign. The Ascendant's sign becomes the 1st house. Works at all latitudes. Preferred in Hellenistic and Vedic astrology. |
 | `A` | Equal (from Asc) | Houses are exactly 30° each, starting from the Ascendant degree. Simple and works at all latitudes. |
 | `D` | Equal (from MC) | Equal 30° houses with the MC on the 10th house cusp. |
@@ -152,6 +153,35 @@ Regiomontanus:
 ```
 
 > **Note:** The Ascendant and MC remain the same across most systems - only the intermediate house cusps differ.
+
+## Inside the Polar Circle
+
+A quadrant system divides the semi-diurnal arc of a degree of the ecliptic.
+Inside the polar circle some degrees never rise or set, so that arc does not
+exist and there is nothing to divide. Kerykeion does not fail there, and does not
+move the observer either: it recomputes the cusps with **Porphyry** (`"O"`) at
+the real latitude, logs a warning naming both systems, and records the
+substitution.
+
+```python
+from kerykeion import AstrologicalSubjectFactory
+
+subject = AstrologicalSubjectFactory.from_birth_data(
+    "Arctic Explorer", 1990, 6, 21, 12, 0,
+    lng=25.0, lat=70.0, tz_str="Europe/Helsinki", online=False,
+    houses_system_identifier="P",
+)
+
+print(subject.lat)                                 # 70.0  — never clamped
+print(subject.houses_system_identifier)            # "P"   — what you asked for
+print(subject.effective_houses_system_identifier)  # "O"   — what the cusps used
+print(subject.polar_house_fallbacks[0].affects)    # ["house_cusps"]
+```
+
+The angles are untouched: the Ascendant, MC, Descendant, IC and Vertex are
+intersections of the ecliptic with the horizon and the meridian, so they do not
+depend on a house system and stay exact at any latitude. Pick `"W"` or `"A"` if
+you would rather choose the division yourself than accept a substitute.
 
 ---
 

--- a/site/examples/index.md
+++ b/site/examples/index.md
@@ -18,6 +18,9 @@ Practical, self-contained examples covering all major Kerykeion features.
 -   **[Minimalist Charts & Aspect Table](/content/examples/minimalist-charts-and-aspect-table)**: Wheel-only and aspect-grid-only components.
 -   **[Modern Charts](/content/examples/modern-charts)**: Modern concentric-ring chart style.
 -   **[Cusp Comparison Grids](/content/examples/cusp-comparison)**: Cusp overlay grids for dual charts.
+-   **[Composite Chart](/content/examples/composite-chart)**: Midpoint and Davison composites, and the `house_anchor` choice.
+-   **[Glyph Sizes](/content/examples/glyph-sizes)**: The three modern planet-cluster sizes.
+-   **[Chart Marks](/content/examples/chart-marks)**: The six opt-in marks — stations, out-of-bounds, aspect movement, and more.
 
 ## Data & Analysis
 
@@ -40,6 +43,7 @@ Practical, self-contained examples covering all major Kerykeion features.
 -   **[Transits Time Range](/content/examples/transits-time-range)**: Calculating transits over a period.
 -   **[House Comparison](/content/examples/house-comparison)**: Bidirectional house overlay analysis.
 -   **[Moon Phase Details](/content/examples/moon-phase-details)**: Rich lunar phase context with illumination and eclipses.
+-   **[Retrograde and Sign Periods](/content/examples/planet-periods)**: Complete retrograde arcs and sign stays over a date range.
 
 ## Predictive Techniques
 

--- a/site/examples/modern-charts.md
+++ b/site/examples/modern-charts.md
@@ -6,9 +6,9 @@ order: 15
 
 # Modern Charts
 
-Since v6 the **modern concentric-ring** layout is Kerykeion's default chart style. It renders charts with graduated ruler scales, clean aspect lines with midpoint glyphs, and a distinct visual hierarchy.
+The **modern concentric-ring** layout is Kerykeion's default chart style. It renders charts with graduated ruler scales, clean aspect lines with midpoint glyphs, and a distinct visual hierarchy.
 
-All chart types and all six themes work with the modern style. The traditional wheel remains available via `style="classic"` — see the [Charts documentation](/content/docs/charts).
+All chart types and all three themes (`"classic"`, `"dark"`, `"black-and-white"`, plus `theme=None` for no CSS at all) work with the modern style. The traditional wheel remains available via `style="classic"` — see the [Charts documentation](/content/docs/charts).
 
 ## Modern Natal Chart
 
@@ -33,7 +33,7 @@ output_dir.mkdir(exist_ok=True)
 chart.save_svg(output_path=output_dir, filename="lennon-modern-natal")
 ```
 
-![Modern Natal Chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/main/tests/data/svg/John%20Lennon%20-%20Natal%20Chart%20-%20Modern.svg)
+![Modern Natal Chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Natal%20Chart%20-%20Modern.svg)
 
 ## Modern Synastry Chart
 
@@ -62,7 +62,7 @@ output_dir.mkdir(exist_ok=True)
 chart.save_svg(output_path=output_dir, filename="lennon-ono-modern-synastry")
 ```
 
-![Modern Synastry Chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/main/tests/data/svg/John%20Lennon%20-%20Synastry%20Chart%20-%20Modern.svg)
+![Modern Synastry Chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Synastry%20Chart%20-%20Modern.svg)
 
 ## Modern Transit Chart
 
@@ -90,7 +90,7 @@ output_dir.mkdir(exist_ok=True)
 chart.save_svg(output_path=output_dir, filename="lennon-modern-transit")
 ```
 
-![Modern Transit Chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/main/tests/data/svg/John%20Lennon%20-%20Transit%20Chart%20-%20Modern.svg)
+![Modern Transit Chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Transit%20Chart%20-%20Modern.svg)
 
 ## Modern Wheel Only
 
@@ -118,7 +118,7 @@ chart.save_wheel_only_svg_file(
 )
 ```
 
-![Modern Wheel Only](https://raw.githubusercontent.com/g-battaglia/kerykeion/main/tests/data/svg/John%20Lennon%20-%20Natal%20Chart%20-%20Modern%20Wheel%20Only.svg)
+![Modern Wheel Only](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Natal%20Chart%20-%20Modern%20Wheel%20Only.svg)
 
 ## Modern-Only Parameters
 
@@ -127,6 +127,10 @@ These keyword arguments are specific to the modern style and are ignored when `s
 | Parameter | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `show_zodiac_background_ring` | `bool` | `True` | Draw colored zodiac wedges behind the outer planet ring |
+| `glyph_size` | `"small" \| "medium" \| "large"` | `"medium"` | Planet-cluster size on the wheel — see [Glyph Sizes](/content/examples/glyph-sizes) |
+
+Both can be set once on the constructor as a per-instance default, or per call
+on any render method.
 
 Example disabling the zodiac background:
 

--- a/site/examples/perspective-type.md
+++ b/site/examples/perspective-type.md
@@ -6,7 +6,7 @@ order: 8
 
 # Perspective Type
 
-The `perspective_type` parameter defines the viewpoint from which planetary positions are calculated. Kerykeion supports four different perspectives.
+The `perspective_type` parameter defines the viewpoint from which planetary positions are calculated. `PerspectiveType` has eleven members; the four below cover nearly all astrological work.
 
 ## Available Perspective Types
 
@@ -16,6 +16,11 @@ The `perspective_type` parameter defines the viewpoint from which planetary posi
 | `True Geocentric` | Earth-centered, without light-time correction. Positions as they "truly" are at that moment. | Research, comparison with astronomical data |
 | `Heliocentric` | Sun-centered. Shows planetary positions as seen from the Sun. Earth replaces Sun in the chart. | Esoteric/cosmobiological techniques, solar system studies |
 | `Topocentric` | Observer's exact location on Earth's surface. Most accurate for Moon position. | Precise lunar work, electional astrology |
+
+The other seven place the observer on another body or at the solar-system
+barycentre: `Selenocentric` (the Moon), `Mercurycentric`, `Venuscentric`,
+`Marscentric`, `Jupitercentric`, `Saturncentric`, and `Barycentric`. Each drops
+the point it is centred on, since a body has no position as seen from itself.
 
 ## Apparent Geocentric (Default)
 
@@ -39,7 +44,7 @@ print(f"Moon: {subject.moon.sign} {subject.moon.position:.2f}°")
 **Output:**
 ```
 Sun: Lib 16.27°
-Moon: Aqu 3.50°
+Moon: Aqu 3.55°
 ```
 
 ## Heliocentric
@@ -75,11 +80,22 @@ out_dir.mkdir(exist_ok=True)
 chart.save_svg(output_path=out_dir, filename="lennon-heliocentric", style="classic")
 ```
 
-The output will be:
+**Output:**
+```
+Earth: Ari 16.27°
+Mars: Vir 24.51°
+```
+
+The chart will be:
 
 ![John Lennon Heliocentric](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Heliocentric%20-%20Natal%20Chart%20-%20Classic.svg)
 
-> **Note:** Heliocentric charts have no houses or Ascendant since there is no observer on Earth. The house system is ignored.
+> **Note:** Heliocentric charts still compute houses and the angles — the
+> Ascendant and MC come from the observer's clock and place, which the subject
+> carries regardless of where the planetary longitudes are measured from. What
+> the perspective drops are the Sun (it is the centre) and the geocentric-only
+> points: the lunar nodes and the Lilith / apogee variants. Both exclusions are
+> logged.
 
 ## True Geocentric
 
@@ -139,12 +155,15 @@ for perspective in perspectives:
 **Output:**
 ```
 Apparent Geocentric:
-  Moon: 15.2347°
+  Moon: 14.8016°
 True Geocentric:
-  Moon: 15.2348°
+  Moon: 14.8018°
 Topocentric:
-  Moon: 15.1892°  # Note the larger difference due to parallax
+  Moon: 13.9628°
 ```
+
+The topocentric figure is nearly a degree away: that is lunar parallax, and it
+is why the Moon is the point the perspective matters most for.
 
 > **Tip:** For most astrological work, stick with the default `Apparent Geocentric`. Use `Topocentric` only when precise Moon timing is critical (e.g., for electional astrology or void-of-course Moon calculations).
 

--- a/site/examples/planet-periods.md
+++ b/site/examples/planet-periods.md
@@ -1,0 +1,143 @@
+---
+title: 'Retrograde and Sign Periods'
+tags: ['examples', 'retrograde', 'ingress', 'calendar', 'forecasting', 'kerykeion']
+order: 19
+---
+
+# Retrograde and Sign Periods
+
+Two factories answer "when did it turn?" and "when did it change sign?" — and
+each has a second method that answers the interval question instead of the
+moment one: how long the retrograde lasted, how long the planet stayed in the
+sign. Both interval methods return **periods**, and a period that runs past the
+edge of the range you asked for says so rather than being silently trimmed away.
+
+## Retrograde periods
+
+`RetrogradeStationFactory.from_iso_range` returns the stations themselves;
+`retrograde_periods_from_iso_range` pairs them into complete retrograde arcs.
+
+```python
+from kerykeion import RetrogradeStationFactory
+
+periods = RetrogradeStationFactory.retrograde_periods_from_iso_range(
+    "2026-01-01", "2026-12-31", planets=["Mercury"]
+)
+
+for period in periods.periods:
+    print(f"{period.planet}: {period.start} -> {period.end}")
+```
+
+**Output:**
+```
+Mercury: 2026-02-26T06:48:10Z -> 2026-03-20T19:32:50Z
+Mercury: 2026-06-29T17:35:55Z -> 2026-07-23T22:57:51Z
+Mercury: 2026-10-24T07:12:42Z -> 2026-11-13T15:53:52Z
+```
+
+The stations that bound them, if you want the turning points rather than the
+spans:
+
+```python
+stations = RetrogradeStationFactory.from_iso_range(
+    "2026-01-01", "2026-12-31", planets=["Mercury"]
+)
+
+for station in stations.stations[:4]:
+    print(f"{station.station_type} {station.iso_utc} {station.sign} {station.degree:.2f}°")
+```
+
+**Output:**
+```
+SR 2026-02-26T06:48:10Z Pis 22.57°
+SD 2026-03-20T19:32:50Z Pis 8.49°
+SR 2026-06-29T17:35:55Z Can 26.26°
+SD 2026-07-23T22:57:51Z Can 16.32°
+```
+
+`SR` opens the retrograde phase and `SD` closes it — the same two labels the
+chart renderer writes when `show_motion_state=True`.
+
+### Chiron is opt-in
+
+`planets=None` scans Mercury through Pluto. The Sun and the Moon never station
+and are refused, as is any other name; `"Chiron"` is accepted **on request**,
+and its slow arcs are where the clip flags earn their place.
+
+```python
+chiron = RetrogradeStationFactory.retrograde_periods_from_iso_range(
+    "2026-01-01", "2026-12-31", planets=["Chiron"]
+)
+
+for period in chiron.periods:
+    print(f"{period.start} -> {period.end} "
+          f"(clipped: start={period.start_clipped}, end={period.end_clipped})")
+```
+
+**Output:**
+```
+2026-01-01T00:00:00Z -> 2026-01-02T14:37:23Z (clipped: start=True, end=False)
+2026-08-03T20:10:11Z -> 2027-01-01T00:00:00Z (clipped: start=False, end=True)
+```
+
+A `True` flag means the boundary shown is the **range edge**, not a station: the
+first retrograde had already begun on 1 January and the second had not ended by
+31 December. Read the flag before treating either timestamp as a turning point.
+
+## Sign periods
+
+`SignIngressFactory.from_iso_range` returns the ingress moments;
+`sign_periods_from_iso_range` returns the stays between them, with the same clip
+flags.
+
+```python
+from kerykeion import SignIngressFactory
+
+periods = SignIngressFactory.sign_periods_from_iso_range(
+    "2026-01-01", "2026-12-31", planets=["Mars"]
+)
+
+for period in periods.periods[:4]:
+    print(f"{period.planet} in {period.sign}: {period.start} -> {period.end} "
+          f"(clipped: {period.start_clipped}/{period.end_clipped})")
+```
+
+**Output:**
+```
+Mars in Cap: 2026-01-01T00:00:00Z -> 2026-01-23T09:16:45Z (clipped: True/False)
+Mars in Aqu: 2026-01-23T09:16:45Z -> 2026-03-02T14:15:50Z (clipped: False/False)
+Mars in Pis: 2026-03-02T14:15:50Z -> 2026-04-09T19:36:09Z (clipped: False/False)
+Mars in Ari: 2026-04-09T19:36:09Z -> 2026-05-18T22:25:28Z (clipped: False/False)
+```
+
+Mars was already in Capricorn when the range opened, so that first period's
+start is the range edge.
+
+## Both methods take the same arguments
+
+`(start_date, end_date, planets=None, zodiac_type="Tropical", sidereal_mode=None)`
+
+A sidereal scan moves every sign boundary by the ayanamsa, so the sign periods
+shift with it while the retrograde stations — which are about motion, not
+longitude — do not.
+
+```python
+sidereal = SignIngressFactory.sign_periods_from_iso_range(
+    "2026-01-01", "2026-06-30",
+    planets=["Sun"],
+    zodiac_type="Sidereal",
+    sidereal_mode="LAHIRI",
+)
+print(f"{len(sidereal.periods)} sidereal Sun periods in the first half of 2026")
+```
+
+Each collection also carries the requested `start_jd` and `end_jd`, so the range
+a result came from travels with it.
+
+See [Retrograde Station Factory](/content/docs/retrograde_station_factory) and
+[Sign Ingress Factory](/content/docs/sign_ingress_factory) for the full field
+reference.
+
+---
+
+> **Need this in production?** Use the [Astrologer API](https://www.kerykeion.net/astrologer-api/subscribe) for hosted calculations, charts, and AI interpretations - no server setup required. [Learn more →](/content/docs/astrologer-api)

--- a/site/examples/report.md
+++ b/site/examples/report.md
@@ -1,6 +1,6 @@
 ---
 title: 'Report'
-tags: ['examples', 'reports', 'cli', 'kerykeion']
+tags: ['examples', 'reports', 'kerykeion']
 order: 14
 ---
 
@@ -13,6 +13,7 @@ from kerykeion import ReportGenerator, AstrologicalSubjectFactory, ChartDataFact
 
 subject = AstrologicalSubjectFactory.from_birth_data(
     "Kanye", 1977, 6, 8, 8, 45,
+    city="Atlanta", nation="US",
     lng=-84.38798, lat=33.7490, tz_str="America/New_York", online=False,
 )
 
@@ -37,8 +38,8 @@ Kanye — Subject Report
 | Name               | Kanye                     |
 | Date               | 08/06/1977                |
 | Time               | 08:45                     |
-| City               | Greenwich                 |
-| Nation             | GB                        |
+| City               | Atlanta                   |
+| Nation             | US                        |
 | Latitude           | 33.7490°                  |
 | Longitude          | -84.3880°                 |
 | Timezone           | America/New_York          |

--- a/site/examples/sidereal-modes.md
+++ b/site/examples/sidereal-modes.md
@@ -8,7 +8,7 @@ order: 9
 
 Kerykeion supports both **Tropical** (default) and **Sidereal** zodiac systems. When using the Sidereal zodiac, you must specify an **ayanamsa** (sidereal mode) that defines the starting point of the zodiac relative to the fixed stars.
 
-As of v5.12, Kerykeion supports **48 sidereal modes** (47 named + USER for custom definitions).
+Kerykeion supports **48 sidereal modes** (47 named + `USER` for custom definitions).
 
 ## Tropical vs Sidereal
 
@@ -46,7 +46,7 @@ Due to the precession of the equinoxes, the tropical and sidereal zodiacs differ
 | `BABYL_ETPSC` | Babylonian (ETPSC). | Historical |
 | `USHASHASHI` | Ushashashi ayanamsa. | India |
 
-### New in v5.12
+### Extended Modes
 
 | Mode | Description | Category |
 |:-----|:------------|:---------|

--- a/site/examples/synastry-chart.md
+++ b/site/examples/synastry-chart.md
@@ -29,7 +29,8 @@ second = AstrologicalSubjectFactory.from_birth_data(
 data = ChartDataFactory.create_synastry_chart_data(first, second)
 drawer = ChartDrawer(data)
 
-out_dir = Path(".")
+out_dir = Path("charts_output")
+out_dir.mkdir(exist_ok=True)
 drawer.save_svg(output_path=out_dir, filename="lennon-mccartney-synastry")
 ```
 
@@ -38,15 +39,15 @@ Note: If you want to save the output in a different directory, pass the `output_
 The output will be:
 ![John Lennon and Paul McCartney Synastry](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20Synastry%20Chart%20-%20Modern.svg)
 
-## New Synastry Chart Features
+## Aspect Table Grid View
 
-### Aspect Table Grid View
-
-You can now display aspects in a grid format, providing a clearer and more organized view compared to the traditional list format. This feature enhances the readability and analysis of synastry charts.
-
-Here is an example of how to enable the Aspect Table Grid View:
+`double_chart_aspect_grid_type="table"` renders the dual-chart aspects as a grid
+instead of the default `"list"`, which is easier to scan when the two charts
+share many contacts.
 
 ```python
+from pathlib import Path
+
 from kerykeion import AstrologicalSubjectFactory
 from kerykeion.chart_data.factory import ChartDataFactory
 from kerykeion.charts.drawer import ChartDrawer
@@ -62,7 +63,9 @@ second = AstrologicalSubjectFactory.from_birth_data(
 
 data = ChartDataFactory.create_synastry_chart_data(first, second)
 drawer = ChartDrawer(data, double_chart_aspect_grid_type="table")
-drawer.save_svg(output_path=".", filename="synastry-grid-view")
+output_dir = Path("charts_output")
+output_dir.mkdir(exist_ok=True)
+drawer.save_svg(output_path=output_dir, filename="synastry-grid-view")
 ```
 
 ---

--- a/site/examples/theming.md
+++ b/site/examples/theming.md
@@ -43,8 +43,15 @@ out_dir = Path("charts_output")
 out_dir.mkdir(exist_ok=True)
 
 for theme in ("classic", "dark", "black-and-white"):
-    ChartDrawer(data, theme=theme).save_svg(output_path=out_dir)
+    ChartDrawer(data, theme=theme).save_svg(
+        output_path=out_dir,
+        filename=f"lennon-{theme}",
+    )
 ```
+
+Without an explicit `filename` every iteration would write the same default name
+(`John Lennon - Natal Chart - Modern.svg`) and each theme would overwrite the
+last.
 
 Passing a name that is not one of the three raises `KerykeionException`. There is
 no silent fallback: a misspelt theme is a bug you want to hear about, not a chart
@@ -99,8 +106,10 @@ is information.
 
 ### Measure what you make
 
-A palette that pleases the eye on a big screen can still lose a reader. Before
-shipping your own, put it through the same measurement the built-in themes are
-held to — every mark against the surface it is actually drawn on, at the
-threshold its role demands. That check exists as a tool, not only as an internal
-guard, precisely so that a custom palette can be held to it.
+A palette that pleases the eye on a big screen can still lose a reader. Hold
+your own to the same thresholds the shipped themes meet: 7:1 (WCAG AAA) for
+everything a reader *reads* — degrees, minutes, house numbers, percentages — and
+at least 3:1 (WCAG AA) for the marks a reader *looks at*: aspect lines, sign
+icons against their own band, the degree indicator, the house cusps. Measure
+each mark against the surface it is actually drawn on, not against the page
+background, since a sign glyph sits on its zodiac band rather than on the paper.

--- a/site/examples/transit-chart.md
+++ b/site/examples/transit-chart.md
@@ -42,13 +42,11 @@ The output will be:
 
 ![John Lennon Transit Chart](https://raw.githubusercontent.com/g-battaglia/kerykeion/refs/heads/alpha/v6/tests/data/svg/John%20Lennon%20-%20All%20Active%20Points%20-%20Transit%20Chart%20-%20Classic.svg)
 
-## New Transit Chart Features
+## Aspect Table Grid View
 
-### Aspect Table Grid View
-
-You can now display aspects in a grid format, providing a clearer and more organized view compared to the traditional list format. This feature enhances the readability and analysis of transit charts.
-
-Here is an example of how to enable the Aspect Table Grid View:
+`double_chart_aspect_grid_type="table"` renders the dual-chart aspects as a grid
+instead of the default `"list"`, which is easier to scan when a transit chart
+carries many contacts.
 
 ```python
 from kerykeion import AstrologicalSubjectFactory
@@ -93,7 +91,7 @@ transit_subject = AstrologicalSubjectFactory.from_birth_data(
 data = ChartDataFactory.create_transit_chart_data(natal_subject, transit_subject)
 drawer = ChartDrawer(data)
 
-out_dir = Path("./transit_charts")
+out_dir = Path("charts_output")
 out_dir.mkdir(exist_ok=True)
 drawer.save_svg(output_path=out_dir, filename="transit-example")
 ```

--- a/site/examples/transits-time-range.md
+++ b/site/examples/transits-time-range.md
@@ -93,8 +93,14 @@ for moment in result.transits:
 | `natal_chart` | `AstrologicalSubjectModel` | **Required** | The natal chart to transit against |
 | `ephemeris_data_points` | `list[AstrologicalSubjectModel]` | **Required** | Time-series data from `EphemerisDataFactory` |
 | `active_points` | `list[AstrologicalPoint]` | `DEFAULT_ACTIVE_POINTS` | Which points to consider |
-| `active_aspects` | `list[ActiveAspect]` | `DEFAULT_ACTIVE_ASPECTS` | Which aspects to detect (with orbs) |
+| `active_aspects` | `list[ActiveAspect]` | `PREDICTIVE_ACTIVE_ASPECTS` | Which aspects to detect (with orbs); the predictive preset is a flat 3° |
+| `settings_file` | `Path`, `KerykeionSettingsModel`, `dict`, or `None` | `None` | Custom orb/calculation settings |
 | `axis_orb_limit` | `float` | `None` | Stricter orb for angles (Asc, MC) *(keyword-only)* |
+
+The time series itself is configured on `EphemerisDataFactory`, whose own
+constructor also takes `is_dst`, `custom_ayanamsa_t0` /
+`custom_ayanamsa_ayan_t0`, `active_points`, `active_fixed_stars` and `altitude`
+— see [Ephemeris Data](/content/examples/ephemeris-data).
 
 ## Tips
 

--- a/skills/kerykeion/SKILL.md
+++ b/skills/kerykeion/SKILL.md
@@ -141,7 +141,7 @@ print(to_context(subject)[:400])                # non-interpretive XML for promp
 
 (`AstrologicalSubjectFactory`, `ChartDataFactory`, `ChartDrawer`,
 `CompositeSubjectFactory`, `KerykeionSettingsModel` are the usual top-level
-imports; the package root exports 120 names. Some public APIs are deliberately
+imports; the package root exports 124 names. Some public APIs are deliberately
 subpackage-only — e.g. `kerykeion.utilities` helpers, `FixedStarCatalog`, the
 named context serializers — and the references mark each one as **Subpackage
 import** with its exact path.)
@@ -187,12 +187,13 @@ import** with its exact path.)
 | Midpoints + aspects to midpoints | `MidpointFactory` | `references/analysis.md` |
 | Positions sampled over a date range | `EphemerisDataFactory` | `references/predictive.md` |
 | Transit aspects over time; exact-hit refinement | `TransitsTimeRangeFactory` | `references/predictive.md` |
-| Solar/lunar/heliocentric returns; node crossings | `PlanetaryReturnFactory` | `references/predictive.md` |
+| Solar/lunar/heliocentric returns; node crossings; walking the sequence | `PlanetaryReturnFactory` | `references/predictive.md` |
 | Secondary progressions | `SecondaryProgressionFactory` | `references/predictive.md` |
 | Solar arc directions | `SolarArcFactory` | `references/predictive.md` |
 | Eclipses (local or global search) | `EclipseFactory` | `references/mundane-events.md` |
 | New/full moons over a range | `LunationFinderFactory` | `references/mundane-events.md` |
 | Retrograde stations; sign ingresses; mundane aspects | `RetrogradeStationFactory`, `SignIngressFactory`, `MundaneAspectFactory` | `references/mundane-events.md` |
+| Which sign a planet is IN over a range; whether it IS retrograde | `sign_periods_from_iso_range`, `retrograde_periods_from_iso_range` | `references/mundane-events.md` |
 | Planetary nodes, phenomena, heliacal events, occultations | `PlanetaryNodesFactory`, `PlanetaryPhenomenaFactory`, `HeliacalFactory`, `OccultationFactory` | `references/mundane-events.md` |
 | Search the fixed-star catalog | `FixedStarCatalog`, `FixedStarDiscoveryFactory` | `references/mundane-events.md` |
 | Moon phase; sunrise/sunset; planetary hours; void-of-course | `MoonPhaseDetailsFactory`, `SunTimesFactory`, `PlanetaryHoursFactory`, `VoidOfCourseMoonFactory` | `references/calendars-hours-moon.md` |
@@ -235,7 +236,9 @@ from bare `kerykeion` — use the exact import path shown there.
 8. **`ChartDrawer`: `theme` defaults to `"classic"` but `style` defaults to
    `"modern"`** — two orthogonal knobs. Default filenames carry the style
    suffix (`" - Modern.svg"` / `" - Classic.svg"`). `external_view`,
-   `show_degree_indicators`, `show_aspect_icons` are classic-only.
+   `show_degree_indicators`, `show_aspect_icons` are classic-only; `glyph_size`
+   (`"small"`/`"medium"`/`"large"`) and `show_zodiac_background_ring` are
+   modern-only and ignored in silence by classic.
 9. **Time is local wall-clock** + `tz_str`; never pre-convert to UTC except
    with `from_iso_utc_time` (which is UTC by contract).
 10. **Sidereal coherence.** The subject factories default a missing

--- a/skills/kerykeion/references/api-index.md
+++ b/skills/kerykeion/references/api-index.md
@@ -1,7 +1,7 @@
 # API Index
 
 Map of every name this skill documents to the reference file that covers it:
-the 120 root exports, the literals and presets, the env vars, and every API
+the 124 root exports, the literals and presets, the env vars, and every API
 the references mark as a **Subpackage import**. Names are importable from
 bare `kerykeion` unless the Kind column says otherwise. Use this file to
 answer "where is X documented?"; the domain file is always the richer source.
@@ -14,6 +14,7 @@ answer "where is X documented?"; the domain file is always the richer source.
 | `ALL_ACTIVE_ASPECTS` | subpackage import — `kerykeion.settings.config_constants` | `references/aspects-and-orbs.md` |
 | `ALL_ACTIVE_POINTS` | constant/function — `kerykeion.settings` | `references/subjects.md` |
 | `AlmutenFigurisStrategy` | subpackage import — `kerykeion.dominants` | `references/analysis.md` |
+| `angle_house_identities` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
 | `AngularityModel` | model | `references/charts-and-drawing.md` |
 | `ApsisKind` | literal — `kerykeion.schemas` | `references/mundane-events.md` |
 | `aspect_to_context` | subpackage import — `kerykeion.context` | `references/reports-and-ai-context.md` |
@@ -46,7 +47,10 @@ answer "where is X documented?"; the domain file is always the richer source.
 | `civil_leap_year` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
 | `classify_motion_state` | subpackage import — `kerykeion.motion` | `references/utilities.md` |
 | `classify_solar_phase` | module import — `kerykeion.planetary_phenomena.factory` | `references/utilities.md` |
+| `coincident_cusp_groups` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
 | `CompositeChartType` | literal — `kerykeion.schemas` | `references/subjects.md` |
+| `CompositeHouseAnchor` | literal — `kerykeion.schemas` | `references/subjects.md` |
+| `CompositeHouseFrame` | literal — `kerykeion.schemas` | `references/subjects.md` |
 | `CompositeSubjectFactory` | factory | `references/subjects.md` |
 | `CompositeSubjectModel` | model | `references/subjects.md` |
 | `compute_rise_set_ephe` | module import — `kerykeion.moon_phase_details.utils` | `references/utilities.md` |
@@ -132,8 +136,11 @@ answer "where is X documented?"; the domain file is always the richer source.
 | `HouseComparisonModel` | model | `references/analysis.md` |
 | `HouseNumbers` | literal — `kerykeion.schemas` | `references/subjects.md` |
 | `Houses` | literal — `kerykeion.schemas` | `references/subjects.md` |
+| `house_spans` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
+| `HouseRing` | subpackage import — `kerykeion.ephemeris_backend` | `references/backends-and-provenance.md` |
 | `houses_ex2_with_polar_fallback` | subpackage import — `kerykeion.ephemeris_backend` | `references/backends-and-provenance.md` |
 | `houses_ex2_with_polar_fallback_ex` | subpackage import — `kerykeion.ephemeris_backend` | `references/backends-and-provenance.md` |
+| `houses_ring_with_polar_fallback` | subpackage import — `kerykeion.ephemeris_backend` | `references/backends-and-provenance.md` |
 | `HousesSystemIdentifier` | literal — `kerykeion.schemas` | `references/zodiac-houses-perspectives.md` |
 | `IndicatorTag` | subpackage import — `kerykeion.charts.svg_metadata` | `references/charts-and-drawing.md` |
 | `IngressModel` | model | `references/mundane-events.md` |
@@ -165,7 +172,11 @@ answer "where is X documented?"; the domain file is always the richer source.
 | `lunar_phase_to_context` | subpackage import — `kerykeion.context` | `references/reports-and-ai-context.md` |
 | `LunarEclipseModel` | model | `references/mundane-events.md` |
 | `LunarPhaseEmoji` | literal — `kerykeion.schemas` | `references/calendars-hours-moon.md` |
+| `lunar_major_phase_from_degrees` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
+| `lunar_phase_name_from_degrees` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
+| `lunar_stage_from_degrees` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
 | `LunarPhaseName` | literal — `kerykeion.schemas` | `references/calendars-hours-moon.md` |
+| `LunarPhaseStage` | literal — `kerykeion.schemas` | `references/calendars-hours-moon.md` |
 | `LunationFinderFactory` | factory | `references/mundane-events.md` |
 | `LunationModel` | model | `references/mundane-events.md` |
 | `LunationsCollectionModel` | model | `references/mundane-events.md` |
@@ -186,6 +197,7 @@ answer "where is X documented?"; the domain file is always the richer source.
 | `MutualReceptionsFactory` | factory | `references/traditional.md` |
 | `MutualReceptionsModel` | model | `references/traditional.md` |
 | `NO_POINT_ORB_ADJUSTMENTS` | subpackage import — `kerykeion.settings.config_constants` | `references/aspects-and-orbs.md` |
+| `normalize_degree` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
 | `normalize_longitude` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
 | `normalize_zodiac_type` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
 | `OccultationFactory` | factory | `references/mundane-events.md` |
@@ -234,10 +246,10 @@ answer "where is X documented?"; the domain file is always the richer source.
 | `resolve_subject_birth_datetime` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
 | `resolve_subject_local_moment` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
 | `resolve_subject_local_now` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
-| `RetrogradeStationFactory` | factory | `references/mundane-events.md` |
-| `RetrogradeStationsCollectionModel` | model | `references/mundane-events.md` |
 | `RetrogradePeriodModel` | model | `references/mundane-events.md` |
 | `RetrogradePeriodsCollectionModel` | model | `references/mundane-events.md` |
+| `RetrogradeStationFactory` | factory | `references/mundane-events.md` |
+| `RetrogradeStationsCollectionModel` | model | `references/mundane-events.md` |
 | `ReturnType` | literal — `kerykeion.schemas` | `references/predictive.md` |
 | `ROYAL_FIXED_STARS` | subpackage import — `kerykeion.settings.config_constants` | `references/subjects.md` |
 | `safe_timezone` | subpackage import — `kerykeion.utilities` | `references/utilities.md` |
@@ -249,9 +261,9 @@ answer "where is X documented?"; the domain file is always the richer source.
 | `Sign` | literal — `kerykeion.schemas` | `references/subjects.md` |
 | `SIGN_CODES` | literal — `kerykeion.schemas` | `references/zodiac-houses-perspectives.md` |
 | `SignIngressesCollectionModel` | model | `references/mundane-events.md` |
+| `SignIngressFactory` | factory | `references/mundane-events.md` |
 | `SignPeriodModel` | model | `references/mundane-events.md` |
 | `SignPeriodsCollectionModel` | model | `references/mundane-events.md` |
-| `SignIngressFactory` | factory | `references/mundane-events.md` |
 | `SignNumbers` | literal — `kerykeion.schemas` | `references/subjects.md` |
 | `single_chart_data_to_context` | subpackage import — `kerykeion.context` | `references/reports-and-ai-context.md` |
 | `SingleChartAspectsModel` | model | `references/aspects-and-orbs.md` |

--- a/skills/kerykeion/references/backends-and-provenance.md
+++ b/skills/kerykeion/references/backends-and-provenance.md
@@ -55,6 +55,8 @@ print(subject.ascendant.source)   # None — house-geometry points carry no prov
     download/degrade. This is the shipped default.
   - `auto` — LEB if available, else Skyfield/DE440 (may download).
   - `skyfield` — always Skyfield/DE440.
+  - `horizons` — query JPL Horizons. Like `auto`/`skyfield` it may reach the
+    network; only `leb` guarantees it will not.
 - **`KERYKEION_EPHE_PATH`** — ephemeris data directory. libephemeris: a no-op
   (manages its own data). swisseph: point it at a directory of `.se1` files;
   without it the default download dir of `python -m kerykeion.swisseph_setup`
@@ -198,7 +200,7 @@ every requested star fails).
 
 ## The ephemeris_backend package facade
 
-**Subpackage import:** `from kerykeion.ephemeris_backend import ephe, BACKEND_NAME, EPHE_DATA_PATH, EPHEMERIS_LOCK, ephemeris_session, reset_ephemeris_session, DEFAULT_SWEPH_DOWNLOAD_DIR, POLAR_HOUSES_ERROR_TYPES, houses_ex2_with_polar_fallback, houses_ex2_with_polar_fallback_ex`
+**Subpackage import:** `from kerykeion.ephemeris_backend import ephe, BACKEND_NAME, EPHE_DATA_PATH, EPHEMERIS_LOCK, ephemeris_session, reset_ephemeris_session, DEFAULT_SWEPH_DOWNLOAD_DIR, POLAR_HOUSES_ERROR_TYPES, houses_ex2_with_polar_fallback, houses_ex2_with_polar_fallback_ex, houses_ring_with_polar_fallback, HouseRing` (the package `__all__`, 12 names)
 
 | Name | What it is |
 |---|---|
@@ -212,6 +214,26 @@ every requested star fails).
 | `POLAR_HOUSES_ERROR_TYPES` | exception types meaning "house system undefined inside the polar circle" (libephemeris `PolarCircleError`; swisseph generic `Error`) |
 | `houses_ex2_with_polar_fallback(tjdut, lat, lon, hsys, flags, *, context="")` | cusps with polar substitution, returns 4-tuple `(cusps, ascmc, cusps_speed, ascmc_speed)` |
 | `houses_ex2_with_polar_fallback_ex(..., polar_strategy="substitute_system")` | same plus a 5th element: the `PolarHouseFallbackModel` record or `None` |
+| `houses_ring_with_polar_fallback(tjdut, lat, lon, hsys, flags, *, context="", polar_strategy="substitute_system")` | same computation, returned as a `HouseRing` — preferred over the two tuple-returning siblings |
+| `HouseRing` | dataclass: `cusps`, `ascmc`, `cusps_speed`, `ascmc_speed`, `polar_fallback`, `angle_houses`, `coincident_cusps` |
+
+`HouseRing` carries the two facts that only the house call itself can know, and
+that twelve cusp longitudes cannot answer afterwards:
+
+- `angle_houses` — which house each angle OPENS, keyed by model field name, for
+  the angles this chart puts on their own cusp (all four under quadrant systems,
+  Asc/Desc only under equal houses, MC/IC only under meridian houses, none under
+  whole sign / Vehlow / Morinus). Where several cusps land on ONE longitude the
+  shared reader answers with the lowest-numbered of them, so an Imum Coeli that
+  IS the fourth cusp would otherwise be filed in the second. The subject factory
+  and the relocated chart both record this at the ring, which is why
+  `subject.imum_coeli.house` is right where a bare cusp scan is not.
+- `coincident_cusps` — groups of house numbers standing on one longitude, which
+  is what `subject.coincident_house_cusps` holds. Empty for every ordinary chart.
+
+Nothing else changed with it: `get_planet_house` behaves exactly as before, and
+every other caller projects a point into a ring that is not its own, where no
+identity exists and none is claimed.
 
 ### Sessions (advanced)
 

--- a/skills/kerykeion/references/calendars-hours-moon.md
+++ b/skills/kerykeion/references/calendars-hours-moon.md
@@ -28,11 +28,13 @@ that instant:
   `phase_name`, `major_phase` (nearest of the four quarters), `stage`
   (`"waxing"`/`"waning"`), `illumination` (e.g. `"51%"`), `age_days` /
   `age_days_precise` (days since last New Moon, exact ephemeris-based),
-  `lunar_cycle`, `emoji`, `zodiac` (Sun/Moon signs), `next_lunar_eclipse`, and
+  `lunar_cycle`, `emoji`, `zodiac` (Sun/Moon signs), `next_lunar_eclipse`, the
+  four rise/set fields `moonrise`/`moonrise_timestamp`/`moonset`/`moonset_timestamp`
+  (all directly on `moon`, not nested), `events` (`MoonPhaseEventsModel`:
+  `moonrise_visible`, `moonset_visible`, `optimal_viewing_period`), and
   `detailed.upcoming_phases` — precise last/next instants for New Moon, First
   Quarter, Full Moon, Last Quarter (each with timestamp, datestamp and
-  days_ago/days_ahead), plus `moonrise`/`moonset` and their
-  `moonrise_timestamp`/`moonset_timestamp`.
+  days_ago/days_ahead).
 - `moonrise`/`moonset` are ISO-8601 strings in the subject's **local** zone (the
   same zone `sun.sunrise` uses — but `str` here against `sun.sunrise`'s
   `datetime`: the moon block mirrors a web-API shape and keeps everything a
@@ -55,7 +57,15 @@ that instant:
 Literals (8 values each): `LunarPhaseEmoji` = 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘;
 `LunarPhaseName` = `"New Moon"`, `"Waxing Crescent"`, `"First Quarter"`,
 `"Waxing Gibbous"`, `"Full Moon"`, `"Waning Gibbous"`, `"Last Quarter"`,
-`"Waning Crescent"`.
+`"Waning Crescent"`. `LunarPhaseStage` (2 values) = `"waxing"` | `"waning"` —
+the type of both `stage` fields.
+
+`major_phase` and `stage` read the SAME definition on `LunarPhaseModel` and on
+this factory's `moon` block: the phase name comes from windows **centred** on
+the syzygy or quadrature (New/Full ±6.4286°, the quarters ±19.2857°, the four
+crescent/gibbous names filling the rest), so the word tracks the event and
+cannot disagree with a 100% illumination. The 1–28 `moon_phase` index is a
+separate, unchanged quantity — see `references/utilities.md`.
 
 ```python
 from kerykeion import AstrologicalSubjectFactory, MoonPhaseDetailsFactory

--- a/skills/kerykeion/references/charts-and-drawing.md
+++ b/skills/kerykeion/references/charts-and-drawing.md
@@ -151,8 +151,18 @@ Constructor: `ChartDrawer(chart_data, *, ...)` — `chart_data` is the only posi
 | `show_aspect_icons` | `True` | Classic style only. |
 | `style` | `"modern"` | `KerykeionChartStyle` — wheel geometry default for render methods. |
 | `show_zodiac_background_ring` | `True` | Colored zodiac wedges (modern only); overridable at render time. |
-| `glyph_size` | `"medium"` | `KerykeionGlyphSize` — planet-cluster size on the modern wheel (`"small"`/`"medium"`/`"large"`; large = classic-parity glyph in the default configuration, ring active and per-glyph map applied); overridable at render time. |
+| `glyph_size` | `"medium"` | `KerykeionGlyphSize` — planet-cluster size on the modern wheel (`"small"`/`"medium"`/`"large"`); classic ignores it in silence, like `show_zodiac_background_ring`. `"medium"` IS the pre-existing drawing, byte for byte. `"small"` scales the whole cluster to 90%. `"large"` draws the planet GLYPH at the classic style's own size — exact in the default configuration (zodiac background ring active, per-glyph optical map applied), and on the dual rings only the glyph grows: degrees, sign, minutes and ℞ stay at the medium size. Overridable at render time. |
 | `show_diurnality` | `True` | Diurnality line in the bottom-left info panel. |
+| `show_motion_state` | `False` | Mark a planet at a station: `SR` (retrograde phase opening) or `SD` (closing). Modern recolours the cluster and reuses the `RX` row; classic writes the letters at the foot of the glyph. |
+| `show_out_of_bounds` | `False` | `OOB` badge in the point tables. |
+| `show_aspect_movement` | `False` | Dash the separating aspect lines. |
+| `show_relationship_score` | `False` | Synastry score in the info panel; needs a score on the chart data (`create_synastry_chart_data` computes one by default). |
+| `show_ayanamsa_value` | `False` | Ayanamsa offset in degrees and minutes on the zodiac line of a sidereal chart. |
+| `show_polar_fallback_note` | `False` | Mark the domification line when the requested house system was substituted at a polar latitude. |
+
+The last six draw facts the chart data already carries. Each is silent where it
+has no referent — no station, no score, a tropical zodiac, a house system that
+was honoured — so turning one on never produces an empty claim.
 
 **THE TRAP — `theme` vs `style` are orthogonal axes.** `theme` selects a CSS palette and defaults to `"classic"`; `style` selects the wheel geometry and defaults to `"modern"`. The default render is therefore classic *palette* on a modern *wheel*. `"classic"` appears in both literals but means different things; to get the traditional v5-style drawing pass `style="classic"` (theme choice is independent).
 
@@ -173,14 +183,16 @@ assert "<svg" in svg
 | Method | Extra kwargs beyond `minify=False, remove_css_variables=False` | Returns |
 |---|---|---|
 | `set_up_theme(theme=None)` | — | `None` (loads `charts/themes/{theme}.css`; `None` clears CSS) |
-| `generate_svg_string(...)` | `*, custom_title=None, style=<ctor>, show_zodiac_background_ring=<ctor>` | `str` |
+| `generate_svg_string(...)` | `*, custom_title=None, style=<ctor>, show_zodiac_background_ring=<ctor>, glyph_size=<ctor>` | `str` |
 | `save_svg(output_path=None, filename=None, ...)` | same as above | `None` |
-| `generate_wheel_only_svg_string(...)` | `*, style=<ctor>, show_zodiac_background_ring=<ctor>` | `str` |
+| `generate_wheel_only_svg_string(...)` | `*, style=<ctor>, show_zodiac_background_ring=<ctor>, glyph_size=<ctor>` | `str` |
 | `save_wheel_only_svg_file(output_path=None, filename=None, ...)` | same as above | `None` |
 | `generate_aspect_grid_only_svg_string(...)` | — | `str` |
 | `save_aspect_grid_only_svg_file(output_path=None, filename=None, ...)` | — | `None` |
 
-`style=` at render time overrides the constructor default per call. `minify=True` strips whitespace/quotes; `remove_css_variables=True` inlines the CSS custom-property definitions (needed by SVG consumers that do not resolve `var(...)`, e.g. many raster converters). `output_path=None` writes to the user's HOME directory — always pass a directory. `filename` is the basename without `.svg`; user-supplied names are sanitized (path separators, `..`, leading dots become underscores) and the resolved path must stay inside the output directory or `KerykeionException` is raised.
+`style=`, `show_zodiac_background_ring=` and `glyph_size=` at render time each
+override the constructor default for that call only (the aspect-grid-only
+methods take none of the three — there is no wheel to size). `minify=True` strips whitespace/quotes; `remove_css_variables=True` inlines the CSS custom-property definitions (needed by SVG consumers that do not resolve `var(...)`, e.g. many raster converters). `output_path=None` writes to the user's HOME directory — always pass a directory. `filename` is the basename without `.svg`; user-supplied names are sanitized (path separators, `..`, leading dots become underscores) and the resolved path must stay inside the output directory or `KerykeionException` is raised.
 
 Layout notes: with more than 24 active points the aspect list/grid moves to a full-height right-side panel instead of below the wheel. `double_chart_aspect_grid_type="table"` renders the dual-chart aspect grid as a matrix instead of the default column list.
 
@@ -233,6 +245,12 @@ Rendered SVGs carry `kr:` metadata: each celestial point is a `<g kr:node="Chart
 
 - `parse_chart_points(svg: str) -> list[ChartPointTag]` — frozen dataclass with `slug: str`, `horoscope: str` (`"0"` single/inner ring, `"1"` dual outer ring), `display_angle: float` (post-decluttering wheel angle), `sign: Optional[str]`, `sign_position: Optional[float]`, `retrograde: bool`.
 - `parse_indicators(svg: str) -> list[IndicatorTag]` — `slug`, `horoscope`, `true_angle: float` (the point's undisplaced angle).
+
+A small or large modern wheel also stamps `kr:glyphsize` on its root
+(`ModernHoroscope` / `ModernDualHoroscope`), so a consumer holding only the SVG
+can tell which cluster profile drew it. `"medium"` is unstamped on purpose:
+the attribute's ABSENCE is the default, and the default render is byte-identical
+to one produced before `glyph_size` existed.
 
 ## Chart settings and translations
 

--- a/skills/kerykeion/references/locational.md
+++ b/skills/kerykeion/references/locational.md
@@ -30,7 +30,7 @@ Semantics — the UTC instant and `julian_day` are unchanged:
 - **Replaced:** `polar_house_fallbacks` records only the relocated house call
   (relocating into a polar latitude may substitute the house system; the
   requested one stays in `houses_system_identifier`).
-- Local date fields (`year`…`seconds`, `iso_formatted_local_datetime`,
+- Local date fields (`year`…`minute`, `iso_formatted_local_datetime`,
   `day_of_week`) are recomputed only when `new_tz_str` is given (always for
   BCE subjects, which use Local Mean Time from the new longitude).
 

--- a/skills/kerykeion/references/mundane-events.md
+++ b/skills/kerykeion/references/mundane-events.md
@@ -18,8 +18,8 @@ Source of each factory: `kerykeion/<subpackage>/factory.py` — subpackages
 - [Shared range-factory contract](#shared-range-factory-contract)
 - [EclipseFactory](#eclipsefactory)
 - [LunationFinderFactory](#lunationfinderfactory)
-- [RetrogradeStationFactory](#retrogradestationfactory)
-- [SignIngressFactory](#signingressfactory)
+- [RetrogradeStationFactory](#retrogradestationfactory) (+ retrograde periods)
+- [SignIngressFactory](#signingressfactory) (+ sign periods)
 - [MundaneAspectFactory](#mundaneaspectfactory)
 - [PlanetaryPhenomenaFactory](#planetaryphenomenafactory)
 - [PlanetaryNodesFactory](#planetarynodesfactory)
@@ -50,6 +50,11 @@ Source of each factory: `kerykeion/<subpackage>/factory.py` — subpackages
   silently truncated); `ValueError` for non-finite JD bounds, over-large
   ranges/counts, or unknown filter names.
 - Collections carry `start_jd`/`end_jd` plus a chronologically sorted list.
+
+`SignIngressFactory` and `RetrogradeStationFactory` each carry a second pair of
+entry points with the same argument list — `sign_periods_from_*` and
+`retrograde_periods_from_*` — reporting the SPANS between the events instead of
+the events (below).
 
 `EclipseFactory`, `OccultationFactory` and `HeliacalFactory` are count-based
 ("next N events from a start point") instead of range-based.
@@ -119,19 +124,40 @@ Pluto` (Sun/Moon never station and are not accepted). `StationModel`: `planet`,
 `station_type` (`"SR"` = turns retrograde, `"SD"` = turns direct),
 `julian_day`, `iso_utc`, `sign`, `sign_num`, `degree`, `ecliptic_longitude`.
 
-### Retrograde periods (a92)
+### Retrograde periods — the spans, not just the turns
 
-`RetrogradeStationFactory.retrograde_periods_from_iso_range(start, end, planets=None, zodiac_type="Tropical", sidereal_mode=None)`
-/ `retrograde_periods_from_julian_day(...)` → `RetrogradePeriodsCollectionModel`
-(`start_jd`, `end_jd`, `periods`). Each `RetrogradePeriodModel` is one retrograde
-span clipped to the range: `planet`, `start_jd`, `end_jd`, `start`, `end`,
-`start_clipped`, `end_clipped`. The motion state at the range start comes from
-the speed there, refined by a probe a solver's resolution (50 ms) past either
-bound so a station sitting on the range start decides it deterministically and
-one sitting on the range end closes the span unclipped — a station any farther
-in is a real station; SR opens a span, SD closes it; clipped bounds are
-flagged, and beyond that probe nothing is searched outside the range — returned periods stay clipped to it. `"Chiron"` is accepted opt-in by both the station
-finder and the periods (default set unchanged).
+`retrograde_periods_from_iso_range(start_date, end_date, planets=None, zodiac_type="Tropical", sidereal_mode=None)`
+/ `retrograde_periods_from_julian_day(start_jd, end_jd, planets=None, ...)` →
+`RetrogradePeriodsCollectionModel` (`start_jd`, `end_jd`, `periods`). Answers
+"is this planet retrograde right now?", which the station list alone cannot.
+
+Each `RetrogradePeriodModel` is one retrograde span clipped to the range:
+`planet`, `start_jd`, `end_jd`, `start`, `end` (ISO UTC), `start_clipped`,
+`end_clipped`. An SR opens a span, an SD closes it; a planet already retrograde
+at the range start is reported from the start with `start_clipped=True`, one
+still retrograde at the range end with `end_clipped=True`. Periods carry **no
+sign or degree** — a station instant is zodiac-independent, so a sidereal
+request returns the same span times.
+
+Edge rules worth knowing:
+
+- The initial motion state comes from the speed at the range start, EXCEPT when
+  a station sits within a solver's resolution (50 ms — ten times the
+  bisection's error, twenty times finer than the second the ISO strings
+  resolve) of a bound. Such a station IS that bound: at the start it sets the
+  state deterministically (rather than the sign of a speed that is numerically
+  ~0 there), at the end it closes the span unclipped. This matters when the
+  bounds are instants this library reported, which bisection leaves a hair to
+  either side of the true zero. A station any farther from a bound is a real
+  station, however close.
+- Beyond that 50 ms probe **nothing is searched outside the range**: a clipped
+  bound says where the range cut the span, not where the real station is.
+- Only an EMPTY span is dropped; a span is as short as the range makes it.
+- Stations that do not alternate (an SR while already retrograde, an SD while
+  not) raise `KerykeionException` rather than folding silently.
+
+`"Chiron"` is accepted opt-in by the station finder and by the periods alike;
+the default set stays Mercury..Pluto, so existing outputs are unchanged.
 
 ## SignIngressFactory
 
@@ -146,12 +172,47 @@ Sun ingresses at 0/90/180/270° with hemisphere-neutral values
 `march_equinox`/`june_solstice`/`september_equinox`/`december_solstice`;
 tropical-only (`None` on every sidereal ingress).
 
+### Sign periods — where a planet IS, not just where it changes
+
+`sign_periods_from_iso_range(start_date, end_date, planets=None, zodiac_type="Tropical", sidereal_mode=None)`
+/ `sign_periods_from_julian_day(start_jd, end_jd, planets=None, ...)` →
+`SignPeriodsCollectionModel` (`start_jd`, `end_jd`, `periods`). The ingress
+finder reports what CHANGES; this reports the stays, so a planet that does not
+ingress inside the range still appears.
+
+Per planet the result is the contiguous list of `SignPeriodModel` covering the
+whole range: `planet`, `sign`, `sign_num`, `start_jd`, `end_jd`, `start`, `end`
+(ISO UTC), `start_clipped`, `end_clipped`. The first stay opens at the range
+start (`start_clipped=True`), each ingress hands over to the next stay (one
+stay's `end` IS the next one's `start`, at the ingress instant and to the same
+bisection), and the last stay closes at the range end (`end_clipped=True`).
+`planets` and the Moon opt-in follow the ingress rules above.
+
+The sign at the range start is read **inside the same ephemeris session** as
+the scan, with that session's `iflag`: a sidereal request therefore yields
+sidereal stays bounded by sidereal ingress instants, and the first stay can
+never disagree with the ingresses that follow it. A range bound that sits
+exactly on an ingress opens or closes its stay there UNCLIPPED — the scan looks
+a solver's resolution (50 ms) beyond either bound, so a bound that is itself an
+instant this library reported is recognised; an ingress any farther in is a
+real boundary and clips nothing.
+
 ```python
 from kerykeion import RetrogradeStationFactory, SignIngressFactory
 st = RetrogradeStationFactory.from_iso_range("2024-01-01", "2024-12-31", planets=["Mercury"])
 print([(s.station_type, s.iso_utc[:10], s.sign) for s in st.stations])
 ing = SignIngressFactory.from_iso_range("2024-03-01", "2024-03-31", planets=["Sun"])
 print([(i.sign, i.iso_utc[:16], i.season_marker) for i in ing.ingresses])
+
+# The spans, not the events: two contiguous stays across the March equinox,
+# each clipped at the range bound it reaches.
+stays = SignIngressFactory.sign_periods_from_iso_range(
+    "2026-03-01", "2026-03-31", planets=["Sun"])
+print([(p.sign, p.start[:10], p.end[:10], p.start_clipped, p.end_clipped)
+       for p in stays.periods])
+spans = RetrogradeStationFactory.retrograde_periods_from_iso_range(
+    "2025-03-01", "2025-03-31", planets=["Mercury"])
+print([(s.planet, s.start[:16], s.end[:16], s.end_clipped) for s in spans.periods])
 ```
 
 ## MundaneAspectFactory
@@ -371,14 +432,3 @@ Cross-references: subjects in `references/subjects.md`; provenance in
 `references/backends-and-provenance.md`; sidereal modes in
 `references/zodiac-houses-perspectives.md`; VoC Moon / sun times / planetary
 hours in `references/calendars-hours-moon.md`.
-
-### Sign periods (a92)
-
-`SignIngressFactory.sign_periods_from_iso_range(start, end, planets=None, zodiac_type="Tropical", sidereal_mode=None)`
-/ `sign_periods_from_julian_day(...)` → `SignPeriodsCollectionModel` (`start_jd`,
-`end_jd`, `periods`). Per planet, contiguous `SignPeriodModel` stays covering
-the whole range: `planet`, `sign`, `sign_num`, `start_jd`, `end_jd`, `start`,
-`end`, `start_clipped`, `end_clipped`. The sign at the range start is read in
-the same ephemeris session (same frame) as the ingress scan, so stays and
-ingresses never disagree — a sidereal request yields sidereal stays. A range that starts or ends exactly on an ingress opens or closes the stay there, unclipped (the scan looks a solver's resolution — 50 ms — beyond either bound; an ingress any farther in is a real boundary). The Moon
-is opt-in, as for ingresses.

--- a/skills/kerykeion/references/predictive.md
+++ b/skills/kerykeion/references/predictive.md
@@ -188,6 +188,56 @@ searches backward in time and requires the libephemeris backend — pyswisseph r
 Searches that walk off the ephemeris date range raise `KerykeionException`. Sidereal
 subjects are searched in sidereal longitude (the crossing tracks the drifting ayanamsa).
 
+### Reported instants are re-usable as seeds
+
+Return instants are reported truncated to the whole second, so ordering between a
+seed and a return is decided at that same resolution. Feed a reported instant back
+into any `*_from_iso_formatted_time` entry point and you step exactly one return:
+
+```
+next(reported(N))     == N + 1
+previous(reported(N)) == N − 1
+previous(next(r))     == r        exactly, instant for instant
+```
+
+A forward search starts from the whole second AFTER the seed's, a backward search
+from the seed's own whole second, so a walk of N steps forward and N back lands on
+each return once and comes home to the same instant. Nothing can be skipped:
+consecutive crossings of one kind are at least ~12.4 days apart. This holds for
+Solar, Lunar, heliocentric and lunar-node searches alike.
+
+Consequences to know:
+
+- **A seed inside the same second as a crossing selects the FOLLOWING return.**
+  Seeding a solar-return search with the natal instant itself — a crossing by
+  construction — returns the first birthday, not the birth moment. `previous` from
+  the natal instant gives the cycle before birth, never a "return" a second earlier.
+- Only the ISO entry points snap their seed. `next_return_from_date` and the
+  `*_from_year` wrappers keep their INCLUSIVE midnight seed: "the first return of
+  this date" still includes one in the date's first second.
+- A seed at the edge of the civil range refuses with `KerykeionException` naming
+  the range (years 1 to 9999) instead of overflowing `datetime`. Seeds are
+  normalized to UTC before the check, so `9999-12-31T23:59:59+14:00` — a
+  mid-morning UTC instant — seeds normally.
+- Heliocentric instants are settled onto the crossing itself by bisection, so the
+  slow bodies can report a second or so away from what a bare solver would answer.
+
+```python
+from kerykeion import AstrologicalSubjectFactory, PlanetaryReturnFactory
+natal = AstrologicalSubjectFactory.from_birth_data(
+    name="Example Person", year=1990, month=7, day=15, hour=10, minute=30,
+    lng=12.4964, lat=41.9028, tz_str="Europe/Rome", city="Rome", nation="IT", online=False)
+factory = PlanetaryReturnFactory(
+    natal, lng=12.4964, lat=41.9028, tz_str="Europe/Rome", online=False)
+this_year = factory.next_return_from_date(2025, 1, 1, return_type="Solar")
+next_year = factory.next_return_from_iso_formatted_time(
+    this_year.iso_formatted_utc_datetime, "Solar")            # steps forward, never stalls
+back = factory.next_return_from_iso_formatted_time(
+    next_year.iso_formatted_utc_datetime, "Solar", backwards=True)
+assert back.iso_formatted_utc_datetime == this_year.iso_formatted_utc_datetime
+print(this_year.iso_formatted_utc_datetime, next_year.iso_formatted_utc_datetime)
+```
+
 Deprecated (DeprecationWarning, removal in 7.0.0 — see `references/migration-and-deprecations.md`):
 `next_return_from_year(year, return_type)` and
 `next_return_from_month_and_year(year, month, return_type)` → use `next_return_from_date`.

--- a/skills/kerykeion/references/reports-and-ai-context.md
+++ b/skills/kerykeion/references/reports-and-ai-context.md
@@ -53,6 +53,22 @@ Attribute after init: `gen.chart_type` (`"Natal"`, `"Synastry"`, `"Subject"`,
 `"Profections"`, ...). Subject-provided strings (name/city/nation) are
 sanitized against terminal-control characters before printing.
 
+Rows a consumer should not be surprised by (both surfaces carry them, and both
+are silent when the chart has nothing to say):
+
+- The house line names the division ACTUALLY cast, not the request:
+  `Porphyry (substituted for Placidus)` on a polar chart. The context emits a
+  `<polar_house_fallback>` element beside it.
+- **Cusps On One Longitude** lists the groups from `coincident_house_cusps` —
+  houses with no width, which can never contain anything. The context emits one
+  `<coincident_house_cusps houses="...">` per group. Empty on every ordinary
+  chart, so nothing is printed there.
+- A midpoint composite prints a **House Anchor** row saying whether the request
+  was granted: `midheaven (not held: the twelve cusps are not a house division)`
+  where `house_frame` is not `"anchored"`. The context carries `house_frame`
+  beside `house_anchor` on its composite element. A Davison chart has neither
+  and prints no such row.
+
 ```python
 from kerykeion import AstrologicalSubjectFactory, ChartDataFactory
 chart_data = ChartDataFactory.create_natal_chart_data(

--- a/skills/kerykeion/references/subjects.md
+++ b/skills/kerykeion/references/subjects.md
@@ -152,7 +152,7 @@ The 23 star names remain in the literal only for v5 type-compatibility; passing 
 
 - `Sign`: 12 three-letter codes `"Ari" "Tau" "Gem" "Can" "Leo" "Vir" "Lib" "Sco" "Sag" "Cap" "Aqu" "Pis"`.
 - `Element`: `"Air" "Fire" "Earth" "Water"`. `Quality`: `"Cardinal" "Fixed" "Mutable"`.
-- `MotionState`: `"retrograde" "stationary" "slow" "average" "fast"` (speed classified against the body's mean daily motion).
+- `MotionState` (7 values): `"retrograde" "stationary" "stationary_retrograde" "stationary_direct" "slow" "average" "fast"` (speed classified against the body's mean daily motion; the stationary band brackets zero and is tested before the sign, and the two station variants are separated by a second speed sample a day later — match this literal exhaustively only if you handle both).
 - All importable from `kerykeion.schemas` (facade over `kerykeion/schemas/literals.py`).
 
 Sign → element/quality mapping (what `point.element` / `point.quality` return):
@@ -260,16 +260,16 @@ read the natal.
 
 - `get_midpoint_composite_subject_model()` — circular midpoints of points and cusps; not a real sky, so `is_diurnal` is `None` and provenance is absent. Composite cusps keep their own house numbers and are deliberately NOT re-sorted by longitude (re-sorting would swap the composite MC and IC).
 
-  Where the two charts' angles are nearly opposed the twelve near midpoints stop running in order — about one pair in sixteen — and the cusps are repaired the way the field does it: one angle keeps its near midpoint and the others move onto their far one. `house_anchor` picks which: `"auto"` (default; whichever of the Ascendant and Midheaven has its base cusps closer together, matching Solar Fire), `"ascendant"` or `"midheaven"` (Kepler's two methods). Anything else raises `KerykeionException`.
+  Where the two charts' angles are nearly opposed the twelve near midpoints stop running in order — about one pair in sixteen — and the cusps are repaired the way the field does it: one angle keeps its near midpoint and the others move onto their far one. `house_anchor` picks which — the `CompositeHouseAnchor` literal (`from kerykeion.schemas import CompositeHouseAnchor`): `"auto"` (default; whichever of the Ascendant and Midheaven has its base cusps closer together, matching Solar Fire), `"ascendant"` or `"midheaven"` (Kepler's two methods). Anything else raises `KerykeionException`.
 
-  It is a request, not a guarantee: a frame can only be read where each parent is itself a house division and the two run the same way, and `house_frame` on the model says whether it was granted. Where it was not, every position is its own near midpoint — bar a cusp the parents put exactly opposite another, which is kept opposite it — and all three anchors give the same chart.
+  It is a request, not a guarantee: a frame can only be read where each parent is itself a house division and the two run the same way, and `house_frame` on the model (the `CompositeHouseFrame` literal) says whether it was granted. Where it was not, every position is its own near midpoint — bar a cusp the parents put exactly opposite another, which is kept opposite it — and all three anchors give the same chart.
 
   The ring is reconciled with the angles by the ARC each angle stands at from the cusp it shares a number with, averaged from the two parents: zero is the case where the angle IS the cusp, and under whole sign, Morinus, meridian or Carter it is something else. An exact identity outranks an arc; where neither is exact the anchor breaks the tie.
 - `get_davison_composite_subject_model(*, custom_ayanamsa_t0=None, custom_ayanamsa_ayan_t0=None)` — midpoint in time (mean Julian Day) and space, cast as a REAL chart at that moment (tz `Etc/GMT`); carries over enrichments both parents share; the keyword pair is required when `sidereal_mode="USER"`.
 
 With `chart_name=None` the composite is named `"{first} and {second} Composite Chart"`.
 
-`CompositeSubjectModel` adds `first_subject`, `second_subject`, `composite_chart_type` (values of the `CompositeChartType` literal: `"Midpoint"` | `"Davison"`), `Optional house_anchor` (which angle the caller ASKED to hold when the cusp ring was repaired; `None` on a Davison chart), `Optional house_frame` (what the twelve turned out to be — `"anchored"` if a frame was hung from that angle and the twelve cover the circle once, `"midpoints"` if no frame spans the two charts but they are still a house division, `"gapped"` if they are not; the two fields are recorded together or not at all, and an a86 payload carrying neither still validates), and `Optional is_diurnal`; location/time metadata fields are optional. It feeds `ChartDataFactory.create_composite_chart_data` — see `references/charts-and-drawing.md`.
+`CompositeSubjectModel` adds `first_subject`, `second_subject`, `composite_chart_type` (values of the `CompositeChartType` literal: `"Midpoint"` | `"Davison"`), `Optional house_anchor` (`CompositeHouseAnchor` — which angle the caller ASKED to hold when the cusp ring was repaired; `None` on a Davison chart), `Optional house_frame` (`CompositeHouseFrame` — what the twelve turned out to be — `"anchored"` if a frame was hung from that angle and the twelve cover the circle once, `"midpoints"` if no frame spans the two charts but they are still a house division, `"gapped"` if they are not; the two fields are recorded together or not at all, and an a86 payload carrying neither still validates), and `Optional is_diurnal`; location/time metadata fields are optional. It feeds `ChartDataFactory.create_composite_chart_data` — see `references/charts-and-drawing.md`.
 
 ```python
 from kerykeion import AstrologicalSubjectFactory, CompositeSubjectFactory

--- a/skills/kerykeion/references/utilities.md
+++ b/skills/kerykeion/references/utilities.md
@@ -4,7 +4,7 @@ Public helpers of `kerykeion.utilities` (a flat facade: `kerykeion/utilities/__i
 re-exports everything from `kerykeion/utilities/core.py`), plus the motion-state
 classifier from `kerykeion.motion`. **Subpackage import:** `from kerykeion.utilities
 import wrap_180` — none of these names are in `kerykeion.__all__`, so `from kerykeion
-import wrap_180` fails. The facade's `__all__` lists 47 functions and 2 constants;
+import wrap_180` fails. The facade's `__all__` lists 54 functions and 2 constants;
 underscore-prefixed re-exports are internal, do not use them.
 
 ## Validation and normalization
@@ -87,6 +87,8 @@ print(localize_naive(gap, tz, is_dst=True).utcoffset())  # 2:00:00
 | `get_kerykeion_point_from_degree` | `(degree, name, point_type, speed=None, declination=None, magnitude=None, ecliptic_latitude=None) -> KerykeionPointModel` | Build a point from a longitude; finite degrees wrapped into [0, 360), non-finite raise |
 | `get_planet_house` | `(planet_degree, houses_degree_ut_list: list) -> Houses` | House containing a longitude (12 cusp degrees in). Direction-aware: several house systems return descending cusps above the polar circle |
 | `house_spans` | `(cusps: Sequence[float]) -> tuple[list[float], list[bool]]` | The twelve house widths and which run against the frame given. Six systems reverse above ~68°, two cross |
+| `angle_house_identities` | `(cusps: Sequence[float], ascendant: float, medium_coeli: float) -> dict[str, Houses]` | Which house each angle OPENS, keyed by model field name (`"ascendant"`, `"medium_coeli"`, `"descendant"`, `"imum_coeli"`). Only for angles the chart puts on their own cusp: all four under quadrant systems, Asc/Desc only under equal houses, MC/IC only under meridian houses, none under whole sign / Vehlow / Morinus. Twelve cusp longitudes alone cannot answer this where several coincide — the subject factory records it at the house call |
+| `coincident_cusp_groups` | `(cusps: Sequence[float]) -> list[list[int]]` | Groups of 1-based house numbers whose cusps share a longitude; `[]` for a chart whose twelve cusps are twelve distinct points. This is what `subject.coincident_house_cusps` holds |
 | `normalize_degree` | `(angle: float) -> float` | Into [0, 360). Use instead of `% 360`, which answers exactly 360.0 for a hair-negative angle; propagates NaN |
 | `get_house_name` | `(house_number: int) -> Houses` | 1–12 → `"First_House"`...; else `ValueError` |
 | `get_house_number` | `(house_name: Houses) -> int` | Inverse of the above |
@@ -115,6 +117,9 @@ print(localize_naive(gap, tz, is_dst=True).utcoffset())  # 2:00:00
 | `calculate_moon_phase` | `(moon_abs_pos: float, sun_abs_pos: float) -> LunarPhaseModel` | Full `LunarPhaseModel` from two longitudes: `degrees_between_s_m`, `moon_phase` (1–28), `moon_emoji`, `moon_phase_name`, `major_phase`, `stage` |
 | `get_moon_emoji_from_phase_int` | `(phase: int) -> LunarPhaseEmoji` | Phase 1–28 → emoji; out of range raises `KerykeionException` |
 | `get_moon_phase_name_from_phase_int` | `(phase: int) -> LunarPhaseName` | Phase 1–28 → name (e.g. `"Full Moon"`) |
+| `lunar_phase_name_from_degrees` | `(degrees: float) -> tuple[LunarPhaseName, LunarPhaseEmoji]` | Name AND emoji from the Sun–Moon separation, off the centred windows — the definition `calculate_moon_phase` and `MoonPhaseDetailsFactory` both read |
+| `lunar_major_phase_from_degrees` | `(degrees: float) -> LunarPhaseName` | The nearest of the four syzygy/quadrature events (what `major_phase` holds) |
+| `lunar_stage_from_degrees` | `(degrees: float) -> LunarPhaseStage` | `"waxing"` or `"waning"` (what `stage` holds); `LunarPhaseStage` imports from `kerykeion.schemas` |
 
 `moon_phase_name` and `moon_emoji` come from windows **centred on the syzygies**:
 New and Full span ±6.4286° of the exact aspect, the two quarters ±19.2857°, and
@@ -145,7 +150,9 @@ you have it.
 **Subpackage import:** `from kerykeion.motion import classify_motion_state`.
 
 `classify_motion_state(point_name: str, speed: Optional[float]) -> Optional[MotionState]`
-— `MotionState = Literal["retrograde", "stationary", "slow", "average", "fast"]`;
+— `MotionState = Literal["retrograde", "stationary", "stationary_retrograde",
+"stationary_direct", "slow", "average", "fast"]` (7 values — the two station
+variants are told apart by a second speed sample, never by the sign);
 returns `None` for bodies without a tabulated mean motion (nodes, asteroids,
 fixed stars, cusps) or unknown speed. Also exported: `MEAN_DAILY_MOTION_DEGREES`
 (dict of mean motions), thresholds `STATIONARY_FRACTION` (0.05), `SLOW_FRACTION`

--- a/tests/core/test_utilities.py
+++ b/tests/core/test_utilities.py
@@ -555,6 +555,31 @@ class TestInlineCssVariables:
         result = inline_css_variables_in_svg(svg)
         assert "blue" in result
 
+    def test_nested_var_fallback_is_consumed_whole(self):
+        """``var(--a, var(--b, #hex))`` must resolve to one value with no
+        trailing ``)``: the modern wheel's cusp colour is written this way, and
+        the README's inlined charts carried ``stroke='#81818d)'`` — an invalid
+        colour the browser drops — while the fallback was matched up to the
+        first ``)`` only."""
+        svg = """
+        <style>:root { --cusp: #81818d; }</style>
+        <line stroke="var(--cusp, var(--stroke, #000000))" />
+        <line stroke="var(--missing, var(--stroke, #123456))" />
+        <line stroke="var(--missing, var(--also-missing, #abcdef))" />
+        """
+        result = inline_css_variables_in_svg(svg)
+        assert 'stroke="#81818d"' in result
+        assert 'stroke="#abcdef"' in result
+        assert ")" not in result.replace("var(", "").replace("<style>", "")
+        assert "var(" not in result
+
+    def test_parenthesised_fallback_is_consumed_whole(self):
+        """A fallback such as ``rgba(...)`` closes its own parenthesis; the
+        outer ``)`` belongs to ``var`` and must go with it."""
+        svg = '<rect fill="var(--missing, rgba(0, 0, 0, 0.5))" stroke="var(--missing, rgba(1,2,3,.4))" />'
+        result = inline_css_variables_in_svg(svg)
+        assert result == '<rect fill="rgba(0, 0, 0, 0.5)" stroke="rgba(1,2,3,.4)" />'
+
     def test_multiple_variables(self):
         svg = """
         <style>:root { --a: red; --b: blue; }</style>

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -83,7 +83,7 @@ workspace/
 
 ## Need Help?
 
-- 📖 Documentation: [kerykeion.readthedocs.io](https://kerykeion.readthedocs.io)
+- 📖 Documentation: [kerykeion.net/content/docs](https://www.kerykeion.net/content/docs/)
 - 💬 Discussions: [GitHub Discussions](https://github.com/g-battaglia/kerykeion/discussions)
 - 🐛 Issues: [GitHub Issues](https://github.com/g-battaglia/kerykeion/issues)
 - 📧 Email: [kerykeion.astrology@gmail.com](mailto:kerykeion.astrology@gmail.com)

--- a/workspace/main.py
+++ b/workspace/main.py
@@ -6,7 +6,7 @@ Feel free to modify, extend, or completely replace this code with your own.
 
 For more examples, check:
 - examples/ directory in the repository
-- Documentation: https://kerykeion.readthedocs.io
+- Documentation: https://www.kerykeion.net/content/docs/
 - README.md in this workspace folder
 """
 


### PR DESCRIPTION
## Summary

- **Fix CSS variable inliner regex** (`kerykeion/utilities/core.py`): nested `var()` fallbacks were truncated, leaving stray parentheses in stroke attributes — modern wheel cusp lines were invisible in the README's inlined SVGs. Two regression tests added.
- **README restructured**: missing sections added (Chart Options, Output Options, Retrograde/Sign Periods, Mundane Aspects, Return Seeding, `house_anchor`, `coincident_house_cusps`), imports unified to public API, all snippets made offline, JSON samples and TOC regenerated.
- **8 modern SVGs** in `docs/charts/` regenerated (stale since a86 palette/glyph-scale changes).
- **58 site/docs pages** updated: missing fields, missing models, corrected counts, new factory docs for a86–a92.
- **22+ site/examples** updated, 4 new example pages added.
- **AI agent skill** (11 files): api-index, utilities, and all references updated for a86–a92.
- **llms.txt**: period sections, model list, env vars completed.
- **Support docs**: DEVELOPMENT.md (real project tree, test tiers), TEST.md (corrected counts, 28 missing test files), MANDATORY_EVOLUTIONS.md (pytz→zoneinfo marked DONE), CHANGELOG.md (missing a85 entry), LICENSING.md (resolved contradiction with COMMERCIAL-LICENSE.md), CONTRIBUTING.md, scripts/README.md.
- **4 new example scripts** + `examples/README.md`.
- **pyproject.toml**: Documentation/Changelog/Issues URLs added.

## Stats

111 files changed, 4134 insertions(+), 1382 deletions(−), 9 new files.

## Test plan

- [x] `docs:snippets` — all corpora green (86/86 README, site/docs, site/examples, skill)
- [x] `docs:check` — 124/124 = 100%
- [x] `ruff check` — clean
- [x] `pyright` — 0 errors
- [x] `test:core` — 7381+ passed
- [x] All 28 examples exit 0 with 0 GeoNames warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9sxkfAeq6reQZL4C3o3eW