### PR TITLE
fix: solar arc motion, heliacal search limits and CLI JSON sequences

### DIFF
--- a/cli/kerykeion_cli/introspect.py
+++ b/cli/kerykeion_cli/introspect.py
@@ -165,7 +165,16 @@ def coerce_value(annotation: Any, raw: str) -> Any:
         return annotation.fromisoformat(raw)
     if origin in (list, set, frozenset, tuple) or origin in _SEQUENCE_ORIGINS:
         inner_types = [a for a in get_args(annotation) if a is not ...] or [str]
-        if raw.lstrip().startswith("[") or not all(_is_csv_scalar(t) for t in inner_types):
+        use_json = not all(_is_csv_scalar(t) for t in inner_types)
+        if not use_json and raw.lstrip().startswith("["):
+            try:
+                json.loads(raw)
+            except json.JSONDecodeError:
+                # A scalar CSV value may literally start with "[".
+                pass
+            else:
+                use_json = True
+        if use_json:
             from pydantic import TypeAdapter
 
             # JSON preserves object boundaries, nested arrays and commas in

--- a/cli/kerykeion_cli/introspect.py
+++ b/cli/kerykeion_cli/introspect.py
@@ -163,6 +163,14 @@ def coerce_value(annotation: Any, raw: str) -> Any:
         return annotation(raw)
     if annotation in (datetime, date):
         return annotation.fromisoformat(raw)
+    if origin in (list, set, frozenset, tuple) or origin in _SEQUENCE_ORIGINS:
+        inner_types = [a for a in get_args(annotation) if a is not ...] or [str]
+        if raw.lstrip().startswith("[") or not all(_is_csv_scalar(t) for t in inner_types):
+            from pydantic import TypeAdapter
+
+            # JSON preserves object boundaries, nested arrays and commas in
+            # strings. Validate elements against the annotated type as well.
+            return TypeAdapter(annotation).validate_json(raw)
     if origin in (list, set, frozenset) or origin in _SEQUENCE_ORIGINS:
         factory = origin if origin in (list, set, frozenset) else list
         (inner,) = get_args(annotation) or (str,)
@@ -192,6 +200,14 @@ def coerce_value(annotation: Any, raw: str) -> Any:
         with open(raw, encoding="utf-8") as fh:
             return annotation.model_validate_json(fh.read())
     return raw
+
+
+def _is_csv_scalar(annotation: Any) -> bool:
+    """Whether comma-separated text can represent this sequence element."""
+    annotation = _strip_optional(annotation)
+    if _is_union(annotation):
+        return all(_is_csv_scalar(a) for a in _union_args(annotation))
+    return annotation in _SCALARS or annotation is Any or get_origin(annotation) is Literal
 
 
 def _classify(annotation: Any) -> str:

--- a/kerykeion/heliacal/factory.py
+++ b/kerykeion/heliacal/factory.py
@@ -481,7 +481,7 @@ class HeliacalFactory:
             # emit the globally earliest, and advance ONLY that combo. This
             # yields the true "next `count` events sorted by JD" without the old
             # hard cap of one-per-combo, while calling the (expensive) heliacal
-            # search at most count + len(combos) times — not count-per-combo.
+            # search at most count + len(combos) - 1 times — not count-per-combo.
             heads = {}
             for planet, etype in combos:
                 ev = _next_event(planet, etype, julian_day)
@@ -492,6 +492,8 @@ class HeliacalFactory:
                 key = min(heads, key=lambda k: heads[k].julian_day)
                 ev = heads.pop(key)
                 events.append(ev)
+                if len(events) == count:
+                    break
                 planet, etype = key
                 # Advance just past this event (+1 day is safely inside any
                 # body's synodic gap; a non-advancing cursor would re-find it).

--- a/kerykeion/secondary_progressions/solar_arc.py
+++ b/kerykeion/secondary_progressions/solar_arc.py
@@ -51,7 +51,7 @@ from kerykeion.utilities.core import (
     get_planet_house,
 )
 
-from .factory import SecondaryProgressionFactory
+from .factory import DAYS_PER_TROPICAL_YEAR, SecondaryProgressionFactory
 
 
 def _normalise_long(value: float) -> float:
@@ -196,26 +196,11 @@ class SolarArcFactory:
         # selected aspects would otherwise be silently ignored.
         validate_point_orb_adjustments(point_orb_adjustments)
 
-        if natal_subject.sun is None:
-            raise KerykeionException("Natal subject is missing the Sun — cannot compute solar arc.")
-        if (target_iso_utc_datetime is None) == (target_year is None):
-            raise KerykeionException(
-                "Pass exactly one of `target_iso_utc_datetime` or `target_year`."
-            )
-
-        target_jd = SecondaryProgressionFactory._target_to_jd(
-            target_iso_utc_datetime, target_year
-        )
-
-        progressed = SecondaryProgressionFactory.compute(
+        solar_arc, target_jd, _ = SolarArcFactory._compute_arc(
             natal_subject,
             target_iso_utc_datetime=target_iso_utc_datetime,
             target_year=target_year,
         )
-        if progressed.sun is None:
-            raise KerykeionException("Progressed subject is missing the Sun — cannot compute solar arc.")
-
-        solar_arc = _forward_arc_diff(progressed.sun.abs_pos, natal_subject.sun.abs_pos)
 
         directed_sources = gather_active_points(natal_subject, active_points)
         natal_targets = gather_active_points(natal_subject, natal_subject.active_points)
@@ -329,6 +314,32 @@ class SolarArcFactory:
             directed_to_natal_aspects=directed_to_natal,
         )
 
+    @staticmethod
+    def _compute_arc(
+        natal_subject: AstrologicalSubjectModel,
+        *,
+        target_iso_utc_datetime: Optional[str],
+        target_year: Optional[int],
+    ) -> tuple[float, float, Optional[float]]:
+        """Return the arc, target JD and Sun speed at the progressed instant."""
+        if natal_subject.sun is None:
+            raise KerykeionException("Natal subject is missing the Sun — cannot compute solar arc.")
+        if (target_iso_utc_datetime is None) == (target_year is None):
+            raise KerykeionException("Pass exactly one of `target_iso_utc_datetime` or `target_year`.")
+        target_jd = SecondaryProgressionFactory._target_to_jd(target_iso_utc_datetime, target_year)
+        progressed = SecondaryProgressionFactory.compute(
+            natal_subject,
+            target_iso_utc_datetime=target_iso_utc_datetime,
+            target_year=target_year,
+        )
+        if progressed.sun is None:
+            raise KerykeionException("Progressed subject is missing the Sun — cannot compute solar arc.")
+        return (
+            _forward_arc_diff(progressed.sun.abs_pos, natal_subject.sun.abs_pos),
+            target_jd,
+            progressed.sun.speed,
+        )
+
     # Names of point fields whose abs_pos must be shifted by the solar arc
     # when building a directed AstrologicalSubjectModel. The four angles
     # (Asc/MC/Desc/IC) ARE directed — solar-arc-directed angles are a standard
@@ -367,14 +378,18 @@ class SolarArcFactory:
         :meth:`compute`, whose aspect list reports directed-angle contacts.
         Only the house CUSPS stay on the natal frame (they define the biwheel's
         house grid): inner ring = natal, outer ring = directed, houses fixed.
+        Directed speeds are in degrees per real-time day, shared by all points;
+        natal planetary motion-state classifications are cleared.
         """
-        result = SolarArcFactory.compute(
+        arc, _, sun_speed = SolarArcFactory._compute_arc(
             natal_subject,
             target_iso_utc_datetime=target_iso_utc_datetime,
             target_year=target_year,
-            compute_aspects=False,
         )
-        arc = result.solar_arc
+        if sun_speed is None:
+            raise KerykeionException("Progressed Sun is missing speed — cannot compute directed motion.")
+        # One ephemeris day corresponds to one tropical year of life.
+        directed_speed = sun_speed / DAYS_PER_TROPICAL_YEAR
 
         directed = natal_subject.model_copy(deep=True)
         directed.name = f"{natal_subject.name} (directed)"
@@ -399,6 +414,9 @@ class SolarArcFactory:
             point.sign = SIGN_CODES[sign_idx]
             point.sign_num = sign_idx
             point.position = new_abs - sign_idx * 30.0
+            point.speed = directed_speed
+            point.retrograde = directed_speed < 0.0
+            point.motion_state = None
             # Recompute sign-derived metadata so downstream consumers
             # (ChartDrawer, AI prompts, PDF exports) stay consistent
             # when a directed point crosses signs.
@@ -457,4 +475,3 @@ class SolarArcFactory:
             )
 
         return directed
-

--- a/skills/kerykeion-cli/references/call-dispatcher.md
+++ b/skills/kerykeion-cli/references/call-dispatcher.md
@@ -44,7 +44,11 @@ kerykeion call MidpointFactory.compute -s ada --param active_points=Sun,Moon -f 
 - `none` / `null` → `None` for a nullable annotation (`Optional[T]` / `T | None`)
 - `datetime` / `date`: ISO
 - `Literal`: membership, case-checked, with a suggestion on a near miss
-- lists **and abstract sequences** (`list[str]`, `Sequence[str]`): comma-separated
+- lists **and abstract sequences** (`list[str]`, `Sequence[str]`): JSON arrays;
+  scalar elements also accept comma-separated text. Structured elements require
+  JSON, e.g. `--param 'active_aspects=[{"name":"trine","orb":5}]'` for
+  `AspectsFactory.single_chart_aspects`. JSON arrays preserve commas inside strings
+  and validate each element against its annotated type.
 - mappings: JSON, e.g. `--param custom_weights='{"Sun": 1.5}'`
 - a Pydantic model parameter: the path to a JSON file holding it
 

--- a/skills/kerykeion-cli/references/call-dispatcher.md
+++ b/skills/kerykeion-cli/references/call-dispatcher.md
@@ -48,7 +48,9 @@ kerykeion call MidpointFactory.compute -s ada --param active_points=Sun,Moon -f 
   scalar elements also accept comma-separated text. Structured elements require
   JSON, e.g. `--param 'active_aspects=[{"name":"trine","orb":5}]'` for
   `AspectsFactory.single_chart_aspects`. JSON arrays preserve commas inside strings
-  and validate each element against its annotated type.
+  and validate each element against its annotated type. For scalar sequences,
+  text starting with `[` uses JSON only if it is syntactically valid JSON;
+  otherwise it retains CSV parsing, so literal values such as `[Sun` still work.
 - mappings: JSON, e.g. `--param custom_weights='{"Sun": 1.5}'`
 - a Pydantic model parameter: the path to a JSON file holding it
 

--- a/skills/kerykeion/references/mundane-events.md
+++ b/skills/kerykeion/references/mundane-events.md
@@ -339,6 +339,8 @@ planets); `count` max 200. `next_heliacal_rising` additionally accepts
 fixed-star names; "no event in window" and a mistyped body both surface as
 `KerykeionException`. `HeliacalEventModel`: `event_type` (label string, e.g.
 `"heliacal_rising"`), `julian_day`, `planet_name`, `datestamp` (`YYYY-MM-DD`).
+`search_events` stops as soon as `count` events have been collected; it does
+not search for an unused successor beyond the requested results.
 
 ```python
 # doc-snippet: no-run  (heliacal searches take ~10-20 s each)

--- a/skills/kerykeion/references/predictive.md
+++ b/skills/kerykeion/references/predictive.md
@@ -321,6 +321,9 @@ kwargs behave exactly as in `SecondaryProgressionFactory` (one of
   stay natal (biwheel: inner natal, outer directed, natal house grid). Position-derived
   enrichments (dignities, decan/term, nakshatra, azimuth/altitude, Gauquelin sector) are
   nulled on shifted points; house placement is recomputed against the natal cusps.
+  Every shifted point shares the progressed Sun's speed divided by 365.24219, in
+  degrees per real-time day, and its retrograde flag follows that speed. Natal
+  `motion_state` classifications are cleared because the motion is symbolic.
 
 ```python
 from kerykeion import AstrologicalSubjectFactory

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1126,6 +1126,7 @@ class TestFullPrReviewFixes:
         assert json.loads(r.output)
 
     def test_call_binds_structured_sequence_json(self, runner, app, ada_profile):
+        """The dispatcher passes structured aspect settings through to the factory."""
         r = runner.invoke(
             app,
             ["call", "AspectsFactory.single_chart_aspects", "-s", ada_profile,
@@ -1150,13 +1151,36 @@ class TestFullPrReviewFixes:
         ],
     )
     def test_sequence_json_preserves_structure_and_coerces_elements(self, annotation, raw, expected):
+        """JSON retains nested values and embedded commas while validating element types."""
         from kerykeion_cli.introspect import coerce_value
 
         assert coerce_value(annotation, raw) == expected
 
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [("[Sun", ["[Sun"]), ("[Sun,Moon]", ["[Sun", "Moon]"]), (" [Sun, Moon ", ["[Sun", "Moon"])],
+    )
+    def test_scalar_sequence_preserves_csv_starting_with_bracket(self, raw, expected):
+        """A literal opening bracket in a CSV string does not require JSON input."""
+        from typing import Sequence
+
+        from kerykeion_cli.introspect import coerce_value
+
+        assert coerce_value(list[str], raw) == expected
+        assert coerce_value(Sequence[str], raw) == expected
+        assert coerce_value(tuple[str, ...], raw) == tuple(expected)
+
+    def test_scalar_sequence_does_not_fallback_on_json_element_errors(self):
+        """Syntactically valid JSON must still reject elements of the wrong type."""
+        from kerykeion_cli.introspect import coerce_value
+
+        with pytest.raises(ValueError):
+            coerce_value(list[str], '[{"name":"Sun"}]')
+
     @pytest.mark.parametrize("raw", ['[{', '["trine"]', '{"name":"trine","orb":5}',
                                      '[{"name":"trine","orb":"invalid"}]'])
     def test_structured_sequence_rejects_invalid_json_or_elements(self, raw):
+        """Structured sequences require valid JSON with correctly typed elements."""
         from typing import get_type_hints
 
         from kerykeion import AspectsFactory

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1125,6 +1125,47 @@ class TestFullPrReviewFixes:
         assert r.exit_code == 0, r.output
         assert json.loads(r.output)
 
+    def test_call_binds_structured_sequence_json(self, runner, app, ada_profile):
+        r = runner.invoke(
+            app,
+            ["call", "AspectsFactory.single_chart_aspects", "-s", ada_profile,
+             "--param", 'active_aspects=[{"name":"trine","orb":5}]', "-f", "json"],
+        )
+        assert r.exit_code == 0, r.output
+        payload = json.loads(r.output)
+        assert payload["aspects"]
+        assert all(a["aspect"] == "trine" and a["orbit"] <= 5 for a in payload["aspects"])
+
+    @pytest.mark.parametrize(
+        ("annotation", "raw", "expected"),
+        [
+            (list[str], '["Sun,Moon", "Venus"]', ["Sun,Moon", "Venus"]),
+            (list[int], '[1, "2"]', [1, 2]),
+            (list[int], "1,2", [1, 2]),
+            (list[dict[str, float]], '[{"Sun": 1.5, "Moon": 2}]', [{"Sun": 1.5, "Moon": 2.0}]),
+            (list[list[int]], '[[1,2],[3]]', [[1, 2], [3]]),
+            (tuple[int, str], '[1,"a,b"]', (1, "a,b")),
+            (set[int], '[1,2,1]', {1, 2}),
+            (list[dict[str, float]], '[]', []),
+        ],
+    )
+    def test_sequence_json_preserves_structure_and_coerces_elements(self, annotation, raw, expected):
+        from kerykeion_cli.introspect import coerce_value
+
+        assert coerce_value(annotation, raw) == expected
+
+    @pytest.mark.parametrize("raw", ['[{', '["trine"]', '{"name":"trine","orb":5}',
+                                     '[{"name":"trine","orb":"invalid"}]'])
+    def test_structured_sequence_rejects_invalid_json_or_elements(self, raw):
+        from typing import get_type_hints
+
+        from kerykeion import AspectsFactory
+        from kerykeion_cli.introspect import coerce_value
+
+        annotation = get_type_hints(AspectsFactory.single_chart_aspects)["active_aspects"]
+        with pytest.raises(ValueError):
+            coerce_value(annotation, raw)
+
     # House letters are case-SIGNIFICANT: 'i' (Sunshine/alt.) != 'I' (Sunshine).
     # Upper-casing every letter made 'i' unreachable and silently re-framed a
     # transit ring inheriting a natal 'i'.

--- a/tests/core/test_heliacal.py
+++ b/tests/core/test_heliacal.py
@@ -161,6 +161,27 @@ class TestSearchEvents:
         events = self._get_events(factory, count=2)
         assert len(events) <= 2
 
+    @pytest.mark.parametrize("count", [1, 3])
+    def test_does_not_search_past_requested_count(self, factory, monkeypatch, count):
+        import kerykeion.heliacal.factory as hf
+
+        calls = []
+
+        def bounded_search(jd, *args, **kwargs):
+            calls.append(jd)
+            if len(calls) > count:
+                raise RuntimeError("Successor is outside ephemeris coverage")
+            return (jd + 10, jd + 10.1, jd + 10.2)
+
+        monkeypatch.setattr(hf.ephe, "heliacal_ut", bounded_search)
+        events = factory.search_events(
+            julian_day=START_JD, geopos=ROME_GEOPOS, count=count,
+            planets=["Jupiter"], event_types=[hf.HELIACAL_RISING],
+        )
+        assert len(events) == count
+        assert len(calls) == count
+        assert [e.julian_day for e in events] == [START_JD + 10 + 11 * i for i in range(count)]
+
     @pytest.mark.parametrize("event_types", [[999], [0], [-1], ["1"]])
     def test_invalid_event_types_rejected(self, factory, event_types):
         with pytest.raises(KerykeionException, match="event_types"):

--- a/tests/core/test_predictive_factories.py
+++ b/tests/core/test_predictive_factories.py
@@ -427,6 +427,37 @@ def test_solar_arc_empty_aspects_disables_aspect_detection():
     assert solar_arc.directed_to_natal_aspects == []
 
 
+def test_solar_arc_directed_motion_matches_positions_and_aspect_movement():
+    from kerykeion import ChartDataFactory
+
+    natal = AstrologicalSubjectFactory.from_birth_data(
+        "Directed motion", 1990, 1, 1, 12, 0,
+        lng=12.5, lat=41.9, tz_str="Europe/Rome", online=False,
+    )
+    original = natal.model_dump()
+    assert natal.mercury.retrograde is True
+    directed = SolarArcFactory.compute_directed_subject(natal, target_year=2026)
+    following = SolarArcFactory.compute_directed_subject(natal, target_year=2027)
+    elapsed_days = ephe.julday(2027, 1, 1, 0) - ephe.julday(2026, 1, 1, 0)
+    for field in SolarArcFactory._DIRECTABLE_FIELDS:
+        point = getattr(directed, field, None)
+        if point is None:
+            continue
+        advance = (getattr(following, field).abs_pos - point.abs_pos) % 360
+        assert point.speed == directed.sun.speed
+        assert point.speed == pytest.approx(advance / elapsed_days, rel=0.001)
+        assert point.retrograde is False
+        assert point.motion_state is None
+    assert natal.model_dump() == original
+
+    chart = ChartDataFactory.create_progression_chart_data(natal, directed)
+    conjunction = next(
+        a for a in chart.aspects
+        if a.p1_name == "Moon" and a.p2_name == "Mercury" and a.aspect == "conjunction"
+    )
+    assert conjunction.aspect_movement == "Applying"
+
+
 def test_solar_arc_roughly_1_deg_per_year():
     natal = _subject()
     solar_arc = SolarArcFactory.compute(natal, target_year=2030, compute_aspects=False)


### PR DESCRIPTION
Fix three regressions found while reviewing the v6 alpha:

- Solar-arc-directed points now share the progressed Sun's motion, converted to degrees per real-time day. Retrograde flags follow that speed and natal motion-state classifications are cleared. The 1990-01-01 Rome natal directed to 2026 now labels directed Mercury's conjunction with natal Moon as Applying.
- Heliacal event searches stop immediately after collecting the requested count. A single Jupiter rising after 2648-12-01 now returns 2649-02-08 without attempting an out-of-coverage successor search.
- CLI sequence parameters accept JSON arrays and validate structured elements, including `active_aspects=[{"name":"trine","orb":5}]`. Scalar sequences retain comma-separated input support, including literal values starting with `[` that are not syntactically valid JSON.

Includes regression tests and updates to the library/CLI reference documentation.

Validation:

- `uv run poe test:core`: 7,625 passed, 134 skipped, 2 xfailed.
- Targeted predictive, heliacal and CLI tests: 461 passed, 7 skipped.
- Latest CLI suite, including bracket-prefixed CSV regressions: 224 passed.
- Reproduced the Jupiter ephemeris-boundary case against the installed medium kernel.
- Repository-wide Ruff check; mypy and Pyright on the three changed source files; documentation coverage audit; `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI sequence parameter handling: valid JSON lists are parsed as structured values, while bracket-prefixed CSV values remain supported.
  - Heliacal event searches now stop after returning the requested number of events.
  - Solar-arc directed charts now report progressed motion speed and retrograde status consistently, with symbolic motion states cleared.

- **Documentation**
  - Clarified CLI sequence parsing, heliacal search limits, and solar-arc motion behavior in the reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->